### PR TITLE
virt-handler: Backport thread-safe CloseLauncherClient to release-1.6

### DIFF
--- a/pkg/virt-handler/cache/maps.go
+++ b/pkg/virt-handler/cache/maps.go
@@ -16,6 +16,21 @@ type LauncherClientInfo struct {
 	DomainPipeStopChan  chan struct{}
 	NotInitializedSince time.Time
 	Ready               bool
+	closeOnce           sync.Once
+}
+
+func (l *LauncherClientInfo) Close() {
+	if l == nil {
+		return
+	}
+	l.closeOnce.Do(func() {
+		if l.Client != nil {
+			l.Client.Close()
+		}
+		if l.DomainPipeStopChan != nil {
+			close(l.DomainPipeStopChan)
+		}
+	})
 }
 
 type LauncherClientInfoByVMI struct {

--- a/pkg/virt-handler/launcher-clients/BUILD.bazel
+++ b/pkg/virt-handler/launcher-clients/BUILD.bazel
@@ -30,6 +30,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//pkg/testutils:go_default_library",
+        "//pkg/virt-handler/cache:go_default_library",
         "//pkg/virt-handler/notify-server:go_default_library",
         "//pkg/virt-launcher/notify-client:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",

--- a/pkg/virt-handler/launcher-clients/launcher-clients.go
+++ b/pkg/virt-handler/launcher-clients/launcher-clients.go
@@ -138,9 +138,8 @@ func (l *launcherClientsManager) CloseLauncherClient(vmi *v1.VirtualMachineInsta
 	}
 
 	clientInfo, exists := l.launcherClients.Load(vmi.UID)
-	if exists && clientInfo.Client != nil {
-		clientInfo.Client.Close()
-		close(clientInfo.DomainPipeStopChan)
+	if exists {
+		clientInfo.Close()
 	}
 
 	virtcache.GhostRecordGlobalStore.Delete(vmi.Namespace, vmi.Name)


### PR DESCRIPTION
Backport kubevirt/kubevirt#16004 (cherry-picked as #16022 on release-1.7) to address a race where CloseLauncherClient could be invoked concurrently from migration finalCleanup, migration execute, and VM controller cleanup.

Make LauncherClientInfo.Close() idempotent using sync.Once so repeated or concurrent closes do not panic on an already-closed domain pipe channel.

This mitigates duplicate virt-launcher pod / migration cleanup issues reported in kubevirt/kubevirt#16557 and kubevirt/kubevirt#16622 on KubeVirt 1.6.x (OpenShift Virtualization 4.20.z).

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
`CloseLauncherClient` could be invoked concurrently from multiple goroutines during VMI migration cleanup (`finalCleanup`, `execute`, and VM controller `processVmCleanup`). The implementation directly closed the gRPC client and DomainPipeStopChan without synchronization, which could panic with `close of closed channel` and disrupt migration finalization. Under load, this race can contribute to duplicate `virt-launcher` pods remaining active after live migration (kubevirt/kubevirt#16622, kubevirt/kubevirt#16557).

#### After this PR:
`LauncherClientInfo.Close()` is idempotent and thread-safe via `sync.Once`. `CloseLauncherClient` delegates to `clientInfo.Close()`, so repeated or concurrent close attempts are safe. Unit tests cover multiple and concurrent `Close()` calls.

This is a backport of kubevirt/kubevirt#16004 (cherry-picked to `release-1.7` as #16022).

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Partially addresses kubevirt/kubevirt#16622
- Partially addresses kubevirt/kubevirt#16557
- Backport of kubevirt/kubevirt#16004
- Related: kubevirt/kubevirt#15373
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
KubeVirt v1.6.x (OpenShift Virtualization 4.20.z) still carries the pre-1.7 migration cleanup race. Upstream fixed this on main and release-1.7 in #16004 by making launcher client teardown idempotent instead of changing migration orchestration.

Tradeoffs made:

Minimal backport: only the sync.Once-based Close() path and tests, matching upstream #16004 exactly.
No change to StopTargetListener timing or finalCleanup defer order in this PR (keeps backport small and reviewable).
Alternatives considered:

Upgrade path to KubeVirt 1.7+ (long-term fix, not a 1.6.z backport).
Moving CloseLauncherClient defer to failure-only path (#16557 workaround) — upstream chose thread-safe close instead; we follow that approach.
Links to places where the discussion took place:
- https://github.com/kubevirt/kubevirt/issues/16622
- https://github.com/kubevirt/kubevirt/issues/16557
- https://github.com/kubevirt/kubevirt/pull/16004

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- This is a straight backport to release-1.6; diff should match #16004 / #16022 except for branch context.
No API or user-facing behavior change — internal virt-handler cleanup only.
Please run migration-related CI lanes if possible. -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

