### PR TITLE
VEP 190: Add plugin.kubevirt.io view RBAC rules

### DIFF
--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -1460,6 +1460,14 @@ spec:
           - list
           - watch
         - apiGroups:
+          - plugin.kubevirt.io
+          resources:
+          - plugins
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
           - instancetype.kubevirt.io
           resources:
           - virtualmachineclusterinstancetypes

--- a/manifests/generated/rbac-operator.authorization.k8s.yaml.in
+++ b/manifests/generated/rbac-operator.authorization.k8s.yaml.in
@@ -1492,6 +1492,14 @@ rules:
   - list
   - watch
 - apiGroups:
+  - plugin.kubevirt.io
+  resources:
+  - plugins
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - instancetype.kubevirt.io
   resources:
   - virtualmachineclusterinstancetypes

--- a/pkg/virt-operator/resource/generate/rbac/BUILD.bazel
+++ b/pkg/virt-operator/resource/generate/rbac/BUILD.bazel
@@ -51,6 +51,7 @@ go_test(
         "//staging/src/kubevirt.io/api/export:go_default_library",
         "//staging/src/kubevirt.io/api/instancetype:go_default_library",
         "//staging/src/kubevirt.io/api/migrations:go_default_library",
+        "//staging/src/kubevirt.io/api/plugin:go_default_library",
         "//staging/src/kubevirt.io/api/pool:go_default_library",
         "//staging/src/kubevirt.io/api/snapshot:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",

--- a/pkg/virt-operator/resource/generate/rbac/cluster.go
+++ b/pkg/virt-operator/resource/generate/rbac/cluster.go
@@ -820,6 +820,17 @@ func newViewClusterRole() *rbacv1.ClusterRole {
 					"get", "list", "watch",
 				},
 			},
+			{
+				APIGroups: []string{
+					plugin.GroupName,
+				},
+				Resources: []string{
+					apiPlugins,
+				},
+				Verbs: []string{
+					"get", "list", "watch",
+				},
+			},
 		},
 	}
 }

--- a/pkg/virt-operator/resource/generate/rbac/cluster_test.go
+++ b/pkg/virt-operator/resource/generate/rbac/cluster_test.go
@@ -30,6 +30,7 @@ import (
 	"kubevirt.io/api/export"
 	"kubevirt.io/api/instancetype"
 	"kubevirt.io/api/migrations"
+	"kubevirt.io/api/plugin"
 	"kubevirt.io/api/pool"
 	"kubevirt.io/api/snapshot"
 
@@ -272,6 +273,8 @@ var _ = Describe("Cluster role and cluster role bindings", func() {
 				Entry(fmt.Sprintf("get, list, watch %s/%s", migrations.GroupName, migrations.ResourceMigrationPolicies), migrations.GroupName, migrations.ResourceMigrationPolicies, "get", "list", "watch"),
 
 				Entry(fmt.Sprintf("get, list, watch %s/%s", backup.GroupName, apiVMBackups), backup.GroupName, apiVMBackups, "get", "list", "watch"),
+
+				Entry(fmt.Sprintf("get, list, watch %s/%s", plugin.GroupName, apiPlugins), plugin.GroupName, apiPlugins, "get", "list", "watch"),
 			)
 		})
 


### PR DESCRIPTION
### What this PR does
#### Before this PR:
The `kubevirt.io:view` ClusterRole has no rules for `plugin.kubevirt.io`.

#### After this PR:
The `kubevirt.io:view` ClusterRole grants `get`, `list`, `watch` on `plugin.kubevirt.io`. Write access remains admin-only.

### References
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/190

### Checklist
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Testing: New unit test entry added
- ~~VEP~~ Not required
- ~~Upgrade~~ No upgrade impact
- ~~Documentation~~ No user-guide update needed
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
Fixed missing RBAC rules for plugin.kubevirt.io in the kubevirt.io:view ClusterRole, restoring cluster-reader access to Plugin resources.
```