### PR TITLE
Add exponential backoff for launcher client connection failures

### DIFF
--- a/pkg/virt-handler/launcher-clients/BUILD.bazel
+++ b/pkg/virt-handler/launcher-clients/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/golang.org/x/sync/singleflight:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
     ],
 )
 
@@ -38,6 +39,7 @@ go_test(
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/watch:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/client-go/tools/record:go_default_library",

--- a/pkg/virt-handler/launcher-clients/launcher-clients.go
+++ b/pkg/virt-handler/launcher-clients/launcher-clients.go
@@ -21,11 +21,15 @@ package launcher_clients
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
+	"sync"
 	"time"
 
 	"golang.org/x/sync/singleflight"
+
+	"k8s.io/apimachinery/pkg/types"
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
@@ -36,6 +40,18 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-handler/notify-server/pipe"
 	"kubevirt.io/kubevirt/pkg/vmitrait"
 )
+
+var ErrConnectionBackoff = errors.New("connection backoff active")
+
+const (
+	initialConnBackoff = 1 * time.Second
+	maxConnBackoff     = 5 * time.Minute
+)
+
+type connBackoffEntry struct {
+	nextRetry      time.Time
+	currentBackoff time.Duration
+}
 
 type LauncherClientsManager interface {
 	GetVerifiedLauncherClient(vmi *v1.VirtualMachineInstance) (client cmdclient.LauncherClient, err error)
@@ -50,6 +66,8 @@ type launcherClientsManager struct {
 	connGroup            singleflight.Group
 	launcherClients      virtcache.LauncherClientInfoByVMI
 	podIsolationDetector isolation.PodIsolationDetector
+	connBackoff          map[types.UID]*connBackoffEntry
+	connBackoffMu        sync.Mutex
 }
 
 func NewLauncherClientsManager(
@@ -61,6 +79,7 @@ func NewLauncherClientsManager(
 		virtShareDir:         virtShareDir,
 		launcherClients:      virtcache.LauncherClientInfoByVMI{},
 		podIsolationDetector: podIsolationDetector,
+		connBackoff:          make(map[types.UID]*connBackoffEntry),
 	}
 
 	return l
@@ -85,6 +104,10 @@ func (l *launcherClientsManager) GetLauncherClient(vmi *v1.VirtualMachineInstanc
 		return clientInfo.Client, nil
 	}
 
+	if err := l.checkConnBackoff(vmi.UID); err != nil {
+		return nil, err
+	}
+
 	// Slow path: use singleflight to ensure only one connection is created per VMI
 	// even when multiple controllers (VM, MigrationSource, MigrationTarget) race
 	// on the same VMI concurrently. Other VMIs are not blocked.
@@ -96,17 +119,20 @@ func (l *launcherClientsManager) GetLauncherClient(vmi *v1.VirtualMachineInstanc
 
 		socketFile, err := cmdclient.FindSocket(vmi)
 		if err != nil {
+			l.recordConnFailure(vmi.UID)
 			return nil, err
 		}
 
 		err = virtcache.GhostRecordGlobalStore.Add(vmi.Namespace, vmi.Name, socketFile, vmi.UID)
 		if err != nil {
+			l.recordConnFailure(vmi.UID)
 			return nil, err
 		}
 
 		client, err := cmdclient.NewClient(socketFile)
 		if err != nil {
 			virtcache.GhostRecordGlobalStore.Delete(vmi.Namespace, vmi.Name)
+			l.recordConnFailure(vmi.UID)
 			return nil, err
 		}
 
@@ -116,6 +142,7 @@ func (l *launcherClientsManager) GetLauncherClient(vmi *v1.VirtualMachineInstanc
 			client.Close()
 			close(domainPipeStopChan)
 			virtcache.GhostRecordGlobalStore.Delete(vmi.Namespace, vmi.Name)
+			l.recordConnFailure(vmi.UID)
 			return nil, err
 		}
 
@@ -127,6 +154,7 @@ func (l *launcherClientsManager) GetLauncherClient(vmi *v1.VirtualMachineInstanc
 			Ready:               true,
 		})
 
+		l.clearConnBackoff(vmi.UID)
 		return client, nil
 	})
 	if err != nil {
@@ -157,6 +185,7 @@ func (l *launcherClientsManager) CloseLauncherClient(vmi *v1.VirtualMachineInsta
 
 	virtcache.GhostRecordGlobalStore.Delete(vmi.Namespace, vmi.Name)
 	l.launcherClients.Delete(vmi.UID)
+	l.clearConnBackoff(vmi.UID)
 }
 
 func (l *launcherClientsManager) IsLauncherClientUnresponsive(vmi *v1.VirtualMachineInstance) (unresponsive bool, initialized bool, err error) {
@@ -205,6 +234,42 @@ func (l *launcherClientsManager) IsLauncherClientUnresponsive(vmi *v1.VirtualMac
 		clientInfo.SocketFile = socketFile
 	}
 	return cmdclient.IsSocketUnresponsive(socketFile), true, nil
+}
+
+func (l *launcherClientsManager) checkConnBackoff(uid types.UID) error {
+	l.connBackoffMu.Lock()
+	defer l.connBackoffMu.Unlock()
+	entry, exists := l.connBackoff[uid]
+	if !exists {
+		return nil
+	}
+	remaining := time.Until(entry.nextRetry)
+	if remaining <= 0 {
+		return nil
+	}
+	return fmt.Errorf("%w for VMI %s, retry in %s", ErrConnectionBackoff, uid, remaining.Truncate(time.Second))
+}
+
+func (l *launcherClientsManager) recordConnFailure(uid types.UID) {
+	l.connBackoffMu.Lock()
+	defer l.connBackoffMu.Unlock()
+	entry, exists := l.connBackoff[uid]
+	if !exists {
+		entry = &connBackoffEntry{currentBackoff: initialConnBackoff}
+		l.connBackoff[uid] = entry
+	} else {
+		entry.currentBackoff *= 2
+		if entry.currentBackoff > maxConnBackoff {
+			entry.currentBackoff = maxConnBackoff
+		}
+	}
+	entry.nextRetry = time.Now().Add(entry.currentBackoff)
+}
+
+func (l *launcherClientsManager) clearConnBackoff(uid types.UID) {
+	l.connBackoffMu.Lock()
+	defer l.connBackoffMu.Unlock()
+	delete(l.connBackoff, uid)
 }
 
 func handleDomainNotifyPipe(ctx context.Context, ln net.Listener, virtShareDir string, vmi *v1.VirtualMachineInstance) {

--- a/pkg/virt-handler/launcher-clients/launcher-clients_test.go
+++ b/pkg/virt-handler/launcher-clients/launcher-clients_test.go
@@ -21,6 +21,7 @@ package launcher_clients
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -30,6 +31,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
@@ -273,5 +275,51 @@ var _ = Describe("LauncherClientInfo Close", func() {
 		for range 5 {
 			<-done
 		}
+	})
+})
+
+var _ = Describe("Connection backoff", func() {
+	It("should back off repeated GetLauncherClient failures and recover after expiry", func() {
+		mgr := &launcherClientsManager{
+			launcherClients: virtcache.LauncherClientInfoByVMI{},
+			connBackoff:     make(map[types.UID]*connBackoffEntry),
+		}
+
+		vmi := api2.NewMinimalVMI("stuck-vm")
+		vmi.UID = "stuck-uid"
+
+		By("allowing the first connection attempt through (fails because no socket exists)")
+		_, err := mgr.GetLauncherClient(vmi)
+		Expect(err).To(HaveOccurred())
+		Expect(errors.Is(err, ErrConnectionBackoff)).To(BeFalse())
+
+		By("rejecting the second attempt immediately due to backoff")
+		_, err = mgr.GetLauncherClient(vmi)
+		Expect(err).To(HaveOccurred())
+		Expect(errors.Is(err, ErrConnectionBackoff)).To(BeTrue())
+
+		By("allowing retry after the backoff timer expires")
+		mgr.connBackoffMu.Lock()
+		mgr.connBackoff[vmi.UID].nextRetry = time.Now().Add(-1 * time.Second)
+		mgr.connBackoffMu.Unlock()
+
+		_, err = mgr.GetLauncherClient(vmi)
+		Expect(err).To(HaveOccurred())
+		Expect(errors.Is(err, ErrConnectionBackoff)).To(BeFalse())
+
+		By("not affecting a different VMI")
+		otherVMI := api2.NewMinimalVMI("other-vm")
+		otherVMI.UID = "other-uid"
+
+		_, err = mgr.GetLauncherClient(otherVMI)
+		Expect(err).To(HaveOccurred())
+		Expect(errors.Is(err, ErrConnectionBackoff)).To(BeFalse())
+
+		By("clearing backoff when CloseLauncherClient is called")
+		mgr.CloseLauncherClient(vmi)
+
+		_, err = mgr.GetLauncherClient(vmi)
+		Expect(err).To(HaveOccurred())
+		Expect(errors.Is(err, ErrConnectionBackoff)).To(BeFalse())
 	})
 })


