### PR TITLE
Adding NoLeadingVirtController alert

### DIFF
--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -114,6 +114,7 @@
 | cluster:kubevirt_virt_api_pods_running:count | Recording rule | Gauge | The number of virt-api pods that are running. |
 | cluster:kubevirt_virt_api_ready:sum | Recording rule | Gauge | The number of virt-api pods that are ready. |
 | cluster:kubevirt_virt_api_up:sum | Recording rule | Gauge | The number of virt-api pods that are up. |
+| cluster:kubevirt_virt_controller_leading:sum | Recording rule | Gauge | The number of virt-controller pods that are leading. |
 | cluster:kubevirt_virt_controller_pods_running:count | Recording rule | Gauge | The number of virt-controller pods that are running. |
 | cluster:kubevirt_virt_controller_ready:sum | Recording rule | Gauge | The number of virt-controller pods that are ready. |
 | cluster:kubevirt_virt_controller_up:sum | Recording rule | Gauge | The number of virt-controller pods that are up. |

--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -447,6 +447,124 @@ tests:
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
 
+  # No virt-controller is leading
+  - interval: 1m
+    input_series:
+      - series: 'kubevirt_virt_controller_leading_status{namespace="ci", pod="virt-controller-1"}'
+        values: "0 0 0 0 0 0 0 0 0 0 0"
+      - series: 'kubevirt_virt_controller_leading_status{namespace="ci", pod="virt-controller-2"}'
+        values: "0 0 0 0 0 0 0 0 0 0 0"
+
+    alert_rule_test:
+      - eval_time: 9m
+        alertname: NoLeadingVirtController
+        exp_alerts: [ ]
+      - eval_time: 10m
+        alertname: NoLeadingVirtController
+        exp_alerts:
+          - exp_annotations:
+              summary: "No leading virt-controller was detected for the last 10 min."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/NoLeadingVirtController"
+            exp_labels:
+              severity: "critical"
+              operator_health_impact: "critical"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+
+  # A virt-controller is leading
+  - interval: 1m
+    input_series:
+      - series: 'kubevirt_virt_controller_leading_status{namespace="ci", pod="virt-controller-1"}'
+        values: "1 1 1 1 1 1 1 1 1 1 1"
+      - series: 'kubevirt_virt_controller_leading_status{namespace="ci", pod="virt-controller-2"}'
+        values: "0 0 0 0 0 0 0 0 0 0 0"
+
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: NoLeadingVirtController
+        exp_alerts: [ ]
+
+  # No virt-controller is leading (stale metrics)
+  - interval: 1m
+    input_series:
+      - series: 'kubevirt_virt_controller_leading_status{namespace="ci", pod="virt-controller-1"}'
+        values: "stale stale stale stale stale stale stale stale stale stale"
+
+    alert_rule_test:
+      - eval_time: 9m
+        alertname: NoLeadingVirtController
+        exp_alerts: [ ]
+      - eval_time: 10m
+        alertname: NoLeadingVirtController
+        exp_alerts:
+          - exp_annotations:
+              summary: "No leading virt-controller was detected for the last 10 min."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/NoLeadingVirtController"
+            exp_labels:
+              severity: "critical"
+              operator_health_impact: "critical"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+
+  # No virt-operator is leading
+  - interval: 1m
+    input_series:
+      - series: 'kubevirt_virt_operator_leading_status{namespace="ci", pod="virt-operator-1"}'
+        values: "0 0 0 0 0 0 0 0 0 0 0"
+      - series: 'kubevirt_virt_operator_leading_status{namespace="ci", pod="virt-operator-2"}'
+        values: "0 0 0 0 0 0 0 0 0 0 0"
+
+    alert_rule_test:
+      - eval_time: 9m
+        alertname: NoLeadingVirtOperator
+        exp_alerts: [ ]
+      - eval_time: 10m
+        alertname: NoLeadingVirtOperator
+        exp_alerts:
+          - exp_annotations:
+              summary: "No leading virt-operator was detected for the last 10 min."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/NoLeadingVirtOperator"
+            exp_labels:
+              severity: "critical"
+              operator_health_impact: "critical"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+
+  # A virt-operator is leading
+  - interval: 1m
+    input_series:
+      - series: 'kubevirt_virt_operator_leading_status{namespace="ci", pod="virt-operator-1"}'
+        values: "1 1 1 1 1 1 1 1 1 1 1"
+      - series: 'kubevirt_virt_operator_leading_status{namespace="ci", pod="virt-operator-2"}'
+        values: "0 0 0 0 0 0 0 0 0 0 0"
+
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: NoLeadingVirtOperator
+        exp_alerts: [ ]
+
+  # No virt-operator is leading (stale metrics)
+  - interval: 1m
+    input_series:
+      - series: 'kubevirt_virt_operator_leading_status{namespace="ci", pod="virt-operator-1"}'
+        values: "stale stale stale stale stale stale stale stale stale stale"
+
+    alert_rule_test:
+      - eval_time: 9m
+        alertname: NoLeadingVirtOperator
+        exp_alerts: [ ]
+      - eval_time: 10m
+        alertname: NoLeadingVirtOperator
+        exp_alerts:
+          - exp_annotations:
+              summary: "No leading virt-operator was detected for the last 10 min."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/NoLeadingVirtOperator"
+            exp_labels:
+              severity: "critical"
+              operator_health_impact: "critical"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+
   # All virt operators are not ready (ImagePullBackOff)
   - interval: 1m
     input_series:

