### PR TITLE
[release-1.8] tests/infrastructure: remove broken TSC label e2e test

### DIFF
--- a/tests/infrastructure/node-labeller.go
+++ b/tests/infrastructure/node-labeller.go
@@ -23,7 +23,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
 
@@ -199,16 +198,6 @@ var _ = Describe(SIGSerial("Node-labeller", func() {
 				}
 				return nil
 			}).WithTimeout(timeout).WithPolling(1 * time.Second).ShouldNot(HaveOccurred())
-		})
-
-		It("[test_id:6995]should expose tsc frequency and tsc scalability", func() {
-			node := nodesWithKVM[0]
-			Expect(node.Labels).To(HaveKey("cpu-timer.node.kubevirt.io/tsc-frequency"))
-			Expect(node.Labels).To(HaveKey("cpu-timer.node.kubevirt.io/tsc-scalable"))
-			Expect(node.Labels["cpu-timer.node.kubevirt.io/tsc-scalable"]).To(Or(Equal(trueStr), Equal("false")))
-			val, err := strconv.ParseInt(node.Labels["cpu-timer.node.kubevirt.io/tsc-frequency"], 10, 64)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(val).To(BeNumerically(">", 0))
 		})
 	})
 


### PR DESCRIPTION
### What this PR does
Manual cherry-pick of #17913 to release-1.8.

The test is breaking on environments that has multi architecture workers nodes.

#### Conflict resolution
Context conflict in `tests/infrastructure/node-labeller.go` due to indentation differences — on main, test_id:6247 was reformatted to a multi-line function signature (with `decorators.WgS390x`), changing the indentation of its closing block. On release-1.8, the original single-line signature and indentation are kept. Also `nodesWithHypervisor` → `nodesWithKVM` rename on release-1.8.

### References
Cherry-pick of #17913
Tracker: #18030

### Release note
```release-note
NONE
```