### PR DESCRIPTION
#### Before this PR:

When a VMI's launcher pod is garbage collected while the VMI is stuck in Scheduled, GetLauncherClient fails on every call because the socket no longer exists. The Kubernetes workqueue rate limiter (AddRateLimited) should throttle retries, but informer events bypass it by calling queue.Add() directly, re-enqueuing the key before the backoff delay expires.

This creates a tight error loop of ~19 connection attempts/second per stuck VMI with no backoff or circuit breaker.

#### Production Evidence: 
```
From a 28-day longevity test: 10,000 VMs across 30 nodes (~333 VMs/node), CNV 4.21.0 / KubeVirt v1.7.0.

On a node with 10 stuck VMIs:

~19 connection attempts/second per stuck VMI
~1,142 error log lines/minute
99.9% of all log lines are domain-notify.sock errors (89,914 out of 89,903 lines)
CPU wasted on futile FindSocket calls that can never succeed
```
Note: The gRPC connection leak fixed in #17798 (singleflight) was amplified by this retry storm, but the retry storm itself is independent - singleflight deduplicates concurrent calls, it does not throttle sequential retries from informer re-enqueues.

#### What this PR does

Adds per-VMI exponential backoff inside GetLauncherClient.

When GetLauncherClient fails to establish a connection (socket not found, gRPC dial failure, or notify pipe setup failure), it records the VMI UID in a backoff map along with a nextRetryTime. The first failure sets nextRetryTime to 1 second from now. Each subsequent failure doubles it: 2s, 4s, 8s, ... up to a cap of 5 minutes.

