### PR TITLE
Improve abort handling (followup to #17596)

### DIFF
--- a/pkg/virt-handler/migration-source.go
+++ b/pkg/virt-handler/migration-source.go
@@ -670,16 +670,16 @@ func (c *MigrationSourceController) updateDomainFunc(_, new interface{}) {
 }
 
 func (c *MigrationSourceController) handleMigrationAbort(vmi *v1.VirtualMachineInstance, domain *api.Domain, client cmdclient.LauncherClient) error {
-	// Check both the VMI status and the domain metadata to avoid redundant cancel RPCs.
+	// Check both the domain metadata and the VMI status to avoid redundant cancel RPCs.
 	// The domain metadata reflects the launcher's abort status before the API server round-trip.
 	abortHandled := func(status v1.MigrationAbortStatus) bool {
 		return status == v1.MigrationAbortInProgress || status == v1.MigrationAbortSucceeded
 	}
-	if abortHandled(vmi.Status.MigrationState.AbortStatus) {
-		return nil
-	}
 	if domain != nil && domain.Spec.Metadata.KubeVirt.Migration != nil &&
 		abortHandled(v1.MigrationAbortStatus(domain.Spec.Metadata.KubeVirt.Migration.AbortStatus)) {
+		return nil
+	}
+	if abortHandled(vmi.Status.MigrationState.AbortStatus) {
 		return nil
 	}
 

--- a/pkg/virt-handler/migration-source_test.go
+++ b/pkg/virt-handler/migration-source_test.go
@@ -431,7 +431,7 @@ var _ = Describe("VirtualMachineInstance migration target", func() {
 				libvmistatus.WithStatus(libvmistatus.New(
 					libvmistatus.WithMigrationState(v1.VirtualMachineInstanceMigrationState{
 						AbortRequested: true,
-						AbortStatus:    v1.MigrationAbortSucceeded,
+						AbortStatus:    v1.MigrationAbortInProgress,
 					})))),
 				nil,
 			),
@@ -439,7 +439,7 @@ var _ = Describe("VirtualMachineInstance migration target", func() {
 				libvmistatus.WithStatus(libvmistatus.New(
 					libvmistatus.WithMigrationState(v1.VirtualMachineInstanceMigrationState{
 						AbortRequested: true,
-						AbortStatus:    v1.MigrationAbortInProgress,
+						AbortStatus:    v1.MigrationAbortSucceeded,
 					})))),
 				nil,
 			),

--- a/pkg/virt-launcher/virtwrap/cmd-server/server.go
+++ b/pkg/virt-launcher/virtwrap/cmd-server/server.go
@@ -177,13 +177,7 @@ func (l *Launcher) CancelVirtualMachineMigration(_ context.Context, request *cmd
 		return response, nil
 	}
 
-	if err := l.domainManager.CancelVMIMigration(vmi); err != nil {
-		log.Log.Object(vmi).Reason(err).Errorf("Failed to abort live migration")
-		response.Success = false
-		response.Message = getErrorMessage(err)
-		return response, nil
-	}
-
+	l.domainManager.CancelVMIMigration(vmi)
 	log.Log.Object(vmi).Info("Live migration has been aborted")
 	return response, nil
 

--- a/pkg/virt-launcher/virtwrap/generated_mock_manager.go
+++ b/pkg/virt-launcher/virtwrap/generated_mock_manager.go
@@ -62,11 +62,9 @@ func (mr *MockDomainManagerMockRecorder) BackupVirtualMachine(arg0, arg1 any) *g
 }
 
 // CancelVMIMigration mocks base method.
-func (m *MockDomainManager) CancelVMIMigration(arg0 *v1.VirtualMachineInstance) error {
+func (m *MockDomainManager) CancelVMIMigration(arg0 *v1.VirtualMachineInstance) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CancelVMIMigration", arg0)
-	ret0, _ := ret[0].(error)
-	return ret0
+	m.ctrl.Call(m, "CancelVMIMigration", arg0)
 }
 
 // CancelVMIMigration indicates an expected call of CancelVMIMigration.

--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -407,7 +407,7 @@ func (l *LibvirtDomainManager) setMigrationResult(failed bool, reason string) {
 
 	if failed {
 		switch {
-		case strings.Contains(reason, "canceled by client"):
+		case v1.MigrationAbortStatus(migrationMetadata.AbortStatus) == v1.MigrationAbortSucceeded:
 			reason = "Live migration has been aborted"
 		case strings.Contains(standardizeSpaces(reason), "has to be smaller or equal to the actual size of the containing file"):
 			reason = fmt.Sprintf("Volume migration cannot be performed because the destination volume is smaller than the source volume: %v", reason)

--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -371,7 +371,7 @@ func (l *LibvirtDomainManager) initializeMigrationMetadata(vmi *v1.VirtualMachin
 	return false, nil
 }
 
-func (l *LibvirtDomainManager) cancelMigration(vmi *v1.VirtualMachineInstance) error {
+func (l *LibvirtDomainManager) cancelMigration(vmi *v1.VirtualMachineInstance) {
 	l.metadataCache.Migration.WithSafeBlock(func(migration *api.MigrationMetadata, _ bool) {
 		if migration.EndTimestamp != nil || migration.Failed || migration.StartTimestamp == nil {
 			log.Log.Object(vmi).Infof("cancel migration ignored: vmi is not migrating")
@@ -390,7 +390,6 @@ func (l *LibvirtDomainManager) cancelMigration(vmi *v1.VirtualMachineInstance) e
 		migration.AbortStatus = string(v1.MigrationAbortInProgress)
 		l.asyncMigrationAbort(vmi)
 	})
-	return nil
 }
 
 func (l *LibvirtDomainManager) setMigrationResult(failed bool, reason string) {

--- a/pkg/virt-launcher/virtwrap/live-migration-source_test.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source_test.go
@@ -253,7 +253,7 @@ var _ = Describe("Live migration source", func() {
 			})
 			original, _ := libvirtDomainManager.metadataCache.Migration.Load()
 
-			Expect(libvirtDomainManager.cancelMigration(vmi)).To(Succeed())
+			libvirtDomainManager.cancelMigration(vmi)
 
 			after, _ := libvirtDomainManager.metadataCache.Migration.Load()
 			Expect(after.AbortStatus).To(Equal(original.AbortStatus))
@@ -264,7 +264,7 @@ var _ = Describe("Live migration source", func() {
 				m.EndTimestamp = pointer.P(metav1.Now())
 			})
 
-			Expect(libvirtDomainManager.cancelMigration(vmi)).To(Succeed())
+			libvirtDomainManager.cancelMigration(vmi)
 
 			after, _ := libvirtDomainManager.metadataCache.Migration.Load()
 			Expect(after.AbortStatus).To(Equal(""))
@@ -273,7 +273,7 @@ var _ = Describe("Live migration source", func() {
 		It("cancelMigration should no-op when abort is already in progress", func() {
 			libvirtDomainManager.setMigrationAbortStatus(v1.MigrationAbortInProgress)
 
-			Expect(libvirtDomainManager.cancelMigration(vmi)).To(Succeed())
+			libvirtDomainManager.cancelMigration(vmi)
 
 			after, _ := libvirtDomainManager.metadataCache.Migration.Load()
 			Expect(after.AbortStatus).To(Equal(string(v1.MigrationAbortInProgress)))
@@ -282,7 +282,7 @@ var _ = Describe("Live migration source", func() {
 		It("cancelMigration should no-op when abort already succeeded", func() {
 			libvirtDomainManager.setMigrationAbortStatus(v1.MigrationAbortSucceeded)
 
-			Expect(libvirtDomainManager.cancelMigration(vmi)).To(Succeed())
+			libvirtDomainManager.cancelMigration(vmi)
 
 			after, _ := libvirtDomainManager.metadataCache.Migration.Load()
 			Expect(after.AbortStatus).To(Equal(string(v1.MigrationAbortSucceeded)))

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -180,7 +180,7 @@ type DomainManager interface {
 	MigrateVMI(*v1.VirtualMachineInstance, *cmdclient.MigrationOptions) error
 	PrepareMigrationTarget(*v1.VirtualMachineInstance, bool, *cmdv1.VirtualMachineOptions) error
 	GetDomainStats() (*stats.DomainStats, error)
-	CancelVMIMigration(*v1.VirtualMachineInstance) error
+	CancelVMIMigration(*v1.VirtualMachineInstance)
 	GetGuestInfo() v1.VirtualMachineInstanceGuestAgentInfo
 	GetUsers() []v1.VirtualMachineInstanceGuestOSUser
 	GetFilesystems() []v1.VirtualMachineInstanceFileSystem
@@ -873,8 +873,8 @@ func getVMIMigrationDataSize(vmi *v1.VirtualMachineInstance, ephemeralDiskDir st
 	return memory.ScaledValue(resource.Giga)
 }
 
-func (l *LibvirtDomainManager) CancelVMIMigration(vmi *v1.VirtualMachineInstance) error {
-	return l.cancelMigration(vmi)
+func (l *LibvirtDomainManager) CancelVMIMigration(vmi *v1.VirtualMachineInstance) {
+	l.cancelMigration(vmi)
 }
 
 func (l *LibvirtDomainManager) MigrateVMI(vmi *v1.VirtualMachineInstance, options *cmdclient.MigrationOptions) error {

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -1922,7 +1922,7 @@ var _ = Describe("Manager", func() {
 			mockLibvirt.DomainEXPECT().GetJobInfo().Return(&libvirt.DomainJobInfo{Type: libvirt.DOMAIN_JOB_UNBOUNDED}, nil)
 			mockLibvirt.DomainEXPECT().AbortJob().DoAndReturn(func() error {
 				go func() {
-					time.Sleep(time.Second)
+					time.Sleep(100 * time.Millisecond)
 					close(migrationDone)
 				}()
 				return nil
@@ -1989,7 +1989,7 @@ var _ = Describe("Manager", func() {
 			})
 			mockLibvirt.DomainEXPECT().AbortJob().DoAndReturn(func() error {
 				go func() {
-					time.Sleep(time.Second)
+					time.Sleep(100 * time.Millisecond)
 					close(migrationDone)
 				}()
 				return nil
@@ -1997,7 +1997,7 @@ var _ = Describe("Manager", func() {
 
 			monitor := newMigrationMonitor(vmi, manager, options, migrationDone)
 			monitor.startMonitor(make(chan error, 1))
-			Eventually(abortStatus, 2*time.Second, 100*time.Millisecond).Should(Equal(string(v1.MigrationAbortSucceeded)))
+			Eventually(abortStatus, 500*time.Millisecond, 50*time.Millisecond).Should(Equal(string(v1.MigrationAbortSucceeded)))
 		})
 		DescribeTable("migration should be canceled when GetJobStats does not report progress", func(stubGetJobStats func()) {
 			migrationDone := make(chan struct{})
@@ -2018,6 +2018,11 @@ var _ = Describe("Manager", func() {
 			migrationMetadata.StartTimestamp = &now
 			metadataCache.Migration.Store(migrationMetadata)
 
+			abortStatus := func() string {
+				m, _ := metadataCache.Migration.Load()
+				return m.AbortStatus
+			}
+
 			manager := &LibvirtDomainManager{
 				virConn:       mockLibvirt.VirtConnection,
 				virtShareDir:  testVirtShareDir,
@@ -2031,12 +2036,16 @@ var _ = Describe("Manager", func() {
 			mockLibvirt.ConnectionEXPECT().LookupDomainByName(testDomainName).DoAndReturn(mockDomainWithFreeExpectation)
 			mockLibvirt.DomainEXPECT().GetJobInfo().Return(&libvirt.DomainJobInfo{Type: libvirt.DOMAIN_JOB_UNBOUNDED}, nil)
 			mockLibvirt.DomainEXPECT().AbortJob().DoAndReturn(func() error {
-				close(migrationDone)
+				go func() {
+					time.Sleep(100 * time.Millisecond)
+					close(migrationDone)
+				}()
 				return nil
 			})
 
 			monitor := newMigrationMonitor(vmi, manager, options, migrationDone)
 			monitor.startMonitor(make(chan error, 1))
+			Eventually(abortStatus, 500*time.Millisecond, 50*time.Millisecond).Should(Equal(string(v1.MigrationAbortSucceeded)))
 		},
 			Entry("because GetJobStats keeps failing", func() {
 				mockLibvirt.DomainEXPECT().GetJobStats(libvirt.DomainGetJobStatsFlags(0)).AnyTimes().Return(nil, fmt.Errorf("persistent stats error"))
@@ -2087,7 +2096,7 @@ var _ = Describe("Manager", func() {
 			mockLibvirt.DomainEXPECT().GetJobInfo().Return(&libvirt.DomainJobInfo{Type: libvirt.DOMAIN_JOB_UNBOUNDED}, nil)
 			mockLibvirt.DomainEXPECT().AbortJob().DoAndReturn(func() error {
 				go func() {
-					time.Sleep(time.Second)
+					time.Sleep(100 * time.Millisecond)
 					close(migrationDone)
 				}()
 				return nil
@@ -2306,7 +2315,7 @@ var _ = Describe("Manager", func() {
 			mockLibvirt.DomainEXPECT().GetJobInfo().Return(&libvirt.DomainJobInfo{Type: libvirt.DOMAIN_JOB_UNBOUNDED}, nil)
 			mockLibvirt.DomainEXPECT().AbortJob().DoAndReturn(func() error {
 				go func() {
-					time.Sleep(time.Second)
+					time.Sleep(100 * time.Millisecond)
 					close(migrationDone)
 				}()
 				return nil

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -2347,7 +2347,7 @@ var _ = Describe("Manager", func() {
 			migrationMetadata.UID = migrationUid
 			metadataCache.Migration.Store(migrationMetadata)
 
-			Expect(manager.CancelVMIMigration(vmi)).To(Succeed())
+			manager.CancelVMIMigration(vmi)
 
 			// Allow the aync-abort (goroutine) to be processed before finishing.
 			// This is required in order to allow the expected calls to occur.
@@ -2375,7 +2375,7 @@ var _ = Describe("Manager", func() {
 			mockLibvirt.DomainEXPECT().GetState().AnyTimes().Return(libvirt.DOMAIN_RUNNING, 1, nil)
 
 			manager, _ := newLibvirtDomainManagerDefault()
-			Expect(manager.CancelVMIMigration(vmi)).To(Succeed())
+			manager.CancelVMIMigration(vmi)
 		})
 		It("monitor should exit when migration done channel is closed", func() {
 			migrationDone := make(chan struct{})
@@ -2597,7 +2597,7 @@ var _ = Describe("Manager", func() {
 
 			// Wait for MigrateToURI3 to be blocking, then trigger abort
 			time.Sleep(500 * time.Millisecond)
-			Expect(manager.CancelVMIMigration(vmi)).To(Succeed())
+			manager.CancelVMIMigration(vmi)
 
 			Eventually(abortOrdered, 5*time.Second).Should(BeClosed())
 			Eventually(done, 10*time.Second).Should(BeClosed())
@@ -2653,7 +2653,7 @@ var _ = Describe("Manager", func() {
 			}()
 
 			time.Sleep(500 * time.Millisecond)
-			Expect(manager.CancelVMIMigration(vmi)).To(Succeed())
+			manager.CancelVMIMigration(vmi)
 			Eventually(done, 10*time.Second).Should(BeClosed())
 
 			migration, _ := metadataCache.Migration.Load()
@@ -2695,7 +2695,7 @@ var _ = Describe("Manager", func() {
 			endTimestamp := migration.EndTimestamp.DeepCopy()
 
 			// Late abort: cancelMigration is a no-op because EndTimestamp is already set
-			Expect(manager.CancelVMIMigration(vmi)).To(Succeed())
+			manager.CancelVMIMigration(vmi)
 
 			// EndTimestamp should not be overwritten
 			migration, _ = metadataCache.Migration.Load()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
improve robustness of migration abort handling 

### References
followup to minor comments in #17596 
fixes possible flake (https://storage.googleapis.com/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/17596/pull-kubevirt-e2e-k8s-1.36-sig-compute-migrations/2066759767971336192)

<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:
replacing the internal libvirt string matching with `AbortStatus` outcome is not only fixing a flake but presumably improve a bit robustness. Downside is that in case of some other unforeseen error that would happen *after* `AbortSucceeded` it would be covered up by a generic "Live migration has been aborted". The actual error would still be in logs, and I believe this is still better than relying on unreliable error messages.

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```
NONE
```

