### PR TITLE
Skip PrometheusRule generation when VMStatsCollector is enabled

### DIFF
--- a/pkg/virt-operator/resource/generate/install/strategy.go
+++ b/pkg/virt-operator/resource/generate/install/strategy.go
@@ -531,16 +531,18 @@ func GenerateCurrentInstallStrategy(config *operatorutil.KubeVirtDeploymentConfi
 		rbaclist = append(rbaclist, rbac.GetAllServiceMonitor(config.GetNamespace(), monitorNamespace, monitorServiceAccount)...)
 		strategy.serviceMonitors = append(strategy.serviceMonitors, components.NewServiceMonitorCR(config.GetNamespace(), serviceMonitorNamespace, true))
 
-		err := rules.SetupRules(config.GetNamespace())
-		if err != nil {
-			return nil, err
-		}
+		if !config.VMStatsCollectorEnabled() {
+			err := rules.SetupRules(config.GetNamespace())
+			if err != nil {
+				return nil, err
+			}
 
-		prometheusRule, err := rules.BuildPrometheusRule(config.GetNamespace())
-		if err != nil {
-			return nil, err
+			prometheusRule, err := rules.BuildPrometheusRule(config.GetNamespace())
+			if err != nil {
+				return nil, err
+			}
+			strategy.prometheusRules = append(strategy.prometheusRules, prometheusRule)
 		}
-		strategy.prometheusRules = append(strategy.prometheusRules, prometheusRule)
 	} else {
 		log.Log.Warningf("failed to create ServiceMonitor resources because couldn't find ServiceAccount %v in any monitoring namespaces : %v", monitorServiceAccount, strings.Join(config.GetPotentialMonitorNamespaces(), ", "))
 	}

--- a/pkg/virt-operator/resource/generate/install/strategy_test.go
+++ b/pkg/virt-operator/resource/generate/install/strategy_test.go
@@ -62,6 +62,19 @@ var _ = Describe("Install Strategy", func() {
 
 	config := getConfig("fake-registry", "v9.9.9")
 
+	getConfigWith := func(kvConfig v1.KubeVirtConfiguration) *util.KubeVirtDeploymentConfig {
+		return util.GetTargetConfigFromKV(&v1.KubeVirt{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: namespace,
+			},
+			Spec: v1.KubeVirtSpec{
+				ImageRegistry: "fake-registry",
+				ImageTag:      "v9.9.9",
+				Configuration: kvConfig,
+			},
+		})
+	}
+
 	Context("monitoring detection", func() {
 		DescribeTable("should", func(expectedNS string, objects ...runtime.Object) {
 			client := fake.NewSimpleClientset(objects...)
@@ -237,19 +250,6 @@ var _ = Describe("Install Strategy", func() {
 			"kubevirt.io:view":  "rbac.authorization.k8s.io/aggregate-to-view",
 		}
 
-		getConfigWith := func(kvConfig v1.KubeVirtConfiguration) *util.KubeVirtDeploymentConfig {
-			return util.GetTargetConfigFromKV(&v1.KubeVirt{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: namespace,
-				},
-				Spec: v1.KubeVirtSpec{
-					ImageRegistry: "fake-registry",
-					ImageTag:      "v9.9.9",
-					Configuration: kvConfig,
-				},
-			})
-		}
-
 		DescribeTable("should set aggregate labels correctly", func(testConfig *util.KubeVirtDeploymentConfig, expectedValue string) {
 			strategy, err := GenerateCurrentInstallStrategy(testConfig, "", namespace)
 			Expect(err).ToNot(HaveOccurred())
@@ -281,6 +281,26 @@ var _ = Describe("Install Strategy", func() {
 					RoleAggregationStrategy: pointer.P(v1.RoleAggregationStrategyAggregateToDefault),
 				}), "true"),
 		)
+	})
+
+	Context("VMStatsCollector", func() {
+		It("should not generate PrometheusRules when VMStatsCollector feature gate is enabled", func() {
+			vmStatsConfig := getConfigWith(v1.KubeVirtConfiguration{
+				DeveloperConfiguration: &v1.DeveloperConfiguration{
+					FeatureGates: []string{"VMStatsCollector"},
+				},
+			})
+
+			strategy, err := GenerateCurrentInstallStrategy(vmStatsConfig, "openshift-monitoring", namespace)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(strategy.prometheusRules).To(BeEmpty())
+		})
+
+		It("should generate PrometheusRules by default", func() {
+			strategy, err := GenerateCurrentInstallStrategy(config, "openshift-monitoring", namespace)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(strategy.prometheusRules).ToNot(BeEmpty())
+		})
 	})
 
 	Context("should match", func() {

--- a/pkg/virt-operator/util/config.go
+++ b/pkg/virt-operator/util/config.go
@@ -101,6 +101,9 @@ const (
 	AdditionalPropertiesOptOutRoleAggregation = "OptOutRoleAggregation"
 
 	// lookup key in AdditionalProperties
+	AdditionalPropertiesVMStatsCollectorEnabled = "VMStatsCollectorEnabled"
+
+	// lookup key in AdditionalProperties
 	AdditionalPropertiesSynchronizationPort       = "SynchronizationPort"
 	DefaultSynchronizationPort              int32 = 9185
 
@@ -202,6 +205,10 @@ func GetTargetConfigFromKVWithEnvVarManager(kv *v1.KubeVirt, envVarManager EnvVa
 
 	hypervisor := virtconfig.GetHypervisorFromKvConfig(&kv.Spec.Configuration, isFeatureGateEnabledInKvConfig(&kv.Spec.Configuration, featuregate.ConfigurableHypervisor))
 	additionalProperties[AdditionalPropertiesHypervisorName] = hypervisor.Name
+
+	if isFeatureGateEnabledInKvConfig(&kv.Spec.Configuration, featuregate.VMStatsCollector) {
+		additionalProperties[AdditionalPropertiesVMStatsCollectorEnabled] = ""
+	}
 
 	if isFeatureGateEnabledInKvConfig(&kv.Spec.Configuration, featuregate.OptOutRoleAggregation) {
 		if kv.Spec.Configuration.RoleAggregationStrategy != nil &&
@@ -564,6 +571,11 @@ func (c *KubeVirtDeploymentConfig) VirtTemplateDeploymentEnabled() bool {
 
 func (c *KubeVirtDeploymentConfig) ExternalNetResourceInjectionEnabled() bool {
 	_, enabled := c.AdditionalProperties[AdditionalPropertiesExternalNetResourceInjection]
+	return enabled
+}
+
+func (c *KubeVirtDeploymentConfig) VMStatsCollectorEnabled() bool {
+	_, enabled := c.AdditionalProperties[AdditionalPropertiesVMStatsCollectorEnabled]
 	return enabled
 }
 

--- a/pkg/virt-operator/util/config_test.go
+++ b/pkg/virt-operator/util/config_test.go
@@ -141,6 +141,20 @@ var _ = Describe("Operator Config", func() {
 			Expect(cfgWith.ID).ToNot(Equal(cfgWithout.ID))
 		})
 
+		It("should propagate VMStatsCollector feature gate into AdditionalProperties", func() {
+			kv := &v1.KubeVirt{}
+			cfgWithout := GetTargetConfigFromKV(kv)
+			Expect(cfgWithout.VMStatsCollectorEnabled()).To(BeFalse())
+
+			kv.Spec.Configuration.DeveloperConfiguration = &v1.DeveloperConfiguration{
+				FeatureGates: []string{"VMStatsCollector"},
+			}
+			cfgWith := GetTargetConfigFromKV(kv)
+			Expect(cfgWith.VMStatsCollectorEnabled()).To(BeTrue())
+
+			Expect(cfgWith.ID).ToNot(Equal(cfgWithout.ID))
+		})
+
 		DescribeTable("should result in different ID when component images change", func(setImage func(*KubeVirtDeploymentConfig, string)) {
 			cfgA := &KubeVirtDeploymentConfig{}
 			cfgA.AdditionalProperties = make(map[string]string)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:

#### After this PR:

Disable PrometheusRule when VMStatsCollector is enabled, allowing new observability controller to manage Alert and Recording Rules instead of virt-operator

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/143

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Skip PrometheusRule generation when VMStatsCollector is enabled
```

