### PR TITLE
Use per-key JSON Patch operations for VMI map fields to fix migration race

### DIFF
--- a/pkg/apimachinery/patch/patch.go
+++ b/pkg/apimachinery/patch/patch.go
@@ -20,8 +20,10 @@
 package patch
 
 import (
+	"cmp"
 	"encoding/json"
 	"fmt"
+	"slices"
 	"strings"
 )
 
@@ -180,4 +182,57 @@ func UnmarshalPatch(patch []byte) ([]PatchOperation, error) {
 func EscapeJSONPointer(ptr string) string {
 	s := strings.ReplaceAll(ptr, "~", "~0")
 	return strings.ReplaceAll(s, "/", "~1")
+}
+
+// GeneratePerKeyMapPatches produces per-key JSON Patch operations for map diffs.
+// A whole-map test+replace fails if ANY key was concurrently modified, even keys
+// unrelated to the change. Per-key operations narrow the conflict surface to only
+// the individual keys being changed:
+//   - Added keys use "add" (no test, so no conflict possible)
+//   - Removed keys use "remove"
+//   - Modified keys use "test"+"replace" on the specific key only
+//
+// When oldMap is nil/empty, a test guards against concurrent writers before
+// adding the new map. Keys are sorted for deterministic patch output.
+func GeneratePerKeyMapPatches[K ~string, V comparable](basePath string, oldMap, newMap map[K]V) []PatchOption {
+	if len(oldMap) == 0 {
+		return []PatchOption{
+			WithTest(basePath, oldMap),
+			WithAdd(basePath, newMap),
+		}
+	}
+
+	var opts []PatchOption
+
+	for _, key := range sortedKeys(oldMap) {
+		keyPath := basePath + "/" + EscapeJSONPointer(string(key))
+		newVal, exists := newMap[key]
+		switch {
+		case !exists:
+			opts = append(opts, WithRemove(keyPath))
+		case oldMap[key] != newVal:
+			opts = append(opts,
+				WithTest(keyPath, oldMap[key]),
+				WithReplace(keyPath, newVal),
+			)
+		}
+	}
+
+	for _, key := range sortedKeys(newMap) {
+		if _, exists := oldMap[key]; !exists {
+			keyPath := basePath + "/" + EscapeJSONPointer(string(key))
+			opts = append(opts, WithAdd(keyPath, newMap[key]))
+		}
+	}
+
+	return opts
+}
+
+func sortedKeys[K ~string, V any](m map[K]V) []K {
+	keys := make([]K, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	slices.SortFunc(keys, func(a, b K) int { return cmp.Compare(string(a), string(b)) })
+	return keys
 }

--- a/pkg/apimachinery/patch/patch_test.go
+++ b/pkg/apimachinery/patch/patch_test.go
@@ -95,3 +95,126 @@ var _ = Describe("PatchSet", func() {
 		Expect(patches.IsEmpty()).To(BeTrue())
 	})
 })
