### PR TITLE
plugins, pipeline: fix plugin-level Condition and FailureStrategy evaluation

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/plugin-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/plugin-admitter.go
@@ -24,6 +24,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
+	"slices"
 
 	admissionv1 "k8s.io/api/admission/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -86,6 +87,17 @@ func validatePlugin(p *pluginv1alpha1.Plugin) []metav1.StatusCause {
 
 	if hasCELExpressions(p) {
 		eval := celutil.GetEvaluator()
+
+		if p.Spec.Condition != "" {
+			if err := eval.CompileCondition(p.Spec.Condition); err != nil {
+				causes = append(causes, metav1.StatusCause{
+					Type:    metav1.CauseTypeFieldValueInvalid,
+					Message: fmt.Sprintf("invalid CEL condition expression: %s", err),
+					Field:   specPath.Child("condition").String(),
+				})
+			}
+		}
+
 		for i, dh := range p.Spec.DomainHooks {
 			causes = append(causes, validateDomainHookCEL(eval, dh, specPath.Child("domainHooks").Index(i))...)
 		}
@@ -110,17 +122,15 @@ func validatePlugin(p *pluginv1alpha1.Plugin) []metav1.StatusCause {
 }
 
 func hasCELExpressions(p *pluginv1alpha1.Plugin) bool {
-	for _, dh := range p.Spec.DomainHooks {
-		if (dh.CEL != nil && dh.CEL.Expression != "") || dh.Condition != "" {
-			return true
-		}
+	if p.Spec.Condition != "" {
+		return true
 	}
-	for _, nh := range p.Spec.NodeHooks {
-		if nh.Condition != "" {
-			return true
-		}
+	if slices.ContainsFunc(p.Spec.NodeHooks, func(nh pluginv1alpha1.NodeHook) bool { return nh.Condition != "" }) {
+		return true
 	}
-	return false
+	return slices.ContainsFunc(p.Spec.DomainHooks, func(dh pluginv1alpha1.DomainHook) bool {
+		return (dh.CEL != nil && dh.CEL.Expression != "") || dh.Condition != ""
+	})
 }
 
 func validateDomainHookCEL(eval *celutil.Evaluator, dh pluginv1alpha1.DomainHook, dhPath *field.Path) []metav1.StatusCause {

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/plugin-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/plugin-admitter_test.go
@@ -156,6 +156,26 @@ var _ = Describe("Validating Plugin Admitter", func() {
 		Expect(resp.Allowed).To(BeTrue())
 	})
 
+	It("should accept valid plugin-level condition", func() {
+		p := newMinimalPlugin()
+		p.Spec.Condition = `vmi.Name == "test"`
+		resp := admit(p)
+		Expect(resp.Allowed).To(BeTrue())
+	})
+
+	DescribeTable("should reject invalid plugin-level condition", func(condition string) {
+		p := newMinimalPlugin()
+		p.Spec.Condition = condition
+		resp := admit(p)
+		Expect(resp.Allowed).To(BeFalse())
+		Expect(resp.Result.Details.Causes).To(ContainElement(
+			WithTransform(func(c metav1.StatusCause) string { return c.Field }, Equal("spec.condition")),
+		))
+	},
+		Entry("with invalid syntax", "invalid!!! condition"),
+		Entry("with non-bool return type", `vmi.Name`),
+	)
+
 	It("should reject CEL domain hook with type-incorrect field value", func() {
 		p := newMinimalPlugin()
 		p.Spec.DomainHooks = []pluginv1alpha1.DomainHook{{

--- a/pkg/virt-launcher/virtwrap/plugins/pipeline.go
+++ b/pkg/virt-launcher/virtwrap/plugins/pipeline.go
@@ -108,28 +108,32 @@ func ApplyDomainHooks(plugins []pluginv1alpha1.Plugin, vmi *v1.VirtualMachineIns
 	for i, plugin := range sortedPlugins {
 		pluginNames[i] = plugin.Name
 	}
-	log.Log.Infof("Applying domain hooks from plugins: [%s]", strings.Join(pluginNames, ", "))
+	log.Log.Infof("Evaluating domain hooks from plugins: [%s]", strings.Join(pluginNames, ", "))
 
 	for _, plugin := range sortedPlugins {
-		for hookIdx, hook := range plugin.Spec.DomainHooks {
-			failureStrategy := hook.FailureStrategy
-			if failureStrategy == "" {
-				failureStrategy = pluginv1alpha1.FailureStrategyFail
+		if plugin.Spec.Condition != "" {
+			matched, err := evaluator.EvaluateCondition(plugin.Spec.Condition, vmi, domain)
+			if err != nil {
+				return nil, "", fmt.Errorf("plugin %s condition evaluation failed: %w", plugin.Name, err)
 			}
+			if !matched {
+				log.Log.Infof("Skipping plugin %s: condition not met", plugin.Name)
+				continue
+			}
+		}
 
+		for hookIdx, hook := range plugin.Spec.DomainHooks {
 			if hook.Condition != "" {
 				matched, err := evaluator.EvaluateCondition(hook.Condition, vmi, domain)
 				if err != nil {
-					if failureStrategy == pluginv1alpha1.FailureStrategyIgnore {
-						log.Log.Warningf("Plugin %s hook %d condition evaluation failed (ignored): %v", plugin.Name, hookIdx, err)
-						continue
-					}
 					return nil, "", fmt.Errorf("plugin %s hook %d condition evaluation failed: %w", plugin.Name, hookIdx, err)
 				}
 				if !matched {
 					continue
 				}
 			}
+
+			failureStrategy := cmp.Or(hook.FailureStrategy, plugin.Spec.FailureStrategy, pluginv1alpha1.FailureStrategyFail)
 
 			var applier hookApplier
 			switch {

--- a/pkg/virt-launcher/virtwrap/plugins/pipeline_test.go
+++ b/pkg/virt-launcher/virtwrap/plugins/pipeline_test.go
@@ -313,32 +313,15 @@ var _ = Describe("Domain Hook Pipeline", func() {
 		})
 	})
 
-	Context("failure strategy", func() {
-		It("should abort on Fail strategy with bad expression", func() {
+	Context("plugin-level condition", func() {
+		It("should skip all hooks when plugin condition is false", func() {
 			plugin := pluginv1alpha1.Plugin{
-				ObjectMeta: metav1.ObjectMeta{Name: "failing"},
+				ObjectMeta: metav1.ObjectMeta{Name: "filtered"},
 				Spec: pluginv1alpha1.PluginSpec{
+					Condition: `vmi.Labels["app"] == "nonexistent"`,
 					DomainHooks: []pluginv1alpha1.DomainHook{
 						{
-							FailureStrategy: pluginv1alpha1.FailureStrategyFail,
-							CEL:             &pluginv1alpha1.CELDomainHook{Expression: `invalid!!! expression`},
-						},
-					},
-				},
-			}
-
-			_, _, err := plugins.ApplyDomainHooks([]pluginv1alpha1.Plugin{plugin}, vmi, spec, pluginv1alpha1.InvocationContextBoot)
-			Expect(err).To(HaveOccurred())
-		})
-
-		It("should continue on Ignore strategy with bad expression", func() {
-			plugin := pluginv1alpha1.Plugin{
-				ObjectMeta: metav1.ObjectMeta{Name: "ignoring"},
-				Spec: pluginv1alpha1.PluginSpec{
-					DomainHooks: []pluginv1alpha1.DomainHook{
-						{
-							FailureStrategy: pluginv1alpha1.FailureStrategyIgnore,
-							CEL:             &pluginv1alpha1.CELDomainHook{Expression: `invalid!!! expression`},
+							CEL: &pluginv1alpha1.CELDomainHook{Expression: `Domain{Title: "should-not-appear"}`},
 						},
 					},
 				},
@@ -346,17 +329,37 @@ var _ = Describe("Domain Hook Pipeline", func() {
 
 			result, xmlStr, err := plugins.ApplyDomainHooks([]pluginv1alpha1.Plugin{plugin}, vmi, spec, pluginv1alpha1.InvocationContextBoot)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(xmlStr).NotTo(BeEmpty())
+			Expect(xmlStr).NotTo(ContainSubstring("should-not-appear"))
 			Expect(result).NotTo(BeNil())
 		})
 
-		It("should default to Fail when no strategy is set", func() {
+		It("should apply hooks when plugin condition is true", func() {
 			plugin := pluginv1alpha1.Plugin{
-				ObjectMeta: metav1.ObjectMeta{Name: "defaulting"},
+				ObjectMeta: metav1.ObjectMeta{Name: "matching"},
 				Spec: pluginv1alpha1.PluginSpec{
+					Condition: `vmi.Labels["app"] == "test"`,
 					DomainHooks: []pluginv1alpha1.DomainHook{
 						{
-							CEL: &pluginv1alpha1.CELDomainHook{Expression: `invalid!!! expression`},
+							CEL: &pluginv1alpha1.CELDomainHook{Expression: `Domain{Title: "plugin-matched"}`},
+						},
+					},
+				},
+			}
+
+			_, xmlStr, err := plugins.ApplyDomainHooks([]pluginv1alpha1.Plugin{plugin}, vmi, spec, pluginv1alpha1.InvocationContextBoot)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(xmlStr).To(ContainSubstring("plugin-matched"))
+		})
+
+		It("should hard-fail on invalid plugin condition regardless of failure strategy", func() {
+			plugin := pluginv1alpha1.Plugin{
+				ObjectMeta: metav1.ObjectMeta{Name: "bad-condition"},
+				Spec: pluginv1alpha1.PluginSpec{
+					Condition:       `invalid!!! expression`,
+					FailureStrategy: pluginv1alpha1.FailureStrategyIgnore,
+					DomainHooks: []pluginv1alpha1.DomainHook{
+						{
+							CEL: &pluginv1alpha1.CELDomainHook{Expression: `Domain{Title: "irrelevant"}`},
 						},
 					},
 				},
@@ -364,7 +367,62 @@ var _ = Describe("Domain Hook Pipeline", func() {
 
 			_, _, err := plugins.ApplyDomainHooks([]pluginv1alpha1.Plugin{plugin}, vmi, spec, pluginv1alpha1.InvocationContextBoot)
 			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("condition"))
 		})
+
+		It("should evaluate hook condition only when plugin condition passes", func() {
+			plugin := pluginv1alpha1.Plugin{
+				ObjectMeta: metav1.ObjectMeta{Name: "both-conditions"},
+				Spec: pluginv1alpha1.PluginSpec{
+					Condition: `vmi.Labels["app"] == "test"`,
+					DomainHooks: []pluginv1alpha1.DomainHook{
+						{
+							Condition: `vmi.Namespace == "wrong"`,
+							CEL:       &pluginv1alpha1.CELDomainHook{Expression: `Domain{Title: "should-not-appear"}`},
+						},
+						{
+							Condition: `vmi.Namespace == "default"`,
+							CEL:       &pluginv1alpha1.CELDomainHook{Expression: `Domain{Title: "both-passed"}`},
+						},
+					},
+				},
+			}
+
+			_, xmlStr, err := plugins.ApplyDomainHooks([]pluginv1alpha1.Plugin{plugin}, vmi, spec, pluginv1alpha1.InvocationContextBoot)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(xmlStr).To(ContainSubstring("both-passed"))
+			Expect(xmlStr).NotTo(ContainSubstring("should-not-appear"))
+		})
+	})
+
+	Context("failure strategy", func() {
+		DescribeTable("should resolve failure strategy correctly", func(pluginStrategy, hookStrategy pluginv1alpha1.FailureStrategy, expectErr bool) {
+			plugin := pluginv1alpha1.Plugin{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-strategy"},
+				Spec: pluginv1alpha1.PluginSpec{
+					FailureStrategy: pluginStrategy,
+					DomainHooks: []pluginv1alpha1.DomainHook{
+						{
+							FailureStrategy: hookStrategy,
+							CEL:             &pluginv1alpha1.CELDomainHook{Expression: `invalid!!! expression`},
+						},
+					},
+				},
+			}
+
+			_, _, err := plugins.ApplyDomainHooks([]pluginv1alpha1.Plugin{plugin}, vmi, spec, pluginv1alpha1.InvocationContextBoot)
+			if expectErr {
+				Expect(err).To(HaveOccurred())
+			} else {
+				Expect(err).NotTo(HaveOccurred())
+			}
+		},
+			Entry("should abort on Fail strategy", pluginv1alpha1.FailureStrategy(""), pluginv1alpha1.FailureStrategyFail, true),
+			Entry("should continue on Ignore strategy", pluginv1alpha1.FailureStrategy(""), pluginv1alpha1.FailureStrategyIgnore, false),
+			Entry("should default to Fail when no strategy is set", pluginv1alpha1.FailureStrategy(""), pluginv1alpha1.FailureStrategy(""), true),
+			Entry("should fall back to plugin-level Ignore when hook has none", pluginv1alpha1.FailureStrategyIgnore, pluginv1alpha1.FailureStrategy(""), false),
+			Entry("should let hook-level Fail override plugin-level Ignore", pluginv1alpha1.FailureStrategyIgnore, pluginv1alpha1.FailureStrategyFail, true),
+		)
 	})
 
 	Context("sidecar hooks", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
`PluginSpec.Condition` was never evaluated so plugins couldn't filter which VMs they apply to. `PluginSpec.FailureStrategy` was also ignored, so hooks without their own strategy always defaulted to Fail.

#### After this PR:
This PR does the following:
- Changes the evaluation to evaluate plugin-level `Condition` before iterating hooks (i.e., skip all hooks if the plugin doesn't match the VM).
- VM matching no longer takes `FailureStrategy` into consideration since those should only apply for the actual domain mutation and also errors out on matcher evaluation errors.
- `FailureStrategy` now correctly resolves hook > plugin > Fail.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

VEP tracking issue: https://github.com/kubevirt/enhancements/issues/190

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

