### PR TITLE
VEP-156: Graduate VmiMemoryOverheadReport feature gate to Beta

### DIFF
--- a/pkg/virt-config/featuregate/active.go
+++ b/pkg/virt-config/featuregate/active.go
@@ -187,6 +187,7 @@ const (
 
 	// Owner: @bmordeha
 	// Alpha: v1.8.0
+	// Beta: v1.9.0
 	//
 	// VmiMemoryOverheadReport enables reporting the memory overhead in the VMI status.
 	// When enabled, the memory overhead is calculated and set in the VMI status.Memory.MemoryOverhead field.
@@ -279,7 +280,7 @@ func init() {
 	RegisterFeatureGate(FeatureGate{Name: ExternalNetResourceInjection, State: Beta})
 	RegisterFeatureGate(FeatureGate{Name: RebootPolicy, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: Template, State: Alpha})
-	RegisterFeatureGate(FeatureGate{Name: VmiMemoryOverheadReport, State: Alpha})
+	RegisterFeatureGate(FeatureGate{Name: VmiMemoryOverheadReport, State: Beta})
 	RegisterFeatureGate(FeatureGate{Name: ContainerPathVolumesGate, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: ReservedOverheadMemlock, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: OptOutRoleAggregation, State: Alpha})

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -514,14 +514,15 @@ var _ = Describe("Template", func() {
 					v1.DeprecatedVirtualMachineNameLabel: "testvmi",
 					v1.VirtualMachineInstanceIDLabel:     "testvmi",
 				}))
-				Expect(pod.ObjectMeta.Annotations).To(Equal(map[string]string{
-					v1.DomainAnnotation:                                  "testvmi",
-					"test":                                               "shouldBeInPod",
-					hooks.HookSidecarListAnnotationName:                  `[{"image": "some-image:v1", "imagePullPolicy": "IfNotPresent"}]`,
-					"kubevirt.io/migrationTransportUnix":                 "true",
-					"kubectl.kubernetes.io/default-container":            "compute",
-					"descheduler.alpha.kubernetes.io/request-evict-only": "",
-				}))
+				Expect(pod.ObjectMeta.Annotations).To(And(
+					HaveKeyWithValue(v1.DomainAnnotation, "testvmi"),
+					HaveKeyWithValue("test", "shouldBeInPod"),
+					HaveKeyWithValue(hooks.HookSidecarListAnnotationName, `[{"image": "some-image:v1", "imagePullPolicy": "IfNotPresent"}]`),
+					HaveKeyWithValue("kubevirt.io/migrationTransportUnix", "true"),
+					HaveKeyWithValue("kubectl.kubernetes.io/default-container", "compute"),
+					HaveKeyWithValue("descheduler.alpha.kubernetes.io/request-evict-only", ""),
+					HaveKey(v1.MemoryOverheadAnnotationBytes),
+				))
 				Expect(pod.ObjectMeta.OwnerReferences).To(Equal([]metav1.OwnerReference{{
 					APIVersion:         v1.VirtualMachineInstanceGroupVersionKind.GroupVersion().String(),
 					Kind:               v1.VirtualMachineInstanceGroupVersionKind.Kind,


### PR DESCRIPTION
Promote the VmiMemoryOverheadReport feature gate from Alpha to
Beta for v1.9.0. Beta feature gates are enabled by default.

## VEP Reference
https://github.com/kubevirt/enhancements/issues/156

### Why we need it and why it was done in this way
The VmiMemoryOverheadReport feature has been in Alpha since v1.8.0
and is ready for broader adoption.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