+
+var _ = Describe("GeneratePerKeyMapPatches", func() {
+	It("should test nil then add entire map when old map is nil", func() {
+		newMap := map[string]string{"key1": "val1", "key2": "val2"}
+		ops := patch.GeneratePerKeyMapPatches("/metadata/labels", nil, newMap)
+		patchSet := patch.New(ops...)
+		patches := patchSet.GetPatches()
+		Expect(patches).To(HaveLen(2))
+		Expect(patches[0].Op).To(Equal("test"))
+		Expect(patches[0].Path).To(Equal("/metadata/labels"))
+		Expect(patches[0].Value).To(BeNil())
+		Expect(patches[1].Op).To(Equal("add"))
+		Expect(patches[1].Path).To(Equal("/metadata/labels"))
+	})
+
+	It("should test empty then add entire map when old map is empty", func() {
+		newMap := map[string]string{"key1": "val1"}
+		ops := patch.GeneratePerKeyMapPatches("/metadata/labels", map[string]string{}, newMap)
+		patchSet := patch.New(ops...)
+		patches := patchSet.GetPatches()
+		Expect(patches).To(HaveLen(2))
+		Expect(patches[0].Op).To(Equal("test"))
+		Expect(patches[0].Path).To(Equal("/metadata/labels"))
+		Expect(patches[1].Op).To(Equal("add"))
+		Expect(patches[1].Path).To(Equal("/metadata/labels"))
+	})
+
+	It("should generate per-key remove when new map is nil", func() {
+		oldMap := map[string]string{"key1": "val1"}
+		ops := patch.GeneratePerKeyMapPatches("/metadata/labels", oldMap, nil)
+		patchSet := patch.New(ops...)
+		patches := patchSet.GetPatches()
+		Expect(patches).To(HaveLen(1))
+		Expect(patches[0].Op).To(Equal("remove"))
+		Expect(patches[0].Path).To(Equal("/metadata/labels/key1"))
+	})
+
+	It("should generate per-key add for new keys", func() {
+		oldMap := map[string]string{"key1": "val1"}
+		newMap := map[string]string{"key1": "val1", "key2": "val2"}
+		ops := patch.GeneratePerKeyMapPatches("/metadata/labels", oldMap, newMap)
+		patchSet := patch.New(ops...)
+		patches := patchSet.GetPatches()
+		Expect(patches).To(HaveLen(1))
+		Expect(patches[0].Op).To(Equal("add"))
+		Expect(patches[0].Path).To(Equal("/metadata/labels/key2"))
+		Expect(patches[0].Value).To(Equal("val2"))
+	})
+
+	It("should generate per-key remove for deleted keys", func() {
+		oldMap := map[string]string{"key1": "val1", "key2": "val2"}
+		newMap := map[string]string{"key1": "val1"}
+		ops := patch.GeneratePerKeyMapPatches("/metadata/labels", oldMap, newMap)
+		patchSet := patch.New(ops...)
+		patches := patchSet.GetPatches()
+		Expect(patches).To(HaveLen(1))
+		Expect(patches[0].Op).To(Equal("remove"))
+		Expect(patches[0].Path).To(Equal("/metadata/labels/key2"))
+	})
+
+	It("should generate per-key test+replace for modified keys", func() {
+		oldMap := map[string]string{"key1": "oldval"}
+		newMap := map[string]string{"key1": "newval"}
+		ops := patch.GeneratePerKeyMapPatches("/metadata/labels", oldMap, newMap)
+		patchSet := patch.New(ops...)
+		patches := patchSet.GetPatches()
+		Expect(patches).To(HaveLen(2))
+		Expect(patches[0].Op).To(Equal("test"))
+		Expect(patches[0].Path).To(Equal("/metadata/labels/key1"))
+		Expect(patches[0].Value).To(Equal("oldval"))
+		Expect(patches[1].Op).To(Equal("replace"))
+		Expect(patches[1].Path).To(Equal("/metadata/labels/key1"))
+		Expect(patches[1].Value).To(Equal("newval"))
+	})
+
+	It("should escape JSON pointer characters in keys", func() {
+		oldMap := map[string]string{"existing": "val"}
+		newMap := map[string]string{"existing": "val", "kubevirt.io/nodeName": "node1"}
+		ops := patch.GeneratePerKeyMapPatches("/metadata/labels", oldMap, newMap)
+		patchSet := patch.New(ops...)
+		patches := patchSet.GetPatches()
+		Expect(patches).To(HaveLen(1))
+		Expect(patches[0].Op).To(Equal("add"))
+		Expect(patches[0].Path).To(Equal("/metadata/labels/kubevirt.io~1nodeName"))
+	})
+
+	It("should generate no ops when maps are equal", func() {
+		oldMap := map[string]string{"key1": "val1"}
+		newMap := map[string]string{"key1": "val1"}
+		ops := patch.GeneratePerKeyMapPatches("/metadata/labels", oldMap, newMap)
+		Expect(ops).To(BeEmpty())
+	})
+
+	It("should not emit test operations when only adding keys", func() {
+		oldMap := map[string]string{"key1": "val1"}
+		newMap := map[string]string{"key1": "val1", "key2": "val2"}
+		ops := patch.GeneratePerKeyMapPatches("/metadata/labels", oldMap, newMap)
+		patchSet := patch.New(ops...)
+		for _, p := range patchSet.GetPatches() {
+			Expect(p.Op).ToNot(Equal("test"),
+				"adding a new key should not require test operations on existing keys")
+		}
+	})
+
+	It("should handle mixed add, remove, and modify in sorted key order", func() {
+		oldMap := map[string]string{"keep": "same", "modify": "old", "remove": "gone"}
+		newMap := map[string]string{"keep": "same", "modify": "new", "added": "fresh"}
+		ops := patch.GeneratePerKeyMapPatches("/metadata/labels", oldMap, newMap)
+		patchSet := patch.New(ops...)
+		patches := patchSet.GetPatches()
+
+		var opPaths []string
+		for _, p := range patches {
+			opPaths = append(opPaths, p.Op+" "+p.Path)
+		}
+		Expect(opPaths).To(Equal([]string{
+			"test /metadata/labels/modify",
+			"replace /metadata/labels/modify",
+			"remove /metadata/labels/remove",
+			"add /metadata/labels/added",
+		}))
+	})
+})