--- a/pkg/monitoring/rules/alerts/virt-controller.go
+++ b/pkg/monitoring/rules/alerts/virt-controller.go
@@ -56,6 +56,18 @@ func virtControllerAlerts(namespace string) []promv1.Rule {
 			},
 		},
 		{
+			Alert: "NoLeadingVirtController",
+			Expr:  intstr.FromString("cluster:kubevirt_virt_controller_leading:sum == 0"),
+			For:   ptr.To(promv1.Duration("10m")),
+			Annotations: map[string]string{
+				summaryAnnotationKey: "No leading virt-controller was detected for the last 10 min.",
+			},
+			Labels: map[string]string{
+				severityAlertLabelKey:        "critical",
+				operatorHealthImpactLabelKey: "critical",
+			},
+		},
+		{
 			Alert: "VirtControllerDown",
 			Expr:  intstr.FromString("cluster:kubevirt_virt_controller_pods_running:count == 0"),
 			For:   ptr.To(promv1.Duration("10m")),

--- a/pkg/monitoring/rules/recordingrules/virt.go
+++ b/pkg/monitoring/rules/recordingrules/virt.go
@@ -96,9 +96,14 @@ func virtRecordingRules(namespace string) []operatorrules.RecordingRule {
 
 		// leading
 		newRecordingRule(
+			"cluster:kubevirt_virt_controller_leading:sum",
+			"The number of virt-controller pods that are leading.",
+			fmt.Sprintf("sum(kubevirt_virt_controller_leading_status{namespace='%s'}) or vector(0)", namespace),
+		),
+		newRecordingRule(
 			"cluster:kubevirt_virt_operator_leading:sum",
 			"The number of virt-operator pods that are leading.",
-			fmt.Sprintf("sum(kubevirt_virt_operator_leading_status{namespace='%s'})", namespace),
+			fmt.Sprintf("sum(kubevirt_virt_operator_leading_status{namespace='%s'}) or vector(0)", namespace),
 		),
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
We had only `kubevirt_virt_controller_leading_status `metric without matching recording rule and alert
#### After this PR:
We added `cluster:kubevirt_virt_controller_leading:sum`  recording rule and `NoLeadingVirtController` alert 
### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://redhat.atlassian.net/browse/CNV-83345
```

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Adding NoLeadingVirtController alert
```

