### PR TITLE
chore(virtiofs): Split test decorators for config and storage volumes

### DIFF
--- a/tests/decorators/decorators.go
+++ b/tests/decorators/decorators.go
@@ -44,7 +44,8 @@ var (
 
 	CPUModel                             = Label("cpumodel")
 	VSOCK                                = Label("vsock")
-	VirtioFS                             = Label("virtiofs")
+	ConfigVolumesVirtiofs                = Label("config-volumes-virtiofs")
+	StorageVolumesVirtiofs               = Label("storage-volumes-virtiofs")
 	Sysprep                              = Label("Sysprep")
 	Windows                              = Label("Windows")
 	Networking                           = Label("Networking")

--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -2761,8 +2761,8 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 		})
 	})
 
-	Context("Virtiofs", decorators.VirtioFS, func() {
-		It("should migrate with a shared ConfigMap", func() {
+	Context("Virtiofs", func() {
+		It("should migrate with a shared ConfigMap", decorators.ConfigVolumesVirtiofs, func() {
 			configMapName := "configmap-" + uuid.NewString()[:6]
 			data := map[string]string{
 				"option1": "value1",
@@ -2812,7 +2812,7 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 			}, 200)).To(Succeed())
 		})
 
-		It("should migrate with a shared DV", decorators.RequiresRWXFilesystemStorage, func() {
+		It("should migrate with a shared DV", decorators.RequiresRWXFilesystemStorage, decorators.StorageVolumesVirtiofs, func() {
 			sc, foundSC := libstorage.GetRWXFileSystemStorageClass()
 
 			if !foundSC {

--- a/tests/virtiofs/config.go
+++ b/tests/virtiofs/config.go
@@ -47,7 +47,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libvmifact"
 )
 
-var _ = Describe("[sig-compute] vitiofs config volumes", decorators.SigCompute, decorators.VirtioFS, func() {
+var _ = Describe("[sig-compute] virtiofs config volumes", decorators.SigCompute, decorators.ConfigVolumesVirtiofs, func() {
 	Context("With a single ConfigMap volume", func() {
 		var (
 			configMapName string

--- a/tests/virtiofs/containerpath.go
+++ b/tests/virtiofs/containerpath.go
@@ -53,7 +53,7 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = Describe("[sig-storage] ContainerPath virtiofs volumes", decorators.SigStorage, decorators.VirtioFS, func() {
+var _ = Describe("[sig-storage] ContainerPath virtiofs volumes", decorators.SigStorage, decorators.ConfigVolumesVirtiofs, func() {
 	Context("With a ContainerPath volume pointing to non-existent path", func() {
 		const (
 			containerPathFilesystemName = "nonexistent-path"

--- a/tests/virtiofs/datavolume.go
+++ b/tests/virtiofs/datavolume.go
@@ -65,7 +65,7 @@ const (
 	checkingVMInstanceConsoleOut = "Checking that the VirtualMachineInstance console has expected output"
 )
 
-var _ = Describe("[sig-storage] virtiofs", decorators.SigStorage, decorators.VirtioFS, func() {
+var _ = Describe("[sig-storage] virtiofs", decorators.SigStorage, decorators.StorageVolumesVirtiofs, func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 	var vmi *virtv1.VirtualMachineInstance


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

In PR #11997, the virtiofs feature gate was split into separate gates for config volumes and storage volumes, allowing each to reach GA independently. However, all functional tests continued using the single `virtiofs` decorator.

Replace the `VirtioFS` decorator with two specific decorators:
- `config-volumes-virtiofs` for config/containerpath volume tests
- `storage-volumes-virtiofs` for datavolume/storage volume tests

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

