### PR TITLE
tests: remove unnecessary static PV skip

### DIFF
--- a/tests/libstorage/storageclass.go
+++ b/tests/libstorage/storageclass.go
@@ -21,11 +21,9 @@ package libstorage
 
 import (
 	"context"
-	"fmt"
 
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 
-	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	k8sv1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
@@ -330,43 +328,4 @@ func IsStorageClassBindingModeWaitForFirstConsumer(sc string) bool {
 	}
 	return storageClass.VolumeBindingMode != nil &&
 		*storageClass.VolumeBindingMode == wffc
-}
-
-func CheckNoProvisionerStorageClassPVs(storageClassName string, numExpectedPVs int) {
-	virtClient := kubevirt.Client()
-	sc, err := virtClient.StorageV1().StorageClasses().Get(context.Background(), storageClassName, metav1.GetOptions{})
-	Expect(err).ToNot(HaveOccurred())
-
-	if sc.Provisioner != "" && sc.Provisioner != "kubernetes.io/no-provisioner" {
-		return
-	}
-
-	// Verify we have at least `numExpectedPVs` available file system PVs
-	pvList, err := virtClient.CoreV1().PersistentVolumes().List(context.TODO(), metav1.ListOptions{})
-	Expect(err).ToNot(HaveOccurred())
-
-	if countLocalStoragePVAvailableForUse(pvList, storageClassName) < numExpectedPVs {
-		Skip(fmt.Sprintf("Not enough available filesystem local storage PVs available, expected: %d", numExpectedPVs)) //nolint:forbidigo
-	}
-}
-
-func countLocalStoragePVAvailableForUse(pvList *k8sv1.PersistentVolumeList, storageClassName string) int {
-	count := 0
-	for _, pv := range pvList.Items {
-		if pv.Spec.StorageClassName == storageClassName && isLocalPV(pv) && isPVAvailable(pv) {
-			count++
-		}
-	}
-	return count
-}
-
-func isLocalPV(pv k8sv1.PersistentVolume) bool {
-	return pv.Spec.NodeAffinity != nil &&
-		pv.Spec.NodeAffinity.Required != nil &&
-		len(pv.Spec.NodeAffinity.Required.NodeSelectorTerms) > 0 &&
-		(pv.Spec.VolumeMode == nil || *pv.Spec.VolumeMode != k8sv1.PersistentVolumeBlock)
-}
-
-func isPVAvailable(pv k8sv1.PersistentVolume) bool {
-	return pv.Spec.ClaimRef == nil
 }

--- a/tests/storage/hotplug.go
+++ b/tests/storage/hotplug.go
@@ -732,17 +732,13 @@ var _ = Describe(SIG("Hotplug", func() {
 			vm *v1.VirtualMachine
 			sc string
 		)
-		const (
-			numPVs = 3
-		)
-
+		const numPVs = 3
 		BeforeEach(func() {
 			var exists bool
 			sc, exists = libstorage.GetRWOFileSystemStorageClass()
 			if !exists || !libstorage.IsStorageClassBindingModeWaitForFirstConsumer(sc) {
 				Fail("fail test, no wffc storage class available")
 			}
-			libstorage.CheckNoProvisionerStorageClassPVs(sc, numPVs)
 		})
 
 		It("Should be able to boot from WFFC local storage", decorators.StorageCritical, func() {

--- a/tests/storage/memorydump.go
+++ b/tests/storage/memorydump.go
@@ -283,19 +283,12 @@ var _ = Describe(SIG("Memory dump", func() {
 			vm             *v1.VirtualMachine
 			memoryDumpPVC  *k8sv1.PersistentVolumeClaim
 			memoryDumpPVC2 *k8sv1.PersistentVolumeClaim
-			sc             string
 		)
-		const (
-			numPVs = 2
-		)
-
 		BeforeEach(func() {
-			var exists bool
-			sc, exists = libstorage.GetRWOFileSystemStorageClass()
+			_, exists := libstorage.GetRWOFileSystemStorageClass()
 			if !exists {
 				Fail("Fail no filesystem storage class available")
 			}
-			libstorage.CheckNoProvisionerStorageClassPVs(sc, numPVs)
 
 			vm = createAndStartVM()
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
None of the tests guarded by CheckNoProvisionerStorageClassPVs require
static PVs - they work with any dynamically-provisioned storage class.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

