### PR TITLE
fix(tests): preserve DisabledFeatureGates in hostdev tests

### DIFF
--- a/tests/usb/BUILD.bazel
+++ b/tests/usb/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//tests/console:go_default_library",
         "//tests/decorators:go_default_library",
+        "//tests/framework/checks:go_default_library",
         "//tests/framework/kubevirt:go_default_library",
         "//tests/libkubevirt:go_default_library",
         "//tests/libkubevirt/config:go_default_library",

--- a/tests/usb/usb.go
+++ b/tests/usb/usb.go
@@ -17,6 +17,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/decorators"
+	"kubevirt.io/kubevirt/tests/framework/checks"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/libkubevirt"
 	kvconfig "kubevirt.io/kubevirt/tests/libkubevirt/config"
@@ -36,9 +37,16 @@ var _ = Describe("[sig-compute][USB] [QUARANTINE] host USB Passthrough", Serial,
 		var virtClient kubecli.KubevirtClient
 		var config v1.KubeVirtConfiguration
 		var vmi *v1.VirtualMachineInstance
+		var fgWasOff bool
 
 		BeforeEach(func() {
 			virtClient = kubevirt.Client()
+
+			fgWasOff = !checks.HasFeature(featuregate.HostDevicesGate)
+			if fgWasOff {
+				kvconfig.EnableFeatureGate(featuregate.HostDevicesGate)
+			}
+
 			kv := libkubevirt.GetCurrentKv(virtClient)
 			config = kv.Spec.Configuration
 
@@ -62,6 +70,14 @@ var _ = Describe("[sig-compute][USB] [QUARANTINE] host USB Passthrough", Serial,
 			Expect(err).ToNot(HaveOccurred(), failedDeleteVMI)
 
 			Expect(libwait.WaitForVirtualMachineToDisappearWithTimeout(vmi, deleteTimeout*time.Second)).To(Succeed())
+
+			if fgWasOff {
+				kvconfig.DisableFeatureGate(featuregate.HostDevicesGate)
+			}
+			kv := libkubevirt.GetCurrentKv(virtClient)
+			config = kv.Spec.Configuration
+			config.PermittedHostDevices = &v1.PermittedHostDevices{}
+			kvconfig.UpdateKubeVirtConfigValueAndWait(config)
 		})
 
 		Context("with usb storage", func() {
@@ -69,9 +85,6 @@ var _ = Describe("[sig-compute][USB] [QUARANTINE] host USB Passthrough", Serial,
 				const resourceName = "kubevirt.io/usb-storage"
 
 				By("Adding the emulated USB device to the permitted host devices")
-				config.DeveloperConfiguration = &v1.DeveloperConfiguration{
-					FeatureGates: []string{featuregate.HostDevicesGate},
-				}
 				config.PermittedHostDevices = &v1.PermittedHostDevices{
 					USB: []v1.USBHostDevice{
 						{

--- a/tests/vmi_hostdev_test.go
+++ b/tests/vmi_hostdev_test.go
@@ -20,6 +20,7 @@ import (
 
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/decorators"
+	"kubevirt.io/kubevirt/tests/framework/checks"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/libkubevirt"
 	kvconfig "kubevirt.io/kubevirt/tests/libkubevirt/config"
@@ -37,19 +38,30 @@ var _ = Describe("[sig-compute]HostDevices", Serial, decorators.SigCompute, func
 	var (
 		virtClient kubecli.KubevirtClient
 		config     v1.KubeVirtConfiguration
+		fgWasOff   bool
 	)
 
 	BeforeEach(func() {
 		virtClient = kubevirt.Client()
+
+		fgWasOff = !checks.HasFeature(featuregate.HostDevicesGate)
+		if fgWasOff {
+			kvconfig.EnableFeatureGate(featuregate.HostDevicesGate)
+		}
+
 		kv := libkubevirt.GetCurrentKv(virtClient)
 		config = kv.Spec.Configuration
 	})
 
 	AfterEach(func() {
+		if fgWasOff {
+			kvconfig.DisableFeatureGate(featuregate.HostDevicesGate)
+		}
 		kv := libkubevirt.GetCurrentKv(virtClient)
-		// Reinitialized the DeveloperConfiguration to avoid to influence the next test
 		config = kv.Spec.Configuration
-		config.DeveloperConfiguration = &v1.DeveloperConfiguration{}
+		if config.DeveloperConfiguration != nil {
+			config.DeveloperConfiguration.DiskVerification = nil
+		}
 		config.PermittedHostDevices = &v1.PermittedHostDevices{}
 		kvconfig.UpdateKubeVirtConfigValueAndWait(config)
 	})
@@ -59,11 +71,8 @@ var _ = Describe("[sig-compute]HostDevices", Serial, decorators.SigCompute, func
 			deviceName := "example.org/soundcard"
 
 			By("Adding the emulated sound card to the permitted host devices")
-			config.DeveloperConfiguration = &v1.DeveloperConfiguration{
-				FeatureGates: []string{featuregate.HostDevicesGate},
-				DiskVerification: &v1.DiskVerification{
-					MemoryLimit: resource.NewScaledQuantity(2, resource.Giga),
-				},
+			config.DeveloperConfiguration.DiskVerification = &v1.DiskVerification{
+				MemoryLimit: resource.NewScaledQuantity(2, resource.Giga),
 			}
 			config.PermittedHostDevices = &v1.PermittedHostDevices{}
 			var hostDevs []v1.HostDevice


### PR DESCRIPTION
### What this PR does
#### Before this PR:

PCI and USB passthrough tests replaced `DeveloperConfiguration` with a new struct containing only `HostDevicesGate`, wiping `DisabledFeatureGates` set by `AdjustKubeVirtResource()`. On k8s <1.35 this re-enabled `ImageVolume`, causing virt-launcher pods to use `ImageVolumeSource` which kubelet cannot handle — VMIs got stuck in `Scheduling` phase and tests timed out after 360s.

#### After this PR:

Tests modify `DeveloperConfiguration` fields in-place (`FeatureGates`, `DiskVerification`) instead of replacing the struct, preserving `DisabledFeatureGates` and any other fields set by `AdjustKubeVirtResource()`.

### References

- Fixes https://github.com/kubevirt/kubevirt/issues/17929

### Why we need it and why it was done in this way

PR #17405 ("Enable beta feature gates by default") added a version guard in `AdjustKubeVirtResource()` that appends `ImageVolume` to `DisabledFeatureGates` on k8s <1.35. The hostdev tests replaced the entire `DeveloperConfiguration` struct, erasing this guard. The in-place field modification approach is the simplest fix and is future-proof — if `AdjustKubeVirtResource` gains more guards, these tests will automatically inherit them.

The following alternatives were considered:
- Duplicating the k8s version check in each test — rejected as fragile and duplicative
- Saving/restoring the full `DeveloperConfiguration` — heavier than needed

### Special notes for your reviewer

The `go.work.sum` change in the worktree is not included — only the two test files are touched.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
NONE
```

🤖 Assisted by Claude