### PR TITLE
Expose FS freeze status early in VirtualMachineBackup

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -18525,6 +18525,10 @@
       "description": "Failed indicates that the backup failed",
       "type": "boolean"
      },
+     "quiesceStatus": {
+      "description": "QuiesceStatus indicates whether filesystem freeze succeeded, failed, or was skipped.",
+      "type": "string"
+     },
      "startTimestamp": {
       "description": "StartTimestamp is the timestamp when the backup started",
       "$ref": "#/definitions/k8s.io.apimachinery.pkg.apis.meta.v1.Time"

--- a/pkg/storage/cbt/backup.go
+++ b/pkg/storage/cbt/backup.go
@@ -575,6 +575,11 @@ func (ctrl *VMBackupController) reconcileActive(backup *backupv1.VirtualMachineB
 		backup.Status.CheckpointName = backupStatus.CheckpointName
 	}
 
+	// Set Quiesced condition early if not already set
+	if backupStatus.QuiesceStatus != "" {
+		ctrl.setQuiescedCondition(backup, backupStatus.QuiesceStatus)
+	}
+
 	return nil
 }
 
@@ -601,6 +606,11 @@ func (ctrl *VMBackupController) reconcileCompleted(backup *backupv1.VirtualMachi
 		backup.Status.CheckpointName = backupStatus.CheckpointName
 	}
 	backup.Status.IncludedVolumes = backupStatus.Volumes
+
+	// Set Quiesced condition at completion
+	if backupStatus.QuiesceStatus != "" {
+		ctrl.setQuiescedCondition(backup, backupStatus.QuiesceStatus)
+	}
 
 	return nil
 }
@@ -1053,4 +1063,34 @@ func setCompleteWithWarning(backup *backupv1.VirtualMachineBackup, message strin
 		Reason: backupv1.ReasonCompletedWithWarning, Message: message,
 	})
 	markTerminal(backup, backupv1.ReasonCompletedWithWarning, message)
+}
+
+func (ctrl *VMBackupController) setQuiescedCondition(backup *backupv1.VirtualMachineBackup, quiesceStatus string) {
+	var status metav1.ConditionStatus
+	var reason string
+	var message string
+
+	switch backupv1.QuiesceStatus(quiesceStatus) {
+	case backupv1.QuiesceSucceeded:
+		status = metav1.ConditionTrue
+		reason = backupv1.ReasonQuiesceSucceeded
+		message = "Guest filesystem was successfully quiesced"
+	case backupv1.QuiesceFailed:
+		status = metav1.ConditionFalse
+		reason = backupv1.ReasonQuiesceFailed
+		message = "Guest filesystem quiesce failed"
+	case backupv1.QuiesceSkipped:
+		status = metav1.ConditionFalse
+		reason = backupv1.ReasonQuiesceSkipped
+		message = "Guest filesystem quiesce was skipped"
+	default:
+		return
+	}
+
+	meta.SetStatusCondition(&backup.Status.Conditions, metav1.Condition{
+		Type:    string(backupv1.ConditionQuiesced),
+		Status:  status,
+		Reason:  reason,
+		Message: message,
+	})
 }

--- a/pkg/storage/cbt/backup.go
+++ b/pkg/storage/cbt/backup.go
@@ -575,7 +575,6 @@ func (ctrl *VMBackupController) reconcileActive(backup *backupv1.VirtualMachineB
 		backup.Status.CheckpointName = backupStatus.CheckpointName
 	}
 
-	// Set Quiesced condition early if not already set
 	if backupStatus.QuiesceStatus != "" {
 		ctrl.setQuiescedCondition(backup, backupStatus.QuiesceStatus)
 	}
@@ -607,7 +606,6 @@ func (ctrl *VMBackupController) reconcileCompleted(backup *backupv1.VirtualMachi
 	}
 	backup.Status.IncludedVolumes = backupStatus.Volumes
 
-	// Set Quiesced condition at completion
 	if backupStatus.QuiesceStatus != "" {
 		ctrl.setQuiescedCondition(backup, backupStatus.QuiesceStatus)
 	}
@@ -1084,6 +1082,7 @@ func (ctrl *VMBackupController) setQuiescedCondition(backup *backupv1.VirtualMac
 		reason = backupv1.ReasonQuiesceSkipped
 		message = "Guest filesystem quiesce was skipped"
 	default:
+		log.Log.Object(backup).Warningf("Invalid QuiesceStatus value: %q, skipping Quiesced condition", quiesceStatus)
 		return
 	}
 

--- a/pkg/storage/cbt/backup_test.go
+++ b/pkg/storage/cbt/backup_test.go
@@ -825,6 +825,138 @@ var _ = Describe("Backup Controller", func() {
 			Expect(backupCopy.Status.IncludedVolumes).To(HaveLen(1))
 		})
 