--- a/pkg/virt-controller/watch/migration/migration.go
+++ b/pkg/virt-controller/watch/migration/migration.go
@@ -347,10 +347,7 @@ func (c *Controller) patchVMI(origVMI, newVMI *virtv1.VirtualMachineInstance) er
 	}
 
 	if !equality.Semantic.DeepEqual(origVMI.Labels, newVMI.Labels) {
-		patchSet.AddOption(
-			patch.WithTest("/metadata/labels", origVMI.Labels),
-			patch.WithReplace("/metadata/labels", newVMI.Labels),
-		)
+		patchSet.AddOption(patch.GeneratePerKeyMapPatches("/metadata/labels", origVMI.Labels, newVMI.Labels)...)
 	}
 
 	if !patchSet.IsEmpty() {

--- a/pkg/virt-controller/watch/vmi/lifecycle.go
+++ b/pkg/virt-controller/watch/vmi/lifecycle.go
@@ -643,6 +643,8 @@ func (c *Controller) addTopologyHints(vmi *virtv1.VirtualMachineInstance, vmiCop
 }
 
 // prepareVMIPatch generates a patch set for updating the VMI status.
+// Map fields (activePods, labels, annotations) use per-key operations to minimize
+// conflicts with concurrent virt-handler Update() calls during migration.
 func prepareVMIPatch(oldVMI, newVMI *virtv1.VirtualMachineInstance) *patch.PatchSet {
 	patchSet := patch.New()
 
@@ -670,10 +672,7 @@ func prepareVMIPatch(oldVMI, newVMI *virtv1.VirtualMachineInstance) *patch.Patch
 	}
 
 	if !equality.Semantic.DeepEqual(newVMI.Status.ActivePods, oldVMI.Status.ActivePods) {
-		patchSet.AddOption(
-			patch.WithTest("/status/activePods", oldVMI.Status.ActivePods),
-			patch.WithReplace("/status/activePods", newVMI.Status.ActivePods),
-		)
+		patchSet.AddOption(patch.GeneratePerKeyMapPatches("/status/activePods", oldVMI.Status.ActivePods, newVMI.Status.ActivePods)...)
 		log.Log.V(3).Object(oldVMI).Infof("Patching VMI activePods")
 	}
 
@@ -697,25 +696,11 @@ func prepareVMIPatch(oldVMI, newVMI *virtv1.VirtualMachineInstance) *patch.Patch
 	}
 
 	if !equality.Semantic.DeepEqual(oldVMI.Labels, newVMI.Labels) {
-		if oldVMI.Labels == nil {
-			patchSet.AddOption(patch.WithAdd("/metadata/labels", newVMI.Labels))
-		} else {
-			patchSet.AddOption(
-				patch.WithTest("/metadata/labels", oldVMI.Labels),
-				patch.WithReplace("/metadata/labels", newVMI.Labels),
-			)
-		}
+		patchSet.AddOption(patch.GeneratePerKeyMapPatches("/metadata/labels", oldVMI.Labels, newVMI.Labels)...)
 	}
 
 	if !equality.Semantic.DeepEqual(oldVMI.Annotations, newVMI.Annotations) {
-		if oldVMI.Annotations == nil {
-			patchSet.AddOption(patch.WithAdd("/metadata/annotations", newVMI.Annotations))
-		} else {
-			patchSet.AddOption(
-				patch.WithTest("/metadata/annotations", oldVMI.Annotations),
-				patch.WithReplace("/metadata/annotations", newVMI.Annotations),
-			)
-		}
+		patchSet.AddOption(patch.GeneratePerKeyMapPatches("/metadata/annotations", oldVMI.Annotations, newVMI.Annotations)...)
 	}
 
 	if !equality.Semantic.DeepEqual(oldVMI.Finalizers, newVMI.Finalizers) {

--- a/pkg/virt-controller/watch/vmi/lifecycle.go
+++ b/pkg/virt-controller/watch/vmi/lifecycle.go
@@ -625,6 +625,8 @@ func (c *Controller) addTopologyHints(vmi *virtv1.VirtualMachineInstance, vmiCop
 }
 
 // prepareVMIPatch generates a patch set for updating the VMI status.
+// Map fields (activePods, labels, annotations) use per-key operations to minimize
+// conflicts with concurrent virt-handler Update() calls during migration.
 func prepareVMIPatch(oldVMI, newVMI *virtv1.VirtualMachineInstance) *patch.PatchSet {
 	patchSet := patch.New()
 
@@ -652,10 +654,7 @@ func prepareVMIPatch(oldVMI, newVMI *virtv1.VirtualMachineInstance) *patch.Patch
 	}
 
 	if !equality.Semantic.DeepEqual(newVMI.Status.ActivePods, oldVMI.Status.ActivePods) {
-		patchSet.AddOption(
-			patch.WithTest("/status/activePods", oldVMI.Status.ActivePods),
-			patch.WithReplace("/status/activePods", newVMI.Status.ActivePods),
-		)
+		patchSet.AddOption(patch.GeneratePerKeyMapPatches("/status/activePods", oldVMI.Status.ActivePods, newVMI.Status.ActivePods)...)
 		log.Log.V(3).Object(oldVMI).Infof("Patching VMI activePods")
 	}
 
@@ -679,14 +678,11 @@ func prepareVMIPatch(oldVMI, newVMI *virtv1.VirtualMachineInstance) *patch.Patch
 	}
 
 	if !equality.Semantic.DeepEqual(oldVMI.Labels, newVMI.Labels) {
-		if oldVMI.Labels == nil {
-			patchSet.AddOption(patch.WithAdd("/metadata/labels", newVMI.Labels))
-		} else {
-			patchSet.AddOption(
-				patch.WithTest("/metadata/labels", oldVMI.Labels),
-				patch.WithReplace("/metadata/labels", newVMI.Labels),
-			)
-		}
+		patchSet.AddOption(patch.GeneratePerKeyMapPatches("/metadata/labels", oldVMI.Labels, newVMI.Labels)...)
+	}
+
+	if !equality.Semantic.DeepEqual(oldVMI.Annotations, newVMI.Annotations) {
+		patchSet.AddOption(patch.GeneratePerKeyMapPatches("/metadata/annotations", oldVMI.Annotations, newVMI.Annotations)...)
 	}
 
 	if !equality.Semantic.DeepEqual(oldVMI.Finalizers, newVMI.Finalizers) {

--- a/pkg/virt-controller/watch/vmi/lifecycle.go
+++ b/pkg/virt-controller/watch/vmi/lifecycle.go
@@ -625,7 +625,7 @@ func (c *Controller) addTopologyHints(vmi *virtv1.VirtualMachineInstance, vmiCop
 }
 
 // prepareVMIPatch generates a patch set for updating the VMI status.
-// Map fields (activePods, labels, annotations) use per-key operations to minimize
+// Map fields (activePods, labels) use per-key operations to minimize
 // conflicts with concurrent virt-handler Update() calls during migration.
 func prepareVMIPatch(oldVMI, newVMI *virtv1.VirtualMachineInstance) *patch.PatchSet {
 	patchSet := patch.New()
@@ -679,10 +679,6 @@ func prepareVMIPatch(oldVMI, newVMI *virtv1.VirtualMachineInstance) *patch.Patch
 
 	if !equality.Semantic.DeepEqual(oldVMI.Labels, newVMI.Labels) {
 		patchSet.AddOption(patch.GeneratePerKeyMapPatches("/metadata/labels", oldVMI.Labels, newVMI.Labels)...)
-	}
-
-	if !equality.Semantic.DeepEqual(oldVMI.Annotations, newVMI.Annotations) {
-		patchSet.AddOption(patch.GeneratePerKeyMapPatches("/metadata/annotations", oldVMI.Annotations, newVMI.Annotations)...)
 	}
 
 	if !equality.Semantic.DeepEqual(oldVMI.Finalizers, newVMI.Finalizers) {

--- a/pkg/virt-controller/watch/vmi/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi/vmi_test.go
@@ -912,6 +912,53 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		})
 	})
 
