### PR TITLE
network: clear stale config-state when target pod is replaced

### DIFF
--- a/pkg/network/setup/netconf.go
+++ b/pkg/network/setup/netconf.go
@@ -85,10 +85,27 @@ func (c *NetConf) Setup(vmi *v1.VirtualMachineInstance, networks []v1.Network, l
 	c.configStateMutex.RLock()
 	state, ok := c.state[string(vmi.UID)]
 	c.configStateMutex.RUnlock()
+
+	// A different launcher PID for the same VMI means the previous target pod
+	// was replaced (e.g. it failed during migration-target preparation). The
+	// per-VMI network config-state (in-memory and on-disk) is keyed only by
+	// vmi.UID and would otherwise be reused as "finished", short-circuiting
+	// netpod.Setup and leaving the new pod without a vif cache. Invalidate it
+	// so the new pod re-discovers and reconfigures its network.
+	if ok && state.LauncherPid != launcherPid {
+		log.Log.Object(vmi).Infof(
+			"target launcher pod changed (pid %d -> %d), clearing stale network config-state",
+			state.LauncherPid, launcherPid)
+		if err := c.Teardown(vmi); err != nil {
+			return fmt.Errorf("failed to clear stale network config-state: %w", err)
+		}
+		ok = false
+	}
+
 	if !ok {
 		configStateCache := NewConfigStateCache(string(vmi.UID), c.cacheCreator)
 		ns := c.nsFactory(launcherPid)
-		state = netpod.NewState(&configStateCache, ns)
+		state = netpod.NewState(&configStateCache, ns, launcherPid)
 		c.configStateMutex.Lock()
 		c.state[string(vmi.UID)] = state
 		c.configStateMutex.Unlock()

--- a/pkg/network/setup/netconf_test.go
+++ b/pkg/network/setup/netconf_test.go
@@ -66,7 +66,7 @@ var _ = Describe("netconf", func() {
 	})
 
 	It("runs setup successfully with networks", func() {
-		stateMap[string(vmi.UID)] = netpod.NewState(stateCache, ns)
+		stateMap[string(vmi.UID)] = netpod.NewState(stateCache, ns, launcherPid)
 		Expect(stateCache.Write(testNetworkName, cache.PodIfaceNetworkPreparationFinished)).To(Succeed())
 
 		vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{{
@@ -84,7 +84,7 @@ var _ = Describe("netconf", func() {
 	DescribeTable("setup ignores specific network bindings", func(binding v1.InterfaceBindingMethod) {
 		netConf = netsetup.NewNetConfWithCustomFactoryAndConfigState(nsFailureFactory, &tempCacheCreator{}, stateMap, cConfigStub{})
 
-		stateMap[string(vmi.UID)] = netpod.NewState(stateCache, ns)
+		stateMap[string(vmi.UID)] = netpod.NewState(stateCache, ns, launcherPid)
 
 		vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{{
 			Name:                   testNetworkName,
@@ -120,6 +120,33 @@ var _ = Describe("netconf", func() {
 	It("fails the teardown run", func() {
 		netConf := netsetup.NewNetConfWithCustomFactoryAndConfigState(nil, failingCacheCreator{}, stateMap, cConfigStub{})
 		Expect(netConf.Teardown(vmi)).NotTo(Succeed())
+	})
+
+	It("reuses the cached state when the launcher PID is unchanged", func() {
+		Expect(netConf.Setup(vmi, vmi.Spec.Networks, launcherPid)).To(Succeed())
+		cachedState := stateMap[string(vmi.UID)]
+		Expect(cachedState).NotTo(BeNil())
+
+		Expect(netConf.Setup(vmi, vmi.Spec.Networks, launcherPid)).To(Succeed())
+		Expect(stateMap[string(vmi.UID)]).To(BeIdenticalTo(cachedState))
+	})
+
+	It("clears the stale state when the launcher PID changes (target pod replaced)", func() {
+		const replacedPid = launcherPid + 1
+		Expect(netConf.Setup(vmi, vmi.Spec.Networks, launcherPid)).To(Succeed())
+		staleState := stateMap[string(vmi.UID)]
+		Expect(staleState).NotTo(BeNil())
+
+		Expect(netConf.Setup(vmi, vmi.Spec.Networks, replacedPid)).To(Succeed())
+		Expect(stateMap[string(vmi.UID)]).NotTo(BeIdenticalTo(staleState))
+	})
+
+	It("propagates the teardown error when clearing stale state fails on PID change", func() {
+		netConf := netsetup.NewNetConfWithCustomFactoryAndConfigState(nsNoopFactory, failingCacheCreator{}, stateMap, cConfigStub{})
+		Expect(netConf.Setup(vmi, vmi.Spec.Networks, launcherPid)).To(Succeed())
+
+		Expect(netConf.Setup(vmi, vmi.Spec.Networks, launcherPid+1)).NotTo(Succeed())
+		Expect(stateMap).NotTo(HaveKey(string(vmi.UID)))
 	})
 })
 

--- a/pkg/network/setup/netpod/netpod_test.go
+++ b/pkg/network/setup/netpod/netpod_test.go
@@ -78,7 +78,7 @@ var _ = Describe("netpod", func() {
 
 	BeforeEach(func() {
 		cache := newConfigStateCacheStub()
-		state = netpod.NewState(cache, netnsStub{})
+		state = netpod.NewState(cache, netnsStub{}, 0)
 	})
 
 	It("fails setup when reading nmstate status fails", func() {

--- a/pkg/network/setup/netpod/state.go
+++ b/pkg/network/setup/netpod/state.go
@@ -38,10 +38,15 @@ type State struct {
 	cache stateCacheReaderWriterDeleter
 
 	NSExec NSExecutor
+
+	// LauncherPid is the virt-launcher PID the namespaced (NSExec) state was
+	// built for. It lets the caller detect a replaced (failed) target pod so
+	// the stale per-VMI network config-state can be invalidated.
+	LauncherPid int
 }
 
-func NewState(cache stateCacheReaderWriterDeleter, ns NSExecutor) *State {
-	return &State{cache: cache, NSExec: ns}
+func NewState(cache stateCacheReaderWriterDeleter, ns NSExecutor, launcherPid int) *State {
+	return &State{cache: cache, NSExec: ns, LauncherPid: launcherPid}
 }
 
 func (s *State) PendingStartedFinished(nets []v1.Network) ([]v1.Network, []v1.Network, []v1.Network, error) {

--- a/pkg/network/setup/netpod/state_test.go
+++ b/pkg/network/setup/netpod/state_test.go
@@ -43,7 +43,7 @@ var _ = Describe("state", func() {
 		cache := newConfigStateCacheStub()
 		cache.readErr = readErr
 
-		state := netpod.NewState(cache, nil)
+		state := netpod.NewState(cache, nil, 0)
 		_, _, _, err := state.PendingStartedFinished([]v1.Network{{Name: netName}})
 
 		Expect(err).To(MatchError(readErr))
@@ -53,7 +53,7 @@ var _ = Describe("state", func() {
 		cache := newConfigStateCacheStub()
 		cache.writeErr = writeErr
 
-		state := netpod.NewState(cache, nil)
+		state := netpod.NewState(cache, nil, 0)
 		Expect(state.SetStarted([]v1.Network{{Name: netName}})).To(MatchError(ContainSubstring(writeErr.Error())))
 	})
 
@@ -61,7 +61,7 @@ var _ = Describe("state", func() {
 		cache := newConfigStateCacheStub()
 		cache.writeErr = writeErr
 
-		state := netpod.NewState(cache, nil)
+		state := netpod.NewState(cache, nil, 0)
 		Expect(state.SetFinished([]v1.Network{{Name: netName}})).To(MatchError(ContainSubstring(writeErr.Error())))
 	})
 
@@ -69,12 +69,12 @@ var _ = Describe("state", func() {
 		cache := newConfigStateCacheStub()
 		cache.deleteErr = deleteErr
 
-		state := netpod.NewState(cache, nil)
+		state := netpod.NewState(cache, nil, 0)
 		Expect(state.Delete([]v1.Network{{Name: netName}})).To(MatchError(ContainSubstring(deleteErr.Error())))
 	})
 
 	It("succeeds setting started state", func() {
-		state := netpod.NewState(newConfigStateCacheStub(), nil)
+		state := netpod.NewState(newConfigStateCacheStub(), nil, 0)
 		Expect(state.SetStarted([]v1.Network{{Name: netName}})).To(Succeed())
 
 		pending, started, finished, err := state.PendingStartedFinished([]v1.Network{{Name: netName}})
@@ -86,7 +86,7 @@ var _ = Describe("state", func() {
 	})
 
 	It("succeeds setting finished state", func() {
-		state := netpod.NewState(newConfigStateCacheStub(), nil)
+		state := netpod.NewState(newConfigStateCacheStub(), nil, 0)
 		Expect(state.SetFinished([]v1.Network{{Name: netName}})).To(Succeed())
 
 		pending, started, finished, err := state.PendingStartedFinished([]v1.Network{{Name: netName}})
@@ -114,7 +114,7 @@ var _ = Describe("state", func() {
 		cache.stateCache[nets[4].Name] = netcache.PodIfaceNetworkPreparationFinished
 		cache.stateCache[nets[5].Name] = netcache.PodIfaceNetworkPreparationFinished
 
-		state := netpod.NewState(cache, nil)
+		state := netpod.NewState(cache, nil, 0)
 		pending, started, finished, err := state.PendingStartedFinished(nets)
 
 		Expect(err).NotTo(HaveOccurred())
@@ -124,7 +124,7 @@ var _ = Describe("state", func() {
 	})
 
 	It("succeeds deleting network state", func() {
-		state := netpod.NewState(newConfigStateCacheStub(), nil)
+		state := netpod.NewState(newConfigStateCacheStub(), nil, 0)
 		nets := []v1.Network{{Name: netName}}
 		Expect(state.SetFinished(nets)).To(Succeed())
 


### PR DESCRIPTION
### What this PR does
#### Before this PR:

On a live-migration target, the VMI network config-state is keyed only by `vmi.UID` (in-memory `NetConf.state` and on-disk `/var/run/kubevirt-private/<vmi.UID>`). If a target pod fails before the migration starts, that state is never cleared, so the next target pod for the same VMI on the same node reuses it as `finished`. `netpod.Setup` short-circuits, skips discovery, and never writes the new pod's vif cache. virt-launcher then fails phase-2 plugging (`vif-cache-…json: no such file`), the pod dies, and a new one is created, looping forever.

`Teardown` only runs from `finalCleanup` or when the VMI is final/deleting, none of which happen while the VMI keeps running on the source and the migration never starts.

#### After this PR:

`Setup` records the launcher PID behind the cached state. A different PID for the same `vmi.UID` means the target pod was replaced, so the stale state is torn down and rebuilt, forcing rediscovery. The target now fails once instead of looping.

### References
- Fixes #18087

### Why we need it and why it was done in this way

The following tradeoffs were made:
- Detection uses `launcherPid` (already passed to `Setup`) to keep the fix contained in the network package.

The following alternatives were considered:
- Clearing from `migration-target.go` using the target pod UID, which also resets `netStat` but spreads cache lifecycle into the controller. Happy to switch if preferred.

### Special notes for your reviewer

Healthy migrations are unaffected: rediscovery only fires on a second target pod on the same node. The full rediscovery path needs the real nmstate adapter (not injectable via `NetConf`), so unit tests cover the teardown/rebuild behavior; an e2e forcing a first-pod failure is a good follow-up.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Testing: New unit tests added; e2e noted as follow-up
- [ ] Documentation: not required

### Release note
```release-note
Fix an infinite virt-launcher pod creation loop on a live-migration target when a target pod fails before the migration starts, caused by stale per-VMI network config-state not being cleared on the node.
```

