### PR TITLE
Revert: Ephemeral Hotplug Volume Metric

### DIFF
--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -30,7 +30,6 @@
 | kubevirt_vm_running_status_last_transition_timestamp_seconds | Metric | Counter | Virtual Machine last transition timestamp to running status. |
 | kubevirt_vm_starting_status_last_transition_timestamp_seconds | Metric | Counter | Virtual Machine last transition timestamp to starting status. |
 | kubevirt_vm_vnic_info | Metric | Gauge | Details of Virtual Machine (VM) vNIC interfaces, such as vNIC name, binding type, network name, and binding name for each vNIC defined in the VM's configuration. |
-| kubevirt_vmi_contains_ephemeral_hotplug_volume | Metric | Gauge | Reported only for VMIs that contain an ephemeral hotplug volume. |
 | kubevirt_vmi_cpu_system_usage_seconds_total | Metric | Counter | Total CPU time spent in system mode. |
 | kubevirt_vmi_cpu_usage_seconds_total | Metric | Counter | Total CPU time spent in all modes (sum of both vcpu and hypervisor usage). |
 | kubevirt_vmi_cpu_user_usage_seconds_total | Metric | Counter | Total CPU time spent in user mode. |

--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -1588,54 +1588,6 @@ tests:
         alertname: GuestFilesystemAlmostOutOfSpace
         exp_alerts: []
 
-  # VirtualMachineInstanceHasEphemeralHotplugVolume
-  - interval: 1m
-    input_series:
-      # VMI without ephemeral hotplug volume
-      - series: 'kubevirt_vmi_contains_ephemeral_hotplug_volume{namespace="test-ns", name="vmi-no-hotplug", volume_name="persistent-vol"}'
-        values: "0x5"
-      # VMI with one ephemeral hotplug volume
-      - series: 'kubevirt_vmi_contains_ephemeral_hotplug_volume{namespace="test-ns", name="vmi-one-hotplug", volume_name="ephemeral-vol"}'
-        values: "_ _ 1 1 1 1"
-      # VMI with multiple ephemeral hotplug volumes
-      - series: 'kubevirt_vmi_contains_ephemeral_hotplug_volume{namespace="test-ns", name="vmi-multi-hotplug", volume_name="ephemeral-vol-1, ephemeral-vol-2"}'
-        values: "_ _ 1 1 1 1"
-
-    alert_rule_test:
-      # at 1m: no VMI with ephemeral hotplug volume
-      - eval_time: 1m
-        alertname: VirtualMachineInstanceHasEphemeralHotplugVolume
-        exp_alerts: []
-
-      # at 2m: both VMIs will trigger the alert
-      - eval_time: 2m
-        alertname: VirtualMachineInstanceHasEphemeralHotplugVolume
-        exp_alerts:
-          - exp_annotations:
-              summary: "Virtual Machine Instance has Ephemeral Hotplug Volume(s). Ephemeral Hotplugs are deprecated and must be converted to persistent volumes! In a future release, feature gate `DeclarativeHotplugVolumes` will replace `HotplugVolumes` and as a result, any remaining ephemeral hotplug volumes will be automatically unplugged"
-              description: "Virtual Machine Instance vmi-one-hotplug in namespace test-ns has ephemeral hotplug volume(s) ephemeral-vol."
-              runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtualMachineInstanceHasEphemeralHotplugVolume"
-            exp_labels:
-              severity: "warning"
-              operator_health_impact: "none"
-              kubernetes_operator_part_of: "kubevirt"
-              kubernetes_operator_component: "kubevirt"
-              name: "vmi-one-hotplug"
-              namespace: "test-ns"
-              volume_name: "ephemeral-vol"
-          - exp_annotations:
-              summary: "Virtual Machine Instance has Ephemeral Hotplug Volume(s). Ephemeral Hotplugs are deprecated and must be converted to persistent volumes! In a future release, feature gate `DeclarativeHotplugVolumes` will replace `HotplugVolumes` and as a result, any remaining ephemeral hotplug volumes will be automatically unplugged"
-              description: "Virtual Machine Instance vmi-multi-hotplug in namespace test-ns has ephemeral hotplug volume(s) ephemeral-vol-1, ephemeral-vol-2."
-              runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtualMachineInstanceHasEphemeralHotplugVolume"
-            exp_labels:
-              severity: "warning"
-              operator_health_impact: "none"
-              kubernetes_operator_part_of: "kubevirt"
-              kubernetes_operator_component: "kubevirt"
-              name: "vmi-multi-hotplug"
-              namespace: "test-ns"
-              volume_name: "ephemeral-vol-1, ephemeral-vol-2"
-
   # GuestFilesystemAlmostOutOfSpace - Exclusions: fuse.* should be excluded
   - interval: 1m
     input_series:

