### PR TITLE
fix(dockerized): mount bazel cache GCS credentials into builder container

### DIFF
--- a/hack/dockerized
+++ b/hack/dockerized
@@ -170,6 +170,11 @@ if [ -n "$ARTIFACTS" ]; then
     fi
 fi
 
+# mount bazel cache GCS credentials if available
+if [ -n "${BAZEL_CACHE_GOOGLE_CREDENTIALS-}" ] && [ -f "${BAZEL_CACHE_GOOGLE_CREDENTIALS}" ]; then
+    volumes="$volumes -v ${BAZEL_CACHE_GOOGLE_CREDENTIALS}:${BAZEL_CACHE_GOOGLE_CREDENTIALS}:ro${selinux_bind_options}"
+fi
+
 # Ensure that a bazel server which is running is the correct one
 if [ -n "$($KUBEVIRT_CRI ps --format '{{.Names}}' | grep ${BUILDER}-bazel-server)" ]; then
     # check if the image is correct


### PR DESCRIPTION
### What this PR does
#### Before this PR:
The dockerized builder container launched by `hack/dockerized` does not mount the bazel cache GCS service account key. Bazel sees `--google_credentials=/etc/bazel-cache-gcs/bazel-cache-sa.json` in `ci.bazelrc` but the file does not exist inside the container, causing all dockerized builds to fail with `Could not open auth credentials file`.

#### After this PR:
`hack/dockerized` conditionally mounts `/etc/bazel-cache-gcs` into the builder container when the directory exists, so Bazel can access the SA key at the same path referenced in `ci.bazelrc`.

### Why we need it and why it was done in this way
The GCS bazel cache migration (kubevirt/project-infra#5126) was reverted (kubevirt/project-infra#5144) because dockerized builds could not access the SA credentials. This fix is needed before re-enabling the GCS cache in project-infra.

### Special notes for your reviewer
/cc @dhiller @dollierp 

### Release note
```release-note

```