### PR TITLE
Decouple Storage and Network validation from VMI Create, VMs and VMIRS Admitters

### DIFF
--- a/pkg/storage/admitters/vmi-storage-admitter.go
+++ b/pkg/storage/admitters/vmi-storage-admitter.go
@@ -26,11 +26,9 @@ import (
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 )
 
-func Validate(field *k8sfield.Path, vmiSpec *v1.VirtualMachineInstanceSpec, clusterCfg *virtconfig.ClusterConfig) []metav1.StatusCause {
+func ValidateVMISpec(field *k8sfield.Path, vmiSpec *v1.VirtualMachineInstanceSpec, _ *virtconfig.ClusterConfig) []metav1.StatusCause {
 	var causes []metav1.StatusCause
 
-	causes = append(causes, ValidateContainerDisks(field, vmiSpec)...)
-	causes = append(causes, ValidateUtilityVolumesNotPresentOnCreation(field, vmiSpec)...)
 	causes = append(causes, ValidateDisks(field.Child("domain", "devices", "disks"), vmiSpec.Domain.Devices.Disks)...)
 
 	return causes

--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -989,20 +989,42 @@ func (app *virtAPIApp) registerValidatingWebhooks(informers *webhooks.Informers)
 				return netadmitter.Validate(field, spec, config)
 			},
 			// SIG-Storage
-			storageadmitters.Validate,
+			storageadmitters.ValidateVMISpec,
 		)
 	})
 	http.HandleFunc(components.VMIUpdateValidatePath, func(w http.ResponseWriter, r *http.Request) {
 		validating_webhook.ServeVMIUpdate(w, r, app.clusterConfig, app.kubeVirtServiceAccounts)
 	})
 	http.HandleFunc(components.VMValidatePath, func(w http.ResponseWriter, r *http.Request) {
-		validating_webhook.ServeVMs(w, r, app.clusterConfig, app.virtCli, informers, app.kubeVirtServiceAccounts)
+		validating_webhook.ServeVMs(w, r, app.clusterConfig, app.virtCli, informers, app.kubeVirtServiceAccounts,
+			// SIG-Network
+			func(field *field.Path, spec *v1.VirtualMachineInstanceSpec, config *virtconfig.ClusterConfig) []metav1.StatusCause {
+				return netadmitter.Validate(field, spec, config)
+			},
+			// SIG-Storage
+			storageadmitters.ValidateVMISpec,
+		)
+
 	})
 	http.HandleFunc(components.VMIRSValidatePath, func(w http.ResponseWriter, r *http.Request) {
-		validating_webhook.ServeVMIRS(w, r, app.clusterConfig)
+		validating_webhook.ServeVMIRS(w, r, app.clusterConfig,
+			// SIG-Network
+			func(field *field.Path, spec *v1.VirtualMachineInstanceSpec, config *virtconfig.ClusterConfig) []metav1.StatusCause {
+				return netadmitter.Validate(field, spec, config)
+			},
+			// SIG-Storage
+			storageadmitters.ValidateVMISpec,
+		)
 	})
 	http.HandleFunc(components.VMPoolValidatePath, func(w http.ResponseWriter, r *http.Request) {
-		validating_webhook.ServeVMPool(w, r, app.clusterConfig, app.kubeVirtServiceAccounts)
+		validating_webhook.ServeVMPool(w, r, app.clusterConfig, app.kubeVirtServiceAccounts,
+			// SIG-Network
+			func(field *field.Path, spec *v1.VirtualMachineInstanceSpec, config *virtconfig.ClusterConfig) []metav1.StatusCause {
+				return netadmitter.Validate(field, spec, config)
+			},
+			// SIG-Storage
+			storageadmitters.ValidateVMISpec,
+		)
 	})
 	http.HandleFunc(components.VMIPresetValidatePath, func(w http.ResponseWriter, r *http.Request) {
 		validating_webhook.ServeVMIPreset(w, r)

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -40,7 +40,6 @@ import (
 	"kubevirt.io/kubevirt/pkg/downwardmetrics"
 	draadmitter "kubevirt.io/kubevirt/pkg/dra/admitter"
 	"kubevirt.io/kubevirt/pkg/hooks"
-	netadmitter "kubevirt.io/kubevirt/pkg/network/admitter"
 	"kubevirt.io/kubevirt/pkg/network/vmispec"
 	storageadmitters "kubevirt.io/kubevirt/pkg/storage/admitters"
 	"kubevirt.io/kubevirt/pkg/storage/reservation"
@@ -196,9 +195,6 @@ func ValidateVirtualMachineInstanceSpec(field *k8sfield.Path, spec *v1.VirtualMa
 	causes = append(causes, validateRealtime(field, spec)...)
 	causes = append(causes, validateSpecAffinity(field, spec)...)
 	causes = append(causes, validateSpecTopologySpreadConstraints(field, spec)...)
-
-	netValidator := netadmitter.NewValidator(field, spec, config)
-	causes = append(causes, netValidator.Validate()...)
 
 	causes = append(causes, draadmitter.ValidateCreation(field, spec, config)...)
 
@@ -1471,7 +1467,6 @@ func smmFeatureEnabled(features *v1.Features) bool {
 func validateDomainSpec(field *k8sfield.Path, spec *v1.DomainSpec) []metav1.StatusCause {
 	var causes []metav1.StatusCause
 
-	causes = append(causes, storageadmitters.ValidateDisks(field.Child("devices").Child("disks"), spec.Devices.Disks)...)
 	causes = append(causes, validateFirmware(field.Child("firmware"), spec.Firmware)...)
 
 	// TDX uses stateless firmware with Secure Boot keys embedded in the ROM;

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -700,44 +700,6 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			Expect(causes[0].Field).To(Equal("fake.domain.volumes[0].name"))
 		})
 
-		It("should reject multiple disks referencing same volume", func() {
-			// verify two disks referencing the same volume are rejected
-			vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
-				Name: "testdisk",
-			})
-			vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
-				Name: "testdisk",
-			})
-
-			vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
-				Name: "testdisk",
-				VolumeSource: v1.VolumeSource{
-					ContainerDisk: testutils.NewFakeContainerDiskSource(),
-				},
-			})
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			Expect(causes).To(HaveLen(1))
-			Expect(causes[0].Field).To(Equal("fake.domain.devices.disks[1].name"))
-		})
-
-		It("should generate multiple causes", func() {
-			vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
-				Name: "testdisk",
-				DiskDevice: v1.DiskDevice{
-					Disk: &v1.DiskTarget{},
-					LUN: &v1.LunTarget{
-						Bus: v1.DiskBusSCSI,
-					},
-				},
-			})
-
-			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
-			// missing volume and multiple targets set. should result in 2 causes
-			Expect(causes).To(HaveLen(2))
-			Expect(causes[0].Field).To(Equal("fake.domain.devices.disks[0].name"))
-			Expect(causes[1].Field).To(Equal("fake.domain.devices.disks[0]"))
-		})
-
 		DescribeTable("should verify input device",
 			func(input v1.Input, expectedErrors int, expectedErrorTypes []string, expectMessage string) {
 				vmi.Spec.Domain.Devices.Inputs = append(vmi.Spec.Domain.Devices.Inputs, input)

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmirs-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmirs-admitter.go
@@ -38,7 +38,8 @@ import (
 )
 
 type VMIRSAdmitter struct {
-	ClusterConfig *virtconfig.ClusterConfig
+	ClusterConfig  *virtconfig.ClusterConfig
+	SpecValidators []SpecValidator
 }
 
 func (admitter *VMIRSAdmitter) Admit(_ context.Context, ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
@@ -60,6 +61,10 @@ func (admitter *VMIRSAdmitter) Admit(_ context.Context, ar *admissionv1.Admissio
 	}
 
 	causes := ValidateVMIRSSpec(k8sfield.NewPath("spec"), &vmirs.Spec, admitter.ClusterConfig)
+
+	for _, validator := range admitter.SpecValidators {
+		causes = append(causes, validator(k8sfield.NewPath("spec", "template", "spec"), &vmirs.Spec.Template.Spec, admitter.ClusterConfig)...)
+	}
 
 	if ar.Request.Operation == admissionv1.Create {
 		clusterCfg := admitter.ClusterConfig.GetConfig()

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmirs-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmirs-admitter_test.go
@@ -28,6 +28,7 @@ import (
 	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
 
 	"kubevirt.io/client-go/api"
 
@@ -35,6 +36,7 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/testutils"
 	"kubevirt.io/kubevirt/pkg/virt-api/webhooks"
+	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 )
 
 var _ = Describe("Validating VMIRS Admitter", func() {
@@ -140,6 +142,41 @@ var _ = Describe("Validating VMIRS Admitter", func() {
 
 		resp := vmirsAdmitter.Admit(context.Background(), ar)
 		Expect(resp.Allowed).To(BeTrue())
+	})
+	It("should invoke injected SpecValidators", func() {
+		called := false
+		stub := func(field *k8sfield.Path, spec *v1.VirtualMachineInstanceSpec, config *virtconfig.ClusterConfig) []metav1.StatusCause {
+			called = true
+			return nil
+		}
+
+		vmirs := &v1.VirtualMachineInstanceReplicaSet{
+			Spec: v1.VirtualMachineInstanceReplicaSetSpec{
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"match": "me"},
+				},
+				Template: newVirtualMachineBuilder().
+					WithDisk(v1.Disk{Name: "testdisk"}).
+					WithVolume(v1.Volume{
+						Name:         "testdisk",
+						VolumeSource: v1.VolumeSource{ContainerDisk: testutils.NewFakeContainerDiskSource()},
+					}).
+					WithLabel("match", "me").
+					BuildTemplate(),
+			},
+		}
+		vmirsBytes, _ := json.Marshal(&vmirs)
+
+		ar := &admissionv1.AdmissionReview{
+			Request: &admissionv1.AdmissionRequest{
+				Resource: webhooks.VirtualMachineInstanceReplicaSetGroupVersionResource,
+				Object:   runtime.RawExtension{Raw: vmirsBytes},
+			},
+		}
+
+		admitter := &VMIRSAdmitter{ClusterConfig: config, SpecValidators: []SpecValidator{stub}}
+		admitter.Admit(context.Background(), ar)
+		Expect(called).To(BeTrue())
 	})
 })
 

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmpool-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmpool-admitter.go
@@ -45,6 +45,7 @@ import (
 type VMPoolAdmitter struct {
 	ClusterConfig           *virtconfig.ClusterConfig
 	KubeVirtServiceAccounts map[string]struct{}
+	SpecValidators          []SpecValidator
 }
 
 func (admitter *VMPoolAdmitter) Admit(_ context.Context, ar *admissionv1.AdmissionReview) *admissionv1.AdmissionResponse {
@@ -83,6 +84,10 @@ func (admitter *VMPoolAdmitter) Admit(_ context.Context, ar *admissionv1.Admissi
 
 	_, isKubeVirtServiceAccount := admitter.KubeVirtServiceAccounts[ar.Request.UserInfo.Username]
 	causes := ValidateVMPoolSpec(ar, k8sfield.NewPath("spec"), &pool, admitter.ClusterConfig, isKubeVirtServiceAccount)
+
+	for _, validator := range admitter.SpecValidators {
+		causes = append(causes, validator(k8sfield.NewPath("spec", "virtualMachineTemplate", "spec", "template", "spec"), &pool.Spec.VirtualMachineTemplate.Spec.Template.Spec, admitter.ClusterConfig)...)
+	}
 
 	if ar.Request.Operation == admissionv1.Create {
 		clusterCfg := admitter.ClusterConfig.GetConfig()

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmpool-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmpool-admitter_test.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
+	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
 	v1 "kubevirt.io/api/core/v1"
 	virtv1 "kubevirt.io/api/core/v1"
 	poolv1 "kubevirt.io/api/pool/v1alpha1"
@@ -37,6 +38,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/pointer"
 	"kubevirt.io/kubevirt/pkg/testutils"
 	"kubevirt.io/kubevirt/pkg/virt-api/webhooks"
+	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 )
 
 var _ = Describe("Validating Pool Admitter", func() {
@@ -316,5 +318,26 @@ var _ = Describe("Validating Pool Admitter", func() {
 
 		resp := poolAdmitter.Admit(context.Background(), ar)
 		Expect(resp.Allowed).To(BeTrue())
+	})
+	It("should invoke injected SpecValidators", func() {
+		called := false
+		stub := func(field *k8sfield.Path, spec *v1.VirtualMachineInstanceSpec, config *virtconfig.ClusterConfig) []metav1.StatusCause {
+			called = true
+			return nil
+		}
+
+		pool := newValidVMPool()
+		poolBytes, _ := json.Marshal(&pool)
+
+		ar := &admissionv1.AdmissionReview{
+			Request: &admissionv1.AdmissionRequest{
+				Resource: webhooks.VirtualMachinePoolGroupVersionResource,
+				Object:   runtime.RawExtension{Raw: poolBytes},
+			},
+		}
+
+		admitter := &VMPoolAdmitter{ClusterConfig: config, SpecValidators: []SpecValidator{stub}}
+		admitter.Admit(context.Background(), ar)
+		Expect(called).To(BeTrue())
 	})
 })

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
@@ -41,7 +41,6 @@ import (
 	instancetypeWebhooks "kubevirt.io/kubevirt/pkg/instancetype/webhooks/vm"
 	"kubevirt.io/kubevirt/pkg/liveupdate/memory"
 	metrics "kubevirt.io/kubevirt/pkg/monitoring/metrics/virt-api"
-	netadmitter "kubevirt.io/kubevirt/pkg/network/admitter"
 	storageadmitters "kubevirt.io/kubevirt/pkg/storage/admitters"
 	migrationutil "kubevirt.io/kubevirt/pkg/util/migrations"
 	webhookutils "kubevirt.io/kubevirt/pkg/util/webhooks"
@@ -71,9 +70,10 @@ type VMsAdmitter struct {
 	InstancetypeAdmitter    instancetypeVMsAdmitter
 	ClusterConfig           *virtconfig.ClusterConfig
 	KubeVirtServiceAccounts map[string]struct{}
+	SpecValidators          []SpecValidator
 }
 
-func NewVMsAdmitter(clusterConfig *virtconfig.ClusterConfig, client kubecli.KubevirtClient, informers *webhooks.Informers, kubeVirtServiceAccounts map[string]struct{}) *VMsAdmitter {
+func NewVMsAdmitter(clusterConfig *virtconfig.ClusterConfig, client kubecli.KubevirtClient, informers *webhooks.Informers, kubeVirtServiceAccounts map[string]struct{}, specValidators ...SpecValidator) *VMsAdmitter {
 	return &VMsAdmitter{
 		VirtClient:              client,
 		DataSourceInformer:      informers.DataSourceInformer,
@@ -81,6 +81,7 @@ func NewVMsAdmitter(clusterConfig *virtconfig.ClusterConfig, client kubecli.Kube
 		InstancetypeAdmitter:    instancetypeWebhooks.NewAdmitter(client),
 		ClusterConfig:           clusterConfig,
 		KubeVirtServiceAccounts: kubeVirtServiceAccounts,
+		SpecValidators:          specValidators,
 	}
 }
 
@@ -139,15 +140,13 @@ func (admitter *VMsAdmitter) Admit(ctx context.Context, ar *admissionv1.Admissio
 				return webhookutils.ToAdmissionResponse(causes)
 			}
 		}
-
-		netValidator := netadmitter.NewValidator(k8sfield.NewPath("spec"), &vmCopy.Spec.Template.Spec, admitter.ClusterConfig)
-		if causes = netValidator.ValidateCreation(); len(causes) > 0 {
-			return webhookutils.ToAdmissionResponse(causes)
-		}
 	}
 
 	_, isKubeVirtServiceAccount := admitter.KubeVirtServiceAccounts[ar.Request.UserInfo.Username]
 	causes = ValidateVirtualMachineSpec(k8sfield.NewPath("spec"), &vmCopy.Spec, admitter.ClusterConfig, isKubeVirtServiceAccount)
+	for _, validator := range admitter.SpecValidators {
+		causes = append(causes, validator(k8sfield.NewPath("spec", "template", "spec"), &vmCopy.Spec.Template.Spec, admitter.ClusterConfig)...)
+	}
 	if len(causes) > 0 {
 		return webhookutils.ToAdmissionResponse(causes)
 	}
@@ -436,6 +435,9 @@ func (admitter *VMsAdmitter) validateVolumeRequests(ctx context.Context, vm *v1.
 
 	// this simulates injecting the changes into the VMI template and validates it will work.
 	causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("spec", "template", "spec"), newSpec, admitter.ClusterConfig)
+	for _, validator := range admitter.SpecValidators {
+		causes = append(causes, validator(k8sfield.NewPath("spec", "template", "spec"), newSpec, admitter.ClusterConfig)...)
+	}
 	if len(causes) > 0 {
 		return causes, nil
 	}
@@ -443,6 +445,9 @@ func (admitter *VMsAdmitter) validateVolumeRequests(ctx context.Context, vm *v1.
 	// This simulates injecting the changes directly into the vmi, if the vmi exists
 	if vmiExists {
 		causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("spec", "template", "spec"), &vmi.Spec, admitter.ClusterConfig)
+		for _, validator := range admitter.SpecValidators {
+			causes = append(causes, validator(k8sfield.NewPath("spec", "template", "spec"), &vmi.Spec, admitter.ClusterConfig)...)
+		}
 		if len(causes) > 0 {
 			return causes, nil
 		}

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter_test.go
@@ -53,6 +53,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/pointer"
 	"kubevirt.io/kubevirt/pkg/testutils"
 	"kubevirt.io/kubevirt/pkg/virt-api/webhooks"
+	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 )
 
@@ -1587,6 +1588,37 @@ var _ = Describe("Validating VM Admitter", func() {
 		Expect(resp.Result.Details.Causes).To(HaveLen(1))
 		Expect(resp.Result.Details.Causes[0].Type).To(Equal(metav1.CauseTypeFieldValueNotSupported))
 		Expect(resp.Result.Details.Causes[0].Message).To(Equal(fgMessage))
+	})
+
+	It("should invoke injected SpecValidators", func() {
+		called := false
+		stub := func(field *k8sfield.Path, spec *v1.VirtualMachineInstanceSpec, config *virtconfig.ClusterConfig) []metav1.StatusCause {
+			called = true
+			return nil
+		}
+		vmsAdmitter.SpecValidators = []SpecValidator{stub}
+
+		vmi := api.NewMinimalVMI("testvmi")
+		vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
+			Name: "testdisk",
+		})
+		vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
+			Name: "testdisk",
+			VolumeSource: v1.VolumeSource{
+				ContainerDisk: testutils.NewFakeContainerDiskSource(),
+			},
+		})
+		vm := &v1.VirtualMachine{
+			Spec: v1.VirtualMachineSpec{
+				Running: pointer.P(false),
+				Template: &v1.VirtualMachineInstanceTemplateSpec{
+					Spec: vmi.Spec,
+				},
+			},
+		}
+
+		admitVm(vmsAdmitter, vm)
+		Expect(called).To(BeTrue())
 	})
 
 	Context("run strategy", func() {

--- a/pkg/virt-api/webhooks/validating-webhook/validating-webhook.go
+++ b/pkg/virt-api/webhooks/validating-webhook/validating-webhook.go
@@ -58,18 +58,22 @@ func ServeVMs(
 	virtCli kubecli.KubevirtClient,
 	informers *webhooks.Informers,
 	kubeVirtServiceAccounts map[string]struct{},
+	specValidators ...admitters.SpecValidator,
 ) {
-	validating_webhooks.Serve(resp, req, admitters.NewVMsAdmitter(clusterConfig, virtCli, informers, kubeVirtServiceAccounts))
+	validating_webhooks.Serve(resp, req, admitters.NewVMsAdmitter(clusterConfig, virtCli, informers, kubeVirtServiceAccounts, specValidators...))
 }
 
-func ServeVMIRS(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig) {
-	validating_webhooks.Serve(resp, req, &admitters.VMIRSAdmitter{ClusterConfig: clusterConfig})
+func ServeVMIRS(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig, specValidators ...admitters.SpecValidator) {
+	validating_webhooks.Serve(resp, req, &admitters.VMIRSAdmitter{ClusterConfig: clusterConfig, SpecValidators: specValidators})
 }
 
-func ServeVMPool(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig, kubeVirtServiceAccounts map[string]struct{}) {
-	validating_webhooks.Serve(resp, req, &admitters.VMPoolAdmitter{ClusterConfig: clusterConfig, KubeVirtServiceAccounts: kubeVirtServiceAccounts})
+func ServeVMPool(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig, kubeVirtServiceAccounts map[string]struct{}, specValidators ...admitters.SpecValidator) {
+	validating_webhooks.Serve(resp, req, &admitters.VMPoolAdmitter{
+		ClusterConfig:           clusterConfig,
+		KubeVirtServiceAccounts: kubeVirtServiceAccounts,
+		SpecValidators:          specValidators,
+	})
 }
-
 func ServeVMIPreset(resp http.ResponseWriter, req *http.Request) {
 	validating_webhooks.Serve(resp, req, &admitters.VMIPresetAdmitter{})
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
SIG-Network and SIG-Storage validation was hardcoded inside `ValidateVirtualMachineInstanceSpec`, tightly coupling core webhook logic with SIG-specific validation in the VM and VMIRS admitters.
#### After this PR:
VM and VMIRS webhook paths inject SIG-Network and SIG-Storage validators via the `SpecValidators` registry, matching the pattern established in #17241 for the VMICreate path.
### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
- Partially addresses #17226
- Follows up on #17241
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
Completing the decoupling discussed in #17241 once all three paths go through the registry, direct SIG-specific calls inside `ValidateVirtualMachineInstanceSpec` can be safely removed. Same variadic `specValidators` pattern used across all VMI webhook paths for consistency.

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: #17241  <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
Depends on #17241 merging first.
<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

