### PR TITLE
virt-handler: prevent launcher client cache poisoning during VMI deletion

### DIFF
--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -1733,6 +1733,9 @@ func (c *VirtualMachineController) shutdownVMI(vmi *v1.VirtualMachineInstance, c
 func (c *VirtualMachineController) processVmDelete(vmi *v1.VirtualMachineInstance) error {
 
 	// Only attempt to shutdown/destroy if we still have a connection established with the pod.
+	// Always clear the cached client afterward so that a stale entry from a
+	// dying launcher cannot poison the cache for subsequent controllers.
+	defer c.launcherClients.CloseLauncherClient(vmi)
 	client, err := c.launcherClients.GetVerifiedLauncherClient(vmi)
 
 	// If the pod has been torn down, we know the VirtualMachineInstance is down.


### PR DESCRIPTION
Fixes a race condition in `processVmDelete` where a stale launcher client
cache entry survives VMI teardown and poisons the next migration's
target controller, causing it to fail with
"Can not update a VirtualMachineInstance with unresponsive command server."

## Observed failure
[pull-kubevirt-e2e-k8s-1.36-sig-compute-migrations #2066092117217775616](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/18119/pull-kubevirt-e2e-k8s-1.36-sig-compute-migrations/2066092117217775616)
Test `[test_id:1783] should be successfully migrated multiple times` —
Migration 0 completes, Migration 1 never starts. The target pod is
created but the source never begins sending data.


## Root cause
During Migration 0 teardown on the source node, the workqueue
re-enqueues the VMI key (triggered by the domain deletion event).
The second `processVmDelete` call runs `GetVerifiedLauncherClient`,
which discovers the still-lingering socket from the dying
virt-launcher pod and dials it successfully, re-creating a
`LauncherClientInfo` entry with `Ready=true`. The subsequent
`DeleteDomain` RPC fails with `codes.Unavailable` (connection refused
to the now-gone process). Because `IsDisconnected` does not recognize
`codes.Unavailable`, `processVmDelete` returns an error, which skips
`processVmCleanup` — the only place that clears the cache entry.
On the next reconcile, `isVMIOwnedByNode` returns false (the VMI has
moved), so the vm controller stops processing and the poisoned cache
entry becomes permanent. When Migration 1's target controller later
calls `GetLauncherClient`, it gets the stale entry, detects the socket
is gone, and enters the "unresponsive command server" error loop.
## Fix
Defer `CloseLauncherClient` at the top of `processVmDelete` so the
cache entry is always cleared regardless of how the function exits.
This matches the pattern already used in `MigrationTargetController.finalCleanup`
(added in PR #14705).


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
VMs migration from A->B->A occasionally fails

#### After this PR:
migrations work, yay!

### References
 - CI flake [pull-kubevirt-e2e-k8s-1.36-sig-compute-migrations #2066092117217775616](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/18119/pull-kubevirt-e2e-k8s-1.36-sig-compute-migrations/2066092117217775616)

<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```
NONE
```

