### PR TITLE
tests: use productVersion to trigger canary upgrade test

### DIFF
--- a/tests/canary_upgrade_test.go
+++ b/tests/canary_upgrade_test.go
@@ -56,8 +56,8 @@ var _ = Describe("[sig-operator]virt-handler canary upgrade", Serial, decorators
 	var updateTimeout time.Duration
 
 	const (
-		e2eCanaryTestAnnotation = "e2e-canary-test"
-		canaryTestNodeTimeout   = 60
+		e2eCanaryTestProductVersion = "e2e-canary-test"
+		canaryTestNodeTimeout       = 60
 	)
 
 	BeforeEach(func() {
@@ -82,7 +82,7 @@ var _ = Describe("[sig-operator]virt-handler canary upgrade", Serial, decorators
 
 	AfterEach(func() {
 		close(stopCh)
-		patchPayload, err := patch.New(patch.WithReplace("/spec/customizeComponents", originalKV.Spec.CustomizeComponents)).GeneratePayload()
+		patchPayload, err := patch.New(patch.WithReplace("/spec/productVersion", originalKV.Spec.ProductVersion)).GeneratePayload()
 		Expect(err).ToNot(HaveOccurred())
 		_, err = virtCli.KubeVirt(flags.KubeVirtInstallNamespace).Patch(context.Background(), originalKV.Name, types.JSONPatchType, patchPayload, metav1.PatchOptions{})
 		Expect(err).ToNot(HaveOccurred())
@@ -96,21 +96,7 @@ var _ = Describe("[sig-operator]virt-handler canary upgrade", Serial, decorators
 	})
 
 	updateVirtHandler := func() error {
-		testPatch := fmt.Sprintf(`{"spec": { "template": {"metadata": {"annotations": {"%s": "test"}}}}}`,
-			e2eCanaryTestAnnotation)
-
-		ccs := v1.CustomizeComponents{
-			Patches: []v1.CustomizeComponentsPatch{
-				{
-					ResourceName: "virt-handler",
-					ResourceType: "DaemonSet",
-					Type:         v1.StrategicMergePatchType,
-					Patch:        testPatch,
-				},
-			},
-		}
-
-		patchPayload, err := patch.New(patch.WithReplace("/spec/customizeComponents", ccs)).GeneratePayload()
+		patchPayload, err := patch.New(patch.WithAdd("/spec/productVersion", e2eCanaryTestProductVersion)).GeneratePayload()
 		if err != nil {
 			return err
 		}
@@ -188,14 +174,13 @@ var _ = Describe("[sig-operator]virt-handler canary upgrade", Serial, decorators
 			ds, err := virtCli.AppsV1().DaemonSets(flags.KubeVirtInstallNamespace).Get(context.Background(), "virt-handler", metav1.GetOptions{})
 			g.Expect(err).ToNot(HaveOccurred())
 			g.Expect(ds.Status.DesiredNumberScheduled).To(Equal(ds.Status.NumberReady))
-			g.Expect(ds.Spec.Template.Annotations).To(HaveKey(e2eCanaryTestAnnotation))
+			g.Expect(ds.Spec.Template.Labels).To(HaveKeyWithValue(v1.AppVersionLabel, e2eCanaryTestProductVersion))
 
 			podList, err := virtCli.CoreV1().Pods(flags.KubeVirtInstallNamespace).List(context.Background(), metav1.ListOptions{LabelSelector: "kubevirt.io=virt-handler"})
 			g.Expect(err).ToNot(HaveOccurred())
 
 			updatedPods := slices.DeleteFunc(podList.Items, func(pod corev1.Pod) bool {
-				_, exists := pod.Annotations[e2eCanaryTestAnnotation]
-				return !exists
+				return pod.Labels[v1.AppVersionLabel] != e2eCanaryTestProductVersion
 			})
 			g.Expect(updatedPods).To(HaveLen(int(ds.Status.DesiredNumberScheduled)))
 		}, updateTimeout*time.Second, 1*time.Second).Should(Succeed())


### PR DESCRIPTION
### What this PR does
#### Before this PR:

The canary upgrade test (`[sig-operator]virt-handler canary upgrade should successfully upgrade virt-handler`) flakes because it uses `spec.customizeComponents` to trigger the virt-handler rollout. Customize-components-only changes do not alter the `deploymentID` — `getKVMapFromSpec` uses `reflect.Value.String()` on the `CustomizeComponents` struct field, which returns a constant type descriptor regardless of content. Since `PodIsUpToDate` checks version/registry/deploymentID annotations but not the customizer hash, `howManyUpdatedAndReadyPods` considers the old (pre-rollout) pods as up to date. The operator sees all pods ready on its very next reconcile and jumps straight to `successful`, skipping the `increasing` (`maxUnavailable=10%`) phase entirely.

This is confirmed by the virt-operator logs from a [failing job](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/18065/pull-kubevirt-e2e-k8s-1.36-sig-operator/2063988861368799232):

```
14:40:04.485Z daemonSet virt-handler started upgrade (apps.go:242)
14:40:04.729Z daemonSet virt-handler is ready        (apps.go:303)
```

The 244ms gap rules out an actual pod rollout — the DS controller had not replaced any pods yet.

#### After this PR:

The test trigger is changed from `spec.customizeComponents` to `spec.productVersion`. Since `productVersion` is a string field on `KubeVirtSpec`, `getKVMapFromSpec` captures the actual value change into `AdditionalProperties`, which changes the `deploymentID`. With a new deploymentID, `PodIsUpToDate` correctly detects old pods as stale (their `install-strategy-identifier` annotation no longer matches `kv.Status.TargetDeploymentID`), and the operator always goes through the full 3-phase canary sequence: `maxUnavailable=1` → `maxUnavailable=10%` → `maxUnavailable=1`.

The test verifies completion by checking the `app.kubernetes.io/version` label on the DaemonSet pod template and all virt-handler pods.

### References

- Related: #16759 (fixed a different canary race — out-of-band changes lost due to generation/spec tracking)

### Why we need it and why it was done in this way
The following tradeoffs were made:

Changing `productVersion` also triggers rollouts of virt-api and virt-controller (not just virt-handler), since it changes the global deploymentID. The test only watches virt-handler DaemonSet events so this does not interfere with the test assertions.

The following alternatives were considered:

1. **Fix `PodIsUpToDate` to check the customizer hash** — More correct but higher risk, needs separate PR with thorough testing
2. **Include the customizer hash in the deployment ID** — Would fix the systemic issue for customize-components-only changes, but requires restructuring the `util`/`apply` package dependency
3. **Relax the test assertion with end-state guard** — Tolerates the skipped phase but doesn't test the full canary path
4. **Use `spec.productVersion` as the trigger (chosen)** — Changes the deploymentID so PodIsUpToDate works correctly, ensuring the full 3-phase canary sequence is always observed

Links to places where the discussion took place:
- virt-operator logs: https://storage.googleapis.com/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/18065/pull-kubevirt-e2e-k8s-1.36-sig-operator/2063988861368799232/artifacts/k8s-reporter/1/pods/1_kubevirt_virt-operator-7b646765b4-dz6n5-virt-operator.log

### Special notes for your reviewer

The root cause — `getKVMapFromSpec` using `reflect.Value.String()` on struct fields, producing a constant type descriptor regardless of content — means the deploymentID never changes for customize-components-only changes. This affects not just this test but any production scenario where only `spec.customizeComponents` is modified. A follow-up to include the customizer hash in the deploymentID computation should be considered.

### Checklist

- [x] Design: A VEP was not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: This is a test fix
- [x] Documentation: A user-guide update was not required
- [x] Community: Announcement to kubevirt-dev was not required
- [x] AI Contributions: The PR abides by the KubeVirt AI Contribution Policy.

### Release note
```release-note
NONE
```