### PR TITLE
Graduate Template feature gate to Beta

### DIFF
--- a/pkg/storage/admitters/vmexport_test.go
+++ b/pkg/storage/admitters/vmexport_test.go
@@ -51,7 +51,8 @@ var _ = Describe("Validating VirtualMachineExport Admitter", func() {
 	config, _, _ := testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{})
 	ociOnlyConfig, _, _ := testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{
 		DeveloperConfiguration: &v1.DeveloperConfiguration{
-			FeatureGates: []string{featuregate.OCIExport},
+			FeatureGates:         []string{featuregate.OCIExport},
+			DisabledFeatureGates: []string{featuregate.Template},
 		},
 	})
 	templateOnlyConfig, _, _ := testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{

--- a/pkg/virt-config/featuregate/active.go
+++ b/pkg/virt-config/featuregate/active.go
@@ -169,6 +169,7 @@ const (
 	// Owner: sig-compute / @0xFelix
 	// Template enables the deployment of virt-template components by virt-operator.
 	// Alpha: v1.8.0
+	// Beta: v1.9.0
 	Template = "Template"
 
 	// Owner: @bmordeha
@@ -308,7 +309,7 @@ func init() {
 	RegisterFeatureGate(FeatureGate{Name: PodSecondaryInterfaceNamingUpgrade, State: Beta})
 	RegisterFeatureGate(FeatureGate{Name: ExternalNetResourceInjection, State: Beta})
 	RegisterFeatureGate(FeatureGate{Name: RebootPolicy, State: Beta})
-	RegisterFeatureGate(FeatureGate{Name: Template, State: Alpha})
+	RegisterFeatureGate(FeatureGate{Name: Template, State: Beta})
 	RegisterFeatureGate(FeatureGate{Name: VmiMemoryOverheadReport, State: Beta})
 	RegisterFeatureGate(FeatureGate{Name: ContainerPathVolumesGate, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: ReservedOverheadMemlock, State: Alpha})

--- a/pkg/virt-controller/watch/application_test.go
+++ b/pkg/virt-controller/watch/application_test.go
@@ -321,6 +321,7 @@ var _ = Describe("Application", func() {
 			app.clusterConfig = clusterConfig
 			app.reInitChan = make(chan string, 10)
 			app.hasCDI = hasCDIAtInit
+			app.isVirtTemplateDeploymentEnabled = clusterConfig.VirtTemplateDeploymentEnabled()
 
 			app.clusterConfig.SetConfigModifiedCallback(app.configModificationCallback)
 

--- a/pkg/virt-operator/kubevirt_test.go
+++ b/pkg/virt-operator/kubevirt_test.go
@@ -1221,10 +1221,6 @@ func (k *KubeVirtTestData) generateRandomResources() int {
 	return len(all)
 }
 
-func enableTemplateFeatureGate(kv *v1.KubeVirt) {
-	enableFeatureGate(kv, featuregate.Template)
-}
-
 func enableFeatureGate(kv *v1.KubeVirt, fg string) {
 	if kv.Spec.Configuration.DeveloperConfiguration == nil {
 		kv.Spec.Configuration.DeveloperConfiguration = &v1.DeveloperConfiguration{}
@@ -1864,7 +1860,6 @@ func (k *KubeVirtTestData) getConfig(registry, version string) *util.KubeVirtDep
 			ImageTag:      version,
 		},
 	}
-	enableTemplateFeatureGate(kv)
 	enableContainerPathVolumesFeatureGate(kv)
 	return util.GetTargetConfigFromKVWithEnvVarManager(kv, k.mockEnvVarManager)
 }
@@ -1904,7 +1899,6 @@ var _ = Describe("KubeVirt Operator", func() {
 					ObservedGeneration: pointer.P(int64(1)),
 				},
 			}
-			enableTemplateFeatureGate(kv)
 			enableContainerPathVolumesFeatureGate(kv)
 			// Add kubevirt deployment and mark everything as ready
 			kvTestData.addKubeVirt(kv)
@@ -1938,7 +1932,6 @@ var _ = Describe("KubeVirt Operator", func() {
 					Phase: v1.KubeVirtPhaseDeleted,
 				},
 			}
-			enableTemplateFeatureGate(kv)
 			enableContainerPathVolumesFeatureGate(kv)
 			kv.DeletionTimestamp = now()
 			util.UpdateConditionsDeleting(kv)
@@ -1977,7 +1970,6 @@ var _ = Describe("KubeVirt Operator", func() {
 					ObservedGeneration: pointer.P(int64(1)),
 				},
 			}
-			enableTemplateFeatureGate(kv)
 			enableContainerPathVolumesFeatureGate(kv)
 
 			// create all resources which should already exist
@@ -2021,7 +2013,6 @@ var _ = Describe("KubeVirt Operator", func() {
 					ObservedGeneration: pointer.P(int64(1)),
 				},
 			}
-			enableTemplateFeatureGate(kv)
 			enableContainerPathVolumesFeatureGate(kv)
 			kvTestData.defaultConfig.SetTargetDeploymentConfig(kv)
 			kvTestData.defaultConfig.SetObservedDeploymentConfig(kv)
@@ -2067,7 +2058,6 @@ var _ = Describe("KubeVirt Operator", func() {
 					OperatorVersion: version.Get().String(),
 				},
 			}
-			enableTemplateFeatureGate(kv)
 			enableContainerPathVolumesFeatureGate(kv)
 			kvTestData.defaultConfig.SetTargetDeploymentConfig(kv)
 			kvTestData.defaultConfig.SetObservedDeploymentConfig(kv)
@@ -2139,7 +2129,6 @@ var _ = Describe("KubeVirt Operator", func() {
 					OperatorVersion: version.Get().String(),
 				},
 			}
-			enableTemplateFeatureGate(kv)
 			enableContainerPathVolumesFeatureGate(kv)
 			kvTestData.defaultConfig.SetTargetDeploymentConfig(kv)
 			kvTestData.defaultConfig.SetObservedDeploymentConfig(kv)
@@ -2163,12 +2152,12 @@ var _ = Describe("KubeVirt Operator", func() {
 			kvTestData.controller.Execute()
 		})
 
-		It("should advance ObservedDeploymentID only once all pods are ready when toggling an optional feature gate", func() {
+		It("should advance ObservedDeploymentID only once all pods are ready when enabling virt-template", func() {
 			kvTestData := KubeVirtTestData{}
 			kvTestData.BeforeTest()
 			defer kvTestData.AfterTest()
 
-			// Start with KubeVirt deployed without any optional feature gates.
+			// Start with KubeVirt deployed with virt-template disabled.
 			kv := &v1.KubeVirt{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:       "test-install",
@@ -2182,6 +2171,9 @@ var _ = Describe("KubeVirt Operator", func() {
 						CommonInstancetypesDeployment: &v1.CommonInstancetypesDeployment{
 							Enabled: pointer.P(false),
 						},
+						VirtTemplateDeployment: &v1.VirtTemplateDeployment{
+							Enabled: pointer.P(false),
+						},
 					},
 				},
 				Status: v1.KubeVirtStatus{
@@ -2191,28 +2183,26 @@ var _ = Describe("KubeVirt Operator", func() {
 				},
 			}
 			oldConfig := util.GetTargetConfigFromKVWithEnvVarManager(kv, kvTestData.mockEnvVarManager)
-			oldConfig.SetTargetDeploymentConfig(kv)
-			oldConfig.SetObservedDeploymentConfig(kv)
+			Expect(oldConfig.SetTargetDeploymentConfig(kv)).To(Succeed())
+			Expect(oldConfig.SetObservedDeploymentConfig(kv)).To(Succeed())
 			util.UpdateConditionsCreated(kv)
 			util.UpdateConditionsAvailable(kv)
 
-			// Toggle the Template feature gate — changes TargetDeploymentID but not version/registry.
-			enableTemplateFeatureGate(kv)
+			// Save a copy before toggling -- used below to skip virt-template
+			// pods in the first cycle (simulating them still starting).
+			kvNoTemplate := kv.DeepCopy()
+
+			// Enable virt-template - changes TargetDeploymentID but not version/registry.
+			kv.Spec.Configuration.VirtTemplateDeployment.Enabled = pointer.P(true)
 			initialObservedID := kv.Status.ObservedDeploymentID
-
 			newConfig := util.GetTargetConfigFromKVWithEnvVarManager(kv, kvTestData.mockEnvVarManager)
-
-			// kvNoFG: a minimal KV without the Template FG, used to restrict
-			// makeDeploymentsReady and addPodsWithOptionalPodDisruptionBudgets to
-			// non-virt-template components only (simulating pods still starting).
-			kvNoFG := &v1.KubeVirt{}
 
 			kubecontroller.SetLatestApiVersionAnnotation(kv)
 			kvTestData.addKubeVirt(kv)
 			kvTestData.addInstallStrategy(newConfig)
 			kvTestData.addAll(newConfig, kv)
-			kvTestData.addPodsWithOptionalPodDisruptionBudgets(newConfig, true, kvNoFG)
-			kvTestData.makeDeploymentsReady(kvNoFG)
+			kvTestData.addPodsWithOptionalPodDisruptionBudgets(newConfig, true, kvNoTemplate)
+			kvTestData.makeDeploymentsReady(kvNoTemplate)
 			kvTestData.makeHandlerReady()
 
 			kvTestData.fakeNamespaceModificationEvent()
@@ -2270,7 +2260,6 @@ var _ = Describe("KubeVirt Operator", func() {
 					ObservedGeneration: pointer.P(int64(1)),
 				},
 			}
-			enableTemplateFeatureGate(kv)
 			enableContainerPathVolumesFeatureGate(kv)
 			kvTestData.defaultConfig.SetTargetDeploymentConfig(kv)
 			kvTestData.defaultConfig.SetObservedDeploymentConfig(kv)
@@ -2336,7 +2325,6 @@ var _ = Describe("KubeVirt Operator", func() {
 					ObservedGeneration: pointer.P(int64(1)),
 				},
 			}
-			enableTemplateFeatureGate(kv)
 			enableContainerPathVolumesFeatureGate(kv)
 			kvTestData.defaultConfig.SetTargetDeploymentConfig(kv)
 			kvTestData.defaultConfig.SetObservedDeploymentConfig(kv)
@@ -2384,7 +2372,6 @@ var _ = Describe("KubeVirt Operator", func() {
 					OperatorVersion: "v0.0.0-master+$Format:%h$",
 				},
 			}
-			enableTemplateFeatureGate(kv1)
 
 			kv2 := &v1.KubeVirt{
 				ObjectMeta: metav1.ObjectMeta{
@@ -2394,7 +2381,6 @@ var _ = Describe("KubeVirt Operator", func() {
 				},
 				Status: v1.KubeVirtStatus{},
 			}
-			enableTemplateFeatureGate(kv2)
 
 			kubecontroller.SetLatestApiVersionAnnotation(kv1)
 			util.UpdateConditionsCreated(kv1)
@@ -2432,7 +2418,6 @@ var _ = Describe("KubeVirt Operator", func() {
 					OperatorVersion: version.Get().String(),
 				},
 			}
-			enableTemplateFeatureGate(kv)
 			enableContainerPathVolumesFeatureGate(kv)
 			kvTestData.defaultConfig.SetTargetDeploymentConfig(kv)
 			kvTestData.defaultConfig.SetObservedDeploymentConfig(kv)
@@ -2549,7 +2534,6 @@ var _ = Describe("KubeVirt Operator", func() {
 				},
 				Status: v1.KubeVirtStatus{},
 			}
-			enableTemplateFeatureGate(kv)
 			enableContainerPathVolumesFeatureGate(kv)
 
 			// create all resources which should already exist
@@ -2679,7 +2663,6 @@ var _ = Describe("KubeVirt Operator", func() {
 				},
 				Status: v1.KubeVirtStatus{},
 			}
-			enableTemplateFeatureGate(kv)
 			enableContainerPathVolumesFeatureGate(kv)
 
 			job, err := kvTestData.controller.generateInstallStrategyJob(&v1.ComponentConfig{}, util.GetTargetConfigFromKV(kv))
@@ -2718,7 +2701,6 @@ var _ = Describe("KubeVirt Operator", func() {
 				},
 				Status: v1.KubeVirtStatus{},
 			}
-			enableTemplateFeatureGate(kv)
 			enableContainerPathVolumesFeatureGate(kv)
 
 			job, err := kvTestData.controller.generateInstallStrategyJob(kv.Spec.Infra, util.GetTargetConfigFromKV(kv))
@@ -2749,7 +2731,6 @@ var _ = Describe("KubeVirt Operator", func() {
 					Namespace: NAMESPACE,
 				},
 			}
-			enableTemplateFeatureGate(kv)
 			enableContainerPathVolumesFeatureGate(kv)
 			kubecontroller.SetLatestApiVersionAnnotation(kv)
 			kvTestData.addKubeVirt(kv)
@@ -2818,7 +2799,6 @@ var _ = Describe("KubeVirt Operator", func() {
 					Finalizers: []string{"foregroundDeleteKubeVirt"},
 				},
 			}
-			enableTemplateFeatureGate(kv)
 			enableContainerPathVolumesFeatureGate(kv)
 			kubecontroller.SetLatestApiVersionAnnotation(kv)
 			kvTestData.addKubeVirt(kv)
@@ -2866,7 +2846,6 @@ var _ = Describe("KubeVirt Operator", func() {
 					OperatorVersion: version.Get().String(),
 				},
 			}
-			enableTemplateFeatureGate(kv)
 			enableContainerPathVolumesFeatureGate(kv)
 			kvTestData.defaultConfig.SetTargetDeploymentConfig(kv)
 			kvTestData.defaultConfig.SetObservedDeploymentConfig(kv)
@@ -2938,7 +2917,6 @@ var _ = Describe("KubeVirt Operator", func() {
 					OperatorVersion: version.Get().String(),
 				},
 			}
-			enableTemplateFeatureGate(kv)
 			enableContainerPathVolumesFeatureGate(kv)
 			kvTestData.defaultConfig.SetTargetDeploymentConfig(kv)
 			kvTestData.defaultConfig.SetObservedDeploymentConfig(kv)
@@ -3009,7 +2987,6 @@ var _ = Describe("KubeVirt Operator", func() {
 					OperatorVersion: version.Get().String(),
 				},
 			}
-			enableTemplateFeatureGate(kv)
 			enableContainerPathVolumesFeatureGate(kv)
 			kvTestData.defaultConfig.SetTargetDeploymentConfig(kv)
 			kvTestData.defaultConfig.SetObservedDeploymentConfig(kv)
@@ -3121,7 +3098,6 @@ var _ = Describe("KubeVirt Operator", func() {
 						},
 					},
 				}
-				enableTemplateFeatureGate(kv)
 				enableContainerPathVolumesFeatureGate(kv)
 
 				kubecontroller.SetLatestApiVersionAnnotation(kv)
@@ -3188,7 +3164,6 @@ var _ = Describe("KubeVirt Operator", func() {
 						Namespace: NAMESPACE,
 					},
 				}
-				enableTemplateFeatureGate(kv)
 				enableContainerPathVolumesFeatureGate(kv)
 
 				kubecontroller.SetLatestApiVersionAnnotation(kv)
@@ -3278,7 +3253,6 @@ var _ = Describe("KubeVirt Operator", func() {
 						OperatorVersion: version.Get().String(),
 					},
 				}
-				enableTemplateFeatureGate(kv)
 				enableContainerPathVolumesFeatureGate(kv)
 				customConfig := util.GetTargetConfigFromKVWithEnvVarManager(kv, kvTestData.mockEnvVarManager)
 
@@ -3464,6 +3438,13 @@ var _ = Describe("KubeVirt Operator", func() {
 				exportProxyDeployment.ObjectMeta.Generation = 123
 				handlerDaemonset.ObjectMeta.Generation = 123
 
+				virtTemplateResources, err := components.NewVirtTemplateResources(customConfig)
+				Expect(err).ToNot(HaveOccurred())
+				for i := range virtTemplateResources.Deployments {
+					virtTemplateResources.Deployments[i].ObjectMeta.Generation = 123
+					kvTestData.addDeployment(virtTemplateResources.Deployments[i], kv)
+				}
+
 				kvTestData.addDeployment(apiDeployment, kv)
 				kvTestData.addDeployment(controllerDeployment, kv)
 				kvTestData.addDeployment(exportProxyDeployment, kv)
@@ -3525,7 +3506,6 @@ var _ = Describe("KubeVirt Operator", func() {
 					OperatorVersion: version.Get().String(),
 				},
 			}
-			enableTemplateFeatureGate(kv)
 			enableContainerPathVolumesFeatureGate(kv)
 			kvTestData.defaultConfig.SetTargetDeploymentConfig(kv)
 			kvTestData.defaultConfig.SetObservedDeploymentConfig(kv)
@@ -3599,7 +3579,6 @@ var _ = Describe("KubeVirt Operator", func() {
 					OperatorVersion: version.Get().String(),
 				},
 			}
-			enableTemplateFeatureGate(kv)
 			enableContainerPathVolumesFeatureGate(kv)
 			kvTestData.defaultConfig.SetTargetDeploymentConfig(kv)
 			kvTestData.defaultConfig.SetObservedDeploymentConfig(kv)
@@ -3688,7 +3667,6 @@ var _ = Describe("KubeVirt Operator", func() {
 					OperatorVersion: version.Get().String(),
 				},
 			}
-			enableTemplateFeatureGate(kv)
 			enableContainerPathVolumesFeatureGate(kv)
 			kvTestData.defaultConfig.SetTargetDeploymentConfig(kv)
 			kvTestData.defaultConfig.SetObservedDeploymentConfig(kv)
@@ -3732,7 +3710,6 @@ var _ = Describe("KubeVirt Operator", func() {
 					Namespace: NAMESPACE,
 				},
 			}
-			enableTemplateFeatureGate(kv)
 			enableContainerPathVolumesFeatureGate(kv)
 			kv.DeletionTimestamp = now()
 			kubecontroller.SetLatestApiVersionAnnotation(kv)
@@ -3775,7 +3752,6 @@ var _ = Describe("KubeVirt Operator", func() {
 					Namespace: NAMESPACE,
 				},
 			}
-			enableTemplateFeatureGate(kv)
 			enableContainerPathVolumesFeatureGate(kv)
 
 			kv.DeletionTimestamp = now()
@@ -3877,7 +3853,8 @@ var _ = Describe("KubeVirt Operator", func() {
 				Spec: v1.KubeVirtSpec{
 					Configuration: v1.KubeVirtConfiguration{
 						DeveloperConfiguration: &v1.DeveloperConfiguration{
-							FeatureGates: []string{featuregate.ContainerPathVolumesGate},
+							FeatureGates:         []string{featuregate.ContainerPathVolumesGate},
+							DisabledFeatureGates: []string{featuregate.Template},
 						},
 						VirtTemplateDeployment: &v1.VirtTemplateDeployment{
 							Enabled: pointer.P(true),
@@ -3893,7 +3870,7 @@ var _ = Describe("KubeVirt Operator", func() {
 				Spec: v1.KubeVirtSpec{
 					Configuration: v1.KubeVirtConfiguration{
 						DeveloperConfiguration: &v1.DeveloperConfiguration{
-							FeatureGates: []string{featuregate.Template, featuregate.ContainerPathVolumesGate},
+							FeatureGates: []string{featuregate.ContainerPathVolumesGate},
 						},
 						VirtTemplateDeployment: &v1.VirtTemplateDeployment{
 							Enabled: pointer.P(false),
@@ -3919,7 +3896,6 @@ var _ = Describe("KubeVirt Operator", func() {
 					},
 				},
 			}
-			enableTemplateFeatureGate(kv)
 			enableContainerPathVolumesFeatureGate(kv)
 			config := util.GetTargetConfigFromKVWithEnvVarManager(kv, kvTestData.mockEnvVarManager)
 
@@ -3976,7 +3952,6 @@ var _ = Describe("KubeVirt Operator", func() {
 					},
 				},
 			}
-			enableTemplateFeatureGate(kv)
 			enableContainerPathVolumesFeatureGate(kv)
 			config := util.GetTargetConfigFromKVWithEnvVarManager(kv, kvTestData.mockEnvVarManager)
 
@@ -4038,7 +4013,6 @@ var _ = Describe("KubeVirt Operator", func() {
 					Namespace: NAMESPACE,
 				},
 			}
-			enableTemplateFeatureGate(kv)
 			// ContainerPathVolumes NOT enabled
 			config := util.GetTargetConfigFromKVWithEnvVarManager(kv, kvTestData.mockEnvVarManager)
 
@@ -4074,16 +4048,13 @@ var _ = Describe("KubeVirt Operator", func() {
 					Finalizers: []string{util.KubeVirtFinalizer},
 				},
 			}
-			enableTemplateFeatureGate(kv)
 			enableContainerPathVolumesFeatureGate(kv)
 			config := util.GetTargetConfigFromKVWithEnvVarManager(kv, kvTestData.mockEnvVarManager)
 
 			// Create new KV with ContainerPathVolumes disabled
 			newKv := kv.DeepCopy()
 			newKv.ObjectMeta.Generation = 2
-			newKv.Spec.Configuration.DeveloperConfiguration = &v1.DeveloperConfiguration{
-				FeatureGates: []string{featuregate.Template},
-			}
+			newKv.Spec.Configuration.DeveloperConfiguration = &v1.DeveloperConfiguration{}
 			newConfig := util.GetTargetConfigFromKVWithEnvVarManager(newKv, kvTestData.mockEnvVarManager)
 
 			kvTestData.deleteFromCache = true
@@ -4123,7 +4094,6 @@ var _ = Describe("KubeVirt Operator", func() {
 					Finalizers: []string{util.KubeVirtFinalizer},
 				},
 			}
-			enableTemplateFeatureGate(kv)
 			// ContainerPathVolumes NOT enabled
 			config := util.GetTargetConfigFromKVWithEnvVarManager(kv, kvTestData.mockEnvVarManager)
 
@@ -4175,7 +4145,6 @@ var _ = Describe("KubeVirt Operator", func() {
 					Finalizers: []string{util.KubeVirtFinalizer},
 				},
 			}
-			enableTemplateFeatureGate(kv)
 			enableContainerPathVolumesFeatureGate(kv)
 			kubecontroller.SetLatestApiVersionAnnotation(kv)
 			kvTestData.addKubeVirt(kv)

--- a/pkg/virt-operator/resource/generate/components/virttemplate.go
+++ b/pkg/virt-operator/resource/generate/components/virttemplate.go
@@ -34,6 +34,7 @@ import (
 	rbacv1 "k8s.io/api/rbac/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	extscheme "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/scheme"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/apimachinery/pkg/util/yaml"
@@ -134,6 +135,12 @@ func parseBundle() (*VirtTemplateResources, error) {
 }
 
 func (r *VirtTemplateResources) addObject(obj runtime.Object) error {
+	if accessor, ok := obj.(metav1.ObjectMetaAccessor); ok {
+		labels := accessor.GetObjectMeta().GetLabels()
+		delete(labels, v1.ManagedByLabel)
+		accessor.GetObjectMeta().SetLabels(labels)
+	}
+
 	switch typedObj := obj.(type) {
 	case *extv1.CustomResourceDefinition:
 		r.CRDs = append(r.CRDs, typedObj)

--- a/pkg/virt-operator/webhooks/kubevirt-update-admitter_test.go
+++ b/pkg/virt-operator/webhooks/kubevirt-update-admitter_test.go
@@ -56,6 +56,9 @@ var _ = Describe("Validating KubeVirtUpdate Admitter", func() {
 		Entry("should reject when VirtTemplateDeployment enabled without Template feature gate",
 			v1.KubeVirtSpec{
 				Configuration: v1.KubeVirtConfiguration{
+					DeveloperConfiguration: &v1.DeveloperConfiguration{
+						DisabledFeatureGates: []string{featuregate.Template},
+					},
 					VirtTemplateDeployment: &v1.VirtTemplateDeployment{
 						Enabled: pointer.P(true),
 					},

--- a/tests/infrastructure/tls-configuration.go
+++ b/tests/infrastructure/tls-configuration.go
@@ -34,7 +34,6 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 
 	kvtls "kubevirt.io/kubevirt/pkg/util/tls"
-	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/flags"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
@@ -72,9 +71,6 @@ var _ = Describe(SIGSerial("tls configuration", func() {
 		})
 
 	It("should enforce TLS configuration on virt-template components", func() {
-		By("Enabling the Template feature gate")
-		config.EnableFeatureGate(featuregate.Template)
-
 		podsToTest := listPods(
 			"app.kubernetes.io/name=virt-template,control-plane=apiserver",
 			"app.kubernetes.io/name=virt-template,control-plane=controller-manager",

--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -2350,6 +2350,23 @@ var _ = Describe("[sig-operator]Operator", Serial, decorators.SigOperator, func(
 	})
 
 	Context("virt-template deployment", func() {
+		var fgDisabled bool
+
+		BeforeEach(func() {
+			fgDisabled = !checks.HasFeature(featuregate.Template)
+			if fgDisabled {
+				kvconfig.EnableFeatureGate(featuregate.Template)
+			}
+		})
+
+		AfterEach(func() {
+			if fgDisabled {
+				kvconfig.DisableFeatureGate(featuregate.Template)
+			} else {
+				kvconfig.EnableFeatureGate(featuregate.Template)
+			}
+		})
+
 		setVirtTemplateDeploymentEnabled := func(enabled bool) {
 			kv := libkubevirt.GetCurrentKv(kubevirt.Client())
 			kv.Spec.Configuration.VirtTemplateDeployment = &v1.VirtTemplateDeployment{
@@ -2361,9 +2378,7 @@ var _ = Describe("[sig-operator]Operator", Serial, decorators.SigOperator, func(
 		// Note: virt-template requires the Snapshot feature gate for full functionality,
 		// but these tests only verify deployment/removal behavior.
 		DescribeTable("should deploy and remove virt-template", func(setup func(), enable func(), disable func()) {
-			if setup != nil {
-				setup()
-			}
+			setup()
 
 			By("Ensuring virt-template deployments do not exist initially")
 			eventuallyVirtTemplateDeploymentsNotFound()
@@ -2381,15 +2396,12 @@ var _ = Describe("[sig-operator]Operator", Serial, decorators.SigOperator, func(
 			eventuallyVirtTemplateDeploymentsNotFound()
 		},
 			Entry("when feature gate is toggled",
-				nil,
+				func() { kvconfig.DisableFeatureGate(featuregate.Template) },
 				func() { kvconfig.EnableFeatureGate(featuregate.Template) },
 				func() { kvconfig.DisableFeatureGate(featuregate.Template) },
 			),
 			Entry("when VirtTemplateDeployment.Enabled is toggled",
-				func() {
-					setVirtTemplateDeploymentEnabled(false)
-					kvconfig.EnableFeatureGate(featuregate.Template)
-				},
+				func() { setVirtTemplateDeploymentEnabled(false) },
 				func() { setVirtTemplateDeploymentEnabled(true) },
 				func() { setVirtTemplateDeploymentEnabled(false) },
 			),


### PR DESCRIPTION
### What this PR does
#### Before this PR:
The Template feature gate is Alpha (disabled by default, opt-in via FeatureGates).

#### After this PR:
The Template feature gate is Beta (enabled by default, opt-out via DisabledFeatureGates or VirtTemplateDeployment.Enabled=false).

Also strips the `app.kubernetes.io/managed-by` kustomize label from virt-template bundle resources at parse time, since the install strategy serializer already removes it during dump.

### References
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/76
- VEP proposal PR: https://github.com/kubevirt/enhancements/pull/245

### Why we need it and why it was done in this way
Graduating to Beta makes virt-template components available by default.

### Special notes for your reviewer
Tests were adjusted to explicitly disable the Template gate where "not enabled" behavior is tested, and redundant `enableTemplateFeatureGate` calls were removed.

A `stripFinalizersFromGVR` helper was extracted to generically handle finalizer stripping during test teardown, replacing inline loops for VMIs, Migrations, and now also VMTRs.

### Checklist
- [x] Design: VEP present (https://github.com/kubevirt/enhancements/issues/76)
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: Existing tests updated for Beta behavior
- [ ] Documentation: A user-guide update was considered and is present (link) or not required
- [ ] Community: Announcement to kubevirt-dev was considered
- [x] AI Contributions: The PR abides by the KubeVirt AI Contribution Policy.

### Release note
```release-note
The Template feature gate has been graduated to Beta and is now enabled by default. Virt-template components are deployed automatically unless explicitly disabled.
```