### PR TITLE
docs: Add section on documenting cherry-pick conflicts

### DIFF
--- a/docs/release-branch-backporting.md
+++ b/docs/release-branch-backporting.md
@@ -45,3 +45,28 @@ a defect. Would this be considered a bug fix? Maybe, maybe not. The reviewers
 will have to weigh whether backporting will improve overall stability or
 introduce unacceptable risk.
 
+# Documenting Cherry-Pick Conflicts
+
+When a cherry-pick does not apply cleanly to a release branch, the author must
+document any meaningful conflicts that were resolved as part of the backport.
+This allows reviewers to focus their attention on the manual conflict
+resolutions rather than re-reviewing the entire change.
+
+Trivial conflicts such as import reordering, generated files, or build system
+files do not need to be listed. Only conflicts that required a judgment call or
+a non-obvious resolution should be documented.
+
+Conflict notes should be added as a comment on the backport pull request using
+the following format:
+
+```
+NOTE($author): This backport required manual conflict resolution.
+
+Conflicts:
+- file/path/to/first_conflict.go
+- file/path/to/second_conflict.go
+```
+
+Replace `$author` with your GitHub username. Include a brief explanation of how
+each conflict was resolved when the resolution is not obvious.
+


### PR DESCRIPTION
### What this PR does
#### Before this PR:

The release branch backporting policy document did not provide guidance on how to document conflicts arising from cherry-picks.

#### After this PR:

A new section documents the expected format for recording cherry-pick conflicts using a `NOTE($author):` block with a list of conflicting files, allowing reviewers to focus on manual conflict resolutions.

### Why we need it and why it was done in this way

Standardizing how cherry-pick conflicts are documented makes backport PRs easier to review by clearly highlighting which files required manual resolution.

### Special notes for your reviewer

Documentation only change.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
NONE
```