--- a/pkg/monitoring/metrics/virt-controller/vmistats_collector.go
+++ b/pkg/monitoring/metrics/virt-controller/vmistats_collector.go
@@ -64,7 +64,6 @@ var (
 			vmiMigrationEndTime,
 			vmiVnicInfo,
 			vmiLauncherMemoryOverhead,
-			vmiEphemeralHotplugVolume,
 		},
 		CollectCallback: vmiStatsCollectorCallback,
 	}
@@ -140,14 +139,6 @@ var (
 		},
 		[]string{"namespace", "name"},
 	)
-
-	vmiEphemeralHotplugVolume = operatormetrics.NewGaugeVec(
-		operatormetrics.MetricOpts{
-			Name: "kubevirt_vmi_contains_ephemeral_hotplug_volume",
-			Help: "Reported only for VMIs that contain an ephemeral hotplug volume.",
-		},
-		[]string{"namespace", "name", "volume_name"},
-	)
 )
 
 func vmiStatsCollectorCallback() []operatormetrics.CollectorResult {
@@ -175,7 +166,6 @@ func reportVmisStats(vmis []*k6tv1.VirtualMachineInstance) []operatormetrics.Col
 		crs = append(crs, collectVMIMigrationTime(vmi)...)
 		crs = append(crs, CollectVmisVnicInfo(vmi)...)
 		crs = append(crs, collectVMILauncherMemoryOverhead(vmi))
-		crs = append(crs, collectVMIEphemeralHotplug(vmi)...)
 	}
 
 	return crs
@@ -507,21 +497,6 @@ func CollectVmisVnicInfo(vmi *k6tv1.VirtualMachineInstance) []operatormetrics.Co
 				model,
 			},
 			Value: 1.0,
