### PR TITLE
VEP-141: Graduate LibvirtHooksServerAndClient feature gate to Beta

### DIFF
--- a/pkg/virt-config/featuregate/active.go
+++ b/pkg/virt-config/featuregate/active.go
@@ -71,6 +71,7 @@ const (
 
 	// Owner: @Barakmor1
 	// Alpha: v1.8.0
+	// Beta: v1.9.0
 	//
 	// LibvirtHooksServerAndClient The LibvirtHooksServerAndClient FG enables running pre-migration
 	// hooks on the target virt-launcher pod, allowing domain XML mutations to be applied
@@ -251,7 +252,7 @@ const (
 )
 
 func init() {
-	RegisterFeatureGate(FeatureGate{Name: LibvirtHooksServerAndClient, State: Alpha})
+	RegisterFeatureGate(FeatureGate{Name: LibvirtHooksServerAndClient, State: Beta})
 	RegisterFeatureGate(FeatureGate{Name: ImageVolume, State: Beta})
 	RegisterFeatureGate(FeatureGate{Name: CPUManager, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: IgnitionGate, State: Alpha})

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -549,6 +549,7 @@ var _ = Describe("Template", func() {
 					"--ovmf-path", ovmfPath,
 					"--disk-memory-limit", strconv.Itoa(virtconfig.DefaultDiskVerificationMemoryLimitBytes),
 					"--hypervisor", config.GetHypervisor().Name,
+					"--libvirt-hook-server-and-client",
 				}))
 				Expect(pod.Spec.Containers[1].Name).To(Equal("hook-sidecar-0"))
 				Expect(pod.Spec.Containers[1].Image).To(Equal("some-image:v1"))
@@ -1150,6 +1151,7 @@ var _ = Describe("Template", func() {
 					"--ovmf-path", ovmfPath,
 					"--disk-memory-limit", strconv.Itoa(virtconfig.DefaultDiskVerificationMemoryLimitBytes),
 					"--hypervisor", config.GetHypervisor().Name,
+					"--libvirt-hook-server-and-client",
 				}))
 				Expect(pod.Spec.Containers[1].Name).To(Equal("hook-sidecar-0"))
 				Expect(pod.Spec.Containers[1].Image).To(Equal("some-image:v1"))

--- a/pkg/virt-controller/watch/migration/decentralized.go
+++ b/pkg/virt-controller/watch/migration/decentralized.go
@@ -47,6 +47,7 @@ func (c *Controller) initializeMigrateSourceState(migration *v1.VirtualMachineIn
 	}
 	vmi.Status.MigrationState.SourceState.MigrationUID = migration.UID
 	vmi.Status.MigrationState.SourceState.VirtualMachineInstanceUID = &vmi.UID
+	vmi.Status.MigrationState.SourceState.DomainNamespace = &vmi.Namespace
 
 	vmi.Status.MigrationState.TargetState.SyncAddress = &migration.Spec.SendTo.ConnectURL
 }

--- a/pkg/virt-launcher/premigration-hook-server/cpuhook/BUILD.bazel
+++ b/pkg/virt-launcher/premigration-hook-server/cpuhook/BUILD.bazel
@@ -6,8 +6,10 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/virt-launcher/premigration-hook-server/cpuhook",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/handler-launcher-com/cmd/v1:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//pkg/virt-launcher/virtwrap/converter/types:go_default_library",
+        "//pkg/virt-launcher/virtwrap/converter/vcpu:go_default_library",
         "//pkg/virt-launcher/virtwrap/cpudedicated:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