+	Context("prepareVMIPatch per-key map operations", func() {
+		It("should use per-key add for activePods during migration", func() {
+			oldVMI := newPendingVirtualMachine("testvmi")
+			newVMI := oldVMI.DeepCopy()
+			oldVMI.Status.ActivePods = map[types.UID]string{"uid-source": "nodeA"}
+			newVMI.Status.ActivePods = map[types.UID]string{"uid-source": "nodeA", "uid-target": "nodeB"}
+
+			p := prepareVMIPatch(oldVMI, newVMI)
+
+			Expect(p.IsEmpty()).To(BeFalse())
+			patches := p.GetPatches()
+			Expect(patches).To(HaveLen(1))
+			Expect(patches[0].Op).To(Equal("add"))
+			Expect(patches[0].Path).To(Equal("/status/activePods/uid-target"))
+		})
+
+		It("should use per-key remove for activePods after migration", func() {
+			oldVMI := newPendingVirtualMachine("testvmi")
+			newVMI := oldVMI.DeepCopy()
+			oldVMI.Status.ActivePods = map[types.UID]string{"uid-source": "nodeA", "uid-target": "nodeB"}
+			newVMI.Status.ActivePods = map[types.UID]string{"uid-target": "nodeB"}
+
+			p := prepareVMIPatch(oldVMI, newVMI)
+
+			Expect(p.IsEmpty()).To(BeFalse())
+			patches := p.GetPatches()
+			Expect(patches).To(HaveLen(1))
+			Expect(patches[0].Op).To(Equal("remove"))
+			Expect(patches[0].Path).To(Equal("/status/activePods/uid-source"))
+		})
+
+		It("should use per-key operations for labels", func() {
+			oldVMI := newPendingVirtualMachine("testvmi")
+			newVMI := oldVMI.DeepCopy()
+			oldVMI.Labels = map[string]string{"existing": "val"}
+			newVMI.Labels = map[string]string{"existing": "val", "kubevirt.io/nodeName": "node1"}
+
+			p := prepareVMIPatch(oldVMI, newVMI)
+
+			Expect(p.IsEmpty()).To(BeFalse())
+			patches := p.GetPatches()
+			Expect(patches).To(HaveLen(1))
+			Expect(patches[0].Op).To(Equal("add"))
+			Expect(patches[0].Path).To(Equal("/metadata/labels/kubevirt.io~1nodeName"))
+		})
+	})
+
 	It("should fail which when network VMI spec validator fail", func() {
 		controller.validateNetworkSpec = validateNetVMISpecStub(metav1.StatusCause{Type: "test", Message: "test", Field: "test"})
 

--- a/pkg/virt-controller/watch/vmi/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi/vmi_test.go
@@ -976,6 +976,53 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		})
 	})
 
