### PR TITLE
docs: clarify NoFlakeCheck decorator policy and usage guidelines

### DIFF
--- a/docs/quarantine.md
+++ b/docs/quarantine.md
@@ -131,6 +131,49 @@ quarantined test will propose a PR to remove the text `[QUARANTINE]` and the
 label decorator from the test description in the code.
 After merging this PR the test will be out of quarantine.
 
+# The `NoFlakeCheck` Decorator
+
+The `decorators.NoFlakeCheck` decorator excludes a test from the
+[`pull-kubevirt-check-tests-for-flakes`] presubmit lane. It exists for tests
+that **cannot run** on the flake-check lane due to infrastructure constraints —
+for example, tests that require storage classes, hardware features, or cluster
+topologies that the flake-check environment does not provide.
+
+## When to use `NoFlakeCheck`
+
+Apply `NoFlakeCheck` only when the flake-check lane lacks the infrastructure a
+test requires. Common legitimate reasons include:
+
+* The test needs a storage class (e.g. RWX filesystem, VM state storage) that
+  is not provisioned on the flake-check cluster.
+* The test requires special hardware (GPU, SRIOV, SEV) that the flake-check
+  nodes do not have.
+* The test depends on a multi-node topology that the flake-check environment
+  cannot satisfy.
+
+## When NOT to use `NoFlakeCheck`
+
+**This decorator must not be used on tests that are flaky.** If a test fails
+intermittently, it must be [quarantined](#putting-tests-in-quarantine) instead.
+Misusing `NoFlakeCheck` to hide flakes undermines CI stability for everyone.
+
+## Requirements when applying the decorator
+
+1. **Document the reason.** The commit message (or an inline code comment next
+   to the decorator) must explain why the test is incompatible with the
+   flake-check lane.
+2. **Treat it as temporary.** The long-term goal is to maximize test coverage
+   on the flake-check lane. When the lane infrastructure is extended to support
+   the test, the decorator should be removed.
+3. **Consider a flake-check clone.** Where possible, create a simplified
+   variant of the test decorated with `decorators.FlakeCheck` that can run on
+   the flake-check lane, so that at least part of the functionality is covered.
+
+For background on this policy see the [kubevirt-dev mailing list discussion].
+
+[`pull-kubevirt-check-tests-for-flakes`]: https://github.com/kubevirt/project-infra/blob/e2fa3f46cb8acbaa4657cdc18a823a0665acbaff/github/ci/prow-deploy/files/jobs/kubevirt/kubevirt/kubevirt-presubmits.yaml#L325
+[kubevirt-dev mailing list discussion]: https://groups.google.com/g/kubevirt-dev/c/7z5TXJwmcrs
+
 # Test Lane Quarantine
 
 There can be cases where required test lanes are flaking in a clustered manner with a large

--- a/tests/decorators/decorators.go
+++ b/tests/decorators/decorators.go
@@ -118,8 +118,18 @@ var (
 	// Virtctl related tests
 	Virtctl = Label("virtctl")
 
-	// NoFlakeCheck decorates tests that are not compatible with the check-tests-for-flakes test lane.
-	// This should only be used for legitimate purposes, like on tests that have a flake-checker-friendly clone.
+	// NoFlakeCheck decorates tests that are not compatible with the
+	// check-tests-for-flakes test lane due to infrastructure constraints
+	// (e.g. missing storage classes, special hardware requirements).
+	//
+	// This decorator must NOT be used on tests that are flaky — flaky tests
+	// must be quarantined instead (see docs/quarantine.md).
+	//
+	// When applying this decorator, authors must document the reason in the
+	// commit message or an inline comment explaining why the test cannot run
+	// on the flake-check lane.
+	//
+	// See also: https://groups.google.com/g/kubevirt-dev/c/7z5TXJwmcrs
 	NoFlakeCheck = Label("no-flake-check")
 	// FlakeCheck decorates tests that are dedicated to the check-tests-for-flakes test lane.
 	FlakeCheck = Label("flake-check")


### PR DESCRIPTION
### What this PR does
#### Before this PR:

The `NoFlakeCheck` decorator comment is minimal and `docs/quarantine.md`
does not document the decorator's purpose or usage policy.

#### After this PR:

- The `NoFlakeCheck` decorator comment in `tests/decorators/decorators.go`
  explicitly states it must not be used for flaky tests and that authors
  must document the reason when applying it.
- `docs/quarantine.md` has a dedicated "The NoFlakeCheck Decorator" section
  covering when to use it, when not to, and requirements for applying it.

### References

- https://groups.google.com/g/kubevirt-dev/c/7z5TXJwmcrs

### Why we need it and why it was done in this way

The mailing list discussion established consensus that `NoFlakeCheck` is
being misused to hide flaky tests. This PR codifies the agreed-upon rules
directly in the code comment and the existing quarantine documentation so
that contributors and reviewers have a single authoritative reference.

### Special notes for your reviewer

Documentation-only change (code comment + markdown).

### Checklist

- [x] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note

```release-note
NONE
```

🤖 Assisted by Claude