On the next call for the same VMI, GetLauncherClient checks the backoff map before doing any work. If the current time is before nextRetryTime, it returns an error immediately - no socket lookup, no gRPC dial, no log noise. The controller receives this error, re-enqueues the key as usual, and processes other VMIs. This makes the repeated calls essentially free (a map lookup + time comparison).

Once nextRetryTime has passed, the next call proceeds normally and attempts a real connection. If it fails again, the backoff doubles. If it succeeds, the backoff entry is deleted and the VMI returns to normal operation with no delays. The backoff is also cleared when CloseLauncherClient is called (e.g., during VMI cleanup), so a replacement VMI always gets an immediate first attempt.

The fix is placed in GetLauncherClient rather than the controller queue because all three controllers (VirtualMachineController, MigrationSourceController, MigrationTargetController) share the same LauncherClientsManager, one fix covers all retry paths without changing any controller code.

#### After this PR:

Reduced futile connection attempts from ~1,140/minute to ~0.2/minute per stuck VMI once the backoff reaches steady state.

#### Test

Added a functional test that exercises the backoff through the real GetLauncherClient path: verifies the first call attempts a real connection, the second call is rejected by backoff, retry is allowed after backoff expiry, a different VMI is unaffected, and CloseLauncherClient clears the backoff for fresh reconnection.

```release-note
Fixed a connection retry storm in virt-handler where failed launcher client connections were retried at ~19 attempts/second with no backoff. Added per-VMI exponential backoff (1s to 5min cap) that reduces futile reconnection attempts from ~1,140/minute to ~0.2/minute per stuck VMI.
```

Jira: https://redhat.atlassian.net/browse/CNV-82348
Co-Authored-By: Claude Sonnet 4.5


