### PR TITLE
volume-migration: validate PVC volumes before migration

### DIFF
--- a/pkg/virt-controller/watch/vm/BUILD.bazel
+++ b/pkg/virt-controller/watch/vm/BUILD.bazel
@@ -80,7 +80,6 @@ go_test(
         "//pkg/libvmi/status:go_default_library",
         "//pkg/pointer:go_default_library",
         "//pkg/storage/cbt:go_default_library",
-        "//pkg/storage/types:go_default_library",
         "//pkg/testutils:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//pkg/virt-config/featuregate:go_default_library",

--- a/pkg/virt-controller/watch/vm/vm_test.go
+++ b/pkg/virt-controller/watch/vm/vm_test.go
@@ -57,8 +57,6 @@ import (
 
 	gomegatypes "github.com/onsi/gomega/types"
 
-	storagetypes "kubevirt.io/kubevirt/pkg/storage/types"
-
 	"kubevirt.io/kubevirt/pkg/libvmi"
 	libvmistatus "kubevirt.io/kubevirt/pkg/libvmi/status"
 )
@@ -6103,7 +6101,7 @@ var _ = Describe("VirtualMachine", func() {
 					Expect(cond.Message).To(ContainSubstring("invalid volumes to update with migration:"))
 				})
 
-				DescribeTable("should return an error", func(dvExist bool, err error) {
+				DescribeTable("should return an error", func(setup func() (*v1.VirtualMachineInstance, *v1.VirtualMachine)) {
 					testutils.UpdateFakeKubeVirtClusterConfig(kvStore, &v1.KubeVirt{
 						Spec: v1.KubeVirtSpec{
 							Configuration: v1.KubeVirtConfiguration{
@@ -6136,15 +6134,8 @@ var _ = Describe("VirtualMachine", func() {
 							return true, vmi, nil
 						})
 
-					if dvExist {
-						dv := libdv.NewDataVolume(libdv.WithName(newDVName), libdv.WithNamespace(ns))
-						Expect(dataVolumeInformer.GetStore().Add(dv)).To(Succeed())
-					}
-					vmi := libvmi.New(libvmi.WithNamespace(ns), libvmi.WithDataVolume(diskName, oldDVName))
-					vm := libvmi.NewVirtualMachine(libvmi.New(libvmi.WithNamespace(ns),
-						libvmi.WithDataVolume(diskName, newDVName)),
-						libvmi.WithUpdateVolumeStrategy(v1.UpdateVolumesStrategyMigration))
-					vm, err = virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Create(context.TODO(), vm,
+					vmi, vm := setup()
+					vm, err := virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Create(context.TODO(), vm,
 						metav1.CreateOptions{})
 					Expect(err).To(Succeed())
 					vmi, err = virtFakeClient.KubevirtV1().VirtualMachineInstances(vmi.Namespace).Create(context.TODO(),
@@ -6154,8 +6145,29 @@ var _ = Describe("VirtualMachine", func() {
 					Expect(virtcontroller.NewVirtualMachineConditionManager().GetCondition(vm,
 						v1.VirtualMachineRestartRequired)).Should(BeNil())
 				},
-					Entry("when the destination DV doesn't exist", false, storagetypes.NewDVNotFoundError(newDVName)),
-					Entry("when the destination DV exist but the PVC", true, storagetypes.NewPVCNotFoundError(newDVName)),
+					Entry("when the destination DV doesn't exist", func() (*v1.VirtualMachineInstance, *v1.VirtualMachine) {
+						vmi := libvmi.New(libvmi.WithNamespace(ns), libvmi.WithDataVolume(diskName, oldDVName))
+						vm := libvmi.NewVirtualMachine(libvmi.New(libvmi.WithNamespace(ns),
+							libvmi.WithDataVolume(diskName, newDVName)),
+							libvmi.WithUpdateVolumeStrategy(v1.UpdateVolumesStrategyMigration))
+						return vmi, vm
+					}),
+					Entry("when the destination DV exists but not the PVC", func() (*v1.VirtualMachineInstance, *v1.VirtualMachine) {
+						dv := libdv.NewDataVolume(libdv.WithName(newDVName), libdv.WithNamespace(ns))
+						Expect(dataVolumeInformer.GetStore().Add(dv)).To(Succeed())
+						vmi := libvmi.New(libvmi.WithNamespace(ns), libvmi.WithDataVolume(diskName, oldDVName))
+						vm := libvmi.NewVirtualMachine(libvmi.New(libvmi.WithNamespace(ns),
+							libvmi.WithDataVolume(diskName, newDVName)),
+							libvmi.WithUpdateVolumeStrategy(v1.UpdateVolumesStrategyMigration))
+						return vmi, vm
+					}),
+					Entry("when the destination PVC doesn't exist", func() (*v1.VirtualMachineInstance, *v1.VirtualMachine) {
+						vmi := libvmi.New(libvmi.WithNamespace(ns), libvmi.WithPersistentVolumeClaim(diskName, "oldPVC"))
+						vm := libvmi.NewVirtualMachine(libvmi.New(libvmi.WithNamespace(ns),
+							libvmi.WithPersistentVolumeClaim(diskName, "newPVC")),
+							libvmi.WithUpdateVolumeStrategy(v1.UpdateVolumesStrategyMigration))
+						return vmi, vm
+					}),
 				)
 			})
 

--- a/pkg/virt-controller/watch/volume-migration/volume-migration.go
+++ b/pkg/virt-controller/watch/volume-migration/volume-migration.go
@@ -171,6 +171,17 @@ func ValidateVolumes(vmi *virtv1.VirtualMachineInstance, vm *virtv1.VirtualMachi
 			continue
 		}
 
+		// PVC volumes
+		if v.VolumeSource.PersistentVolumeClaim != nil {
+			pvc, err := storagetypes.GetPersistentVolumeClaimFromCache(vm.Namespace, v.VolumeSource.PersistentVolumeClaim.ClaimName, pvcStore)
+			if err != nil {
+				return err
+			}
+			if pvc == nil {
+				return storagetypes.NewPVCNotFoundError(v.VolumeSource.PersistentVolumeClaim.ClaimName)
+			}
+		}
+
 		// DataVolumes with a no-csi storage class
 		if v.VolumeSource.DataVolume != nil {
 			dv, err := storagetypes.GetDataVolumeFromCache(vm.Namespace, v.VolumeSource.DataVolume.Name, dvStore)

--- a/pkg/virt-controller/watch/volume-migration/volume-migration_test.go
+++ b/pkg/virt-controller/watch/volume-migration/volume-migration_test.go
@@ -56,6 +56,8 @@ var _ = Describe("Volume Migration", func() {
 
 			dvCSI    *cdiv1.DataVolume
 			dvNoSCSI *cdiv1.DataVolume
+
+			existingPVCs = []string{"vol2", "vol3", "vol4"}
 		)
 		const (
 			noCSIDVName = "nocsi-dv"
@@ -91,6 +93,17 @@ var _ = Describe("Volume Migration", func() {
 			Expect(dataVolumeStore.Add(dvNoSCSI)).To(Succeed())
 			Expect(pvcStore.Add(pvcCSI)).To(Succeed())
 			Expect(pvcStore.Add(pvcNOCSI)).To(Succeed())
+			for _, pvcName := range existingPVCs {
+				Expect(pvcStore.Add(&k8sv1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      pvcName,
+						Namespace: ns,
+					},
+					Spec: k8sv1.PersistentVolumeClaimSpec{
+						VolumeMode: pointer.P(k8sv1.PersistentVolumeBlock),
+					},
+				})).To(Succeed())
+			}
 		})
 
 		DescribeTable("should validate the migrated volumes", func(vmi *v1.VirtualMachineInstance, vm *v1.VirtualMachine, expectError error) {
@@ -103,34 +116,34 @@ var _ = Describe("Volume Migration", func() {
 		},
 			Entry("with empty VMI", nil, &v1.VirtualMachine{}, fmt.Errorf("cannot validate the migrated volumes for an empty VMI")),
 			Entry("with empty VM", &v1.VirtualMachineInstance{}, nil, fmt.Errorf("cannot validate the migrated volumes for an empty VM")),
-			Entry("without any migrated volumes", libvmi.New(
+			Entry("without any migrated volumes", libvmi.New(libvmi.WithNamespace(ns),
 				libvmi.WithPersistentVolumeClaim("disk0", "vol0"), libvmi.WithPersistentVolumeClaim("disk1", "vol1"),
-			), libvmi.NewVirtualMachine(libvmi.New(
+			), libvmi.NewVirtualMachine(libvmi.New(libvmi.WithNamespace(ns),
 				libvmi.WithPersistentVolumeClaim("disk0", "vol0"), libvmi.WithPersistentVolumeClaim("disk1", "vol1"),
 			)), nil),
-			Entry("with valid volumes", libvmi.New(
+			Entry("with valid volumes", libvmi.New(libvmi.WithNamespace(ns),
 				libvmi.WithPersistentVolumeClaim("disk0", "vol0"), libvmi.WithPersistentVolumeClaim("disk1", "vol1"),
-			), libvmi.NewVirtualMachine(libvmi.New(
+			), libvmi.NewVirtualMachine(libvmi.New(libvmi.WithNamespace(ns),
 				libvmi.WithPersistentVolumeClaim("disk0", "vol2"), libvmi.WithPersistentVolumeClaim("disk1", "vol3"),
 			)), nil),
-			Entry("with an invalid lun volume", libvmi.New(
+			Entry("with an invalid lun volume", libvmi.New(libvmi.WithNamespace(ns),
 				libvmi.WithPersistentVolumeClaim("disk0", "vol0"), libvmi.WithPersistentVolumeClaimLun("disk1", "vol1", false),
-			), libvmi.NewVirtualMachine(libvmi.New(
+			), libvmi.NewVirtualMachine(libvmi.New(libvmi.WithNamespace(ns),
 				libvmi.WithPersistentVolumeClaim("disk0", "vol2"), libvmi.WithPersistentVolumeClaimLun("disk1", "vol4", false),
 			)), fmt.Errorf("invalid volumes to update with migration: luns: [disk1]")),
-			Entry("with an invalid shareable volume", libvmi.New(
+			Entry("with an invalid shareable volume", libvmi.New(libvmi.WithNamespace(ns),
 				libvmi.WithPersistentVolumeClaim("disk0", "vol0"), withShareableVolume("disk1", "vol1"),
-			), libvmi.NewVirtualMachine(libvmi.New(
+			), libvmi.NewVirtualMachine(libvmi.New(libvmi.WithNamespace(ns),
 				libvmi.WithPersistentVolumeClaim("disk0", "vol2"), withShareableVolume("disk1", "vol4"),
 			)), fmt.Errorf("invalid volumes to update with migration: shareable: [disk1]")),
-			Entry("with an invalid filesystem volume", libvmi.New(
+			Entry("with an invalid filesystem volume", libvmi.New(libvmi.WithNamespace(ns),
 				libvmi.WithPersistentVolumeClaim("disk0", "vol0"), withFilesystemVolume("disk1", "vol1"),
-			), libvmi.NewVirtualMachine(libvmi.New(
+			), libvmi.NewVirtualMachine(libvmi.New(libvmi.WithNamespace(ns),
 				libvmi.WithPersistentVolumeClaim("disk0", "vol2"), withFilesystemVolume("disk1", "vol4"),
 			)), fmt.Errorf("invalid volumes to update with migration: filesystems: [disk1]")),
-			Entry("with valid hotplugged volume", libvmi.New(
+			Entry("with valid hotplugged volume", libvmi.New(libvmi.WithNamespace(ns),
 				libvmi.WithPersistentVolumeClaim("disk0", "vol0"), withHotpluggedVolume("disk1", "vol1"),
-			), libvmi.NewVirtualMachine(libvmi.New(
+			), libvmi.NewVirtualMachine(libvmi.New(libvmi.WithNamespace(ns),
 				libvmi.WithPersistentVolumeClaim("disk0", "vol2"), withHotpluggedVolume("disk1", "vol4"),
 			)), nil),
 			Entry("with a DV with a csi storageclass", libvmi.New(libvmi.WithNamespace(ns), libvmi.WithDataVolume("disk0", "vol0")),

--- a/tests/storage/migration.go
+++ b/tests/storage/migration.go
@@ -529,21 +529,15 @@ var _ = Describe(SIG("Volumes update with migration", decorators.RequiresTwoSche
 			vm := createVMWithDV(srcDV, volName)
 			By("Update volumes")
 			updateVMWithPVC(vm, volName, destPVC)
-			Eventually(func() virtv1.VirtualMachineInstanceMigrationPhase {
-				ls := labels.Set{
-					virtv1.VolumesUpdateMigration: vm.Name,
-				}
-				migList, err := virtClient.VirtualMachineInstanceMigration(ns).List(context.Background(),
-					metav1.ListOptions{
-						LabelSelector: ls.String(),
-					})
+			Eventually(func() []virtv1.VirtualMachineInstanceCondition {
+				vmi, err := virtClient.VirtualMachineInstance(ns).Get(context.Background(), vm.Name, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				if migList == nil || len(migList.Items) == 0 {
-					return virtv1.MigrationPhaseUnset
-				}
-				Expect(migList.Items).To(HaveLen(1))
-				return migList.Items[0].Status.Phase
-			}, 120*time.Second, time.Second).Should(Equal(virtv1.MigrationPending))
+				return vmi.Status.Conditions
+			}, 30*time.Second, time.Second).Should(ContainElement(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+				"Type":    Equal(virtv1.VirtualMachineInstanceVolumesChange),
+				"Status":  Equal(k8sv1.ConditionFalse),
+				"Message": ContainSubstring("One of the destination volumes doesn't exist"),
+			})))
 
 			By("Create the destination PVC")
 			libstorage.CreateBlankFSDataVolume(destPVC, ns, "2Gi", nil)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
PVC-based volumes (VolumeSource.PVC instead of VolumeSource.DataVolume)
were not checked for existence or CSI support before
migration, allowing incomplete MigratedVolumes entries to be written
which silently broke the migration flow. The migration target would get
`<disk type="file">` instead of `<disk type="block">` in the domain XML.

Add existence and CSI/volume-populator validation for PVC source
volumes, matching the existing DataVolume validation behavior.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: Storage Live Migration Filesystem-to-Block fails with libvirt error Code 84 pre-creation of storage target for incremental storage migration of disk is not supported
```

