### PR TITLE
tests: fix Cirros boot order test on IPv6-only clusters

### DIFF
--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -320,7 +320,7 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 					"Welcome to Alpine"),
 				Entry("[test_id:1628]Cirros as first boot",
 					libvmi.WithContainerDisk("disk1", cd.ContainerDiskFor(cd.ContainerDiskAlpine), bootOrderToDisk(2)), libvmi.WithContainerDisk("disk2", cd.ContainerDiskFor(cd.ContainerDiskCirros), bootOrderToDisk(1)),
-					"cirros"),
+					"rc.sysinit"),
 			)
 		})
 


### PR DESCRIPTION
### What this PR does
Changes the expected console text for `test_id:1628` (Cirros as first boot) from `"cirros"` to `"rc.sysinit"` so the boot order test passes on IPv6-only clusters without losing coverage.

#### Before this PR:
- `test_id:1628` fails on IPv6-only clusters because Cirros's `udhcpc` (DHCPv4 client) blocks boot waiting for a DHCP server that doesn't exist on IPv6-only networks
- The `"cirros"` login banner only appears after DHCP gives up, which exceeds the 90-second console timeout
- Boot order verification is lost on IPv6-only CI lanes

#### After this PR:
- The test matches `"rc.sysinit"` which Cirros outputs at ~1.9s into boot, well before networking starts
- Alpine uses OpenRC and does not produce this string, so it remains a reliable discriminator proving which disk booted
- Boot order coverage is preserved on all cluster configurations (IPv4, IPv6, dual-stack)

### Alternative considered
Adding a `RequiresIPv4Cluster` decorator to skip the test on IPv6-only lanes.
This was rejected because the test verifies boot order, not Cirros networking, and skipping it would lose coverage on IPv6-only clusters entirely.

### Release note
```release-note
NONE
```