### PR TITLE
virt-handler: Fix hotplug mount resolution for multiple attachment pods

### DIFF
--- a/pkg/virt-handler/hotplug-disk/mount.go
+++ b/pkg/virt-handler/hotplug-disk/mount.go
@@ -142,8 +142,10 @@ var (
 		parent isolation.IsolationResult,
 		child isolation.IsolationResult,
 		findmntInfo FindmntInfo,
+		podUID string,
+		kubeletPodsDir string,
 	) (*safepath.Path, error) {
-		return isolation.ParentPathForMount(parent, child, findmntInfo.Source, findmntInfo.Target)
+		return isolation.ParentPathForMount(parent, child, findmntInfo.Source, findmntInfo.Target, podUID, kubeletPodsDir)
 	}
 )
 
@@ -357,10 +359,11 @@ func (m *volumeMounter) mountFromPod(vmi *v1.VirtualMachineInstance, sourceUID t
 		}
 
 		mountDirectory := m.isDirectoryMounted(vmi, volumeStatus.Name)
-		if sourceUID == "" {
-			sourceUID = volumeStatus.HotplugVolume.AttachPodUID
+		volumeSourceUID := sourceUID
+		if volumeSourceUID == "" {
+			volumeSourceUID = volumeStatus.HotplugVolume.AttachPodUID
 		}
-		if err := m.mountHotplugVolume(vmi, volumeStatus.Name, sourceUID, record, mountDirectory, cgroupManager); err != nil {
+		if err := m.mountHotplugVolume(vmi, volumeStatus.Name, volumeSourceUID, record, mountDirectory, cgroupManager); err != nil {
 			return err
 		}
 	}
@@ -608,7 +611,7 @@ func (m *volumeMounter) getSourcePodFilePath(sourceUID types.UID, vmi *v1.Virtua
 	for _, findmnt := range findmounts {
 		if filepath.Base(findmnt.Target) == volume {
 			source := findmnt.GetSourcePath()
-			path, err := parentPathForMount(nodeIsoRes, isoRes, findmnt)
+			path, err := parentPathForMount(nodeIsoRes, isoRes, findmnt, string(sourceUID), m.kubeletPodsDir)
 			exists := !errors.Is(err, os.ErrNotExist)
 			if err != nil && !errors.Is(err, os.ErrNotExist) {
 				return nil, err

--- a/pkg/virt-handler/hotplug-disk/mount_test.go
+++ b/pkg/virt-handler/hotplug-disk/mount_test.go
@@ -143,6 +143,8 @@ var _ = Describe("HotplugVolume", func() {
 			parent isolation.IsolationResult,
 			_ isolation.IsolationResult,
 			findmntInfo FindmntInfo,
+			_ string,
+			_ string,
 		) (*safepath.Path, error) {
 			path, err := parent.MountRoot()
 			Expect(err).ToNot(HaveOccurred())
@@ -425,6 +427,77 @@ var _ = Describe("HotplugVolume", func() {
 			expectCgroupRule(devices.BlockDevice, 482, 64, false)
 			err = m.unmountBlockHotplugVolumes(deviceFile, cgroupManagerMock)
 			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should not reuse a previous source UID for subsequent hotplug volumes", func() {
+			sourcePodUIDA := types.UID("source-a")
+			sourcePodUIDC := types.UID("source-c")
+			blockMode := k8sv1.PersistentVolumeBlock
+			vmi.Status.VolumeStatus = []v1.VolumeStatus{
+				{
+					Name: "volume-a",
+					PersistentVolumeClaimInfo: &v1.PersistentVolumeClaimInfo{
+						VolumeMode: &blockMode,
+					},
+					HotplugVolume: &v1.HotplugVolumeStatus{
+						AttachPodName: "pod-a",
+						AttachPodUID:  sourcePodUIDA,
+					},
+				},
+				{
+					Name: "volume-b",
+					PersistentVolumeClaimInfo: &v1.PersistentVolumeClaimInfo{
+						VolumeMode: &blockMode,
+					},
+					HotplugVolume: &v1.HotplugVolumeStatus{},
+				},
+				{
+					Name: "volume-c",
+					PersistentVolumeClaimInfo: &v1.PersistentVolumeClaimInfo{
+						VolumeMode: &blockMode,
+					},
+					HotplugVolume: &v1.HotplugVolumeStatus{
+						AttachPodName: "pod-c",
+						AttachPodUID:  sourcePodUIDC,
+					},
+				},
+			}
+
+			for _, volume := range []struct {
+				sourceUID types.UID
+				name      string
+			}{
+				{sourcePodUIDA, "volume-a"},
+				{sourcePodUIDC, "volume-c"},
+			} {
+				_, err := newDir(tempDir, string(volume.sourceUID), "volumeDevices", volume.name)
+				Expect(err).ToNot(HaveOccurred())
+			}
+
+			usedSourceUIDs := []types.UID{}
+			deviceBasePath = func(sourceUID types.UID, kubeletPodDir string) (*safepath.Path, error) {
+				usedSourceUIDs = append(usedSourceUIDs, sourceUID)
+				return newDir(tempDir, string(sourceUID), "volumeDevices")
+			}
+			mknodCommand = func(basePath *safepath.Path, deviceName string, dev uint64, blockDevicePermissions os.FileMode) error {
+				_, err := newFile(unsafepath.UnsafeAbsolute(basePath.Raw()), deviceName)
+				Expect(err).ToNot(HaveOccurred())
+				return nil
+			}
+			isBlockDevice = func(fileName *safepath.Path) (bool, error) {
+				return true, nil
+			}
+
+			setExpectedCgroupRuns(2)
+			expectCgroupRule(devices.BlockDevice, 482, 64, true)
+			ownershipManager.EXPECT().SetFileOwnership(gomock.Any()).Times(2)
+
+			err = m.Mount(vmi, cgroupManagerMock)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(usedSourceUIDs).To(Equal([]types.UID{sourcePodUIDA, sourcePodUIDC}))
+
+			_, err = os.Stat(filepath.Join(targetPodPath, "volume-b"))
+			Expect(errors.Is(err, os.ErrNotExist)).To(BeTrue())
 		})
 
 		It("getSourceMajorMinor should return an error if no uid", func() {
@@ -728,6 +801,46 @@ var _ = Describe("HotplugVolume", func() {
 			err = m.mountFileSystemHotplugVolume(vmi, "testvolume", types.UID("ghfjk"), record, false)
 			Expect(err).To(HaveOccurred())
 			Expect(err).To(MatchError(ErrWaitingForHotplugMount), "expected error waiting for hotplug mount")
+		})
+
+		It("should pass the correct sourceUID to parentPathForMount", func() {
+			const expectedSourceUID = "test-source-pod-uid-12345"
+			path, err := newDir(tempDir, expectedSourceUID, "volumes")
+			Expect(err).ToNot(HaveOccurred())
+			_, err = newFile(unsafepath.UnsafeAbsolute(path.Raw()), "disk.img")
+			Expect(err).ToNot(HaveOccurred())
+			findMntByVolume = func(volumeName string, pid int) ([]byte, error) {
+				return []byte(fmt.Sprintf(findmntByVolumeRes, "testvolume", unsafepath.UnsafeAbsolute(path.Raw()))), nil
+			}
+			targetFilePath, err := newFile(unsafepath.UnsafeAbsolute(targetPodPath.Raw()), "testvolume.img")
+			Expect(err).ToNot(HaveOccurred())
+			mountCommand = func(sourcePath, targetPath *safepath.Path) ([]byte, error) {
+				return []byte("Success"), nil
+			}
+
+			// Override the mock to assert that the correct podUID is passed
+			uidWasVerified := false
+			parentPathForMount = func(
+				parent isolation.IsolationResult,
+				_ isolation.IsolationResult,
+				findmntInfo FindmntInfo,
+				podUID string,
+				kubeletPodsDir string,
+			) (*safepath.Path, error) {
+				Expect(podUID).To(Equal(expectedSourceUID), "parentPathForMount should receive the correct sourceUID")
+				Expect(kubeletPodsDir).To(Equal("/var/lib/kubelet/pods"), "parentPathForMount should receive the configured kubelet pods directory")
+				uidWasVerified = true
+				path, err := parent.MountRoot()
+				Expect(err).ToNot(HaveOccurred())
+				return path.AppendAndResolveWithRelativeRoot(findmntInfo.GetSourcePath())
+			}
+
+			m.kubeletPodsDir = "/var/lib/kubelet/pods"
+			ownershipManager.EXPECT().SetFileOwnership(targetFilePath)
+
+			err = m.mountFileSystemHotplugVolume(vmi, "testvolume", types.UID(expectedSourceUID), record, false)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(uidWasVerified).To(BeTrue(), "parentPathForMount mock should have been called and verified the UID")
 		})
 
 		It("unmountFileSystemHotplugVolumes should return error if isMounted returns error", func() {

--- a/pkg/virt-handler/isolation/isolation.go
+++ b/pkg/virt-handler/isolation/isolation.go
@@ -194,21 +194,39 @@ func MountInfoRoot(r IsolationResult) (mountinfo *mount.Info, err error) {
 	return mountInfoFor(r, "/")
 }
 
-func mountsFilter(compare, m *mount.Info, source string) (bool, bool) {
+func mountsFilter(compare, m *mount.Info, source, podUID, kubeletPodsDir string) (bool, bool) {
 	nfsMatch := false
 	if strings.Contains(m.FSType, "nfs") && compare.FSType == m.FSType {
 		nfsMatch = m.Source != source
 	}
 
+	// Filter out mounts that are clearly for a different attachment pod.
+	// Kubelet mounts volumes at /var/lib/kubelet/pods/<UID>/volumes/...
+	// When multiple attachment pods co-exist with volumes from the same underlying
+	// device (same major:minor), a mount under the kubelet pods directory but for
+	// a different pod UID is definitely wrong and should be excluded.
+	// Mounts outside the kubelet pods path (e.g., the root filesystem mount at "/",
+	// or a device mount at "/mnt/data") are valid parent candidates for hostPath-backed
+	// volumes and must NOT be filtered by pod UID.
+	podUIDMismatch := false
+	if podUID != "" && kubeletPodsDir != "" {
+		kubeletPodsPrefix := strings.TrimRight(filepath.Clean(kubeletPodsDir), "/") + "/"
+		podMountPrefix := kubeletPodsPrefix + podUID + "/"
+		mountpoint := filepath.Clean(m.Mountpoint)
+		hasKubeletPodsPrefix := strings.HasPrefix(mountpoint, kubeletPodsPrefix)
+		podMountForUID := strings.HasPrefix(mountpoint, podMountPrefix)
+		podUIDMismatch = hasKubeletPodsPrefix && !podMountForUID
+	}
+
 	return m.Major != compare.Major || m.Minor != compare.Minor ||
-		!strings.HasPrefix(compare.Root, m.Root) || nfsMatch, false
+		!strings.HasPrefix(compare.Root, m.Root) || nfsMatch || podUIDMismatch, false
 }
 
 // parentMountInfoFor takes the mountInfo record of a container (child) and
 // attempts to locate a mountpoint containing it on the parent.
-func parentMountInfoFor(parent IsolationResult, mountInfo *mount.Info, source string) (*mount.Info, error) {
+func parentMountInfoFor(parent IsolationResult, mountInfo *mount.Info, source, podUID, kubeletPodsDir string) (*mount.Info, error) {
 	mounts, err := parent.Mounts(func(m *mount.Info) (bool, bool) {
-		return mountsFilter(mountInfo, m, source)
+		return mountsFilter(mountInfo, m, source, podUID, kubeletPodsDir)
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to find mount for %v in the mount namespace of pid %d", mountInfo.Root, parent.Pid())
@@ -226,12 +244,12 @@ func parentMountInfoFor(parent IsolationResult, mountInfo *mount.Info, source st
 	return mounts[0], nil
 }
 
-func ParentPathForMount(parent IsolationResult, child IsolationResult, source, target string) (*safepath.Path, error) {
+func ParentPathForMount(parent IsolationResult, child IsolationResult, source, target, podUID, kubeletPodsDir string) (*safepath.Path, error) {
 	childMountInfo, err := mountInfoFor(child, target)
 	if err != nil {
 		return nil, err
 	}
-	parentMountInfo, err := parentMountInfoFor(parent, childMountInfo, source)
+	parentMountInfo, err := parentMountInfoFor(parent, childMountInfo, source, podUID, kubeletPodsDir)
 	if err != nil {
 		return nil, err
 	}
@@ -250,7 +268,7 @@ func ParentPathForMount(parent IsolationResult, child IsolationResult, source, t
 // ParentPathForRootMount takes a container (child) and composes a path to
 // the root mount point in the context of the parent.
 func ParentPathForRootMount(parent IsolationResult, child IsolationResult) (*safepath.Path, error) {
-	return ParentPathForMount(parent, child, "", "/")
+	return ParentPathForMount(parent, child, "", "/", "", "")
 }
 
 func SafeJoin(res IsolationResult, elems ...string) (*safepath.Path, error) {

--- a/pkg/virt-handler/isolation/isolation_test.go
+++ b/pkg/virt-handler/isolation/isolation_test.go
@@ -253,9 +253,104 @@ var _ = Describe("IsolationResult", func() {
 					},
 					rootMountPoint,
 				})
-				path, err := ParentPathForMount(mockIsolationResultNode, mockIsolationResultContainer, "somehost:/somepath", "/target")
+				path, err := ParentPathForMount(mockIsolationResultNode, mockIsolationResultContainer, "somehost:/somepath", "/target", "", "")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(unsafepath.UnsafeAbsolute(path.Raw())).To(Equal(filepath.Join("/proc/self/root", tmpDir, "/match")))
+			})
+
+			It("Should find the correct mount based on the full pod UID path segment when multiple pods have volumes from the same device", func() {
+				// This test simulates issue #16520: when multiple attachment pods exist
+				// with volumes from the same underlying device (same major:minor), we need
+				// the full pod UID path segment to disambiguate and select the correct mount.
+				// Use a wrong UID that contains the target UID as a prefix to catch
+				// substring-based false positives.
+				const targetPodUID = "target-pod-uid"
+				const wrongPodUID = "target-pod-uid-suffix"
+				Expect(os.MkdirAll(filepath.Join(tmpDir, "/var/lib/kubelet/pods", targetPodUID, "volumes/kubernetes.io~csi/pvc-123/mount"), os.ModePerm)).To(Succeed())
+				Expect(os.MkdirAll(filepath.Join(tmpDir, "/var/lib/kubelet/pods", wrongPodUID, "volumes/kubernetes.io~csi/pvc-123/mount"), os.ModePerm)).To(Succeed())
+				initMountsMock(mockIsolationResultContainer, []*mount.Info{
+					{
+						Major:      200,
+						Minor:      123,
+						Mountpoint: "/target",
+						Root:       "/",
+					},
+					rootMountPoint,
+				})
+				initMountsMock(mockIsolationResultNode, []*mount.Info{
+					{
+						Major:      200,
+						Minor:      123,
+						Mountpoint: "/var/lib/kubelet/pods/" + wrongPodUID + "/volumes/kubernetes.io~csi/pvc-123/mount",
+						Root:       "/",
+					}, {
+						Major:      200,
+						Minor:      123,
+						Mountpoint: "/var/lib/kubelet/pods/" + targetPodUID + "/volumes/kubernetes.io~csi/pvc-123/mount",
+						Root:       "/",
+					},
+					rootMountPoint,
+				})
+				path, err := ParentPathForMount(mockIsolationResultNode, mockIsolationResultContainer, "", "/target", targetPodUID, util.KubeletPodsDir)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(unsafepath.UnsafeAbsolute(path.Raw())).To(Equal(filepath.Join("/proc/self/root", tmpDir, "/var/lib/kubelet/pods", targetPodUID, "volumes/kubernetes.io~csi/pvc-123/mount")))
+			})
+
+			It("Should not apply pod UID filtering to non-kubelet paths containing pods", func() {
+				const attachPodUID = "attach-pod-uid"
+				Expect(os.MkdirAll(filepath.Join(tmpDir, "/mnt/storage/pods/unrelated/hotplug-test"), os.ModePerm)).To(Succeed())
+				initMountsMock(mockIsolationResultContainer, []*mount.Info{
+					{
+						Major:      200,
+						Minor:      123,
+						Mountpoint: "/target",
+						Root:       "/mnt/storage/pods/unrelated/hotplug-test",
+					},
+					rootMountPoint,
+				})
+				initMountsMock(mockIsolationResultNode, []*mount.Info{
+					{
+						Major:      200,
+						Minor:      123,
+						Mountpoint: "/mnt/storage/pods/unrelated",
+						Root:       "/mnt/storage/pods/unrelated",
+					},
+					rootMountPoint,
+				})
+				path, err := ParentPathForMount(mockIsolationResultNode, mockIsolationResultContainer, "", "/target", attachPodUID, util.KubeletPodsDir)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(unsafepath.UnsafeAbsolute(path.Raw())).To(Equal(filepath.Join("/proc/self/root", tmpDir, "/mnt/storage/pods/unrelated/hotplug-test")))
+			})
+
+			It("Should find the correct mount for hostPath-backed volumes using root mount as parent", func() {
+				// Regression test: for hostPath PVC-backed volumes, the only matching
+				// parent mount in the node's mountinfo is the root filesystem mount at "/".
+				// The pod UID filter must NOT filter out non-kubelet-pods mounts like "/".
+				Expect(os.MkdirAll(filepath.Join(tmpDir, "/mnt/local-storage/hotplug-test"), os.ModePerm)).To(Succeed())
+				const attachPodUID = "attach-pod-uid-abcd"
+				initMountsMock(mockIsolationResultContainer, []*mount.Info{
+					{
+						Major:      200,
+						Minor:      123,
+						Mountpoint: "/var/run/kubevirt/hotplug-disks/testvolume",
+						Root:       "/mnt/local-storage/hotplug-test",
+					},
+					rootMountPoint,
+				})
+				// Node mountinfo: only the root mount (no pod-specific bind mount exists
+				// for hostPath volumes).
+				initMountsMock(mockIsolationResultNode, []*mount.Info{
+					{
+						Major:      200,
+						Minor:      123,
+						Mountpoint: "/",
+						Root:       "/",
+					},
+					rootMountPoint,
+				})
+				path, err := ParentPathForMount(mockIsolationResultNode, mockIsolationResultContainer, "", "/var/run/kubevirt/hotplug-disks/testvolume", attachPodUID, util.KubeletPodsDir)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(unsafepath.UnsafeAbsolute(path.Raw())).To(Equal(filepath.Join("/proc/self/root", tmpDir, "/mnt/local-storage/hotplug-test")))
 			})
 
 			It("Should find the longest root, if major and minor match", func() {
@@ -288,7 +383,7 @@ var _ = Describe("IsolationResult", func() {
 					},
 					rootMountPoint,
 				})
-				path, err := ParentPathForMount(mockIsolationResultNode, mockIsolationResultContainer, "", "/target")
+				path, err := ParentPathForMount(mockIsolationResultNode, mockIsolationResultContainer, "", "/target", "", "")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(unsafepath.UnsafeAbsolute(path.Raw())).To(Equal(filepath.Join("/proc/self/root", tmpDir, "/match/something")))
 			})


### PR DESCRIPTION
## What this PR does

### Before this PR

When multiple hotplug attachment pods co-exist, and these pods have volumes mounted from the same underlying block device, `parentMountInfoFor()` could select the wrong parent mount on the node.

This could result in intermittent mount/unmount cleanup failures and repeated VMI sync retries.

Additionally, `mountFromPod()` reused the same `sourceUID` variable while iterating over hotplug `VolumeStatus` entries. If one volume populated `sourceUID`, later volumes in the same sync loop could accidentally reuse that UID instead of their own `AttachPodUID`.

### After this PR

Mount resolution now uses pod UID-based disambiguation for kubelet pod mount paths:

`/var/lib/kubelet/pods/<POD_UID>/volumes/...`

This lets virt-handler select the mount belonging to the specific attachment pod it is operating on when multiple attachment pods exist simultaneously.

The pod UID filter is applied only to mountpoints under the configured kubelet pods directory, and it matches the pod UID as a full path segment. Mounts outside that directory, such as hostPath-backed parent mounts, keep the existing behavior.

This PR also scopes `sourceUID` per volume in `mountFromPod()`. If a later volume has no `AttachPodUID` yet, virt-handler skips mounting it until status is updated instead of reusing a stale UID from a previous volume.

## References

- Fixes: https://github.com/kubevirt/kubevirt/issues/16520
- Related PR: https://github.com/kubevirt/kubevirt/pull/9591
- Related issues:
  - https://github.com/kubevirt/kubevirt/issues/16532
  - https://github.com/kubevirt/kubevirt/issues/16537

## Why we need it and why it was done in this way

Hotplug volumes can share the same mount root on the node. During attach/detach operations, multiple hotplug attachment pods may briefly coexist, and a given volume can be attached to multiple pods concurrently.

Matching only by major/minor and mount root is not enough to disambiguate these mounts. Passing the attachment pod UID through the existing mount resolution path gives virt-handler the context it needs without adding API calls or changing stored data.

The per-volume `sourceUID` change keeps virt-handler aligned with the VMI status model: each hotplug volume status owns its own `AttachPodUID`.

## Special notes for your reviewer

- The pod UID filter is backward-compatible: an empty pod UID keeps the previous behavior.
- The filter only rejects mismatched kubelet pod mount paths, preserving hostPath-backed volume behavior.
- `MountFromPod(vmi, explicitUID, ...)` still uses the explicit UID for all volumes, which is needed for migration paths.
- Normal `Mount(vmi, ...)` now resolves the UID independently for each hotplug `VolumeStatus`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: fixed hotplug mount resolution when multiple attachment pods exist for volumes from the same underlying device, and prevented virt-handler from reusing one hotplug volume's source pod UID for later volumes in the same sync loop.
```