### PR TITLE
tests: add StorageCritical decorator to 9 storage tests

### DIFF
--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -302,7 +302,7 @@ var _ = Describe(SIG("DataVolume Integration", func() {
 				}
 			})
 
-			It("[test_id:6686]should successfully start multiple concurrent VMIs", func() {
+			It("[test_id:6686]should successfully start multiple concurrent VMIs", decorators.StorageCritical, func() {
 
 				sc, exists := libstorage.GetRWOFileSystemStorageClass()
 				if !exists {
@@ -616,7 +616,7 @@ var _ = Describe(SIG("DataVolume Integration", func() {
 			}
 		})
 
-		It("[test_id:837]deleting VM with background propagation policy should automatically delete DataVolumes and VMI owned by VM.", func() {
+		It("[test_id:837]deleting VM with background propagation policy should automatically delete DataVolumes and VMI owned by VM.", decorators.StorageCritical, func() {
 			vm := renderVMWithRegistryImportDataVolume(cd.ContainerDiskAlpine, sc)
 			vm, err = virtClient.VirtualMachine(testsuite.GetTestNamespace(nil)).Create(context.Background(), vm, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
@@ -833,7 +833,7 @@ var _ = Describe(SIG("DataVolume Integration", func() {
 				}
 			}
 
-			DescribeTable("should resolve DataVolume sourceRef", func(createDataSourceFunc func() *cdiv1.DataSource) {
+			DescribeTable("should resolve DataVolume sourceRef", decorators.StorageCritical, func(createDataSourceFunc func() *cdiv1.DataSource) {
 				// convert DV to use datasource
 				dvt := &vm.Spec.DataVolumeTemplates[0]
 				ds := createDataSourceFunc()

--- a/tests/storage/migration.go
+++ b/tests/storage/migration.go
@@ -371,7 +371,7 @@ var _ = Describe(SIG("Volumes update with migration", decorators.RequiresTwoSche
 			)
 		})
 
-		DescribeTable("should migrate the source volume from a source DV to a destination DV", func(allowPostCopy bool) {
+		DescribeTable("should migrate the source volume from a source DV to a destination DV", decorators.StorageCritical, func(allowPostCopy bool) {
 			policyName := fmt.Sprintf("testpolicy-%s", rand.String(5))
 			migrationPolicy := kubecli.NewMinimalMigrationPolicy(policyName)
 			migrationPolicy.Spec.AllowPostCopy = pointer.P(allowPostCopy)

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -287,7 +287,7 @@ var _ = Describe(SIG("Storage", func() {
 
 		Context("[rfe_id:3106][crit:medium][vendor:cnv-qe@redhat.com][level:component]With an emptyDisk defined", func() {
 			// The following case is mostly similar to the alpine PVC test above, except using different VirtualMachineInstance.
-			It("[test_id:3134]should create a writeable emptyDisk with the right capacity", func() {
+			It("[test_id:3134]should create a writeable emptyDisk with the right capacity", decorators.StorageCritical, func() {
 
 				// Start the VirtualMachineInstance with the empty disk attached
 				vmi = libvmifact.NewAlpineWithTestTooling(
@@ -324,7 +324,7 @@ var _ = Describe(SIG("Storage", func() {
 
 		Context("[rfe_id:3106][crit:medium][vendor:cnv-qe@redhat.com][level:component]With an emptyDisk defined and a specified serial number", func() {
 			// The following case is mostly similar to the alpine PVC test above, except using different VirtualMachineInstance.
-			It("[test_id:3135]should create a writeable emptyDisk with the specified serial number", func() {
+			It("[test_id:3135]should create a writeable emptyDisk with the specified serial number", decorators.StorageCritical, func() {
 
 				// Start the VirtualMachineInstance with the empty disk attached
 				vmi = libvmifact.NewAlpineWithTestTooling(libnet.WithMasqueradeNetworking())
@@ -390,7 +390,7 @@ var _ = Describe(SIG("Storage", func() {
 				})
 
 				// The following case is mostly similar to the alpine PVC test above, except using different VirtualMachineInstance.
-				It("[test_id:3136]started with Ephemeral PVC", func() {
+				It("[test_id:3136]started with Ephemeral PVC", decorators.StorageCritical, func() {
 					pvName = diskAlpineHostPath
 
 					vmi = libvmi.New(
@@ -1082,7 +1082,7 @@ var _ = Describe(SIG("Storage", func() {
 				vmi2.Spec.Affinity = affinityRule
 			})
 
-			It("should successfully start 2 VMs with a shareable disk", func() {
+			It("should successfully start 2 VMs with a shareable disk", decorators.StorageCritical, func() {
 				setShareable(vmi1, "disk0")
 				setShareable(vmi2, "disk0")
 
@@ -1092,7 +1092,7 @@ var _ = Describe(SIG("Storage", func() {
 			})
 		})
 		Context("write and read data from a shared disk", func() {
-			It("should successfully write and read data", decorators.RequiresBlockStorage, func() {
+			It("should successfully write and read data", decorators.RequiresBlockStorage, decorators.StorageCritical, func() {
 				const diskName = "disk1"
 				const pvcClaim = "pvc-test-disk1"
 				const labelKey = "testshareablekey"


### PR DESCRIPTION
Add `decorators.StorageCritical` to 9 storage tests to include them in the self-certification suite.

The self-certification suite is what cloud providers run to validate their storage infrastructure for OpenShift Virtualization. Currently 71 tests run, but 3 categories have zero or minimal coverage:

- **DataVolume lifecycle** (3 tests): concurrent VMIs, VM deletion cleanup, sourceRef resolution,
- **Storage Migration** (1 test): DV-to-DV migration
- **Storage Fundamentals** (5 tests): emptyDisk, serial number, ephemeral PVC, shareable disk, block I/O

All 11 tests were validated on a live cluster (test-gcnv16, GCP Hyperdisk) and passed.

Full proposal with rationale for each test: https://github.com/Ahmad-Hafe/ocp-virt-validation-checkup/blob/docs/storage-self-certification-proposal/docs/SELF_CERTIFICATION_PROPOSAL.md

```release-note
Add StorageCritical decorator to 11 storage tests covering DataVolume lifecycle, storage migration, and storage fundamentals.
```

Signed-off-by: Ahmad Hafe <ahafe@redhat.com>