### PR TITLE
virt-operator: only create route.openshift.io RBAC on OpenShift

### DIFF
--- a/pkg/util/cluster/BUILD.bazel
+++ b/pkg/util/cluster/BUILD.bazel
@@ -6,7 +6,6 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/util/cluster",
     visibility = ["//visibility:public"],
     deps = [
-        "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//vendor/github.com/openshift/api/security/v1:go_default_library",
         "//vendor/k8s.io/client-go/discovery:go_default_library",
     ],
@@ -22,12 +21,10 @@ go_test(
     race = "on",
     deps = [
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
-        "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/github.com/openshift/api/security/v1:go_default_library",
-        "//vendor/go.uber.org/mock/gomock:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/client-go/discovery/fake:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/fake:go_default_library",

--- a/pkg/util/cluster/cluster.go
+++ b/pkg/util/cluster/cluster.go
@@ -3,12 +3,10 @@ package cluster
 import (
 	secv1 "github.com/openshift/api/security/v1"
 	"k8s.io/client-go/discovery"
-
-	"kubevirt.io/client-go/kubecli"
 )
 
-func IsOnOpenShift(clientset kubecli.KubevirtClient) (bool, error) {
-	_, apis, err := clientset.DiscoveryClient().ServerGroupsAndResources()
+func IsOnOpenShift(discoveryClient discovery.DiscoveryInterface) (bool, error) {
+	_, apis, err := discoveryClient.ServerGroupsAndResources()
 	if err != nil && !discovery.IsGroupDiscoveryFailedError(err) {
 		return false, err
 	}

--- a/pkg/util/cluster/cluster_test.go
+++ b/pkg/util/cluster/cluster_test.go
@@ -5,7 +5,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"go.uber.org/mock/gomock"
 
 	secv1 "github.com/openshift/api/security/v1"
 
@@ -14,24 +13,16 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 
 	v1 "kubevirt.io/api/core/v1"
-	"kubevirt.io/client-go/kubecli"
 )
 
 var _ = Describe("OpenShift Test", func() {
 
-	var ctrl *gomock.Controller
-	var virtClient *kubecli.MockKubevirtClient
 	var discoveryClient *discoveryFake.FakeDiscovery
 
 	BeforeEach(func() {
-
-		ctrl = gomock.NewController(GinkgoT())
-		virtClient = kubecli.NewMockKubevirtClient(ctrl)
 		discoveryClient = &discoveryFake.FakeDiscovery{
 			Fake: &fake.NewSimpleClientset().Fake,
 		}
-		virtClient.EXPECT().DiscoveryClient().Return(discoveryClient).AnyTimes()
-
 	})
 
 	getServerResources := func(onOpenShift bool) []*metav1.APIResourceList {
@@ -61,7 +52,7 @@ var _ = Describe("OpenShift Test", func() {
 	DescribeTable("Testing for OpenShift", func(onOpenShift bool) {
 
 		discoveryClient.Fake.Resources = getServerResources(onOpenShift)
-		isOnOpenShift, err := IsOnOpenShift(virtClient)
+		isOnOpenShift, err := IsOnOpenShift(discoveryClient)
 		Expect(err).ToNot(HaveOccurred(), "should not return an error")
 		Expect(isOnOpenShift).To(Equal(onOpenShift), "should return "+strconv.FormatBool(onOpenShift))
 

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -438,7 +438,7 @@ func Execute() {
 		log.Log.Infof("CDI not detected, DataVolume integration disabled")
 	}
 
-	onOpenShift, err := clusterutil.IsOnOpenShift(app.clientSet)
+	onOpenShift, err := clusterutil.IsOnOpenShift(app.clientSet.DiscoveryClient())
 	if err != nil {
 		golog.Fatalf("Error determining cluster type: %v", err)
 	}

--- a/pkg/virt-operator/application.go
+++ b/pkg/virt-operator/application.go
@@ -251,7 +251,7 @@ func Execute() {
 		Leases:                   app.informerFactory.Leases(),
 	}
 
-	onOpenShift, err := clusterutil.IsOnOpenShift(app.virtClient)
+	onOpenShift, err := clusterutil.IsOnOpenShift(app.virtClient.DiscoveryClient())
 	if err != nil {
 		golog.Fatalf("Error determining cluster type: %v", err)
 	}

--- a/pkg/virt-operator/kubevirt_test.go
+++ b/pkg/virt-operator/kubevirt_test.go
@@ -1260,7 +1260,7 @@ func (k *KubeVirtTestData) addAllWithExclusionMap(config *util.KubeVirtDeploymen
 	all = append(all, rbac.GetAllCluster()...)
 	all = append(all, rbac.GetAllApiServer(NAMESPACE)...)
 	all = append(all, rbac.GetAllHandler(NAMESPACE)...)
-	all = append(all, rbac.GetAllController(NAMESPACE, true)...)
+	all = append(all, rbac.GetAllController(NAMESPACE, true, true)...)
 	all = append(all, rbac.GetAllExportProxy(NAMESPACE)...)
 	all = append(all, rbac.GetAllSynchronizationController(NAMESPACE)...)
 
@@ -1684,7 +1684,7 @@ func (k *KubeVirtTestData) addValidatingWebhook(wh *admissionregistrationv1.Vali
 
 func (k *KubeVirtTestData) addInstallStrategy(config *util.KubeVirtDeploymentConfig) {
 	// install strategy config
-	resource, err := install.NewInstallStrategyConfigMap(config, "openshift-monitoring", NAMESPACE)
+	resource, err := install.NewInstallStrategyConfigMap(config, true, "openshift-monitoring", NAMESPACE)
 	Expect(err).ToNot(HaveOccurred())
 
 	resource.Name = fmt.Sprintf("%s-%s", resource.Name, rand.String(10))
@@ -4150,7 +4150,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			kvTestData.addKubeVirt(kv)
 
 			// install strategy config
-			resource, _ := install.NewInstallStrategyConfigMap(kvTestData.defaultConfig, "", NAMESPACE)
+			resource, _ := install.NewInstallStrategyConfigMap(kvTestData.defaultConfig, true, "", NAMESPACE)
 			resource.Name = fmt.Sprintf("%s-%s", resource.Name, rand.String(10))
 			kvTestData.addResource(resource, kvTestData.defaultConfig, nil)
 

--- a/pkg/virt-operator/resource/generate/install/BUILD.bazel
+++ b/pkg/virt-operator/resource/generate/install/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/monitoring/rules:go_default_library",
+        "//pkg/util/cluster:go_default_library",
         "//pkg/virt-operator/resource/generate/components:go_default_library",
         "//pkg/virt-operator/resource/generate/components/validatingadmissionpolicies:go_default_library",
         "//pkg/virt-operator/resource/generate/rbac:go_default_library",

--- a/pkg/virt-operator/resource/generate/install/strategy.go
+++ b/pkg/virt-operator/resource/generate/install/strategy.go
@@ -54,6 +54,7 @@ import (
 	"kubevirt.io/client-go/log"
 
 	"kubevirt.io/kubevirt/pkg/monitoring/rules"
+	"kubevirt.io/kubevirt/pkg/util/cluster"
 	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/components"
 	vap "kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/components/validatingadmissionpolicies"
 	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/rbac"
@@ -318,8 +319,8 @@ func decodeManifests(strategy []byte) (string, error) {
 	return decodedStrategy.String(), nil
 }
 
-func NewInstallStrategyConfigMap(config *operatorutil.KubeVirtDeploymentConfig, monitorNamespace string, operatorNamespace string) (*corev1.ConfigMap, error) {
-	strategy, err := GenerateCurrentInstallStrategy(config, monitorNamespace, operatorNamespace)
+func NewInstallStrategyConfigMap(config *operatorutil.KubeVirtDeploymentConfig, onOpenShift bool, monitorNamespace string, operatorNamespace string) (*corev1.ConfigMap, error) {
+	strategy, err := GenerateCurrentInstallStrategy(config, onOpenShift, monitorNamespace, operatorNamespace)
 	if err != nil {
 		return nil, err
 	}
@@ -396,7 +397,12 @@ func DumpInstallStrategyToConfigMap(clientset kubernetes.Interface, operatorName
 		return err
 	}
 
-	configMap, err := NewInstallStrategyConfigMap(config, monitorNamespace, operatorNamespace)
+	onOpenShift, err := cluster.IsOnOpenShift(clientset.Discovery())
+	if err != nil {
+		return fmt.Errorf("failed to determine cluster type: %v", err)
+	}
+
+	configMap, err := NewInstallStrategyConfigMap(config, onOpenShift, monitorNamespace, operatorNamespace)
 	if err != nil {
 		return err
 	}
@@ -487,7 +493,7 @@ func dumpInstallStrategyToBytes(strategy *Strategy) []byte {
 	return b.Bytes()
 }
 
-func GenerateCurrentInstallStrategy(config *operatorutil.KubeVirtDeploymentConfig, monitorNamespace string, operatorNamespace string) (*Strategy, error) {
+func GenerateCurrentInstallStrategy(config *operatorutil.KubeVirtDeploymentConfig, onOpenShift bool, monitorNamespace string, operatorNamespace string) (*Strategy, error) {
 
 	strategy := &Strategy{}
 
@@ -514,7 +520,7 @@ func GenerateCurrentInstallStrategy(config *operatorutil.KubeVirtDeploymentConfi
 	rbaclist := make([]runtime.Object, 0)
 	rbaclist = append(rbaclist, rbac.GetAllCluster()...)
 	rbaclist = append(rbaclist, rbac.GetAllApiServer(config.GetNamespace())...)
-	rbaclist = append(rbaclist, rbac.GetAllController(config.GetNamespace(), !config.ExternalNetResourceInjectionEnabled())...)
+	rbaclist = append(rbaclist, rbac.GetAllController(config.GetNamespace(), !config.ExternalNetResourceInjectionEnabled(), onOpenShift)...)
 	rbaclist = append(rbaclist, rbac.GetAllHandler(config.GetNamespace())...)
 	rbaclist = append(rbaclist, rbac.GetAllExportProxy(config.GetNamespace())...)
 	rbaclist = append(rbaclist, rbac.GetAllSynchronizationController(config.GetNamespace())...)

--- a/pkg/virt-operator/resource/generate/install/strategy_test.go
+++ b/pkg/virt-operator/resource/generate/install/strategy_test.go
@@ -110,7 +110,7 @@ var _ = Describe("Install Strategy", func() {
 
 	Context("should generate", func() {
 		It("install strategy convertable back to objects", func() {
-			strategy, err := GenerateCurrentInstallStrategy(config, "openshift-monitoring", namespace)
+			strategy, err := GenerateCurrentInstallStrategy(config, true, "openshift-monitoring", namespace)
 			Expect(err).NotTo(HaveOccurred())
 
 			data := string(dumpInstallStrategyToBytes(strategy))
@@ -129,7 +129,7 @@ var _ = Describe("Install Strategy", func() {
 
 		})
 		It("latest install strategy with lossless byte conversion.", func() {
-			strategy, err := GenerateCurrentInstallStrategy(config, "openshift-monitoring", namespace)
+			strategy, err := GenerateCurrentInstallStrategy(config, true, "openshift-monitoring", namespace)
 			Expect(err).ToNot(HaveOccurred())
 
 			strategyStr := string(dumpInstallStrategyToBytes(strategy))
@@ -251,7 +251,7 @@ var _ = Describe("Install Strategy", func() {
 		}
 
 		DescribeTable("should set aggregate labels correctly", func(testConfig *util.KubeVirtDeploymentConfig, expectedValue string) {
-			strategy, err := GenerateCurrentInstallStrategy(testConfig, "", namespace)
+			strategy, err := GenerateCurrentInstallStrategy(testConfig, true, "", namespace)
 			Expect(err).ToNot(HaveOccurred())
 
 			for _, cr := range strategy.clusterRoles {
@@ -295,13 +295,13 @@ var _ = Describe("Install Strategy", func() {
 				},
 			})
 
-			strategy, err := GenerateCurrentInstallStrategy(vmStatsConfig, "openshift-monitoring", namespace)
+			strategy, err := GenerateCurrentInstallStrategy(vmStatsConfig, true, "openshift-monitoring", namespace)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(strategy.prometheusRules).To(BeEmpty())
 		})
 
 		It("should generate PrometheusRules by default", func() {
-			strategy, err := GenerateCurrentInstallStrategy(config, "openshift-monitoring", namespace)
+			strategy, err := GenerateCurrentInstallStrategy(config, true, "openshift-monitoring", namespace)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(strategy.prometheusRules).ToNot(BeEmpty())
 		})
@@ -340,7 +340,7 @@ var _ = Describe("Install Strategy", func() {
 			// for backwards compatibility
 			stores := util.Stores{}
 			stores.InstallStrategyConfigMapCache = cache.NewStore(cache.MetaNamespaceKeyFunc)
-			strategy, err := GenerateCurrentInstallStrategy(config, "openshift-monitoring", namespace)
+			strategy, err := GenerateCurrentInstallStrategy(config, true, "openshift-monitoring", namespace)
 			Expect(err).ToNot(HaveOccurred())
 			data := string(dumpInstallStrategyToBytes(strategy))
 
@@ -365,7 +365,7 @@ var _ = Describe("Install Strategy", func() {
 		It("a gzip+base64 encoded install strategy.", func() {
 			stores := util.Stores{}
 			stores.InstallStrategyConfigMapCache = cache.NewStore(cache.MetaNamespaceKeyFunc)
-			configMap, err := NewInstallStrategyConfigMap(config, "openshift-monitoring", namespace)
+			configMap, err := NewInstallStrategyConfigMap(config, true, "openshift-monitoring", namespace)
 			Expect(err).ToNot(HaveOccurred())
 			stores.InstallStrategyConfigMapCache.Add(configMap)
 			_, err = LoadInstallStrategyFromCache(stores, config)

--- a/pkg/virt-operator/resource/generate/rbac/controller.go
+++ b/pkg/virt-operator/resource/generate/rbac/controller.go
@@ -35,12 +35,12 @@ import (
 	"kubevirt.io/api/migrations"
 )
 
-func GetAllController(namespace string, includeNADRules bool) []runtime.Object {
+func GetAllController(namespace string, includeNADRules bool, onOpenShift bool) []runtime.Object {
 	return []runtime.Object{
 		newControllerServiceAccount(namespace),
 		newControllerClusterRole(includeNADRules),
 		newControllerClusterRoleBinding(namespace),
-		newControllerRole(namespace),
+		newControllerRole(namespace, onOpenShift),
 		newControllerRoleBinding(namespace),
 	}
 }
@@ -61,7 +61,65 @@ func newControllerServiceAccount(namespace string) *corev1.ServiceAccount {
 	}
 }
 
-func newControllerRole(namespace string) *rbacv1.Role {
+func newControllerRole(namespace string, onOpenShift bool) *rbacv1.Role {
+	var rules []rbacv1.PolicyRule
+
+	if onOpenShift {
+		rules = append(rules, rbacv1.PolicyRule{
+			APIGroups: []string{
+				GroupNameRoute,
+			},
+			Resources: []string{
+				"routes",
+			},
+			Verbs: []string{
+				"list",
+				"get",
+				"watch",
+			},
+		})
+	}
+
+	rules = append(rules,
+		rbacv1.PolicyRule{
+			APIGroups: []string{
+				"",
+			},
+			Resources: []string{
+				"secrets",
+			},
+			Verbs: []string{
+				"list",
+				"get",
+				"watch",
+			},
+		},
+		rbacv1.PolicyRule{
+			APIGroups: []string{
+				"networking.k8s.io",
+			},
+			Resources: []string{
+				"ingresses",
+			},
+			Verbs: []string{
+				"list",
+				"get",
+				"watch",
+			},
+		},
+		rbacv1.PolicyRule{
+			APIGroups: []string{
+				"coordination.k8s.io",
+			},
+			Resources: []string{
+				"leases",
+			},
+			Verbs: []string{
+				"get", "list", "watch", "delete", "update", "create", "patch",
+			},
+		},
+	)
+
 	return &rbacv1.Role{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: VersionNamev1,
@@ -74,58 +132,7 @@ func newControllerRole(namespace string) *rbacv1.Role {
 				virtv1.AppLabel: "",
 			},
 		},
-		Rules: []rbacv1.PolicyRule{
-			{
-				APIGroups: []string{
-					GroupNameRoute,
-				},
-				Resources: []string{
-					"routes",
-				},
-				Verbs: []string{
-					"list",
-					"get",
-					"watch",
-				},
-			},
-			{
-				APIGroups: []string{
-					"",
-				},
-				Resources: []string{
-					"secrets",
-				},
-				Verbs: []string{
-					"list",
-					"get",
-					"watch",
-				},
-			},
-			{
-				APIGroups: []string{
-					"networking.k8s.io",
-				},
-				Resources: []string{
-					"ingresses",
-				},
-				Verbs: []string{
-					"list",
-					"get",
-					"watch",
-				},
-			},
-			{
-				APIGroups: []string{
-					"coordination.k8s.io",
-				},
-				Resources: []string{
-					"leases",
-				},
-				Verbs: []string{
-					"get", "list", "watch", "delete", "update", "create", "patch",
-				},
-			},
-		},
+		Rules: rules,
 	}
 }
 

--- a/pkg/virt-operator/resource/generate/rbac/controller_test.go
+++ b/pkg/virt-operator/resource/generate/rbac/controller_test.go
@@ -37,7 +37,7 @@ var _ = Describe("RBAC", func() {
 	const expectedNamespace = "default"
 
 	Context("GetAllController", func() {
-		forController := GetAllController(expectedNamespace, true)
+		forController := GetAllController(expectedNamespace, true, true)
 
 		DescribeTable("has finalizer rbac for installs with OwnerReferencesPermissionEnforcement", func(apiGroup, resource string) {
 			clusterRole := getObject(forController, reflect.TypeOf(&rbacv1.ClusterRole{}), components.ControllerServiceAccountName).(*rbacv1.ClusterRole)
@@ -70,12 +70,32 @@ var _ = Describe("RBAC", func() {
 		})
 
 		It("should exclude NAD rules when includeNADRules is false", func() {
-			forControllerWithoutNAD := GetAllController(expectedNamespace, false)
+			forControllerWithoutNAD := GetAllController(expectedNamespace, false, true)
 			clusterRole := getObject(forControllerWithoutNAD, reflect.TypeOf(&rbacv1.ClusterRole{}), components.ControllerServiceAccountName).(*rbacv1.ClusterRole)
 			Expect(clusterRole.Rules).ToNot(
 				ContainElement(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
 					"APIGroups": ContainElement("k8s.cni.cncf.io"),
 					"Resources": ContainElement("network-attachment-definitions"),
+				})),
+			)
+		})
+
+		It("should include route.openshift.io rules when onOpenShift is true", func() {
+			role := getObject(forController, reflect.TypeOf(&rbacv1.Role{}), components.ControllerServiceAccountName).(*rbacv1.Role)
+			Expect(role.Rules).To(
+				ContainElement(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+					"APIGroups": ContainElement(GroupNameRoute),
+					"Resources": ContainElement("routes"),
+				})),
+			)
+		})
+
+		It("should exclude route.openshift.io rules when onOpenShift is false", func() {
+			forControllerOnKubernetes := GetAllController(expectedNamespace, true, false)
+			role := getObject(forControllerOnKubernetes, reflect.TypeOf(&rbacv1.Role{}), components.ControllerServiceAccountName).(*rbacv1.Role)
+			Expect(role.Rules).ToNot(
+				ContainElement(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+					"APIGroups": ContainElement(GroupNameRoute),
 				})),
 			)
 		})

--- a/pkg/virt-operator/resource/generate/rbac/operator.go
+++ b/pkg/virt-operator/resource/generate/rbac/operator.go
@@ -391,7 +391,7 @@ func getKubeVirtComponentsClusterRules() []rbacv1.PolicyRule {
 
 	// namespace doesn't matter, we are only interested in the rules of ClusterRoles
 	all := GetAllApiServer("")
-	all = append(all, GetAllController("", true)...)
+	all = append(all, GetAllController("", true, true)...)
 	all = append(all, GetAllHandler("")...)
 	all = append(all, GetAllExportProxy("")...)
 	all = append(all, GetAllSynchronizationController("")...)
@@ -442,7 +442,7 @@ func getKubeVirtComponentsRules() []rbacv1.PolicyRule {
 
 	// namespace doesn't matter, we are only interested in the rules
 	all := GetAllApiServer("")
-	all = append(all, GetAllController("", true)...)
+	all = append(all, GetAllController("", true, true)...)
 	all = append(all, GetAllHandler("")...)
 	all = append(all, GetAllExportProxy("")...)
 	all = append(all, GetAllSynchronizationController("")...)

--- a/tests/framework/checks/checks.go
+++ b/tests/framework/checks/checks.go
@@ -111,7 +111,7 @@ func HasAtLeastTwoNodes() bool {
 func IsOpenShift() bool {
 	virtClient := kubevirt.Client()
 
-	isOpenShift, err := cluster.IsOnOpenShift(virtClient)
+	isOpenShift, err := cluster.IsOnOpenShift(virtClient.DiscoveryClient())
 	if err != nil {
 		fmt.Printf("ERROR: Can not determine cluster type %v\n", err)
 		panic(err)


### PR DESCRIPTION
### What this PR does
Uses the existing OpenShift cluster detection to ensure `route.openshift.io` permissions are only added to the `kubevirt-controller` role when on OpenShift.

#### Before this PR: 
The `kubevirt-controller` role gets created with OpenShift-only permissions leading to either noise in the role or failures ot install or upgrade due to admission failures should a cluster enforce strict admission control for existing resources.
 
#### After this PR:
The controller will no longer attempt to grant OpenShift-only permissions on non-OpenShift clusters 

### Why we need it and why it was done in this way
The following tradeoffs were made:
- Considered adding it to generated manifests but many installations already have a solution for gating these e.g. cdk8s filtering for the resources or patches on top of the deployed manifests. This may be worth it in the future but I think is out of scope since it's easy to work around. 

### Release note

```release-note
virt-operator reconcile no longer creates route.openshift.io RBAC on non-OpenShift clusters
```

