### PR TITLE
vGPU: Display options for SRIOV 

### DIFF
--- a/pkg/virt-launcher/virtwrap/device/hostdevice/hostdev.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/hostdev.go
@@ -52,10 +52,26 @@ func CreatePCIHostDevices(hostDevicesData []HostDeviceMetaData, pciAddrPool Addr
 	return createHostDevices(hostDevicesData, pciAddrPool, createPCIHostDevice)
 }
 
-func isVgpuDisplaySet(hostDevicesData []HostDeviceMetaData) bool {
+func isVgpuDisplaySet(hostDeviceMetadata HostDeviceMetaData) bool {
+	return hostDeviceMetadata.VirtualGPUOptions != nil &&
+		hostDeviceMetadata.VirtualGPUOptions.Display != nil
+}
+
+func isVgpuDisplayExplicitlyEnabled(display *v1.VGPUDisplayOptions) bool {
+	return display.Enabled != nil &&
+		*display.Enabled
+}
+
+func isRamFBSet(hostDeviceMetadata HostDeviceMetaData) bool {
+	return hostDeviceMetadata.VirtualGPUOptions != nil &&
+		hostDeviceMetadata.VirtualGPUOptions.Display != nil &&
+		hostDeviceMetadata.VirtualGPUOptions.Display.RamFB != nil &&
+		hostDeviceMetadata.VirtualGPUOptions.Display.RamFB.Enabled != nil &&
+		*hostDeviceMetadata.VirtualGPUOptions.Display.RamFB.Enabled
+}
+func isVgpuDisplaySetIn(hostDevicesData []HostDeviceMetaData) bool {
 	for _, hostDeviceData := range hostDevicesData {
-		if hostDeviceData.VirtualGPUOptions != nil &&
-			hostDeviceData.VirtualGPUOptions.Display != nil {
+		if isVgpuDisplaySet(hostDeviceData) {
 			return true
 		}
 	}
@@ -70,7 +86,7 @@ func CreateMDEVHostDevices(hostDevicesData []HostDeviceMetaData, mdevAddrPool Ad
 		}
 		// add a default single display option with enabled ramfb
 		// only if no vgpuDisplay option was configured.
-		if !isVgpuDisplaySet(hostDevicesData) && len(devices) > 0 {
+		if !isVgpuDisplaySetIn(hostDevicesData) && len(devices) > 0 {
 			devices[0].Display = "on"
 			devices[0].RamFB = "on"
 		}
@@ -132,6 +148,14 @@ func createPCIHostDevice(hostDeviceData HostDeviceMetaData, hostPCIAddress strin
 		Source:  api.HostDeviceSource{Address: hostAddr},
 		Type:    api.HostDevicePCI,
 		Managed: "no",
+	}
+
+	// For PCI we require explicit enablement as it can be pass-through or vgpu
+	if isVgpuDisplaySet(hostDeviceData) && isVgpuDisplayExplicitlyEnabled(hostDeviceData.VirtualGPUOptions.Display) {
+		domainHostDevice.Display = "on"
+		if isRamFBSet(hostDeviceData) {
+			domainHostDevice.RamFB = "on"
+		}
 	}
 	return domainHostDevice, nil
 }

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/hostdev_test.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/hostdev_test.go
@@ -153,10 +153,96 @@ var _ = Describe("HostDevice", func() {
 		})
 	})
 
-	Context("SRIOV GPU", func() {
+	Context("PCI display options", func() {
 		hostPCIAddress0 := api.Address{Type: api.AddressPCI, Domain: "0x0000", Bus: "0x81", Slot: "0x01", Function: "0x0"}
+		basePCIDevice := api.HostDevice{
+			Alias:   newAlias(devName0),
+			Source:  api.HostDeviceSource{Address: &hostPCIAddress0},
+			Type:    api.HostDevicePCI,
+			Managed: "no",
+		}
 
-		It("makes sure that a vGPU SRIOV device will turn display and ramfb on", func() {
+		It("does not set display when VirtualGPUOptions is nil", func() {
+			hostDevicesMetaData := []hostdevice.HostDeviceMetaData{
+				{AliasPrefix: aliasPrefix, Name: devName0, ResourceName: resourceName0},
+			}
+			pool.AddResource(resourceName0, pciAddresses0)
+
+			hostDevices, err := hostdevice.CreatePCIHostDevices(hostDevicesMetaData, pool)
+
+			Expect(hostDevices, err).To(Equal([]api.HostDevice{basePCIDevice}))
+		})
+
+		It("does not set display when Display is set but Enabled is nil", func() {
+			hostDevicesMetaData := []hostdevice.HostDeviceMetaData{
+				{AliasPrefix: aliasPrefix, Name: devName0, ResourceName: resourceName0,
+					VirtualGPUOptions: &v1.VGPUOptions{
+						Display: &v1.VGPUDisplayOptions{},
+					}},
+			}
+			pool.AddResource(resourceName0, pciAddresses0)
+
+			hostDevices, err := hostdevice.CreatePCIHostDevices(hostDevicesMetaData, pool)
+
+			Expect(hostDevices, err).To(Equal([]api.HostDevice{basePCIDevice}))
+		})
+
+		It("does not set display when Display.Enabled is false", func() {
+			hostDevicesMetaData := []hostdevice.HostDeviceMetaData{
+				{AliasPrefix: aliasPrefix, Name: devName0, ResourceName: resourceName0,
+					VirtualGPUOptions: &v1.VGPUOptions{
+						Display: &v1.VGPUDisplayOptions{
+							Enabled: pointer.P(false),
+						},
+					}},
+			}
+			pool.AddResource(resourceName0, pciAddresses0)
+
+			hostDevices, err := hostdevice.CreatePCIHostDevices(hostDevicesMetaData, pool)
+
+			Expect(hostDevices, err).To(Equal([]api.HostDevice{basePCIDevice}))
+		})
+
+		It("sets display on when explicitly enabled, without ramfb", func() {
+			hostDevicesMetaData := []hostdevice.HostDeviceMetaData{
+				{AliasPrefix: aliasPrefix, Name: devName0, ResourceName: resourceName0,
+					VirtualGPUOptions: &v1.VGPUOptions{
+						Display: &v1.VGPUDisplayOptions{
+							Enabled: pointer.P(true),
+						},
+					}},
+			}
+			pool.AddResource(resourceName0, pciAddresses0)
+
+			hostDevices, err := hostdevice.CreatePCIHostDevices(hostDevicesMetaData, pool)
+			expected := basePCIDevice
+			expected.Display = "on"
+
+			Expect(hostDevices, err).To(Equal([]api.HostDevice{expected}))
+		})
+
+		It("does not set ramfb when RamFB.Enabled is false", func() {
+			hostDevicesMetaData := []hostdevice.HostDeviceMetaData{
+				{AliasPrefix: aliasPrefix, Name: devName0, ResourceName: resourceName0,
+					VirtualGPUOptions: &v1.VGPUOptions{
+						Display: &v1.VGPUDisplayOptions{
+							Enabled: pointer.P(true),
+							RamFB: &v1.FeatureState{
+								Enabled: pointer.P(false),
+							},
+						},
+					}},
+			}
+			pool.AddResource(resourceName0, pciAddresses0)
+
+			hostDevices, err := hostdevice.CreatePCIHostDevices(hostDevicesMetaData, pool)
+			expected := basePCIDevice
+			expected.Display = "on"
+
+			Expect(hostDevices, err).To(Equal([]api.HostDevice{expected}))
+		})
+
+		It("sets display and ramfb on when both explicitly enabled", func() {
 			hostDevicesMetaData := []hostdevice.HostDeviceMetaData{
 				{AliasPrefix: aliasPrefix, Name: devName0, ResourceName: resourceName0,
 					VirtualGPUOptions: &v1.VGPUOptions{
@@ -165,21 +251,36 @@ var _ = Describe("HostDevice", func() {
 							RamFB: &v1.FeatureState{
 								Enabled: pointer.P(true),
 							},
-						}}},
+						},
+					}},
 			}
 			pool.AddResource(resourceName0, pciAddresses0)
 
 			hostDevices, err := hostdevice.CreatePCIHostDevices(hostDevicesMetaData, pool)
-			expectHostDevice1 := api.HostDevice{
-				Alias:   newAlias(devName0),
-				Source:  api.HostDeviceSource{Address: &hostPCIAddress0},
-				Type:    api.HostDevicePCI,
-				Managed: "no",
-			}
-			expectHostDevice1.Display = "on"
-			expectHostDevice1.RamFB = "on"
+			expected := basePCIDevice
+			expected.Display = "on"
+			expected.RamFB = "on"
 
-			Expect(hostDevices, err).To(Equal([]api.HostDevice{expectHostDevice1}))
+			Expect(hostDevices, err).To(Equal([]api.HostDevice{expected}))
+		})
+
+		It("does not set ramfb when RamFB is present but Enabled is nil", func() {
+			hostDevicesMetaData := []hostdevice.HostDeviceMetaData{
+				{AliasPrefix: aliasPrefix, Name: devName0, ResourceName: resourceName0,
+					VirtualGPUOptions: &v1.VGPUOptions{
+						Display: &v1.VGPUDisplayOptions{
+							Enabled: pointer.P(true),
+							RamFB:   &v1.FeatureState{},
+						},
+					}},
+			}
+			pool.AddResource(resourceName0, pciAddresses0)
+
+			hostDevices, err := hostdevice.CreatePCIHostDevices(hostDevicesMetaData, pool)
+			expected := basePCIDevice
+			expected.Display = "on"
+
+			Expect(hostDevices, err).To(Equal([]api.HostDevice{expected}))
 		})
 	})
 

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/hostdev_test.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/hostdev_test.go
@@ -153,6 +153,36 @@ var _ = Describe("HostDevice", func() {
 		})
 	})
 
+	Context("SRIOV GPU", func() {
+		hostPCIAddress0 := api.Address{Type: api.AddressPCI, Domain: "0x0000", Bus: "0x81", Slot: "0x01", Function: "0x0"}
+
+		It("makes sure that a vGPU SRIOV device will turn display and ramfb on", func() {
+			hostDevicesMetaData := []hostdevice.HostDeviceMetaData{
+				{AliasPrefix: aliasPrefix, Name: devName0, ResourceName: resourceName0,
+					VirtualGPUOptions: &v1.VGPUOptions{
+						Display: &v1.VGPUDisplayOptions{
+							Enabled: pointer.P(true),
+							RamFB: &v1.FeatureState{
+								Enabled: pointer.P(true),
+							},
+						}}},
+			}
+			pool.AddResource(resourceName0, pciAddresses0)
+
+			hostDevices, err := hostdevice.CreatePCIHostDevices(hostDevicesMetaData, pool)
+			expectHostDevice1 := api.HostDevice{
+				Alias:   newAlias(devName0),
+				Source:  api.HostDeviceSource{Address: &hostPCIAddress0},
+				Type:    api.HostDevicePCI,
+				Managed: "no",
+			}
+			expectHostDevice1.Display = "on"
+			expectHostDevice1.RamFB = "on"
+
+			Expect(hostDevices, err).To(Equal([]api.HostDevice{expectHostDevice1}))
+		})
+	})
+
 	Context("MDEV", func() {
 		const uuid0 = "0123456789-0"
 		hostMDEVAddress0 := api.Address{UUID: uuid0}


### PR DESCRIPTION
### What this PR does
This PR is follow up to https://github.com/kubevirt/kubevirt/pull/16890, as such implementing the Display option. 
The API doesn't differ the GPU or vGPU and as such setting the display option can result in startup failure if set on pGPU rather than vGPU. Some profiles might not support display as well. 

Note: KubeVirt PCI plugin is not capable to expose different profiles under different resource.

### Special notes for your reviewer
E2E tests are missing as we don't have a capable HW in our CI for now. I have tested these changes against supported HW (NVIDIA A2).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
SRIOV vGPU now supports display 
```

