### PR TITLE
tests: switch vsock guest-agent checksum to sha256

### DIFF
--- a/tests/vmi_vsock_test.go
+++ b/tests/vmi_vsock_test.go
@@ -20,7 +20,7 @@
 package tests_test
 
 import (
-	"crypto/md5"
+	"crypto/sha256"
 	"fmt"
 	"io"
 	"net"
@@ -281,22 +281,22 @@ func copyExampleGuestAgent(vmi *v1.VirtualMachineInstance) {
 	}, 60*time.Second, 1*time.Second).Should(Succeed())
 
 	conn := stream.AsConn()
-	md5Hasher := md5.New()
-	_, err = io.Copy(conn, io.TeeReader(file, md5Hasher))
+	sha256Hasher := sha256.New()
+	_, err = io.Copy(conn, io.TeeReader(file, sha256Hasher))
 	Expect(err).ToNot(HaveOccurred())
 	err = conn.Close()
 	Expect(err).ToNot(HaveOccurred())
 
-	expectedMD5 := fmt.Sprintf("%x", md5Hasher.Sum(nil))
-	guestAgentMD5Command := fmt.Sprintf("md5sum %s | awk '{print $1}'", guestAgentPath)
+	expectedSHA256 := fmt.Sprintf("%x", sha256Hasher.Sum(nil))
+	guestAgentSHA256Command := fmt.Sprintf("sha256sum %s | awk '{print $1}'", guestAgentPath)
 	Eventually(func() error {
-		guestMD5Output, err := console.RunCommandAndStoreOutput(vmi, guestAgentMD5Command, 30*time.Second)
+		guestSHA256Output, err := console.RunCommandAndStoreOutput(vmi, guestAgentSHA256Command, 30*time.Second)
 		if err != nil {
 			return err
 		}
-		guestMD5 := strings.TrimSpace(guestMD5Output)
-		if guestMD5 != expectedMD5 {
-			return fmt.Errorf("guest agent md5 mismatch: got %q, expected %q", guestMD5, expectedMD5)
+		guestSHA256 := strings.TrimSpace(guestSHA256Output)
+		if guestSHA256 != expectedSHA256 {
+			return fmt.Errorf("guest agent sha256 mismatch: got %q, expected %q", guestSHA256, expectedSHA256)
 		}
 		return nil
 	}, 2*time.Minute, 10*time.Second).Should(Succeed(), "should validate the guest agent file was copied correctly")


### PR DESCRIPTION



<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Avoid dragging md5 into the vsock test path.
Even though this checksum is only used for copy verification, md5 frequently triggers security-review questions and follow-up proof requests about non-security usage.

Use sha256 instead to keep the intent unchanged while avoiding repeated md5 review churn.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