+	Context("prepareVMIPatch per-key map operations", func() {
+		It("should use per-key add for activePods during migration", func() {
+			oldVMI := newPendingVirtualMachine("testvmi")
+			newVMI := oldVMI.DeepCopy()
+			oldVMI.Status.ActivePods = map[types.UID]string{"uid-source": "nodeA"}
+			newVMI.Status.ActivePods = map[types.UID]string{"uid-source": "nodeA", "uid-target": "nodeB"}
+
+			p := prepareVMIPatch(oldVMI, newVMI)
+
+			Expect(p.IsEmpty()).To(BeFalse())
+			patches := p.GetPatches()
+			Expect(patches).To(HaveLen(1))
+			Expect(patches[0].Op).To(Equal("add"))
+			Expect(patches[0].Path).To(Equal("/status/activePods/uid-target"))
+		})
+
+		It("should use per-key remove for activePods after migration", func() {
+			oldVMI := newPendingVirtualMachine("testvmi")
+			newVMI := oldVMI.DeepCopy()
+			oldVMI.Status.ActivePods = map[types.UID]string{"uid-source": "nodeA", "uid-target": "nodeB"}
+			newVMI.Status.ActivePods = map[types.UID]string{"uid-target": "nodeB"}
+
+			p := prepareVMIPatch(oldVMI, newVMI)
+
+			Expect(p.IsEmpty()).To(BeFalse())
+			patches := p.GetPatches()
+			Expect(patches).To(HaveLen(1))
+			Expect(patches[0].Op).To(Equal("remove"))
+			Expect(patches[0].Path).To(Equal("/status/activePods/uid-source"))
+		})
+
+		It("should use per-key operations for labels", func() {
+			oldVMI := newPendingVirtualMachine("testvmi")
+			newVMI := oldVMI.DeepCopy()
+			oldVMI.Labels = map[string]string{"existing": "val"}
+			newVMI.Labels = map[string]string{"existing": "val", "kubevirt.io/nodeName": "node1"}
+
+			p := prepareVMIPatch(oldVMI, newVMI)
+
+			Expect(p.IsEmpty()).To(BeFalse())
+			patches := p.GetPatches()
+			Expect(patches).To(HaveLen(1))
+			Expect(patches[0].Op).To(Equal("add"))
+			Expect(patches[0].Path).To(Equal("/metadata/labels/kubevirt.io~1nodeName"))
+		})
+	})
+
 	It("should fail which when network VMI spec validator fail", func() {
 		controller.validateNetworkSpec = validateNetVMISpecStub(metav1.StatusCause{Type: "test", Message: "test", Field: "test"})
 


### PR DESCRIPTION
### What this PR does
#### Before this PR:

`prepareVMIPatch` (VMI controller) and `patchVMI` (migration controller) used whole-map `test`+`replace` JSON Patch operations for `activePods`, `labels`, and `annotations`. A concurrent change to *any* key in the map caused the entire patch to fail, even if the controller was modifying a different key. During mass live migration (2000+ VMs), virt-handler `Update()` calls on the same VMI made these test operations fail repeatedly, leaving VMIs with stale IP addresses in `status.interfaces`.

#### After this PR:

Map fields are patched per-key: added keys use `add`, removed keys use `remove`, and modified keys use `test`+`replace` on the individual key. Adding a target pod UID to `activePods` now emits a single `add` with no test operation, so it cannot conflict with unrelated concurrent changes.

The new `GeneratePerKeyMapPatches` helper lives in `pkg/apimachinery/patch` so other controllers can reuse it.

### References

- Jira: https://redhat.atlassian.net/browse/CNV-88918
- Upstream blocker for test vs validation error detection: https://github.com/kubernetes/kubernetes/issues/68202

### Why we need it and why it was done in this way
The following tradeoffs were made:
- Conditions, interfaces, finalizers, and volumeStatus still use whole-slice `test`+`replace` because JSON Patch has no stable key for array elements. Per-key patching only applies to Go `map` fields.
- The workqueue rate limiter is unchanged. Per-key patching eliminates the main source of false conflicts (`activePods` add/remove), so the default backoff no longer causes cascading delays.

The following alternatives were considered:
- Lowering the max exponential backoff from 1000s to 30s. Dropped because it changes controller timing globally and the per-key fix addresses the root cause directly.
- Splitting the patch into multiple independent API calls (one per field category). Rejected because it increases API server load during mass migration.
- Server-side apply (SSA) with field ownership. Too large a refactor for this fix, but would be the ideal long-term solution.

### Special notes for your reviewer

The synchronization controller already has a similar per-field pattern (`addMigrationStateFieldPatches` / `patchMigrationStateField`) for `MigrationState`. Several other controllers (`vm.go`, `pool.go`, `synchronization-controller.go`) still use whole-map `test`+`replace` for labels and could adopt `GeneratePerKeyMapPatches` in follow-up PRs.

### AI disclosure

This PR was developed with significant AI assistance (Claude via Cursor). Specifically:
- **Root cause analysis**: AI traced the code paths across the VMI controller, migration controller, and virt-handler to understand the race condition.
- **Fix design and implementation**: AI wrote the `GeneratePerKeyMapPatches` helper and the changes to both controllers, with human review and direction on scope, placement, and commit structure.
- **Tests**: AI wrote the unit and integration tests.
- **PR description**: AI drafted this PR description based on the KubeVirt PR template.

All code and text were reviewed, refined, and approved by the human author. Commits carry the `Assisted-by: Claude (Anthropic AI assistant)` and `Made-with: Cursor` trailers per [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Checklist

- [x] Design: A VEP was not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires new unit tests
- [ ] Documentation: A user-guide update was not required
- [ ] Community: Announcement to kubevirt-dev was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
NONE
```
