### PR TITLE
feat: VEP 222: add on-demand VSOCK CA service

### DIFF
--- a/cmd/virt-handler/BUILD.bazel
+++ b/cmd/virt-handler/BUILD.bazel
@@ -45,6 +45,7 @@ go_library(
         "//pkg/virt-handler/rest:go_default_library",
         "//pkg/virt-handler/seccomp:go_default_library",
         "//pkg/virt-handler/selinux:go_default_library",
+        "//pkg/virt-handler/vsock:go_default_library",
         "//pkg/vsock/mode:go_default_library",
         "//pkg/vsock/server:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",

--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -88,6 +88,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-handler/rest"
 	"kubevirt.io/kubevirt/pkg/virt-handler/seccomp"
 	"kubevirt.io/kubevirt/pkg/virt-handler/selinux"
+	"kubevirt.io/kubevirt/pkg/virt-handler/vsock"
 	vsockmode "kubevirt.io/kubevirt/pkg/vsock/mode"
 	"kubevirt.io/kubevirt/pkg/vsock/server"
 )
@@ -554,7 +555,7 @@ func (app *virtHandlerApp) Run() {
 	consoleHandler := rest.NewConsoleHandler(
 		podIsolationDetector,
 		vmiSourceInformer.GetStore(),
-		app.vsockClientCertManager,
+		vsock.NewDefaultDialer(podIsolationDetector, app.vsockClientCertManager),
 	)
 
 	errCh := make(chan error)

--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -555,7 +555,7 @@ func (app *virtHandlerApp) Run() {
 	consoleHandler := rest.NewConsoleHandler(
 		podIsolationDetector,
 		vmiSourceInformer.GetStore(),
-		vsock.NewDefaultDialer(podIsolationDetector, app.vsockClientCertManager),
+		vsock.NewDefaultDialer(podIsolationDetector, app.vsockClientCertManager, app.caManager),
 	)
 
 	errCh := make(chan error)

--- a/pkg/virt-handler/rest/BUILD.bazel
+++ b/pkg/virt-handler/rest/BUILD.bazel
@@ -14,7 +14,6 @@ go_library(
     deps = [
         "//pkg/handler-launcher-com/cmd/v1:go_default_library",
         "//pkg/monitoring/metrics/virt-handler/collector:go_default_library",
-        "//pkg/network/netns:go_default_library",
         "//pkg/safepath:go_default_library",
         "//pkg/util:go_default_library",
         "//pkg/virt-config:go_default_library",
@@ -22,19 +21,16 @@ go_library(
         "//pkg/virt-handler/isolation:go_default_library",
         "//pkg/virt-handler/vsock:go_default_library",
         "//pkg/virt-launcher/virtwrap/stats:go_default_library",
-        "//pkg/vsock/mode:go_default_library",
         "//staging/src/kubevirt.io/api/backup/v1alpha1:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubevirt/typed/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/github.com/emicklei/go-restful/v3:go_default_library",
-        "//vendor/github.com/mdlayher/vsock:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/yaml:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/client-go/tools/record:go_default_library",
-        "//vendor/k8s.io/client-go/util/certificate:go_default_library",
     ],
 )
 

--- a/pkg/virt-handler/rest/console.go
+++ b/pkg/virt-handler/rest/console.go
@@ -20,7 +20,6 @@
 package rest
 
 import (
-	"crypto/tls"
 	"errors"
 	"fmt"
 	"io"
@@ -30,21 +29,16 @@ import (
 	"sync"
 
 	"github.com/emicklei/go-restful/v3"
-	"github.com/mdlayher/vsock"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
-	"k8s.io/client-go/util/certificate"
-
 	v1 "kubevirt.io/api/core/v1"
 	kvcorev1 "kubevirt.io/client-go/kubevirt/typed/core/v1"
 	"kubevirt.io/client-go/log"
 
-	"kubevirt.io/kubevirt/pkg/network/netns"
 	"kubevirt.io/kubevirt/pkg/safepath"
 	"kubevirt.io/kubevirt/pkg/util"
 	"kubevirt.io/kubevirt/pkg/virt-handler/isolation"
 	virtvsock "kubevirt.io/kubevirt/pkg/virt-handler/vsock"
-	"kubevirt.io/kubevirt/pkg/vsock/mode"
 )
 
 type ConsoleHandler struct {
@@ -56,14 +50,14 @@ type ConsoleHandler struct {
 	vmiStore             cache.Store
 	usbredir             map[types.UID]UsbredirHandlerVMI
 	usbredirLock         *sync.Mutex
-	vsockCertManager     certificate.Manager
+	vsockDialer          *virtvsock.Dialer
 }
 
 type UsbredirHandlerVMI struct {
 	stopChans map[int]chan struct{}
 }
 
-func NewConsoleHandler(podIsolationDetector isolation.PodIsolationDetector, vmiStore cache.Store, certManager certificate.Manager) *ConsoleHandler {
+func NewConsoleHandler(podIsolationDetector isolation.PodIsolationDetector, vmiStore cache.Store, vsockDialer *virtvsock.Dialer) *ConsoleHandler {
 	return &ConsoleHandler{
 		podIsolationDetector: podIsolationDetector,
 		serialStopChans:      make(map[types.UID]chan struct{}),
@@ -73,7 +67,7 @@ func NewConsoleHandler(podIsolationDetector isolation.PodIsolationDetector, vmiS
 		usbredirLock:         &sync.Mutex{},
 		vmiStore:             vmiStore,
 		usbredir:             make(map[types.UID]UsbredirHandlerVMI),
-		vsockCertManager:     certManager,
+		vsockDialer:          vsockDialer,
 	}
 }
 
@@ -235,43 +229,8 @@ func (t *ConsoleHandler) VSOCKHandler(request *restful.Request, response *restfu
 		return
 	}
 	t.stream(vmi, request, response, func() (net.Conn, error) {
-		return t.dialVSOCK(vmi, uint32(port), useTLS)
+		return t.vsockDialer.Dial(vmi, uint32(port), useTLS)
 	}, make(chan struct{})) // It is legitimate and up to the guest-application to accept multiple connections.
-}
-
-func (t *ConsoleHandler) dialVSOCK(vmi *v1.VirtualMachineInstance, port uint32, useTLS bool) (net.Conn, error) {
-	dialer := virtvsock.NewDialer(t.podIsolationDetector,
-		mode.DefaultProcPath,
-		func(pid int, fn func() error) error { return netns.New(pid).Do(fn) },
-		vsock.Dial)
-
-	conn, err := dialer.Dial(vmi, port)
-	if err != nil {
-		return nil, fmt.Errorf("failed to dial VSOCK for VM: %w", err)
-	}
-	if !useTLS {
-		return conn, nil
-	}
-	tlsConn := tls.Client(conn, &tls.Config{
-		InsecureSkipVerify: true,
-		MinVersion:         tls.VersionTLS13,
-		GetClientCertificate: func(info *tls.CertificateRequestInfo) (*tls.Certificate, error) {
-			certificate := t.vsockCertManager.Current()
-			if certificate == nil {
-				return nil, fmt.Errorf("missing VSOCK certificate")
-			}
-			return certificate, nil
-		},
-	})
-	if err := tlsConn.Handshake(); err != nil {
-		closeErr := tlsConn.Close()
-		return nil, errors.Join(
-			fmt.Errorf("failed to connect to VSOCK port %d in VM %s/%s over TLS: %w", port, vmi.Namespace, vmi.Name, err),
-			closeErr,
-		)
-	}
-	log.Log.Object(vmi).Infof("Connected to VSOCK port %d in VM %s/%s over TLS", port, vmi.Namespace, vmi.Name)
-	return tlsConn, nil
 }
 
 func newStopChan(uid types.UID, lock *sync.Mutex, stopChans map[types.UID]chan struct{}) chan struct{} {

--- a/pkg/virt-handler/rest/console.go
+++ b/pkg/virt-handler/rest/console.go
@@ -264,11 +264,11 @@ func (t *ConsoleHandler) dialVSOCK(vmi *v1.VirtualMachineInstance, port uint32, 
 		},
 	})
 	if err := tlsConn.Handshake(); err != nil {
-		log.Log.Object(vmi).Reason(err).Errorf("Failed to connect to VSOCK port %d in VM %s/%s over TLS", port, vmi.Namespace, vmi.Name)
-		if closeErr := tlsConn.Close(); closeErr != nil {
-			log.Log.Object(vmi).Reason(closeErr).Info("Failed to close connection.")
-		}
-		return nil, err
+		closeErr := tlsConn.Close()
+		return nil, errors.Join(
+			fmt.Errorf("failed to connect to VSOCK port %d in VM %s/%s over TLS: %w", port, vmi.Namespace, vmi.Name, err),
+			closeErr,
+		)
 	}
 	log.Log.Object(vmi).Infof("Connected to VSOCK port %d in VM %s/%s over TLS", port, vmi.Namespace, vmi.Name)
 	return tlsConn, nil
@@ -317,8 +317,7 @@ func unixSocketDialer(vmi *v1.VirtualMachineInstance, socketPath *safepath.Path)
 			var dialErr error
 			conn, dialErr = net.Dial("unix", safePath)
 			if dialErr != nil {
-				log.Log.Object(vmi).Reason(dialErr).Errorf("failed to dial unix socket %s", safePath)
-				return dialErr
+				return fmt.Errorf("failed to dial unix socket %s: %w", safePath, dialErr)
 			}
 			log.Log.Object(vmi).Infof("Connected to %s", safePath)
 			return nil
@@ -341,6 +340,7 @@ func (t *ConsoleHandler) stream(vmi *v1.VirtualMachineInstance, request *restful
 
 	conn, err := dial()
 	if err != nil {
+		log.Log.Object(vmi).Reason(err).Error("Failed to dial connection")
 		response.WriteHeader(http.StatusInternalServerError)
 		return
 	}

--- a/pkg/virt-handler/vsock/BUILD.bazel
+++ b/pkg/virt-handler/vsock/BUILD.bazel
@@ -6,12 +6,14 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/virt-handler/vsock",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/network/netns:go_default_library",
         "//pkg/virt-handler/isolation:go_default_library",
         "//pkg/vsock:go_default_library",
         "//pkg/vsock/mode:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/github.com/mdlayher/vsock:go_default_library",
+        "//vendor/k8s.io/client-go/util/certificate:go_default_library",
     ],
 )
 

--- a/pkg/virt-handler/vsock/BUILD.bazel
+++ b/pkg/virt-handler/vsock/BUILD.bazel
@@ -2,17 +2,25 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["dial.go"],
+    srcs = [
+        "dial.go",
+        "refcount.go",
+        "servers.go",
+    ],
     importpath = "kubevirt.io/kubevirt/pkg/virt-handler/vsock",
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/network/netns:go_default_library",
+        "//pkg/util/tls:go_default_library",
         "//pkg/virt-handler/isolation:go_default_library",
         "//pkg/vsock:go_default_library",
         "//pkg/vsock/mode:go_default_library",
+        "//pkg/vsock/system:go_default_library",
+        "//pkg/vsock/system/v1:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/github.com/mdlayher/vsock:go_default_library",
+        "//vendor/google.golang.org/grpc:go_default_library",
         "//vendor/k8s.io/client-go/util/certificate:go_default_library",
     ],
 )
@@ -21,6 +29,7 @@ go_test(
     name = "go_default_test",
     srcs = [
         "dial_test.go",
+        "refcount_test.go",
         "vsock_suite_test.go",
     ],
     race = "on",

--- a/pkg/virt-handler/vsock/dial.go
+++ b/pkg/virt-handler/vsock/dial.go
@@ -31,6 +31,7 @@ import (
 	"kubevirt.io/client-go/log"
 
 	"kubevirt.io/kubevirt/pkg/network/netns"
+	kvtls "kubevirt.io/kubevirt/pkg/util/tls"
 	"kubevirt.io/kubevirt/pkg/virt-handler/isolation"
 	virtvsock "kubevirt.io/kubevirt/pkg/vsock"
 	"kubevirt.io/kubevirt/pkg/vsock/mode"
@@ -49,6 +50,7 @@ type tlsWrapperFunc func(conn net.Conn) TLSConn
 
 type Dialer struct {
 	isolationDetector isolation.PodIsolationDetector
+	servers           *ServerCache
 	procPath          string
 	netnsDoFn         netnsDoFunc
 	dialFn            vsockDialFunc
@@ -57,6 +59,7 @@ type Dialer struct {
 
 func NewDialer(
 	isolationDetector isolation.PodIsolationDetector,
+	serverCache *ServerCache,
 	procPath string,
 	netnsFn netnsDoFunc,
 	dialFn vsockDialFunc,
@@ -64,6 +67,7 @@ func NewDialer(
 ) *Dialer {
 	return &Dialer{
 		isolationDetector: isolationDetector,
+		servers:           serverCache,
 		procPath:          procPath,
 		dialFn:            dialFn,
 		netnsDoFn:         netnsFn,
@@ -71,8 +75,13 @@ func NewDialer(
 	}
 }
 
-func NewDefaultDialer(isolationDetector isolation.PodIsolationDetector, certManager certificate.Manager) *Dialer {
+func NewDefaultDialer(
+	isolationDetector isolation.PodIsolationDetector,
+	certManager certificate.Manager,
+	caManager kvtls.ClientCAManager,
+) *Dialer {
 	return NewDialer(isolationDetector,
+		NewServerCache(caManager),
 		mode.DefaultProcPath,
 		func(pid int, fn func() error) error { return netns.New(pid).Do(fn) },
 		vsock.Dial,
@@ -101,14 +110,25 @@ func (d *Dialer) Dial(vmi *v1.VirtualMachineInstance, port uint32, useTLS bool) 
 		return nil, fmt.Errorf("failed to detect pod isolation: %w", err)
 	}
 
+	pid := isolationRes.Pid()
+
 	cid := *vmi.Status.VSOCKCID
 	vsockMode := mode.ModeGlobal
 
 	var conn net.Conn
-	nsErr := d.netnsDoFn(isolationRes.Pid(), func() error {
+	var releaseCAServer func()
+	nsErr := d.netnsDoFn(pid, func() error {
 		if mode.VsockNsMode(d.procPath) == mode.ModeLocal {
 			cid = virtvsock.LocalCID
 			vsockMode = mode.ModeLocal
+
+			if useTLS {
+				var serverErr error
+				releaseCAServer, serverErr = d.servers.StartCAServer(pid)
+				if serverErr != nil {
+					return serverErr
+				}
+			}
 		}
 
 		log.Log.Object(vmi).Infof("Connecting to %d:%d in %s mode", cid, port, vsockMode)
@@ -119,8 +139,13 @@ func (d *Dialer) Dial(vmi *v1.VirtualMachineInstance, port uint32, useTLS bool) 
 		conn = c
 		return nil
 	})
+	defer func() {
+		if releaseCAServer != nil {
+			releaseCAServer()
+		}
+	}()
 	if nsErr != nil {
-		return nil, nsErr
+		return nil, fmt.Errorf("failed to dial VSOCK for VM: %w", nsErr)
 	}
 
 	if !useTLS {

--- a/pkg/virt-handler/vsock/dial.go
+++ b/pkg/virt-handler/vsock/dial.go
@@ -20,13 +20,17 @@
 package vsock
 
 import (
+	"crypto/tls"
+	"errors"
 	"fmt"
 	"net"
 
 	"github.com/mdlayher/vsock"
+	"k8s.io/client-go/util/certificate"
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
 
+	"kubevirt.io/kubevirt/pkg/network/netns"
 	"kubevirt.io/kubevirt/pkg/virt-handler/isolation"
 	virtvsock "kubevirt.io/kubevirt/pkg/vsock"
 	"kubevirt.io/kubevirt/pkg/vsock/mode"
@@ -36,23 +40,58 @@ type vsockDialFunc func(contextID, port uint32, cfg *vsock.Config) (*vsock.Conn,
 
 type netnsDoFunc func(pid int, fn func() error) error
 
+type TLSConn interface {
+	net.Conn
+	Handshake() error
+}
+
+type tlsWrapperFunc func(conn net.Conn) TLSConn
+
 type Dialer struct {
 	isolationDetector isolation.PodIsolationDetector
 	procPath          string
 	netnsDoFn         netnsDoFunc
 	dialFn            vsockDialFunc
+	tlsWrapperFn      tlsWrapperFunc
 }
 
-func NewDialer(isolationDetector isolation.PodIsolationDetector, procPath string, netnsFn netnsDoFunc, dialFn vsockDialFunc) *Dialer {
+func NewDialer(
+	isolationDetector isolation.PodIsolationDetector,
+	procPath string,
+	netnsFn netnsDoFunc,
+	dialFn vsockDialFunc,
+	tlsWrapperFn tlsWrapperFunc,
+) *Dialer {
 	return &Dialer{
 		isolationDetector: isolationDetector,
 		procPath:          procPath,
 		dialFn:            dialFn,
 		netnsDoFn:         netnsFn,
+		tlsWrapperFn:      tlsWrapperFn,
 	}
 }
 
-func (d *Dialer) Dial(vmi *v1.VirtualMachineInstance, port uint32) (net.Conn, error) {
+func NewDefaultDialer(isolationDetector isolation.PodIsolationDetector, certManager certificate.Manager) *Dialer {
+	return NewDialer(isolationDetector,
+		mode.DefaultProcPath,
+		func(pid int, fn func() error) error { return netns.New(pid).Do(fn) },
+		vsock.Dial,
+		func(conn net.Conn) TLSConn {
+			return tls.Client(conn, &tls.Config{
+				InsecureSkipVerify: true, //nolint:gosec
+				MinVersion:         tls.VersionTLS13,
+				GetClientCertificate: func(info *tls.CertificateRequestInfo) (*tls.Certificate, error) {
+					cert := certManager.Current()
+					if cert == nil {
+						return nil, fmt.Errorf("missing VSOCK certificate")
+					}
+					return cert, nil
+				},
+			})
+		})
+}
+
+func (d *Dialer) Dial(vmi *v1.VirtualMachineInstance, port uint32, useTLS bool) (net.Conn, error) {
 	if vmi.Status.VSOCKCID == nil {
 		return nil, fmt.Errorf("VSOCK is not enabled for the VM")
 	}
@@ -77,12 +116,29 @@ func (d *Dialer) Dial(vmi *v1.VirtualMachineInstance, port uint32) (net.Conn, er
 		if err != nil {
 			return fmt.Errorf("failed to dial VSOCK %d:%d: %w", cid, port, err)
 		}
-		log.Log.Object(vmi).Infof("Connected to %d:%d in %s mode", cid, port, vsockMode)
 		conn = c
 		return nil
 	})
 	if nsErr != nil {
 		return nil, nsErr
 	}
-	return conn, nil
+
+	if !useTLS {
+		log.Log.Object(vmi).Infof("Connected to %d:%d in %s mode", cid, port, vsockMode)
+		return conn, nil
+	}
+
+	// The TLS connection and handshake is done outside of netns.Do(),
+	// otherwise blocking this goroutine would also block the OS thread,
+	// leaving less threads to run other goroutines.
+	tlsConn := d.tlsWrapperFn(conn)
+	if err := tlsConn.Handshake(); err != nil {
+		closeErr := tlsConn.Close()
+		return nil, errors.Join(
+			fmt.Errorf("failed to connect to VSOCK port %d in VM %s/%s over TLS: %w", port, vmi.Namespace, vmi.Name, err),
+			closeErr,
+		)
+	}
+	log.Log.Object(vmi).Infof("Connected to VSOCK port %d in VM %s/%s over TLS", port, vmi.Namespace, vmi.Name)
+	return tlsConn, nil
 }

--- a/pkg/virt-handler/vsock/dial_test.go
+++ b/pkg/virt-handler/vsock/dial_test.go
@@ -87,7 +87,9 @@ var _ = Describe("Dialer", func() {
 			return nil
 		}
 
-		dialer = virthandlervsock.NewDialer(fakeIsolation, procPath,
+		dialer = virthandlervsock.NewDialer(fakeIsolation,
+			virthandlervsock.NewServerCache(nil),
+			procPath,
 			func(pid int, fn func() error) error {
 				netnsDoFnCalled = true
 				return netnsDoFn(pid, fn)

--- a/pkg/virt-handler/vsock/dial_test.go
+++ b/pkg/virt-handler/vsock/dial_test.go
@@ -21,6 +21,7 @@ package vsock_test
 
 import (
 	"errors"
+	"net"
 	"os"
 	"path/filepath"
 
@@ -57,6 +58,7 @@ var _ = Describe("Dialer", func() {
 		dialFnCalled    bool
 		netnsDoFn       func(pid int, fn func() error) error
 		netnsDoFnCalled bool
+		tlsWrapperFn    func(conn net.Conn) *fakeTLSConn
 	)
 
 	BeforeEach(func() {
@@ -80,6 +82,11 @@ var _ = Describe("Dialer", func() {
 			return fn()
 		}
 
+		tlsWrapperFn = func(conn net.Conn) *fakeTLSConn {
+			Fail("tlsWrapperFn called unexpectedly - tests that use TLS should override this function")
+			return nil
+		}
+
 		dialer = virthandlervsock.NewDialer(fakeIsolation, procPath,
 			func(pid int, fn func() error) error {
 				netnsDoFnCalled = true
@@ -88,12 +95,15 @@ var _ = Describe("Dialer", func() {
 			func(contextID, port uint32, cfg *vsock.Config) (*vsock.Conn, error) {
 				dialFnCalled = true
 				return dialFn(contextID, port, cfg)
+			},
+			func(conn net.Conn) virthandlervsock.TLSConn {
+				return tlsWrapperFn(conn)
 			})
 	})
 
 	Context("with valid configuration", func() {
-		It("should dial successfully", func() {
-			conn, err := dialer.Dial(vmi, testPort)
+		It("should dial successfully without TLS", func() {
+			conn, err := dialer.Dial(vmi, testPort, false)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(conn).ToNot(BeNil())
 			Expect(netnsDoFnCalled).To(BeTrue())
@@ -109,7 +119,7 @@ var _ = Describe("Dialer", func() {
 				return &vsock.Conn{}, nil
 			}
 
-			conn, err := dialer.Dial(vmi, testPort)
+			conn, err := dialer.Dial(vmi, testPort, false)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(conn).ToNot(BeNil())
 			Expect(netnsDoFnCalled).To(BeTrue())
@@ -124,7 +134,7 @@ var _ = Describe("Dialer", func() {
 				return &vsock.Conn{}, nil
 			}
 
-			conn, err := dialer.Dial(vmi, customPort)
+			conn, err := dialer.Dial(vmi, customPort, false)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(conn).ToNot(BeNil())
 			Expect(netnsDoFnCalled).To(BeTrue())
@@ -149,7 +159,7 @@ var _ = Describe("Dialer", func() {
 				return &vsock.Conn{}, nil
 			}
 
-			conn, err := dialer.Dial(vmi, testPort)
+			conn, err := dialer.Dial(vmi, testPort, false)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(conn).ToNot(BeNil())
 			Expect(netnsDoFnCalled).To(BeTrue())
@@ -165,7 +175,7 @@ var _ = Describe("Dialer", func() {
 				return &vsock.Conn{}, nil
 			}
 
-			conn, err := dialer.Dial(vmi, testPort)
+			conn, err := dialer.Dial(vmi, testPort, false)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(conn).ToNot(BeNil())
 			Expect(netnsDoFnCalled).To(BeTrue())
@@ -179,7 +189,7 @@ var _ = Describe("Dialer", func() {
 				return &vsock.Conn{}, nil
 			}
 
-			conn, err := dialer.Dial(vmi, testPort)
+			conn, err := dialer.Dial(vmi, testPort, false)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(conn).ToNot(BeNil())
 			Expect(netnsDoFnCalled).To(BeTrue())
@@ -194,7 +204,7 @@ var _ = Describe("Dialer", func() {
 				return fn()
 			}
 
-			conn, err := dialer.Dial(vmi, testPort)
+			conn, err := dialer.Dial(vmi, testPort, false)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(conn).ToNot(BeNil())
 			Expect(netnsDoFnCalled).To(BeTrue())
@@ -207,7 +217,7 @@ var _ = Describe("Dialer", func() {
 			expectedErr := errors.New("isolation detection failed")
 			fakeIsolation.err = expectedErr
 
-			conn, err := dialer.Dial(vmi, testPort)
+			conn, err := dialer.Dial(vmi, testPort, false)
 			Expect(err).To(MatchError(expectedErr))
 			Expect(conn).To(BeNil())
 			Expect(netnsDoFnCalled).To(BeFalse())
@@ -217,7 +227,7 @@ var _ = Describe("Dialer", func() {
 		It("should return error when VSOCK is not enabled", func() {
 			vmi.Status.VSOCKCID = nil
 
-			conn, err := dialer.Dial(vmi, testPort)
+			conn, err := dialer.Dial(vmi, testPort, false)
 			Expect(err).To(MatchError("VSOCK is not enabled for the VM"))
 			Expect(conn).To(BeNil())
 			Expect(netnsDoFnCalled).To(BeFalse())
@@ -232,7 +242,7 @@ var _ = Describe("Dialer", func() {
 				return nil, expectedErr
 			}
 
-			conn, err := dialer.Dial(vmi, testPort)
+			conn, err := dialer.Dial(vmi, testPort, false)
 			Expect(err).To(MatchError(expectedErr))
 			Expect(conn).To(BeNil())
 			Expect(netnsDoFnCalled).To(BeTrue())
@@ -246,11 +256,68 @@ var _ = Describe("Dialer", func() {
 				return expectedErr
 			}
 
-			conn, err := dialer.Dial(vmi, testPort)
+			conn, err := dialer.Dial(vmi, testPort, false)
 			Expect(err).To(MatchError(expectedErr))
 			Expect(conn).To(BeNil())
 			Expect(netnsDoFnCalled).To(BeTrue())
 			Expect(dialFnCalled).To(BeFalse())
+		})
+	})
+
+	Context("TLS parameter", func() {
+		It("should wrap connection with TLS when useTLS is true", func() {
+			tlsWrapperCalled := false
+			tlsWrapperFn = func(conn net.Conn) *fakeTLSConn {
+				tlsWrapperCalled = true
+				return &fakeTLSConn{Conn: conn}
+			}
+
+			conn, err := dialer.Dial(vmi, testPort, true)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(conn).ToNot(BeNil())
+			Expect(netnsDoFnCalled).To(BeTrue())
+			Expect(dialFnCalled).To(BeTrue())
+			Expect(tlsWrapperCalled).To(BeTrue())
+
+			mockConn, ok := conn.(*fakeTLSConn)
+			Expect(ok).To(BeTrue())
+			Expect(mockConn.handshakeCalled).To(BeTrue())
+		})
+
+		It("should return error when TLS handshake fails", func() {
+			expectedErr := errors.New("handshake failed")
+			tlsWrapperCalled := false
+			tlsWrapperFn = func(conn net.Conn) *fakeTLSConn {
+				tlsWrapperCalled = true
+				return &fakeTLSConn{
+					Conn:         conn,
+					handshakeErr: expectedErr,
+				}
+			}
+
+			conn, err := dialer.Dial(vmi, testPort, true)
+			Expect(err).To(MatchError(expectedErr))
+			Expect(conn).To(BeNil())
+			Expect(netnsDoFnCalled).To(BeTrue())
+			Expect(dialFnCalled).To(BeTrue())
+			Expect(tlsWrapperCalled).To(BeTrue())
+		})
+
+		It("should close connection when TLS handshake fails", func() {
+			expectedErr := errors.New("handshake failed")
+			var capturedMockConn *fakeTLSConn
+			tlsWrapperFn = func(conn net.Conn) *fakeTLSConn {
+				capturedMockConn = &fakeTLSConn{
+					Conn:         conn,
+					handshakeErr: expectedErr,
+				}
+				return capturedMockConn
+			}
+
+			conn, err := dialer.Dial(vmi, testPort, true)
+			Expect(err).To(MatchError(expectedErr))
+			Expect(conn).To(BeNil())
+			Expect(capturedMockConn.closeCalled).To(BeTrue())
 		})
 	})
 })
@@ -297,4 +364,22 @@ func (f *fakeIsolationDetector) Detect(_ *v1.VirtualMachineInstance) (isolation.
 
 func (f *fakeIsolationDetector) DetectForSocket(_ string) (isolation.IsolationResult, error) {
 	panic("should not be called")
+}
+
+type fakeTLSConn struct {
+	net.Conn
+	handshakeCalled bool
+	handshakeErr    error
+	closeCalled     bool
+	closeErr        error
+}
+
+func (m *fakeTLSConn) Close() error {
+	m.closeCalled = true
+	return m.closeErr
+}
+
+func (m *fakeTLSConn) Handshake() error {
+	m.handshakeCalled = true
+	return m.handshakeErr
 }

--- a/pkg/virt-handler/vsock/refcount.go
+++ b/pkg/virt-handler/vsock/refcount.go
@@ -1,0 +1,110 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package vsock
+
+import (
+	"sync"
+)
+
+type RefCounter[K comparable, T any] struct {
+	lock sync.Mutex
+	refs map[K]*refEntry[T]
+}
+
+type refEntry[T any] struct {
+	entryRefCount int
+
+	valueLock     sync.Mutex
+	valueRefCount int
+	value         *T
+	destroyFn     func()
+}
+
+func NewRefCounter[K comparable, T any]() *RefCounter[K, T] {
+	return &RefCounter[K, T]{
+		refs: make(map[K]*refEntry[T]),
+	}
+}
+
+func (r *RefCounter[K, T]) Get(key K, createFn func() (T, func(), error)) (value T, release func(), err error) {
+	entry := r.getOrCreateEntry(key)
+
+	entry.valueLock.Lock()
+	if entry.value == nil {
+		val, destroyFn, err := createFn()
+		if err != nil {
+			entry.valueLock.Unlock()
+			r.removeEntry(key, entry)
+			var zero T
+			return zero, nil, err
+		}
+		entry.value = &val
+		entry.destroyFn = destroyFn
+	}
+	entry.valueRefCount++
+	entry.valueLock.Unlock()
+
+	var once sync.Once
+	release = func() {
+		once.Do(func() {
+			// Wrapping in func in case entry.destroyFn panics.
+			func() {
+				entry.valueLock.Lock()
+				defer entry.valueLock.Unlock()
+
+				entry.valueRefCount--
+				if entry.valueRefCount > 0 {
+					return
+				}
+
+				if entry.destroyFn != nil {
+					entry.destroyFn()
+				}
+				entry.value = nil
+				entry.destroyFn = nil
+			}()
+
+			r.removeEntry(key, entry)
+		})
+	}
+	return *entry.value, release, nil
+}
+
+func (r *RefCounter[K, T]) getOrCreateEntry(key K) *refEntry[T] {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	entry, exists := r.refs[key]
+	if !exists {
+		entry = &refEntry[T]{}
+		r.refs[key] = entry
+	}
+	entry.entryRefCount++
+
+	return entry
+}
+
+func (r *RefCounter[K, T]) removeEntry(key K, entry *refEntry[T]) {
+	r.lock.Lock()
+	defer r.lock.Unlock()
+	entry.entryRefCount--
+	if entry.entryRefCount == 0 {
+		delete(r.refs, key)
+	}
+}

--- a/pkg/virt-handler/vsock/refcount_test.go
+++ b/pkg/virt-handler/vsock/refcount_test.go
@@ -1,0 +1,188 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package vsock_test
+
+import (
+	"errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"kubevirt.io/kubevirt/pkg/virt-handler/vsock"
+)
+
+var _ = Describe("RefCounter", func() {
+	const testValue = "test-value"
+
+	var rc *vsock.RefCounter[int, string]
+
+	BeforeEach(func() {
+		rc = vsock.NewRefCounter[int, string]()
+	})
+
+	It("should create object on first Get", func() {
+		createCount := 0
+		createFn := func() (string, func(), error) {
+			createCount++
+			return testValue, nil, nil
+		}
+
+		obj, _, err := rc.Get(1, createFn)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(obj).To(Equal(testValue))
+		Expect(createCount).To(Equal(1))
+	})
+
+	It("should reuse object on second Get with same key", func() {
+		createCount := 0
+		createFn := func() (string, func(), error) {
+			createCount++
+			return testValue, nil, nil
+		}
+
+		obj1, _, err := rc.Get(1, createFn)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(obj1).To(Equal(testValue))
+		Expect(createCount).To(Equal(1))
+
+		obj2, _, err := rc.Get(1, createFn)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(obj2).To(Equal(testValue))
+		Expect(createCount).To(Equal(1))
+	})
+
+	It("should call destroyFn when last reference is released", func() {
+		destroyCount := 0
+		createFn := func() (string, func(), error) {
+			return testValue, func() { destroyCount++ }, nil
+		}
+
+		_, release1, err := rc.Get(1, createFn)
+		Expect(err).ToNot(HaveOccurred())
+
+		_, release2, err := rc.Get(1, createFn)
+		Expect(err).ToNot(HaveOccurred())
+
+		release1()
+		Expect(destroyCount).To(Equal(0))
+
+		release2()
+		Expect(destroyCount).To(Equal(1))
+	})
+
+	It("should handle nil destroyFn", func() {
+		createFn := func() (string, func(), error) {
+			return testValue, nil, nil
+		}
+
+		_, release, err := rc.Get(1, createFn)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(release).ToNot(Panic())
+	})
+
+	It("should recreate object after all references are released", func() {
+		createCount := 0
+		createFn := func() (string, func(), error) {
+			createCount++
+			return testValue, nil, nil
+		}
+
+		_, release1, err := rc.Get(1, createFn)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(createCount).To(Equal(1))
+		release1()
+
+		_, release2, err := rc.Get(1, createFn)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(createCount).To(Equal(2))
+		release2()
+	})
+
+	It("should isolate different keys", func() {
+		const object1 = "object-1"
+		obj1, _, err := rc.Get(1, func() (string, func(), error) {
+			return object1, nil, nil
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		const object2 = "object-2"
+		obj2, _, err := rc.Get(2, func() (string, func(), error) {
+			return object2, nil, nil
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(obj1).To(Equal(object1))
+		Expect(obj2).To(Equal(object2))
+	})
+
+	It("should independently track references for different keys", func() {
+		destroy1, destroy2 := 0, 0
+
+		_, release1, err := rc.Get(1, func() (string, func(), error) {
+			return "obj-1", func() { destroy1++ }, nil
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		_, release2, err := rc.Get(2, func() (string, func(), error) {
+			return "obj-2", func() { destroy2++ }, nil
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		release1()
+		Expect(destroy1).To(Equal(1))
+		Expect(destroy2).To(Equal(0))
+
+		release2()
+		Expect(destroy1).To(Equal(1))
+		Expect(destroy2).To(Equal(1))
+	})
+
+	It("should return error when createFn fails", func() {
+		createFn := func() (string, func(), error) {
+			return "", nil, errors.New("creation failed")
+		}
+
+		obj, release, err := rc.Get(1, createFn)
+
+		Expect(err).To(MatchError("creation failed"))
+		Expect(obj).To(BeZero())
+		Expect(release).To(BeNil())
+	})
+
+	It("should not store failed object in cache", func() {
+		createCount := 0
+
+		failFn := func() (string, func(), error) {
+			return "", nil, errors.New("fail")
+		}
+		_, _, err := rc.Get(1, failFn)
+		Expect(err).To(HaveOccurred())
+
+		const value = "success"
+		successFn := func() (string, func(), error) {
+			createCount++
+			return value, nil, nil
+		}
+		obj, _, err := rc.Get(1, successFn)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(obj).To(Equal(value))
+		Expect(createCount).To(Equal(1))
+	})
+})

--- a/pkg/virt-handler/vsock/servers.go
+++ b/pkg/virt-handler/vsock/servers.go
@@ -1,0 +1,80 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package vsock
+
+import (
+	"fmt"
+
+	"github.com/mdlayher/vsock"
+	"google.golang.org/grpc"
+	"kubevirt.io/client-go/log"
+
+	kvtls "kubevirt.io/kubevirt/pkg/util/tls"
+	"kubevirt.io/kubevirt/pkg/vsock/system"
+	systemv1 "kubevirt.io/kubevirt/pkg/vsock/system/v1"
+)
+
+type ServerCache struct {
+	caManager kvtls.ClientCAManager
+	servers   *RefCounter[int, *grpc.Server]
+}
+
+func (s *ServerCache) StartCAServer(pid int) (func(), error) {
+	_, release, err := s.servers.Get(pid, func() (*grpc.Server, func(), error) {
+		return s.startServer(pid)
+	})
+	if err != nil {
+		return nil, err
+	}
+	return release, nil
+}
+
+func (s *ServerCache) startServer(pid int) (*grpc.Server, func(), error) {
+	const vsockPort = 1
+	listener, lisErr := vsock.ListenContextID(vsock.Host, vsockPort, &vsock.Config{})
+	if lisErr != nil {
+		return nil, nil, fmt.Errorf("failed to listen on VSOCK CID %d port %d in namespace of PID %d: %w", vsock.Host, vsockPort, pid, lisErr)
+	}
+
+	server := grpc.NewServer()
+	systemv1.RegisterSystemServer(server, system.NewSystemService(s.caManager))
+	go func() {
+		serveErr := server.Serve(listener)
+		if serveErr != nil {
+			log.DefaultLogger().Errorf("VSOCK ns listener for PID %d on port %d failed: %v", pid, vsockPort, serveErr)
+		}
+	}()
+
+	log.DefaultLogger().Infof("VSOCK ns listener created for PID %d on port %d", pid, vsockPort)
+
+	destroyFn := func() {
+		server.Stop()
+		log.DefaultLogger().Infof("VSOCK ns listener removed for PID %d", pid)
+	}
+
+	return server, destroyFn, nil
+}
+
+func NewServerCache(caManager kvtls.ClientCAManager) *ServerCache {
+	return &ServerCache{
+		caManager: caManager,
+		servers:   NewRefCounter[int, *grpc.Server](),
+	}
+}


### PR DESCRIPTION
### What this PR does
#### Before this PR:

There was only one global VSOCK CA service, that was not reachable from VMs in local VSOCK namespaces.

#### After this PR:

The VSOCK CA service is created on-demand in the local namespace, when a connection to VM is created.

### References
- VEP: https://github.com/kubevirt/enhancements/blob/main/veps/sig-compute/222-vsock-netns-vep/vsock-netns-vep.md 
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/222

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
None
```

