### PR TITLE
Quarantine flaky VirtOperatorRESTErrorsBurst sig-monitoring test

### DIFF
--- a/tests/monitoring/component_monitoring.go
+++ b/tests/monitoring/component_monitoring.go
@@ -337,27 +337,28 @@ var _ = Describe("[sig-monitoring]Component Monitoring", Serial, Ordered, decora
 			}, 5*time.Minute, 500*time.Millisecond).Should(Succeed())
 		})
 
-		It("VirtOperatorRESTErrorsBurst should be triggered when requests to virt-operator are failing", func() {
-			By("Restoring the operator")
-			scales.RestoreScale(virtOperator.deploymentName)
+		It("[QUARANTINE] VirtOperatorRESTErrorsBurst should be triggered when requests to virt-operator are failing",
+			decorators.Quarantine, func() {
+				By("Restoring the operator")
+				scales.RestoreScale(virtOperator.deploymentName)
 
-			By("Deleting the operator cluster role binding")
-			err = virtClient.RbacV1().ClusterRoleBindings().Delete(
-				context.Background(), crb.Name, metav1.DeleteOptions{},
-			)
-			Expect(err).ToNot(HaveOccurred())
+				By("Deleting the operator cluster role binding")
+				err = virtClient.RbacV1().ClusterRoleBindings().Delete(
+					context.Background(), crb.Name, metav1.DeleteOptions{},
+				)
+				Expect(err).ToNot(HaveOccurred())
 
-			By("Deleting the operator role binding")
-			err = virtClient.RbacV1().RoleBindings(flags.KubeVirtInstallNamespace).Delete(
-				context.Background(), operatorRoleBindingName, metav1.DeleteOptions{},
-			)
-			Expect(err).ToNot(HaveOccurred())
+				By("Deleting the operator role binding")
+				err = virtClient.RbacV1().RoleBindings(flags.KubeVirtInstallNamespace).Delete(
+					context.Background(), operatorRoleBindingName, metav1.DeleteOptions{},
+				)
+				Expect(err).ToNot(HaveOccurred())
 
-			By("Waiting for the alert to exist")
-			Eventually(func(g Gomega) {
-				g.Expect(libmonitoring.CheckAlertExists(virtClient, virtOperator.restErrorsBurtsAlert)).To(BeTrue())
-			}, 5*time.Minute, 500*time.Millisecond).Should(Succeed())
-		})
+				By("Waiting for the alert to exist")
+				Eventually(func(g Gomega) {
+					g.Expect(libmonitoring.CheckAlertExists(virtClient, virtOperator.restErrorsBurtsAlert)).To(BeTrue())
+				}, 5*time.Minute, 500*time.Millisecond).Should(Succeed())
+			})
 
 		PIt("VirtControllerRESTErrorsBurst should be triggered for virt-controller", func() {
 			checkRESTErrorsBurst(virtClient, "kubevirt-controller", virtController.restErrorsBurtsAlert)


### PR DESCRIPTION
### What this PR does
#### Before this PR:
The `pull-kubevirt-e2e-k8s-1.34-sig-monitoring` job has a 100% failure rate (0/12 runs passing across multiple unrelated PRs since Jun 13) due to two broken tests:

- `VirtOperatorRESTErrorsBurst should be triggered when requests to virt-operator are failing` , consistently times out after 300s waiting for the alert to fire.
- `should contain virt components metrics` , admission webhook rejects VM creation due to memory request (544Mi) exceeding the hardcoded limit (512Mi). This has a fix in #18119 but CI is blocked because the `VirtOperatorRESTErrorsBurst` test is still failing.

#### After this PR:
Quarantines the `VirtOperatorRESTErrorsBurst` test, unblocking CI for the sig-monitoring job on k8s 1.34.

### References
-  #18119  fixes the `should contain virt components metrics` failure

### Special notes for your reviewer
/cc @dhiller 
