### PR TITLE
backend-storage: use rootless image for migration recovery job

### DIFF
--- a/cmd/virt-launcher/BUILD.bazel
+++ b/cmd/virt-launcher/BUILD.bazel
@@ -257,5 +257,6 @@ oci_image(
     base = ":version-container",
     entrypoint = ["/usr/bin/virt-launcher"],
     tars = [":setcaps"],
+    user = "107",
     visibility = ["//visibility:public"],
 )

--- a/cmd/virt-launcher/qemu
+++ b/cmd/virt-launcher/qemu
@@ -3,3 +3,4 @@ if [ "$2" != "release" ] || [ "$3" != "end" ] || [ "$4" != "migrated" ]; then
 	exit
 fi
 touch /run/kubevirt-private/backend-storage-meta/migrated
+chmod 0644 /run/kubevirt-private/backend-storage-meta/migrated

--- a/pkg/storage/backend-storage/BUILD.bazel
+++ b/pkg/storage/backend-storage/BUILD.bazel
@@ -12,7 +12,6 @@ go_library(
         "//pkg/storage/cbt:go_default_library",
         "//pkg/storage/types:go_default_library",
         "//pkg/tpm:go_default_library",
-        "//pkg/util:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/api/snapshot/v1beta1:go_default_library",

--- a/pkg/storage/backend-storage/backend-storage.go
+++ b/pkg/storage/backend-storage/backend-storage.go
@@ -45,7 +45,6 @@ import (
 	"kubevirt.io/kubevirt/pkg/storage/cbt"
 	storagetypes "kubevirt.io/kubevirt/pkg/storage/types"
 	"kubevirt.io/kubevirt/pkg/tpm"
-	"kubevirt.io/kubevirt/pkg/util"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 )
 
@@ -209,9 +208,6 @@ func buildRecoveryJob(jobName, launcherImage string, migration *corev1.VirtualMa
 					RestartPolicy: v1.RestartPolicyNever,
 					SecurityContext: &v1.PodSecurityContext{
 						RunAsNonRoot: pointer.P(true),
-						RunAsUser:    pointer.P(int64(util.NonRootUID)),
-						RunAsGroup:   pointer.P(int64(util.NonRootUID)),
-						FSGroup:      pointer.P(int64(util.NonRootUID)),
 						SeccompProfile: &v1.SeccompProfile{
 							Type: v1.SeccompProfileTypeRuntimeDefault,
 						},

--- a/pkg/storage/backend-storage/backend-storage_test.go
+++ b/pkg/storage/backend-storage/backend-storage_test.go
@@ -256,6 +256,16 @@ var _ = Describe("Backend Storage", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(sourcePVC.Labels).To(HaveKeyWithValue("persistent-state-for", vmiName))
 		})
+		It("Should build a recovery job without RunAsUser, RunAsGroup, or FSGroup", func() {
+			job := buildRecoveryJob("test-recovery", "test-image", migration)
+
+			psc := job.Spec.Template.Spec.SecurityContext
+			Expect(psc).NotTo(BeNil())
+			Expect(psc.RunAsNonRoot).To(HaveValue(BeTrue()))
+			Expect(psc.RunAsUser).To(BeNil())
+			Expect(psc.RunAsGroup).To(BeNil())
+			Expect(psc.FSGroup).To(BeNil())
+		})
 	})
 
 	Context("createPVC", func() {

--- a/pkg/virt-operator/resource/generate/components/daemonsets.go
+++ b/pkg/virt-operator/resource/generate/components/daemonsets.go
@@ -164,6 +164,7 @@ func NewHandlerDaemonSet(config *operatorutil.KubeVirtDeploymentConfig, productN
 			},
 			SecurityContext: &corev1.SecurityContext{
 				Privileged: pointer.P(true),
+				RunAsUser:  pointer.P(int64(0)),
 			},
 			VolumeMounts: []corev1.VolumeMount{
 				{


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
 The virt-launcher oci_image had no user directive, defaulting to root (UID 0). The migration recovery job had RunAsUser/RunAsGroup/FSGroup hardcoded to 107. Unlike virt-launcher pods managed by virt-controller, the recovery job runs through the regular job controller and must pass standard admission. On clusters that enforce restricted admission policies, UID 107 is rejected because it falls outside the allowed range, causing the recovery job pod to never start and leaving migrations stuck, blocking node drains and cluster upgrades

#### After this PR:
The virt-launcher image defaults to user 107, making it rootless by default. The virt-handler init container that requires root for device setup explicitly sets RunAsUser: 0. The recovery job's hardcoded UIDs are removed so with the now-rootless image, the pod satisfies RunAsNonRoot, making it compatible with any admission policy the cluster enforces.

### References
Jira  https://issues.redhat.com/browse/CNV-80517
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer


### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

