### PR TITLE
[release-1.1] Fix deep subresource truncation in SubjectAccessReview

### DIFF
--- a/pkg/virt-api/rest/authorizer.go
+++ b/pkg/virt-api/rest/authorizer.go
@@ -227,7 +227,15 @@ func addNamespacedResourceAttributes(pathSplit []string, httpRequest *http.Reque
 	namespace := pathSplit[5]
 	resource := pathSplit[6]
 	resourceName := pathSplit[7]
-	subresource := pathSplit[8]
+
+	// portforward requires special handling since it encodes the protocol and port into the URI.
+	// Protocol and port should not be subject to RBAC.
+	var subresource string
+	if pathSplit[8] == "portforward" {
+		subresource = pathSplit[8]
+	} else {
+		subresource = strings.Join(pathSplit[8:], "/")
+	}
 
 	if resource != "virtualmachineinstances" && resource != "virtualmachines" {
 		return fmt.Errorf("unknown resource type %s", resource)

--- a/pkg/virt-api/rest/authorizer_test.go
+++ b/pkg/virt-api/rest/authorizer_test.go
@@ -248,6 +248,26 @@ var _ = Describe("Authorizer", func() {
 				Entry("subresource v1alpha3 dump profiler", "/apis/subresources.kubevirt.io/v1alpha3/dump-cluster-profiler"),
 			)
 
+			DescribeTable("should use correct subresource in SAR", func(pathSuffix, expectedSubresource string) {
+				req.Request.Method = http.MethodGet
+				req.Request.URL.Path = "/apis/subresources.kubevirt.io/v1/namespaces/default/virtualmachineinstances/testvmi/" + pathSuffix
+				result, err := app.generateAccessReview(req)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(result.Spec.ResourceAttributes).ToNot(BeNil())
+				Expect(result.Spec.ResourceAttributes.Subresource).To(Equal(expectedSubresource))
+			},
+				Entry("single-segment: console", "console", "console"),
+				Entry("single-segment: vnc", "vnc", "vnc"),
+				Entry("deep: vnc/screenshot", "vnc/screenshot", "vnc/screenshot"),
+				Entry("deep: sev/fetchcertchain", "sev/fetchcertchain", "sev/fetchcertchain"),
+				Entry("deep: sev/querylaunchmeasurement", "sev/querylaunchmeasurement", "sev/querylaunchmeasurement"),
+				Entry("deep: sev/setupsession", "sev/setupsession", "sev/setupsession"),
+				Entry("deep: sev/injectlaunchsecret", "sev/injectlaunchsecret", "sev/injectlaunchsecret"),
+				Entry("deep: evacuate/cancel", "evacuate/cancel", "evacuate/cancel"),
+				Entry("portforward with port", "portforward/8080", "portforward"),
+				Entry("portforward with port and protocol", "portforward/8080/tcp", "portforward"),
+			)
+
 			DescribeTable("should reject all users for unknown endpoint paths", func(path string) {
 				req.Request.TLS = &tls.ConnectionState{}
 				req.Request.TLS.PeerCertificates = append(req.Request.TLS.PeerCertificates, fakecert)


### PR DESCRIPTION
### What this PR does

This is a manual cherry-pick of #17954, replacing the automated #18033 which fails CI due to test infrastructure differences between main and release-1.1.

### Why we need it and why it was done in this way

The test is adapted to use `generateAccessReview()` directly instead of the `allowedFn` reactor pattern that only exists on main.

### Checklist
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
Fixed virt-api truncating deep subresources (vnc/screenshot, sev/*, evacuate/cancel) when constructing SubjectAccessReviews, causing authorization checks against incorrect subresource names.
```