+		It("should set Quiesced condition early when backup in progress", func() {
+			backup := createBackup(backupName, vmName, pvcName, backupv1.PushMode)
+			backup.Finalizers = []string{vmBackupFinalizer}
+			backup.Status = &backupv1.VirtualMachineBackupStatus{
+				Conditions: []metav1.Condition{
+					newCondition(string(backupv1.ConditionProgressing), metav1.ConditionTrue, "Progressing", ""),
+				},
+			}
+
+			vm := createVM(vmName)
+			controller.vmStore.Add(vm)
+
+			volumesInfo := []backupv1.BackupVolumeInfo{
+				{VolumeName: "rootdisk", DiskTarget: "vda"},
+			}
+			vmi := createInitializedVMI()
+			vmi.Status.ChangedBlockTracking.BackupStatus.Completed = false
+			vmi.Status.ChangedBlockTracking.BackupStatus.Volumes = volumesInfo
+			vmi.Status.ChangedBlockTracking.BackupStatus.QuiesceStatus = "Succeeded"
+			controller.vmiStore.Add(vmi)
+
+			pvc := createPVC(pvcName)
+			controller.pvcStore.Add(pvc)
+
+			err := controller.sync(backup)
+			Expect(err).ToNot(HaveOccurred())
+
+			condition := meta.FindStatusCondition(backup.Status.Conditions, string(backupv1.ConditionQuiesced))
+			Expect(condition).ToNot(BeNil())
+			Expect(condition.Status).To(Equal(metav1.ConditionTrue))
+			Expect(condition.Reason).To(Equal(backupv1.ReasonQuiesceSucceeded))
+		})
+
+		It("should set Quiesced condition as Failed when quiesce failed", func() {
+			backup := createBackup(backupName, vmName, pvcName, backupv1.PushMode)
+			backup.Finalizers = []string{vmBackupFinalizer}
+			backup.Status = &backupv1.VirtualMachineBackupStatus{
+				Conditions: []metav1.Condition{
+					newCondition(string(backupv1.ConditionProgressing), metav1.ConditionTrue, "Progressing", ""),
+				},
+			}
+
+			vm := createVM(vmName)
+			controller.vmStore.Add(vm)
+
+			volumesInfo := []backupv1.BackupVolumeInfo{
+				{VolumeName: "rootdisk", DiskTarget: "vda"},
+			}
+			vmi := createInitializedVMI()
+			vmi.Status.ChangedBlockTracking.BackupStatus.Completed = false
+			vmi.Status.ChangedBlockTracking.BackupStatus.Volumes = volumesInfo
+			vmi.Status.ChangedBlockTracking.BackupStatus.QuiesceStatus = string(backupv1.QuiesceFailed)
+			controller.vmiStore.Add(vmi)
+
+			pvc := createPVC(pvcName)
+			controller.pvcStore.Add(pvc)
+
+			err := controller.sync(backup)
+			Expect(err).ToNot(HaveOccurred())
+
+			condition := meta.FindStatusCondition(backup.Status.Conditions, string(backupv1.ConditionQuiesced))
+			Expect(condition).ToNot(BeNil())
+			Expect(condition.Status).To(Equal(metav1.ConditionFalse))
+			Expect(condition.Reason).To(Equal(backupv1.ReasonQuiesceFailed))
+		})
+
+		It("should set Quiesced condition as Skipped when quiesce was skipped", func() {
+			backup := createBackup(backupName, vmName, pvcName, backupv1.PushMode)
+			backup.Finalizers = []string{vmBackupFinalizer}
+			backup.Status = &backupv1.VirtualMachineBackupStatus{
+				Conditions: []metav1.Condition{
+					newCondition(string(backupv1.ConditionProgressing), metav1.ConditionTrue, "Progressing", ""),
+				},
+			}
+
+			vm := createVM(vmName)
+			controller.vmStore.Add(vm)
+
+			volumesInfo := []backupv1.BackupVolumeInfo{
+				{VolumeName: "rootdisk", DiskTarget: "vda"},
+			}
+			vmi := createInitializedVMI()
+			vmi.Status.ChangedBlockTracking.BackupStatus.Completed = false
+			vmi.Status.ChangedBlockTracking.BackupStatus.Volumes = volumesInfo
+			vmi.Status.ChangedBlockTracking.BackupStatus.QuiesceStatus = string(backupv1.QuiesceSkipped)
+			controller.vmiStore.Add(vmi)
+
+			pvc := createPVC(pvcName)
+			controller.pvcStore.Add(pvc)
+
+			err := controller.sync(backup)
+			Expect(err).ToNot(HaveOccurred())
+
+			condition := meta.FindStatusCondition(backup.Status.Conditions, string(backupv1.ConditionQuiesced))
+			Expect(condition).ToNot(BeNil())
+			Expect(condition.Status).To(Equal(metav1.ConditionFalse))
+			Expect(condition.Reason).To(Equal(backupv1.ReasonQuiesceSkipped))
+		})
+
+		It("should set Quiesced condition when backup completes before reconcileActive runs", func() {
+			backup := createBackup(backupName, vmName, pvcName, backupv1.PushMode)
+			backup.Finalizers = []string{vmBackupFinalizer}
+			backup.Status = &backupv1.VirtualMachineBackupStatus{
+				Conditions: []metav1.Condition{
+					newCondition(string(backupv1.ConditionProgressing), metav1.ConditionTrue, "Progressing", ""),
+				},
+			}
+
+			vm := createVM(vmName)
+			controller.vmStore.Add(vm)
+
+			volumesInfo := []backupv1.BackupVolumeInfo{
+				{VolumeName: "rootdisk", DiskTarget: "vda"},
+			}
+			vmi := createInitializedVMI()
+			vmi.Status.ChangedBlockTracking.BackupStatus.Completed = true
+			vmi.Status.ChangedBlockTracking.BackupStatus.Volumes = volumesInfo
+			vmi.Status.ChangedBlockTracking.BackupStatus.QuiesceStatus = string(backupv1.QuiesceSucceeded)
+			controller.vmiStore.Add(vmi)
+
+			pvc := createPVC(pvcName)
+			controller.pvcStore.Add(pvc)
+
+			err := controller.sync(backup)
+			Expect(err).ToNot(HaveOccurred())
+
+			condition := meta.FindStatusCondition(backup.Status.Conditions, string(backupv1.ConditionQuiesced))
+			Expect(condition).ToNot(BeNil())
+			Expect(condition.Status).To(Equal(metav1.ConditionTrue))
+			Expect(condition.Reason).To(Equal(backupv1.ReasonQuiesceSucceeded))
+		})
+
 		It("should patch VMI to remove backup status when backup is completed", func() {
 			backup := createBackup(backupName, vmName, pvcName, backupv1.PushMode)
 			backup.Finalizers = []string{vmBackupFinalizer}

--- a/pkg/storage/cbt/backup_test.go
+++ b/pkg/storage/cbt/backup_test.go
@@ -825,104 +825,43 @@ var _ = Describe("Backup Controller", func() {
 			Expect(backupCopy.Status.IncludedVolumes).To(HaveLen(1))
 		})
 
-		It("should set Quiesced condition early when backup in progress", func() {
-			backup := createBackup(backupName, vmName, pvcName, backupv1.PushMode)
-			backup.Finalizers = []string{vmBackupFinalizer}
-			backup.Status = &backupv1.VirtualMachineBackupStatus{
-				Conditions: []metav1.Condition{
-					newCondition(string(backupv1.ConditionProgressing), metav1.ConditionTrue, "Progressing", ""),
-				},
-			}
+		DescribeTable("should set Quiesced condition correctly",
+			func(quiesceStatus string, expectedConditionStatus metav1.ConditionStatus, expectedReason string) {
+				backup := createBackup(backupName, vmName, pvcName, backupv1.PushMode)
+				backup.Finalizers = []string{vmBackupFinalizer}
+				backup.Status = &backupv1.VirtualMachineBackupStatus{
+					Conditions: []metav1.Condition{
+						newCondition(string(backupv1.ConditionProgressing), metav1.ConditionTrue, "Progressing", ""),
+					},
+				}
 
-			vm := createVM(vmName)
-			controller.vmStore.Add(vm)
+				vm := createVM(vmName)
+				controller.vmStore.Add(vm)
 
-			volumesInfo := []backupv1.BackupVolumeInfo{
-				{VolumeName: "rootdisk", DiskTarget: "vda"},
-			}
-			vmi := createInitializedVMI()
-			vmi.Status.ChangedBlockTracking.BackupStatus.Completed = false
-			vmi.Status.ChangedBlockTracking.BackupStatus.Volumes = volumesInfo
-			vmi.Status.ChangedBlockTracking.BackupStatus.QuiesceStatus = "Succeeded"
-			controller.vmiStore.Add(vmi)
+				volumesInfo := []backupv1.BackupVolumeInfo{
+					{VolumeName: "rootdisk", DiskTarget: "vda"},
+				}
+				vmi := createInitializedVMI()
+				vmi.Status.ChangedBlockTracking.BackupStatus.Completed = false
+				vmi.Status.ChangedBlockTracking.BackupStatus.Volumes = volumesInfo
+				vmi.Status.ChangedBlockTracking.BackupStatus.QuiesceStatus = quiesceStatus
+				controller.vmiStore.Add(vmi)
 
-			pvc := createPVC(pvcName)
-			controller.pvcStore.Add(pvc)
+				pvc := createPVC(pvcName)
+				controller.pvcStore.Add(pvc)
 
-			err := controller.sync(backup)
-			Expect(err).ToNot(HaveOccurred())
+				err := controller.sync(backup)
+				Expect(err).ToNot(HaveOccurred())
 
-			condition := meta.FindStatusCondition(backup.Status.Conditions, string(backupv1.ConditionQuiesced))
-			Expect(condition).ToNot(BeNil())
-			Expect(condition.Status).To(Equal(metav1.ConditionTrue))
-			Expect(condition.Reason).To(Equal(backupv1.ReasonQuiesceSucceeded))
-		})
-
-		It("should set Quiesced condition as Failed when quiesce failed", func() {
-			backup := createBackup(backupName, vmName, pvcName, backupv1.PushMode)
-			backup.Finalizers = []string{vmBackupFinalizer}
-			backup.Status = &backupv1.VirtualMachineBackupStatus{
-				Conditions: []metav1.Condition{
-					newCondition(string(backupv1.ConditionProgressing), metav1.ConditionTrue, "Progressing", ""),
-				},
-			}
-
-			vm := createVM(vmName)
-			controller.vmStore.Add(vm)
-
-			volumesInfo := []backupv1.BackupVolumeInfo{
-				{VolumeName: "rootdisk", DiskTarget: "vda"},
-			}
-			vmi := createInitializedVMI()
-			vmi.Status.ChangedBlockTracking.BackupStatus.Completed = false
-			vmi.Status.ChangedBlockTracking.BackupStatus.Volumes = volumesInfo
-			vmi.Status.ChangedBlockTracking.BackupStatus.QuiesceStatus = string(backupv1.QuiesceFailed)
-			controller.vmiStore.Add(vmi)
-
-			pvc := createPVC(pvcName)
-			controller.pvcStore.Add(pvc)
-
-			err := controller.sync(backup)
-			Expect(err).ToNot(HaveOccurred())
-
-			condition := meta.FindStatusCondition(backup.Status.Conditions, string(backupv1.ConditionQuiesced))
-			Expect(condition).ToNot(BeNil())
-			Expect(condition.Status).To(Equal(metav1.ConditionFalse))
-			Expect(condition.Reason).To(Equal(backupv1.ReasonQuiesceFailed))
-		})
-
-		It("should set Quiesced condition as Skipped when quiesce was skipped", func() {
-			backup := createBackup(backupName, vmName, pvcName, backupv1.PushMode)
-			backup.Finalizers = []string{vmBackupFinalizer}
-			backup.Status = &backupv1.VirtualMachineBackupStatus{
-				Conditions: []metav1.Condition{
-					newCondition(string(backupv1.ConditionProgressing), metav1.ConditionTrue, "Progressing", ""),
-				},
-			}
-
-			vm := createVM(vmName)
-			controller.vmStore.Add(vm)
-
-			volumesInfo := []backupv1.BackupVolumeInfo{
-				{VolumeName: "rootdisk", DiskTarget: "vda"},
-			}
-			vmi := createInitializedVMI()
-			vmi.Status.ChangedBlockTracking.BackupStatus.Completed = false
-			vmi.Status.ChangedBlockTracking.BackupStatus.Volumes = volumesInfo
-			vmi.Status.ChangedBlockTracking.BackupStatus.QuiesceStatus = string(backupv1.QuiesceSkipped)
-			controller.vmiStore.Add(vmi)
-
-			pvc := createPVC(pvcName)
-			controller.pvcStore.Add(pvc)
-
-			err := controller.sync(backup)
-			Expect(err).ToNot(HaveOccurred())
-
-			condition := meta.FindStatusCondition(backup.Status.Conditions, string(backupv1.ConditionQuiesced))
-			Expect(condition).ToNot(BeNil())
-			Expect(condition.Status).To(Equal(metav1.ConditionFalse))
-			Expect(condition.Reason).To(Equal(backupv1.ReasonQuiesceSkipped))
-		})
+				condition := meta.FindStatusCondition(backup.Status.Conditions, string(backupv1.ConditionQuiesced))
+				Expect(condition).ToNot(BeNil())
+				Expect(condition.Status).To(Equal(expectedConditionStatus))
+				Expect(condition.Reason).To(Equal(expectedReason))
+			},
+			Entry("when quiesce succeeded", string(backupv1.QuiesceSucceeded), metav1.ConditionTrue, backupv1.ReasonQuiesceSucceeded),
+			Entry("when quiesce failed", string(backupv1.QuiesceFailed), metav1.ConditionFalse, backupv1.ReasonQuiesceFailed),
+			Entry("when quiesce was skipped", string(backupv1.QuiesceSkipped), metav1.ConditionFalse, backupv1.ReasonQuiesceSkipped),
+		)
 
 		It("should set Quiesced condition when backup completes before reconcileActive runs", func() {
 			backup := createBackup(backupName, vmName, pvcName, backupv1.PushMode)
@@ -939,14 +878,22 @@ var _ = Describe("Backup Controller", func() {
 			volumesInfo := []backupv1.BackupVolumeInfo{
 				{VolumeName: "rootdisk", DiskTarget: "vda"},
 			}
-			vmi := createInitializedVMI()
-			vmi.Status.ChangedBlockTracking.BackupStatus.Completed = true
-			vmi.Status.ChangedBlockTracking.BackupStatus.Volumes = volumesInfo
-			vmi.Status.ChangedBlockTracking.BackupStatus.QuiesceStatus = string(backupv1.QuiesceSucceeded)
+			vmi := createVMI()
+			vmi.Status.ChangedBlockTracking.BackupStatus = &v1.VirtualMachineInstanceBackupStatus{
+				BackupName:     backupName,
+				Completed:      true,
+				CheckpointName: pointer.P(checkpointName),
+				Volumes:        volumesInfo,
+				QuiesceStatus:  string(backupv1.QuiesceSucceeded),
+			}
 			controller.vmiStore.Add(vmi)
 
 			pvc := createPVC(pvcName)
 			controller.pvcStore.Add(pvc)
+
+			vmiInterface.EXPECT().
+				Patch(gomock.Any(), vmName, types.JSONPatchType, gomock.Any(), gomock.Any()).
+				Return(vmi, nil)
 
 			err := controller.sync(backup)
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -2439,4 +2439,7 @@ func (c *VirtualMachineController) updateBackupStatus(vmi *v1.VirtualMachineInst
 			vmi.Status.ChangedBlockTracking.BackupStatus.Volumes = volumes
 		}
 	}
+	if backupMetadata.QuiesceStatus != "" {
+		vmi.Status.ChangedBlockTracking.BackupStatus.QuiesceStatus = backupMetadata.QuiesceStatus
+	}
 }

--- a/pkg/virt-launcher/virtwrap/api/schema.go
+++ b/pkg/virt-launcher/virtwrap/api/schema.go
@@ -467,6 +467,7 @@ type BackupMetadata struct {
 	BackupMsg      string       `xml:"backupMsg,omitempty"`
 	CheckpointName string       `xml:"checkpointName,omitempty"`
 	Volumes        string       `xml:"volumes,omitempty"`
+	QuiesceStatus  string       `xml:"quiesceStatus,omitempty"`
 }
 
 type GracePeriodMetadata struct {

--- a/pkg/virt-launcher/virtwrap/storage/backup.go
+++ b/pkg/virt-launcher/virtwrap/storage/backup.go
@@ -176,38 +176,31 @@ func (m *StorageManager) backup(vmi *v1.VirtualMachineInstance, backupOptions *b
 		backupMetadata.Volumes = string(volumesJSON)
 	})
 
-	frozenFS := false
 	if !backupOptions.SkipQuiesce {
 		logger.Info("Freezing VMI to capture backup state")
-		if err := dom.FSFreeze(nil, 0); err != nil {
+		if err := m.FreezeVMI(vmi, 0); err != nil {
 			logger.Warningf(freezeFailedMsg, err)
 			m.metadataCache.Backup.WithSafeBlock(func(backupMetadata *api.BackupMetadata, _ bool) {
-				backupMetadata.BackupMsg = fmt.Sprintf(freezeFailedMsg, err)
 				backupMetadata.QuiesceStatus = string(backupv1.QuiesceFailed)
+				backupMetadata.BackupMsg = err.Error()
 			})
 		} else {
-			frozenFS = true
 			m.metadataCache.Backup.WithSafeBlock(func(backupMetadata *api.BackupMetadata, _ bool) {
 				backupMetadata.QuiesceStatus = string(backupv1.QuiesceSucceeded)
 			})
 		}
+
+		defer func() {
+			logger.Info("Thawing VMI after backup job started")
+			if err := m.UnfreezeVMI(vmi); err != nil {
+				logger.Reason(err).Error(unfreezeFailedMsg)
+			}
+		}()
 	} else {
 		m.metadataCache.Backup.WithSafeBlock(func(backupMetadata *api.BackupMetadata, _ bool) {
 			backupMetadata.QuiesceStatus = string(backupv1.QuiesceSkipped)
 		})
 	}
-
-	defer func() {
-		if frozenFS {
-			logger.Info("Thawing VMI after backup job started")
-			if err := dom.FSThaw(nil, 0); err != nil {
-				logger.Reason(err).Error(unfreezeFailedMsg)
-				m.metadataCache.Backup.WithSafeBlock(func(backupMetadata *api.BackupMetadata, _ bool) {
-					backupMetadata.BackupMsg = unfreezeFailedMsg
-				})
-			}
-		}
-	}()
 
 	return dom.BackupBegin(strings.ToLower(string(backupXML)), strings.ToLower(string(checkpointXML)), 0)
 }

--- a/pkg/virt-launcher/virtwrap/storage/backup.go
+++ b/pkg/virt-launcher/virtwrap/storage/backup.go
@@ -183,10 +183,18 @@ func (m *StorageManager) backup(vmi *v1.VirtualMachineInstance, backupOptions *b
 			logger.Warningf(freezeFailedMsg, err)
 			m.metadataCache.Backup.WithSafeBlock(func(backupMetadata *api.BackupMetadata, _ bool) {
 				backupMetadata.BackupMsg = fmt.Sprintf(freezeFailedMsg, err)
+				backupMetadata.QuiesceStatus = string(backupv1.QuiesceFailed)
 			})
 		} else {
 			frozenFS = true
+			m.metadataCache.Backup.WithSafeBlock(func(backupMetadata *api.BackupMetadata, _ bool) {
+				backupMetadata.QuiesceStatus = string(backupv1.QuiesceSucceeded)
+			})
 		}
+	} else {
+		m.metadataCache.Backup.WithSafeBlock(func(backupMetadata *api.BackupMetadata, _ bool) {
+			backupMetadata.QuiesceStatus = string(backupv1.QuiesceSkipped)
+		})
 	}
 
 	defer func() {

--- a/pkg/virt-launcher/virtwrap/storage/backup_test.go
+++ b/pkg/virt-launcher/virtwrap/storage/backup_test.go
@@ -258,9 +258,15 @@ var _ = Describe("Backup", func() {
 			It("should freeze, start backup, and thaw", func() {
 				mockConn.EXPECT().LookupDomainByName(gomock.Any()).Return(mockDomain, nil)
 				mockDomain.EXPECT().GetXMLDesc(gomock.Any()).Return(domainXML, nil)
+				mockConn.EXPECT().QemuAgentCommand(gomock.Any(), gomock.Any()).Return(`{"return":"thawed"}`, nil)
+				mockConn.EXPECT().LookupDomainByName(gomock.Any()).Return(mockDomain, nil)
 				mockDomain.EXPECT().FSFreeze(gomock.Any(), gomock.Any()).Return(nil)
+				mockDomain.EXPECT().Free().Return(nil)
 				mockDomain.EXPECT().BackupBegin(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+				mockConn.EXPECT().QemuAgentCommand(gomock.Any(), gomock.Any()).Return(`{"return":"frozen"}`, nil)
+				mockConn.EXPECT().LookupDomainByName(gomock.Any()).Return(mockDomain, nil)
 				mockDomain.EXPECT().FSThaw(gomock.Any(), gomock.Any()).Return(nil)
+				mockDomain.EXPECT().Free().Return(nil)
 				mockDomain.EXPECT().Free().Return(nil)
 
 				err := manager.BackupVirtualMachine(vmi, backupOptions)
@@ -280,21 +286,23 @@ var _ = Describe("Backup", func() {
 		})
 
 		Context("when freeze fails", func() {
-			It("should continue backup without freeze and skip thaw", func() {
+			It("should continue backup with QuiesceStatus=Failed", func() {
 				mockConn.EXPECT().LookupDomainByName(gomock.Any()).Return(mockDomain, nil)
 				mockDomain.EXPECT().GetXMLDesc(gomock.Any()).Return(domainXML, nil)
+				mockConn.EXPECT().QemuAgentCommand(gomock.Any(), gomock.Any()).Return(`{"return":"thawed"}`, nil)
+				mockConn.EXPECT().LookupDomainByName(gomock.Any()).Return(mockDomain, nil)
 				mockDomain.EXPECT().FSFreeze(gomock.Any(), gomock.Any()).Return(fmt.Errorf("freeze error"))
+				mockDomain.EXPECT().Free().Return(nil)
 				mockDomain.EXPECT().BackupBegin(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
-				// FSThaw should NOT be called since freeze failed
+				mockConn.EXPECT().QemuAgentCommand(gomock.Any(), gomock.Any()).Return(`{"return":"thawed"}`, nil)
 				mockDomain.EXPECT().Free().Return(nil)
 
 				err := manager.BackupVirtualMachine(vmi, backupOptions)
 				Expect(err).ToNot(HaveOccurred())
 
-				// Verify backup message was set
 				backupMetadata, exists := metadataCache.Backup.Load()
 				Expect(exists).To(BeTrue())
-				Expect(backupMetadata.BackupMsg).To(ContainSubstring("Failed freezing guest filesystem"))
+				Expect(backupMetadata.QuiesceStatus).To(Equal(string(backupv1.QuiesceFailed)))
 			})
 		})
 
@@ -302,40 +310,49 @@ var _ = Describe("Backup", func() {
 			It("should record thaw failure in metadata", func() {
 				mockConn.EXPECT().LookupDomainByName(gomock.Any()).Return(mockDomain, nil)
 				mockDomain.EXPECT().GetXMLDesc(gomock.Any()).Return(domainXML, nil)
+				mockConn.EXPECT().QemuAgentCommand(gomock.Any(), gomock.Any()).Return(`{"return":"thawed"}`, nil)
+				mockConn.EXPECT().LookupDomainByName(gomock.Any()).Return(mockDomain, nil)
 				mockDomain.EXPECT().FSFreeze(gomock.Any(), gomock.Any()).Return(nil)
+				mockDomain.EXPECT().Free().Return(nil)
 				mockDomain.EXPECT().BackupBegin(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+				mockConn.EXPECT().QemuAgentCommand(gomock.Any(), gomock.Any()).Return(`{"return":"frozen"}`, nil)
+				mockConn.EXPECT().LookupDomainByName(gomock.Any()).Return(mockDomain, nil)
 				mockDomain.EXPECT().FSThaw(gomock.Any(), gomock.Any()).Return(fmt.Errorf("thaw error"))
+				mockDomain.EXPECT().Free().Return(nil)
 				mockDomain.EXPECT().Free().Return(nil)
 
 				err := manager.BackupVirtualMachine(vmi, backupOptions)
 				Expect(err).ToNot(HaveOccurred())
 
-				// Verify thaw failure was recorded
 				backupMetadata, exists := metadataCache.Backup.Load()
 				Expect(exists).To(BeTrue())
-				Expect(backupMetadata.BackupMsg).To(Equal(unfreezeFailedMsg))
+				Expect(backupMetadata.QuiesceStatus).To(Equal(string(backupv1.QuiesceSucceeded)))
 			})
 		})
 
 		Context("when BackupBegin fails after freeze", func() {
 			It("should still thaw the filesystem", func() {
-				backupOptions.SkipQuiesce = false // Ensure quiesce is enabled
+				backupOptions.SkipQuiesce = false
 
 				mockConn.EXPECT().LookupDomainByName(gomock.Any()).Return(mockDomain, nil)
 				mockDomain.EXPECT().GetXMLDesc(gomock.Any()).Return(domainXML, nil)
+				mockConn.EXPECT().QemuAgentCommand(gomock.Any(), gomock.Any()).Return(`{"return":"thawed"}`, nil)
+				mockConn.EXPECT().LookupDomainByName(gomock.Any()).Return(mockDomain, nil)
 				mockDomain.EXPECT().FSFreeze(gomock.Any(), gomock.Any()).Return(nil)
+				mockDomain.EXPECT().Free().Return(nil)
 				mockDomain.EXPECT().BackupBegin(gomock.Any(), gomock.Any(), gomock.Any()).Return(fmt.Errorf("backup begin failed"))
+				mockConn.EXPECT().QemuAgentCommand(gomock.Any(), gomock.Any()).Return(`{"return":"frozen"}`, nil)
+				mockConn.EXPECT().LookupDomainByName(gomock.Any()).Return(mockDomain, nil)
 				mockDomain.EXPECT().FSThaw(gomock.Any(), gomock.Any()).Return(nil)
+				mockDomain.EXPECT().Free().Return(nil)
 				mockDomain.EXPECT().Free().Return(nil)
 
 				err := manager.BackupVirtualMachine(vmi, backupOptions)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("backup begin failed"))
 
-				// Verify backup metadata was cleared due to failure
-				// The metadata cache stores an empty BackupMetadata on failure
 				backupMetadata, exists := metadataCache.Backup.Load()
-				Expect(exists).To(BeTrue()) // An empty backup metadata is stored
+				Expect(exists).To(BeTrue())
 				Expect(backupMetadata.Name).To(BeEmpty())
 			})
 		})

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -8783,6 +8783,10 @@ var CRDsValidation map[string]string = map[string]string{
                 failed:
                   description: Failed indicates that the backup failed
                   type: boolean
+                quiesceStatus:
+                  description: QuiesceStatus indicates whether filesystem freeze succeeded,
+                    failed, or was skipped.
+                  type: string
                 startTimestamp:
                   description: StartTimestamp is the timestamp when the backup started
                   format: date-time
@@ -14956,6 +14960,10 @@ var CRDsValidation map[string]string = map[string]string{
                 failed:
                   description: Failed indicates that the backup failed
                   type: boolean
+                quiesceStatus:
+                  description: QuiesceStatus indicates whether filesystem freeze succeeded,
+                    failed, or was skipped.
+                  type: string
                 startTimestamp:
                   description: StartTimestamp is the timestamp when the backup started
                   format: date-time
@@ -32280,6 +32288,10 @@ var CRDsValidation map[string]string = map[string]string{
                             failed:
                               description: Failed indicates that the backup failed
                               type: boolean
+                            quiesceStatus:
+                              description: QuiesceStatus indicates whether filesystem
+                                freeze succeeded, failed, or was skipped.
+                              type: string
                             startTimestamp:
                               description: StartTimestamp is the timestamp when the
                                 backup started

--- a/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachine.json
+++ b/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachine.json
@@ -1365,7 +1365,8 @@
             "dataEndpoint": "dataEndpointValue",
             "mapEndpoint": "mapEndpointValue"
           }
-        ]
+        ],
+        "quiesceStatus": "quiesceStatusValue"
       }
     },
     "instancetypeRef": {

--- a/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachine.yaml
+++ b/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachine.yaml
@@ -825,6 +825,7 @@ status:
       completed: true
       endTimestamp: "1988-01-01T01:01:01Z"
       failed: true
+      quiesceStatus: quiesceStatusValue
       startTimestamp: "1986-01-01T01:01:01Z"
       volumes:
       - dataEndpoint: dataEndpointValue

--- a/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachineInstance.json
+++ b/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachineInstance.json
@@ -1184,7 +1184,8 @@
             "dataEndpoint": "dataEndpointValue",
             "mapEndpoint": "mapEndpointValue"
           }
-        ]
+        ],
+        "quiesceStatus": "quiesceStatusValue"
       }
     }
   }

--- a/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachineInstance.yaml
+++ b/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachineInstance.yaml
@@ -630,6 +630,7 @@ status:
       completed: true
       endTimestamp: "1988-01-01T01:01:01Z"
       failed: true
+      quiesceStatus: quiesceStatusValue
       startTimestamp: "1986-01-01T01:01:01Z"
       volumes:
       - dataEndpoint: dataEndpointValue

--- a/staging/src/kubevirt.io/api/backup/v1alpha1/types.go
+++ b/staging/src/kubevirt.io/api/backup/v1alpha1/types.go
@@ -206,6 +206,18 @@ type VirtualMachineBackupSpec struct {
 	TTLDuration *metav1.Duration `json:"ttlDuration,omitempty"`
 }
 
+// QuiesceStatus represents the outcome of a filesystem quiesce operation
+type QuiesceStatus string
+
+const (
+	// QuiesceSucceeded indicates the filesystem was successfully quiesced
+	QuiesceSucceeded QuiesceStatus = "Succeeded"
+	// QuiesceFailed indicates the filesystem quiesce failed
+	QuiesceFailed QuiesceStatus = "Failed"
+	// QuiesceSkipped indicates the filesystem quiesce was skipped
+	QuiesceSkipped QuiesceStatus = "Skipped"
+)
+
 // VirtualMachineBackupStatus is the status for a VirtualMachineBackup resource
 type VirtualMachineBackupStatus struct {
 	// +optional
@@ -244,9 +256,12 @@ const (
 
 	// ConditionProgressing indicates the backup is in progress
 	ConditionProgressing ConditionType = "Progressing"
+
+	// ConditionQuiesced indicates whether the VM filesystem was quiesced (frozen) during backup
+	ConditionQuiesced ConditionType = "Quiesced"
 )
 
-// Reason constants for ConditionProgressing, ConditionComplete, and ConditionFailed
+// Reason constants for ConditionProgressing, ConditionComplete, ConditionFailed, and ConditionQuiesced
 const (
 	ReasonInitializing         = "Initializing"
 	ReasonInitiated            = "Initiated"
@@ -257,6 +272,9 @@ const (
 	ReasonCompleted            = "Completed"
 	ReasonCompletedWithWarning = "CompletedWithWarning"
 	ReasonFailed               = "Failed"
+	ReasonQuiesceSucceeded     = "QuiesceSucceeded"
+	ReasonQuiesceFailed        = "QuiesceFailed"
+	ReasonQuiesceSkipped       = "QuiesceSkipped"
 	ReasonSourceLost           = "SourceLost"
 	ReasonSourceUnhealthy      = "SourceUnhealthy"
 	ReasonDeletedDuringInit    = "DeletedDuringInit"

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -2245,6 +2245,9 @@ type VirtualMachineInstanceBackupStatus struct {
 	// +optional
 	// +listType=atomic
 	Volumes []backupv1.BackupVolumeInfo `json:"volumes,omitempty"`
+	// QuiesceStatus indicates whether filesystem freeze succeeded, failed, or was skipped.
+	// +optional
+	QuiesceStatus string `json:"quiesceStatus,omitempty"`
 }
 
 // ChangedBlockTrackingStatus represents the status of ChangedBlockTracking for a VM

--- a/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
@@ -509,6 +509,7 @@ func (VirtualMachineInstanceBackupStatus) SwaggerDoc() map[string]string {
 		"backupMsg":      "BackupMsg resturns any relevant information like failure reason\nunfreeze failed etc...\n+optional",
 		"checkpointName": "CheckpointName is the name of the checkpoint created for the backup\n+optional",
 		"volumes":        "Volumes lists the volumes included in the backup\n+optional\n+listType=atomic",
+		"quiesceStatus":  "QuiesceStatus indicates whether filesystem freeze succeeded, failed, or was skipped.\n+optional",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -26951,6 +26951,13 @@ func schema_kubevirtio_api_core_v1_VirtualMachineInstanceBackupStatus(ref common
 							},
 						},
 					},
+					"quiesceStatus": {
+						SchemaProps: spec.SchemaProps{
+							Description: "QuiesceStatus indicates whether filesystem freeze succeeded, failed, or was skipped.",
+							Type:        []string{"string"},
+							Format:      "",
+						},
+					},
 				},
 			},
 		},

--- a/tests/storage/backup.go
+++ b/tests/storage/backup.go
@@ -122,6 +122,80 @@ var _ = Describe(SIG("Backup", func() {
 		Entry("2 backups to the same PVC should succeed", getDoubleTargetPVCSize(cd.AlpineVolumeSize), 2),
 	)
 
+	It("Should expose FS Freeze status early in backup", func() {
+		dv := libdv.NewDataVolume(
+			libdv.WithRegistryURLSource(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpineTestTooling)),
+			libdv.WithNamespace(testsuite.GetTestNamespace(nil)),
+			libdv.WithStorage(
+				libdv.StorageWithVolumeSize(cd.AlpineVolumeSize),
+			),
+		)
+		vm = libstorage.RenderVMWithDataVolumeTemplate(dv,
+			libvmi.WithLabels(cbt.CBTLabel),
+			libvmi.WithRunStrategy(v1.RunStrategyAlways),
+		)
+
+		By(fmt.Sprintf("Creating VM %s", vm.Name))
+		vm, err = virtClient.VirtualMachine(vm.Namespace).Create(context.Background(), vm, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		Eventually(matcher.ThisVMIWith(vm.Namespace, vm.Name), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
+		libstorage.WaitForCBTEnabled(virtClient, vm.Namespace, vm.Name)
+
+		targetPVC := libstorage.CreateFSPVC("target-pvc", testsuite.GetTestNamespace(vm), getTargetPVCSizeWithOverhead(cd.AlpineVolumeSize), libstorage.WithStorageProfile())
+
+		By("Creating BackupTracker")
+		tracker := createBackupTracker(virtClient, vm)
+
+		tokenValue := "backup-token-" + rand.String(5)
+		tokenSecret := &corev1.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "backup-secret-" + rand.String(5),
+				Namespace: vm.Namespace,
+			},
+			StringData: map[string]string{
+				"token": tokenValue,
+			},
+		}
+		_, err = virtClient.CoreV1().Secrets(vm.Namespace).Create(context.Background(), tokenSecret, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Creating backup")
+		backupName := backupName(vm.Name)
+		backup := NewBackup(backupName, vm.Namespace, targetPVC.Name)
+		backup.Spec.Source = corev1.TypedLocalObjectReference{
+			APIGroup: pointer.P(backupapi.GroupName),
+			Kind:     backupv1.VirtualMachineBackupTrackerGroupVersionKind.Kind,
+			Name:     tracker.Name,
+		}
+		backup.Spec.Mode = pointer.P(backupv1.PullMode)
+		backup.Spec.TokenSecretRef = tokenSecret.Name
+		backup, err = virtClient.VirtualMachineBackup(backup.Namespace).Create(context.Background(), backup, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Waiting for Quiesced condition to be set early (before backup completion)")
+		Eventually(func() *metav1.Condition {
+			var err error
+			backup, err = virtClient.VirtualMachineBackup(backup.Namespace).Get(context.Background(), backup.Name, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			if backup.Status == nil {
+				return nil
+			}
+			return meta.FindStatusCondition(backup.Status.Conditions, string(backupv1.ConditionQuiesced))
+		}, 60*time.Second, 2*time.Second).ShouldNot(BeNil(), "Quiesced condition should be set early in backup process")
+
+		By("Verifying Quiesced condition is True with Succeeded reason")
+		condition := meta.FindStatusCondition(backup.Status.Conditions, string(backupv1.ConditionQuiesced))
+		Expect(condition).ToNot(BeNil())
+		Expect(condition.Status).To(Equal(metav1.ConditionTrue), "Quiesced condition should be True when guest agent is available")
+		Expect(condition.Reason).To(Equal(backupv1.ReasonQuiesceSucceeded))
+
+		By("Waiting for export to be ready before cleanup")
+		backup = waitBackupExportReady(virtClient, backup.Namespace, backup.Name)
+
+		By("Deleting backup")
+		deleteVMBackup(virtClient, backup.Namespace, backup.Name)
+	})
+
 	It("Full and Incremental Backup with BackupTracker", func() {
 		const (
 			testDataSizeMB    = 50
@@ -1429,6 +1503,10 @@ func waitBackupSucceeded(virtClient kubecli.KubevirtClient, namespace string, ba
 	))
 
 	events.ExpectEvent(vmbackup, corev1.EventTypeNormal, "VirtualMachineBackupCompletedSuccessfully")
+
+	condition := meta.FindStatusCondition(vmbackup.Status.Conditions, string(backupv1.ConditionQuiesced))
+	Expect(condition).ToNot(BeNil(), "Quiesced condition should be set in successful backups")
+
 	return vmbackup
 }
 


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

This PR adds the ConditionQuiesced field to VirtualMachineBackup.Status that indicates whether filesystem freeze succeeded, failed, or was skipped.

This status is set immediately after backup initiation (within seconds) rather than at backup completion. Backup providers can now check FSFreezeStatus early and fail fast

### References

- Fixes # https://redhat.atlassian.net/browse/CNV-84886

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Expose FS freeze status early in VirtualMachineBackup 
```

