### PR TITLE
VEP-190: Fix CEL native type registration crash on structs with multiple inline embeds

### DIFF
--- a/pkg/plugins/cel/evaluator.go
+++ b/pkg/plugins/cel/evaluator.go
@@ -22,6 +22,7 @@ package cel
 import (
 	"fmt"
 	"reflect"
+	"strings"
 	"sync"
 
 	"github.com/google/cel-go/cel"
@@ -81,7 +82,14 @@ func NewEvaluator(opts ...Option) (*Evaluator, error) {
 	}
 
 	envOpts := []cel.EnvOption{
-		ext.NativeTypes(append(nativeTypes, ext.ParseStructTag("json"))...),
+		ext.NativeTypes(append(nativeTypes, ext.ParseStructField(func(field reflect.StructField) string {
+			if tag, ok := field.Tag.Lookup("json"); ok {
+				if name := strings.SplitN(tag, ",", 2)[0]; name != "" {
+					return name
+				}
+			}
+			return field.Name
+		}))...),
 		ext.Strings(),
 		ext.Math(),
 		ext.Lists(),


### PR DESCRIPTION
### What this PR does
This PR fixes CEL native type registration for structs with multiple inline embeds. The problem was discovered by @Aseeef while working on https://github.com/kubevirt/kubevirt/pull/17860.

#### Before this PR:
cel-go's `ParseStructTag("json")` produces empty-string field names for `json:",inline"` embedded structs. When a type reachable from `VirtualMachineInstance` has multiple inline embeds, `NewEvaluator()` crashes with a duplicate field name error.

#### After this PR:
Uses a custom `ParseStructField` handler that falls back to the Go field name when the JSON tag name is empty (inline embeds), preventing the duplicate name collision.

### References
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/190

### Why we need it and why it was done in this way
The following tradeoffs were made:
Inline-embedded fields are accessible via their Go struct name rather than being flattened into the parent. This is a minor ergonomic difference with no correctness impact.

The following alternatives were considered:
- Switching to a map-based approach (marshal VMI to `map[string]any`), but this would lose compile-time field validation in `CompileCondition`.
- Flattening inline embeds in a custom TypeProvider, but cel-go doesn't support this without reimplementing the entire type provider interface.

### Checklist
- [X] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] ~Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)~
- [ ] ~Upgrade: Impact of this change on upgrade flows was considered and addressed if required~
- [ ] ~Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test~
- [ ] ~Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.~
- [ ] ~Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered~
- [X] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

