### PR TITLE
tests: refactor for wffc hotplug

### DIFF
--- a/tests/libstorage/storageclass.go
+++ b/tests/libstorage/storageclass.go
@@ -21,6 +21,7 @@ package libstorage
 
 import (
 	"context"
+	"fmt"
 
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 
@@ -219,6 +220,35 @@ func GetWFFCStorageSnapshotClass(client kubecli.KubevirtClient) (string, error) 
 	}
 
 	return "", nil
+}
+
+func CreateWFFCStorageClass(client kubecli.KubevirtClient) (string, error) {
+	scName, exist := GetCSIStorageClass()
+	wffcName := fmt.Sprintf("%s-wffc", scName)
+
+	if !exist {
+		return "", fmt.Errorf("no CSI Storage Class exists")
+	}
+
+	sc, err := client.StorageV1().StorageClasses().Get(context.Background(), scName, metav1.GetOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	// use the same storage provider, but change the binding mode to wffc
+	wffcSc := sc.DeepCopy()
+	wffcSc.ObjectMeta = metav1.ObjectMeta{
+		GenerateName: wffcName,
+		Labels: map[string]string{
+			kubevirtIoTest: wffcName,
+		},
+	}
+	wffcSc.VolumeBindingMode = &wffc
+	sc, err = client.StorageV1().StorageClasses().Create(context.Background(), wffcSc, metav1.CreateOptions{})
+	if err != nil {
+		return "", err
+	}
+	return sc.Name, nil
 }
 
 func GetCSIStorageClass() (string, bool) {

--- a/tests/storage/hotplug.go
+++ b/tests/storage/hotplug.go
@@ -727,21 +727,26 @@ var _ = Describe(SIG("Hotplug", func() {
 		})
 	})
 
-	Context("WFFC storage", decorators.RequiresWFFCStorageClass, func() {
+	Context("WFFC storage", func() {
 		var (
 			vm *v1.VirtualMachine
 			sc string
 		)
-		const numPVs = 3
+		const (
+			numDVs = 3
+		)
+
 		BeforeEach(func() {
-			var exists bool
-			sc, exists = libstorage.GetRWOFileSystemStorageClass()
-			if !exists || !libstorage.IsStorageClassBindingModeWaitForFirstConsumer(sc) {
-				Fail("fail test, no wffc storage class available")
-			}
+			sc, err = libstorage.CreateWFFCStorageClass(virtClient)
+			Expect(err).ToNot(HaveOccurred(), "Could not create dummy wffc storage class, %s", err)
 		})
 
-		It("Should be able to boot from WFFC local storage", decorators.StorageCritical, func() {
+		AfterEach(func() {
+			// clean up the storage class created for this test
+			libstorage.DeleteStorageClass(sc)
+		})
+
+		It("Should be able to boot from WFFC storage", decorators.StorageCritical, func() {
 			dvName := "disk0"
 			vm = createBootableHotplugVM(sc)
 			vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
@@ -752,7 +757,7 @@ var _ = Describe(SIG("Hotplug", func() {
 			verifySingleAttachmentPod(virtClient, vmi)
 		})
 
-		It("Should be able to add and use WFFC local storage", func() {
+		It("Should be able to add and use WFFC storage", func() {
 			vm = createAndStartWFFCStorageHotplugVM()
 			vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred(), "failed to get VMI %s for WFFC storage test", vm.Name)
@@ -760,7 +765,7 @@ var _ = Describe(SIG("Hotplug", func() {
 				libwait.WithTimeout(240),
 			)
 			dvNames := make([]string, 0)
-			for i := 0; i < numPVs; i++ {
+			for i := 0; i < numDVs; i++ {
 				dv := libdv.NewDataVolume(
 					libdv.WithBlankImageSource(),
 					libdv.WithStorage(libdv.StorageWithStorageClass(sc), libdv.StorageWithVolumeSize(cd.BlankVolumeSize)),
@@ -771,7 +776,7 @@ var _ = Describe(SIG("Hotplug", func() {
 				dvNames = append(dvNames, dv.Name)
 			}
 
-			for i := 0; i < numPVs; i++ {
+			for i := 0; i < numDVs; i++ {
 				By("Adding volume " + strconv.Itoa(i) + " to running VM, dv name:" + dvNames[i])
 				addDVVolumeVM(vm.Name, vm.Namespace, dvNames[i], dvNames[i], v1.DiskBusSCSI, false, "")
 			}

--- a/tests/storage/migration.go
+++ b/tests/storage/migration.go
@@ -40,7 +40,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
 
-	storagev1 "k8s.io/api/storage/v1"
 	v1 "kubevirt.io/api/core/v1"
 	virtv1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
@@ -61,7 +60,6 @@ import (
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/checks"
-	"kubevirt.io/kubevirt/tests/framework/cleanup"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/framework/matcher"
 	"kubevirt.io/kubevirt/tests/libinfra"
@@ -81,7 +79,6 @@ import (
 var _ = Describe(SIG("Volumes update with migration", decorators.RequiresTwoSchedulableNodes, decorators.VMLiveUpdateRolloutStrategy, func() {
 	var virtClient kubecli.KubevirtClient
 	var testSc string
-	getCSIStorageClass := libstorage.GetCSIStorageClass
 	createBlankDV := func(virtClient kubecli.KubevirtClient, ns, size string) *cdiv1.DataVolume {
 		dv := libdv.NewDataVolume(
 			libdv.WithBlankImageSource(),
@@ -116,25 +113,9 @@ var _ = Describe(SIG("Volumes update with migration", decorators.RequiresTwoSche
 			config.ExpectResourceVersionToBeLessEqualThanConfigVersion,
 			time.Minute)
 
-		scName, exist := getCSIStorageClass()
-
-		if !exist {
-			Fail("Fail test when a CSI storage class is not present")
-		}
-
-		sc, err := virtClient.StorageV1().StorageClasses().Get(context.Background(), scName, metav1.GetOptions{})
+		scName, err := libstorage.CreateWFFCStorageClass(virtClient)
 		Expect(err).ToNot(HaveOccurred())
-		wffcSc := sc.DeepCopy()
-		wffcSc.ObjectMeta = metav1.ObjectMeta{
-			GenerateName: fmt.Sprintf("%s-wffc", scName),
-			Labels: map[string]string{
-				cleanup.TestLabelForNamespace(testsuite.GetTestNamespace(nil)): "",
-			},
-		}
-		wffcSc.VolumeBindingMode = pointer.P(storagev1.VolumeBindingWaitForFirstConsumer)
-		sc, err = virtClient.StorageV1().StorageClasses().Create(context.Background(), wffcSc, metav1.CreateOptions{})
-		Expect(err).ToNot(HaveOccurred())
-		testSc = sc.Name
+		testSc = scName
 	})
 	AfterEach(func() {
 		virtClient.StorageV1().StorageClasses().Delete(context.Background(), testSc, metav1.DeleteOptions{})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Intention of this refactor is to enable this hotplug test to run in gating CI environments where a wffc storage class is not defined.  To accomplish this, we create a temporary wffc storage class based off an existing csi storage class from the running cluster. 

A byproduct of this refactor is that these tests no longer focus on wffc _local_ storage testing. However, since the tests previously used `GetRWOFileSystemStorageClass`, the `local` storage class was only exercised when an unmodified default `config.json` was used, which is not usually the case in downstream CI. 

Addresses: https://redhat.atlassian.net/browse/CNV-64413

#### Before this PR:

#### After this PR:

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