@@ -25,6 +27,7 @@ go_test(
     race = "on",
     deps = [
         "//pkg/handler-launcher-com/cmd/v1:go_default_library",
+        "//pkg/virt-launcher/virtwrap/converter/types:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",

--- a/pkg/virt-launcher/premigration-hook-server/cpuhook/cpu_hook.go
+++ b/pkg/virt-launcher/premigration-hook-server/cpuhook/cpu_hook.go
@@ -22,19 +22,23 @@ import (
 	"encoding/xml"
 	"fmt"
 
-	convertertypes "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter/types"
-	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/cpudedicated"
-
 	"libvirt.org/go/libvirtxml"
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
 
+	cmdv1 "kubevirt.io/kubevirt/pkg/handler-launcher-com/cmd/v1"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
+	convertertypes "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter/types"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter/vcpu"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/cpudedicated"
 )
 
-// CPUDedicatedHook handles CPU pinning adjustments for dedicated CPU migrations
-func CPUDedicatedHook(_ *convertertypes.ConverterContext, vmi *v1.VirtualMachineInstance, domain *libvirtxml.Domain) error {
+// CPUDedicatedHook handles CPU pinning adjustments for dedicated CPU migrations.
+// It uses the ConverterContext's CPUSet and Topology, which are computed locally
+// on the target pod, instead of relying on VMI status fields that may not be
+// available yet during the hook execution.
+func CPUDedicatedHook(c *convertertypes.ConverterContext, vmi *v1.VirtualMachineInstance, domain *libvirtxml.Domain) error {
 	if !vmi.IsCPUDedicated() {
 		return nil
 	}
@@ -51,7 +55,7 @@ func CPUDedicatedHook(_ *convertertypes.ConverterContext, vmi *v1.VirtualMachine
 		return fmt.Errorf("failed to unmarshal XML to api.DomainSpec: %w", err)
 	}
 
-	processedDomain, err := cpudedicated.GenerateDomainForTargetCPUSetAndTopology(vmi, &apiDomainSpec)
+	processedDomain, err := generateDomainForTargetCPU(vmi, &apiDomainSpec, c.Topology, c.CPUSet)
 	if err != nil {
 		return fmt.Errorf("failed to generate domain for target CPU set and topology: %w", err)
 	}
@@ -62,4 +66,27 @@ func CPUDedicatedHook(_ *convertertypes.ConverterContext, vmi *v1.VirtualMachine
 
 	log.Log.Object(vmi).Info("cpuDedicatedHook: CPU dedicated processing completed")
 	return nil
+}
+
+func generateDomainForTargetCPU(vmi *v1.VirtualMachineInstance, domSpec *api.DomainSpec, topology *cmdv1.Topology, cpuSet []int) (*api.Domain, error) {
+	domain := api.NewMinimalDomain(vmi.Name)
+	domain.Spec = *domSpec
+	cpuTopology := vcpu.GetCPUTopology(vmi)
+	cpuCount := vcpu.CalculateRequestedVCPUs(cpuTopology)
+
+	vmiCPU := vmi.Spec.Domain.CPU
+	if vmiCPU != nil && vmiCPU.MaxSockets != 0 {
+		cpuTopology.Sockets = vmiCPU.MaxSockets
+		cpuCount = vcpu.CalculateRequestedVCPUs(cpuTopology)
+	}
+	domain.Spec.CPU.Topology = cpuTopology
+	domain.Spec.VCPU = &api.VCPU{
+		Placement: "static",
+		CPUs:      cpuCount,
+	}
+	if err := vcpu.AdjustDomainForTopologyAndCPUSet(domain, vmi, topology, cpuSet); err != nil {
+		return nil, err
+	}
+
+	return domain, nil
 }

--- a/pkg/virt-launcher/premigration-hook-server/cpuhook/cpu_hook_test.go
+++ b/pkg/virt-launcher/premigration-hook-server/cpuhook/cpu_hook_test.go
@@ -19,8 +19,6 @@
 package cpuhook
 
 import (
-	"encoding/json"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"libvirt.org/go/libvirtxml"
@@ -28,6 +26,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 
 	cmdv1 "kubevirt.io/kubevirt/pkg/handler-launcher-com/cmd/v1"
+	convertertypes "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter/types"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -71,7 +70,7 @@ var _ = Describe("Premigration Hook Server", func() {
 				},
 			}
 
-			By("making up a target topology")
+			By("making up a target topology and CPU set")
 			topology := &cmdv1.Topology{NumaCells: []*cmdv1.Cell{{
 				Id: 0,
 				Cpus: []*cmdv1.CPU{
@@ -85,22 +84,18 @@ var _ = Describe("Premigration Hook Server", func() {
 					},
 				},
 			}}}
-			targetNodeTopology, err := json.Marshal(topology)
-			Expect(err).NotTo(HaveOccurred(), "failed to marshall the topology")
-
-			By("saving that topology in the migration state of the VMI")
-			vmi.Status.MigrationState = &v1.VirtualMachineInstanceMigrationState{
-				TargetCPUSet:       []int{6, 7},
-				TargetNodeTopology: string(targetNodeTopology),
+			c := &convertertypes.ConverterContext{
+				CPUSet:   []int{6, 7},
+				Topology: topology,
 			}
 
 			By("parsing the input domain XML")
 			var domain libvirtxml.Domain
-			err = domain.Unmarshal(domXML)
+			err := domain.Unmarshal(domXML)
 			Expect(err).NotTo(HaveOccurred(), "failed to parse input domain XML")
 
 			By("running the CPU dedicated hook")
-			err = CPUDedicatedHook(nil, vmi, &domain)
+			err = CPUDedicatedHook(c, vmi, &domain)
 			Expect(err).NotTo(HaveOccurred(), "failed to modify domain")
 
 			By("marshaling the modified domain back to XML")

--- a/pkg/virt-launcher/premigration-hook-server/disk/source_path.go
+++ b/pkg/virt-launcher/premigration-hook-server/disk/source_path.go
@@ -30,7 +30,7 @@ import (
 )
 
 // DiskSourcePathHook updates disk source file paths in the domain XML by
-// replacing the VMI namespace with the target domain namespace.
+// replacing the source domain namespace with the target domain namespace.
 // This is the target-side equivalent of the source-side
 // updateFilePathsToNewDomain() + convertDisks() functions.
 func DiskSourcePathHook(_ *convertertypes.ConverterContext, vmi *v1.VirtualMachineInstance, domain *libvirtxml.Domain) error {
@@ -38,12 +38,13 @@ func DiskSourcePathHook(_ *convertertypes.ConverterContext, vmi *v1.VirtualMachi
 		return nil
 	}
 
+	sourceDomainNamespace := getSourceDomainNamespace(vmi)
 	targetDomainNamespace := getTargetDomainNamespace(vmi)
-	if targetDomainNamespace == "" || targetDomainNamespace == vmi.Namespace {
+	if targetDomainNamespace == "" || sourceDomainNamespace == targetDomainNamespace {
 		return nil
 	}
 
-	oldSegment := "/" + vmi.Namespace + "/"
+	oldSegment := "/" + sourceDomainNamespace + "/"
 	newSegment := "/" + targetDomainNamespace + "/"
 
 	for i := range domain.Devices.Disks {
@@ -68,6 +69,15 @@ func DiskSourcePathHook(_ *convertertypes.ConverterContext, vmi *v1.VirtualMachi
 	}
 
 	return nil
+}
+
+func getSourceDomainNamespace(vmi *v1.VirtualMachineInstance) string {
+	if vmi.Status.MigrationState != nil &&
+		vmi.Status.MigrationState.SourceState != nil &&
+		vmi.Status.MigrationState.SourceState.DomainNamespace != nil {
+		return *vmi.Status.MigrationState.SourceState.DomainNamespace
+	}
+	return vmi.Namespace
 }
 
 func getTargetDomainNamespace(vmi *v1.VirtualMachineInstance) string {

--- a/pkg/virt-launcher/premigration-hook-server/disk/source_path_test.go
+++ b/pkg/virt-launcher/premigration-hook-server/disk/source_path_test.go
@@ -43,11 +43,17 @@ var _ = Describe("DiskSourcePathHook", func() {
 	var vmi *v1.VirtualMachineInstance
 
 	BeforeEach(func() {
+		sourceNs := sourceNamespace
 		targetNs := targetNamespace
 		vmi = libvmi.New(
 			libvmi.WithNamespace(sourceNamespace),
 			libvmistatus.WithStatus(libvmistatus.New(
 				libvmistatus.WithMigrationState(v1.VirtualMachineInstanceMigrationState{
+					SourceState: &v1.VirtualMachineInstanceMigrationSourceState{
+						VirtualMachineInstanceCommonMigrationState: v1.VirtualMachineInstanceCommonMigrationState{
+							DomainNamespace: &sourceNs,
+						},
+					},
 					TargetState: &v1.VirtualMachineInstanceMigrationTargetState{
 						VirtualMachineInstanceCommonMigrationState: v1.VirtualMachineInstanceCommonMigrationState{
 							DomainNamespace: &targetNs,


### PR DESCRIPTION
Promote the LibvirtHooksServerAndClient feature gate from Alpha to
Beta for v1.9.0. Beta feature gates are enabled by default.

## VEP Reference
https://github.com/kubevirt/enhancements/issues/141

### Why we need it and why it was done in this way
All target-side pre-migration hooks are now implemented and covered
by existing tests. The feature is ready for broader adoption.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

The 3rd commit removes the dependency on `vmi.Status.MigrationState.TargetCPUSet` and `vmi.Status.MigrationState.TargetNodeTopology` in the CPU dedicated hook.

These fields aren't available to the target-side hook because in `sync()`, `processVMI()` (which starts the hook server) runs before `updateStatus() `(which sets these fields). Previously, `processVMI()` ran on every reconcile, so on the second reconcile it would call `SyncMigrationTarget` again with the updated VMI. [This early return](https://github.com/kubevirt/kubevirt/blob/main/pkg/virt-handler/migration-target.go#L771-L774), introduced in PR #15117, prevents `processVMI` from running a second time, so the hook server never receives the updated VMI with those fields populated.

Instead of adding VMI status synchronization to restore the previous behavior, this commit reads the CPU set and topology directly from the `ConverterContext`, which is generated locally on the target pod. This is aligned with the expected deprecation of these fields as part of VEP-141 post-GA requirements and leads to a cleaner solution.

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

