### PR TITLE
rbac: add resourceclaims/driver for DRA granular status authorization

### DIFF
--- a/kubevirtci/cluster-up/cluster/kind-sriov/sriov-components/manifests/dra/sriov_dra.yaml
+++ b/kubevirtci/cluster-up/cluster/kind-sriov/sriov-components/manifests/dra/sriov_dra.yaml
@@ -115,6 +115,10 @@ rules:
 - apiGroups: ["resource.k8s.io"]
   resources: ["resourceclaims/status"]
   verbs: ["get","list","update","patch"]
+- apiGroups: ["resource.k8s.io"]
+  resources: ["resourceclaims/driver"]
+  verbs: ["associated-node:update", "associated-node:patch"]
+  resourceNames: ["sriovnetwork.k8snetworkplumbingwg.io"]
 - apiGroups: [""]
   resources: ["nodes"]
   verbs: ["get", "list", "watch"]  # Cluster-scoped resource, needs cluster permissions


### PR DESCRIPTION
## What this does

Adds `resourceclaims/driver` RBAC rule to the sriov DRA ClusterRole with
`associated-node:update` and `associated-node:patch` verbs, scoped to the
`sriovnetwork.k8snetworkplumbingwg.io` driver name.

## Why

Kubernetes v1.36 introduces `DRAResourceClaimGranularStatusAuthorization`
(beta, on by default). Node-local DRA drivers running as DaemonSets now
require additional permissions on the `resourceclaims/driver` subresource
on top of the existing `resourceclaims/status` permission.

Without this, the driver will fail authorization checks when updating
device status on Kubernetes v1.36+.

Ref: kubernetes/kubernetes#138149