### PR TITLE
notify-client, notify_test: fix data race in K8s Events tests

### DIFF
--- a/pkg/virt-launcher/notify-client/notify_test.go
+++ b/pkg/virt-launcher/notify-client/notify_test.go
@@ -342,11 +342,6 @@ var _ = Describe("Notify", func() {
 	})
 
 	Describe("K8s Events", func() {
-		var err error
-		var shareDir string
-		var stop chan struct{}
-		var stopped bool
-		var eventChan chan watch.Event
 		var deleteNotificationSent chan watch.Event
 		var client *Notifier
 		var recorder *record.FakeRecorder
@@ -354,11 +349,10 @@ var _ = Describe("Notify", func() {
 		var e *eventCaller
 
 		BeforeEach(func() {
-			stop = make(chan struct{})
-			eventChan = make(chan watch.Event, 100)
+			stop := make(chan struct{})
+			eventChan := make(chan watch.Event, 100)
 			deleteNotificationSent = make(chan watch.Event, 100)
-			stopped = false
-			shareDir, err = os.MkdirTemp("", "kubevirt-share")
+			shareDir, err := os.MkdirTemp("", "kubevirt-share")
 			Expect(err).ToNot(HaveOccurred())
 
 			recorder = record.NewFakeRecorder(10)
@@ -367,25 +361,21 @@ var _ = Describe("Notify", func() {
 			vmiStore = vmiInformer.GetStore()
 			e = &eventCaller{}
 
-			go func() {
-				notifyserver.RunServer(shareDir, stop, eventChan, recorder, vmiStore)
-			}()
+			go func(rec record.EventRecorder, store cache.Store) {
+				notifyserver.RunServer(shareDir, stop, eventChan, rec, store)
+			}(recorder, vmiStore)
 			// mimic pipe
 			notifyServer := filepath.Join(shareDir, "domain-notify.sock")
 			pipePath := filepath.Join(shareDir, "domain-notify-pipe.sock")
 			Expect(os.Symlink(notifyServer, pipePath)).To(Succeed())
 
-			time.Sleep(1 * time.Second)
-
 			client = NewNotifier(shareDir)
-		})
 
-		AfterEach(func() {
-			if stopped == false {
+			DeferCleanup(func() {
 				close(stop)
-			}
-			client.Close()
-			os.RemoveAll(shareDir)
+				client.Close()
+				os.RemoveAll(shareDir)
+			})
 		})
 
 		It("Should send a k8s event", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
K8s Events Describe declared `stop`, `eventChan`, `shareDir`, `recorder`, and `vmiStore` as Describe scope. The BeforeEach goroutine running RunServer captured them by reference. Between test iterations, the next BeforeEach would write to these shared variables while the previous goroutine was still reading them resulting in a data race which caused the UTs to often fail with `WARNING: DATA RACE`.

#### After this PR:
Make goroutine-captured variables local to BeforeEach and pass the remaining Describe-scoped ones as goroutine function parameters. Replace AfterEach with DeferCleanup so cleanup can access BeforeEach locals. Also drop the 1 second sleep since NewNotifier is lazy and connects on first use with its own retry logic.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

Failure lookup: https://search.ci.kubevirt.io/?search=WARNING%3A+DATA+RACE&maxAge=336h&context=1&type=all&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job

Verified via `ginkgo --race --repeat=100 --focus="K8s Events" ./pkg/virt-launcher/notify-client/...`

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```