### PR TITLE
tests: stabilize vsock guest-agent copy verification

### DIFF
--- a/tests/vmi_vsock_test.go
+++ b/tests/vmi_vsock_test.go
@@ -20,6 +20,7 @@
 package tests_test
 
 import (
+	"crypto/md5"
 	"fmt"
 	"io"
 	"net"
@@ -261,9 +262,12 @@ var _ = Describe("[sig-compute]VSOCK", Serial, decorators.SigCompute, decorators
 })
 
 func copyExampleGuestAgent(vmi *v1.VirtualMachineInstance) {
-	const port = 4444
+	const (
+		port           = 4444
+		guestAgentPath = "/usr/bin/example-guest-agent"
+	)
 
-	err := console.RunCommand(vmi, fmt.Sprintf("nc -vl %d > /usr/bin/example-guest-agent < /dev/null &", port), 60*time.Second)
+	err := console.RunCommand(vmi, fmt.Sprintf("nc -vl %d > %s < /dev/null &", port, guestAgentPath), 60*time.Second)
 	Expect(err).ToNot(HaveOccurred())
 
 	file, err := os.Open(flags.KubeVirtExampleGuestAgentPath)
@@ -277,14 +281,25 @@ func copyExampleGuestAgent(vmi *v1.VirtualMachineInstance) {
 	}, 60*time.Second, 1*time.Second).Should(Succeed())
 
 	conn := stream.AsConn()
-	_, err = io.Copy(conn, file)
+	md5Hasher := md5.New()
+	_, err = io.Copy(conn, io.TeeReader(file, md5Hasher))
 	Expect(err).ToNot(HaveOccurred())
 	err = conn.Close()
 	Expect(err).ToNot(HaveOccurred())
 
-	// Wait for netcat to exit
-	err = console.RunCommand(vmi, "while pgrep netcat; do sleep 1; done", 90*time.Second)
-	Expect(err).ToNot(HaveOccurred())
+	expectedMD5 := fmt.Sprintf("%x", md5Hasher.Sum(nil))
+	guestAgentMD5Command := fmt.Sprintf("md5sum %s | awk '{print $1}'", guestAgentPath)
+	Eventually(func() error {
+		guestMD5Output, err := console.RunCommandAndStoreOutput(vmi, guestAgentMD5Command, 30*time.Second)
+		if err != nil {
+			return err
+		}
+		guestMD5 := strings.TrimSpace(guestMD5Output)
+		if guestMD5 != expectedMD5 {
+			return fmt.Errorf("guest agent md5 mismatch: got %q, expected %q", guestMD5, expectedMD5)
+		}
+		return nil
+	}, 2*time.Minute, 10*time.Second).Should(Succeed(), "should validate the guest agent file was copied correctly")
 }
 
 func startExampleGuestAgent(vmi *v1.VirtualMachineInstance, useTLS bool, port uint32) error {


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Replace flaky and complex netcat process polling with md5-based content verification
and extend the wait budget to reduce copy timing flakes.

Fix flakes
https://search.ci.kubevirt.io/?search=communicating+with+VMI+via+VSOCK+should+succeed&maxAge=336h&context=1&type=bug%2Bissue%2Bjunit&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