-		})
-	}
-
-	return results
-}
-
-func collectVMIEphemeralHotplug(vmi *k6tv1.VirtualMachineInstance) []operatormetrics.CollectorResult {
-	results := []operatormetrics.CollectorResult{}
-
-	annotations := vmi.GetAnnotations()
-	if volumeName, exists := annotations[k6tv1.EphemeralHotplugAnnotation]; exists {
-		results = append(results, operatormetrics.CollectorResult{
-			Metric: vmiEphemeralHotplugVolume,
-			Labels: []string{vmi.Namespace, vmi.Name, volumeName},
-			Value:  float64(1),
 		})
 	}
 

--- a/pkg/monitoring/rules/alerts/vms.go
+++ b/pkg/monitoring/rules/alerts/vms.go
@@ -227,21 +227,6 @@ var vmsAlerts = []promv1.Rule{
 		},
 	},
 	{
-		Alert: "VirtualMachineInstanceHasEphemeralHotplugVolume",
-		Expr:  intstr.FromString("kubevirt_vmi_contains_ephemeral_hotplug_volume == 1"),
-		Annotations: map[string]string{
-			summaryAnnotationKey: "Virtual Machine Instance has Ephemeral Hotplug Volume(s). Ephemeral Hotplugs are deprecated and " +
-				"must be converted to persistent volumes! In a future release, feature gate `DeclarativeHotplugVolumes` will replace " +
-				"`HotplugVolumes` and as a result, any remaining ephemeral hotplug volumes will be automatically unplugged",
-			descriptionAnnotationKey: "Virtual Machine Instance {{ $labels.name }} in namespace {{ $labels.namespace }} has ephemeral " +
-				"hotplug volume(s) {{ $labels.volume_name }}.",
-		},
-		Labels: map[string]string{
-			severityAlertLabelKey:        "warning",
-			operatorHealthImpactLabelKey: "none",
-		},
-	},
-	{
 		Alert: "KubeVirtVMGuestMemoryAvailableLow",
 		Expr: intstr.FromString(
 			"((" +

--- a/pkg/virt-controller/watch/vmi/lifecycle.go
+++ b/pkg/virt-controller/watch/vmi/lifecycle.go
@@ -252,22 +252,6 @@ func (c *Controller) sync(vmi *virtv1.VirtualMachineInstance, pod *k8sv1.Pod, da
 	return nil, pod
 }
 
-func (c *Controller) getOwnerVM(vmi *virtv1.VirtualMachineInstance) *virtv1.VirtualMachine {
-	controllerRef := v1.GetControllerOf(vmi)
-	if controllerRef == nil || controllerRef.Kind != virtv1.VirtualMachineGroupVersionKind.Kind {
-		return nil
-	}
-	obj, exists, _ := c.vmStore.GetByKey(controller.NamespacedKey(vmi.Namespace, controllerRef.Name))
-	if !exists {
-		return nil
-	}
-	ownerVM := obj.(*virtv1.VirtualMachine)
-	if controllerRef.UID == ownerVM.UID {
-		return ownerVM.DeepCopy()
-	}
-	return nil
-}
-
 // updateStatus handles the VMI's lifecycle status updates.
 func (c *Controller) updateStatus(vmi *virtv1.VirtualMachineInstance, pod *k8sv1.Pod, dataVolumes []*cdiv1.DataVolume, syncErr common.SyncError) error {
 	key := controller.VirtualMachineInstanceKey(vmi)
@@ -529,8 +513,6 @@ func (c *Controller) updateStatus(vmi *virtv1.VirtualMachineInstance, pod *k8sv1
 
 		c.syncMigrationRequiredCondition(vmiCopy, pod)
 
-		c.checkEphemeralHotplugVolumes(vmiCopy)
-
 	case vmi.IsScheduled():
 		if !vmiPodExists || (vmiCopy.IsMigrationTarget() && controller.PodIsDown(pod)) || migrationTargetFailed {
 			if vmiCopy.IsMigrationTarget() {
@@ -703,17 +685,6 @@ func prepareVMIPatch(oldVMI, newVMI *virtv1.VirtualMachineInstance) *patch.Patch
 			patchSet.AddOption(
 				patch.WithTest("/metadata/labels", oldVMI.Labels),
 				patch.WithReplace("/metadata/labels", newVMI.Labels),
-			)
-		}
-	}
-
-	if !equality.Semantic.DeepEqual(oldVMI.Annotations, newVMI.Annotations) {
-		if oldVMI.Annotations == nil {
-			patchSet.AddOption(patch.WithAdd("/metadata/annotations", newVMI.Annotations))
-		} else {
-			patchSet.AddOption(
-				patch.WithTest("/metadata/annotations", oldVMI.Annotations),
-				patch.WithReplace("/metadata/annotations", newVMI.Annotations),
 			)
 		}
 	}

--- a/pkg/virt-controller/watch/vmi/storage.go
+++ b/pkg/virt-controller/watch/vmi/storage.go
@@ -20,7 +20,6 @@
 package vmi
 
 import (
-	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
@@ -89,31 +88,6 @@ func (c *Controller) updatePVC(old, cur interface{}) {
 	for _, vmi := range vmis {
 		log.Log.V(4).Object(curPVC).Infof("PVC updated for vmi %s", vmi.Name)
 		c.enqueueVirtualMachine(vmi)
-	}
-}
-
-// updateVM handles updates to a VM, enqueuing affected VMI only when VM's volumes update.
-// NOTE: this is temporary to support ephemeral hotplug volume metrics
-// will be removed once DeclarativeHotplugVolumes feature gate is enabled by default
-func (c *Controller) updateVM(prev, curr interface{}) {
-	currVM := curr.(*virtv1.VirtualMachine)
-	prevVM := prev.(*virtv1.VirtualMachine)
-	if currVM.ResourceVersion == prevVM.ResourceVersion {
-		return
-	}
-	// only requeue VMI if VM's volumes have changed
-	if !equality.Semantic.DeepEqual(currVM.Spec.Template.Spec.Volumes, prevVM.Spec.Template.Spec.Volumes) {
-		vmiKey := controller.NamespacedKey(currVM.Namespace, currVM.Name)
-		obj, exists, err := c.vmiIndexer.GetByKey(vmiKey)
-		if err != nil || !exists {
-			return
-		}
-		vmi := obj.(*virtv1.VirtualMachineInstance)
-		controllerRef := v1.GetControllerOf(vmi)
-		if controllerRef != nil && controllerRef.UID == currVM.UID {
-			log.Log.V(4).Object(currVM).Infof("VM volumes updated for vmi %s", vmi.Name)
-			c.enqueueVirtualMachine(vmi)
-		}
 	}
 }
 
@@ -365,47 +339,6 @@ func (c *Controller) updateVolumeStatus(vmi *virtv1.VirtualMachineInstance, virt
 	})
 	vmi.Status.VolumeStatus = newStatus
 	return nil
-}
-
-func (c *Controller) checkEphemeralHotplugVolumes(vmi *virtv1.VirtualMachineInstance) {
-	vm := c.getOwnerVM(vmi)
-	if vmi == nil || vm == nil {
-		return
-	}
-
-	vmVolumeMap := map[string]struct{}{}
-	for _, volume := range vm.Spec.Template.Spec.Volumes {
-		vmVolumeMap[volume.Name] = struct{}{}
-	}
-
-	annotations := vmi.Annotations
-	if annotations == nil {
-		annotations = make(map[string]string)
-	}
-	var ephemeralVols []string
-	// check if the vmi has any volumes that are not in the vm spec
-	for _, volume := range vmi.Spec.Volumes {
-		if !storagetypes.IsHotplugVolume(&volume) {
-			continue
-		}
-		if _, exists := vmVolumeMap[volume.Name]; !exists {
-			ephemeralVols = append(ephemeralVols, volume.Name)
-		}
-	}
-
-	if len(ephemeralVols) == 0 {
-		// no ephemeral hotplugs were found, remove label if it exists
-		delete(vmi.Annotations, virtv1.EphemeralHotplugAnnotation)
-	} else {
-		formattedVols, err := json.Marshal(ephemeralVols)
-		if err != nil {
-			log.Log.Reason(err).Error("could not serialize ephemeral volume list")
-			return
-		}
-		annotations[virtv1.EphemeralHotplugAnnotation] = string(formattedVols)
-		// will be patched at the end of updateStatus
-		vmi.Annotations = annotations
-	}
 }
 
 func phaseForUnpluggedVolume(phase virtv1.VolumePhase) virtv1.VolumePhase {

--- a/pkg/virt-controller/watch/vmi/vmi.go
+++ b/pkg/virt-controller/watch/vmi/vmi.go
@@ -152,15 +152,6 @@ func NewController(templateService templateService,
 		return nil, err
 	}
 
-	// NOTE: this is temporary to support ephemeral hotplug volume metrics
-	// will be removed once DeclarativeHotplugVolumes feature gate is enabled by default
-	_, err = vmInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
-		UpdateFunc: c.updateVM,
-	})
-	if err != nil {
-		return nil, err
-	}
-
 	_, err = kubeVirtInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
 		UpdateFunc: c.updateKubeVirt,
 	})

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -1220,8 +1220,6 @@ const (
 	EphemeralProvisioningObject string = "kubevirt.io/ephemeral-provisioning"
 	// This annotation stores the memory overhead calculated for the virt-launcher pod
 	MemoryOverheadAnnotationBytes string = "kubevirt.io/memory-overhead-bytes"
-	// This annotation indicates the VMI contains an ephemeral hotplug volume
-	EphemeralHotplugAnnotation string = "kubevirt.io/ephemeral-hotplug-volumes"
 
 	// This label indicates the object is a part of the install strategy retrieval process.
 	InstallStrategyLabel = "kubevirt.io/install-strategy"

--- a/tests/monitoring/metrics.go
+++ b/tests/monitoring/metrics.go
@@ -97,9 +97,6 @@ var _ = Describe("[sig-monitoring]Metrics", decorators.SigMonitoring, func() {
 			// Verify separately after deletion
 			"kubevirt_vmi_phase_transition_time_from_deletion_seconds": true,
 
-			// This metric is being tested in storage hotplug
-			"kubevirt_vmi_contains_ephemeral_hotplug_volume": true,
-
 			// Needs a guest crash - tested in VM Monitoring, guest panic metrics
 			"kubevirt_vmi_guest_os_panic_total": true,
 

--- a/tests/storage/hotplug.go
+++ b/tests/storage/hotplug.go
@@ -53,13 +53,11 @@ import (
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 	"kubevirt.io/kubevirt/tests/decorators"
-	"kubevirt.io/kubevirt/tests/framework/checks"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/framework/matcher"
 	"kubevirt.io/kubevirt/tests/libkubevirt"
 	kvconfig "kubevirt.io/kubevirt/tests/libkubevirt/config"
 	"kubevirt.io/kubevirt/tests/libmigration"
-	"kubevirt.io/kubevirt/tests/libmonitoring"
 	"kubevirt.io/kubevirt/tests/libnode"
 	"kubevirt.io/kubevirt/tests/libpod"
 	"kubevirt.io/kubevirt/tests/libregistry"
@@ -824,103 +822,6 @@ var _ = Describe(SIG("Hotplug", func() {
 			addVolumeFunc(obj.GetName(), obj.GetNamespace(), "testvolume", dv.Name, v1.DiskBusSCSI, true, "")
 			verifyNoVolumeAttached(vmi, "testvolume")
 		}
-
-		Context("Ephemeral Metrics", decorators.SigMonitoring, func() {
-
-			var (
-				vm *v1.VirtualMachine
-				sc string
-			)
-
-			BeforeEach(func() {
-				exists := false
-				sc, exists = libstorage.GetRWOFileSystemStorageClass()
-				if !exists {
-					Skip("Fail no filesystem storage class available") //nolint:forbidigo
-				}
-
-				vmi := libvmifact.NewAlpineWithTestTooling()
-				vm, err = virtClient.VirtualMachine(testsuite.GetTestNamespace(vmi)).Create(context.Background(), libvmi.NewVirtualMachine(vmi, libvmi.WithRunStrategy(v1.RunStrategyAlways)), metav1.CreateOptions{})
-				Expect(err).ToNot(HaveOccurred(), "failed to create VirtualMachine")
-				Eventually(matcher.ThisVM(vm)).WithTimeout(300 * time.Second).WithPolling(time.Second).Should(matcher.BeReady())
-			})
-
-			AfterEach(func() {
-				kvconfig.DisableFeatureGate(featuregate.DeclarativeHotplugVolumesGate)
-				kvconfig.DisableFeatureGate(featuregate.HotplugVolumesGate)
-			})
-
-			isPrometheusDeployed := func() bool {
-				ns := "monitoring"
-				if checks.IsOpenShift() {
-					ns = "openshift-monitoring"
-				}
-
-				_, err := virtClient.CoreV1().ServiceAccounts(ns).Get(context.Background(), "prometheus-k8s", metav1.GetOptions{})
-				return err == nil
-			}
-
-			It("should count only vmis with hotplug ephemeral volumes, ignoring persistent volumes and unplugs", Serial, func() {
-				if !isPrometheusDeployed() {
-					Skip("Prometheus not deployed") //nolint:forbidigo
-				}
-				kvconfig.DisableFeatureGate(featuregate.DeclarativeHotplugVolumesGate)
-				kvconfig.EnableFeatureGate(featuregate.HotplugVolumesGate)
-				ephemeralCount := 0.0
-
-				By("Creating hotplug volume that will persist")
-				dvPersistent := createDataVolumeAndWaitForImport(sc, k8sv1.PersistentVolumeFilesystem)
-				addDVVolumeVM(vm.Name, vm.Namespace, "persistent-volume", dvPersistent.Name, v1.DiskBusSCSI, false, "")
-
-				By("Creating hotplug volume that will be unplugged")
-				dvUnplug := createDataVolumeAndWaitForImport(sc, k8sv1.PersistentVolumeFilesystem)
-				addDVVolumeVM(vm.Name, vm.Namespace, "unplug-volume", dvUnplug.Name, v1.DiskBusSCSI, false, "")
-				removeVolumeVM(vm.Name, vm.Namespace, "unplug-volume", false)
-
-				By("Creating ephemeral hotplug volume")
-				dvEphemeral := createDataVolumeAndWaitForImport(sc, k8sv1.PersistentVolumeFilesystem)
-				addDVVolumeVMI(vm.Name, vm.Namespace, "ephemeral-volume", dvEphemeral.Name, v1.DiskBusSCSI, false, "")
-				ephemeralCount++
-
-				vmi := libvmifact.NewAlpineWithTestTooling()
-				vm2, err := virtClient.VirtualMachine(testsuite.GetTestNamespace(vm)).Create(context.Background(), libvmi.NewVirtualMachine(vmi, libvmi.WithRunStrategy(v1.RunStrategyAlways)), metav1.CreateOptions{})
-				Expect(err).ToNot(HaveOccurred(), "failed to create VirtualMachine")
-
-				Eventually(matcher.ThisVM(vm2)).WithTimeout(300 * time.Second).WithPolling(time.Second).Should(matcher.BeReady())
-
-				By("Creating second ephemeral hotplug volume on separate vm")
-				dvEphemeral2 := createDataVolumeAndWaitForImport(sc, k8sv1.PersistentVolumeFilesystem)
-				addDVVolumeVMI(vm2.Name, vm2.Namespace, "ephemeral-volume2", dvEphemeral2.Name, v1.DiskBusSCSI, false, "")
-				ephemeralCount++
-
-				libmonitoring.WaitForMetricValue(virtClient, "sum(kubevirt_vmi_contains_ephemeral_hotplug_volume)", ephemeralCount)
-
-				By("Removing ephemeral volume")
-				removeVolumeVMI(vm2.Name, vm2.Namespace, "ephemeral-volume2", false)
-				ephemeralCount--
-
-				By("Expecting metric to have decremented")
-				libmonitoring.WaitForMetricValue(virtClient, "sum(kubevirt_vmi_contains_ephemeral_hotplug_volume)", ephemeralCount)
-
-				By("Checking Alert is fired")
-				libmonitoring.VerifyAlertExist(virtClient, "VirtualMachineInstanceHasEphemeralHotplugVolume")
-			})
-
-			It("should ignore delcarative hotplugs", Serial, func() {
-				if !isPrometheusDeployed() {
-					Skip("Prometheus not deployed") //nolint:forbidigo
-				}
-				kvconfig.EnableFeatureGate(featuregate.DeclarativeHotplugVolumesGate)
-				kvconfig.DisableFeatureGate(featuregate.HotplugVolumesGate)
-
-				By("Adding delcarative hotplug")
-				dvPersistent := createDataVolumeAndWaitForImport(sc, k8sv1.PersistentVolumeFilesystem)
-				addDVVolumeVM(vm.Name, vm.Namespace, "persistent-volume", dvPersistent.Name, v1.DiskBusSCSI, false, "")
-
-				By("Expecting no ephemeral metrics")
-				libmonitoring.WaitForMetricValue(virtClient, "sum(kubevirt_vmi_contains_ephemeral_hotplug_volume)", -1)
-			})
-		})
 
 		Context("VMI", func() {
 			var (


### PR DESCRIPTION
This reverts PR #15815.

The ephemeral hotplug volume metric and alert were introduced as a temporary measure to track VMIs with ephemeral hotplug volumes during the transition to DeclarativeHotplugVolumes. The collection window is now over, so this logic is no longer needed.

Addresses: 
https://redhat.atlassian.net/browse/CNV-69387
https://redhat.atlassian.net/browse/CNV-81709

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:

#### After this PR:

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Remove ephemeral hotplug volume metric and alert
```

