### PR TITLE
[release-1.8] tests/libinfra: use machine-type label to verify node-labeller resumed

### DIFF
--- a/tests/libinfra/node-labeller.go
+++ b/tests/libinfra/node-labeller.go
@@ -91,12 +91,9 @@ func ExpectResumingNodeLabellerToSucceed(nodeName string, virtClient kubecli.Kub
 	By(fmt.Sprintf("Patching node %s to not include %s annotation", nodeName, v1.LabellerSkipNodeAnnotation))
 	libnode.RemoveAnnotationFromNode(nodeName, v1.LabellerSkipNodeAnnotation)
 
-	// In order to make sure node-labeller has updated the node, the host-model label (which node-labeller
-	// makes sure always resides on any node) will be removed. After node-labeller is enabled again, the
-	// host model label would be expected to show up again on the node.
-	By(fmt.Sprintf("Removing host model label %s from node %s (so we can later expect it to return)", v1.HostModelCPULabel, nodeName))
-	for _, label := range node.Labels {
-		if strings.HasPrefix(label, v1.HostModelCPULabel) {
+	By(fmt.Sprintf("Removing machine type labels from node %s (so we can later expect them to return)", nodeName))
+	for label := range node.Labels {
+		if strings.HasPrefix(label, v1.SupportedMachineTypeLabel) {
 			libnode.RemoveLabelFromNode(nodeName, label)
 		}
 	}
@@ -113,15 +110,15 @@ func ExpectResumingNodeLabellerToSucceed(nodeName string, virtClient kubecli.Kub
 			return fmt.Errorf("node %s is expected to not have annotation %s", node.Name, v1.LabellerSkipNodeAnnotation)
 		}
 
-		foundHostModelLabel := false
+		foundMachineTypeLabel := false
 		for labelKey := range node.Labels {
-			if strings.HasPrefix(labelKey, v1.HostModelCPULabel) {
-				foundHostModelLabel = true
+			if strings.HasPrefix(labelKey, v1.SupportedMachineTypeLabel) {
+				foundMachineTypeLabel = true
 				break
 			}
 		}
-		if !foundHostModelLabel {
-			return fmt.Errorf("node %s is expected to have a label with %s prefix. this means node-labeller is not enabled for the node", nodeName, v1.HostModelCPULabel)
+		if !foundMachineTypeLabel {
+			return fmt.Errorf("node %s is expected to have a label with %s prefix. this means node-labeller is not enabled for the node", nodeName, v1.SupportedMachineTypeLabel)
 		}
 
 		return nil


### PR DESCRIPTION
### What this PR does
Manual cherry-pick of #17912 to release-1.8.

#### Conflict resolution
The label removal loop used `for _, label := range node.Labels` on release-1.8 (iterating map values), while main already had `for label := range node.Labels` (iterating map keys). Resolved by taking the main syntax since prefix-checking map values was a no-op.

### References
Map-iteration-fix: https://github.com/kubevirt/kubevirt/pull/16910
Cherry-pick of #17912
Tracker: #18030

### Release note
```release-note
NONE
```