### PR TITLE
virt-operator: clear stale SynchronizationAddresses for terminating pods

### DIFF
--- a/pkg/virt-operator/resource/apply/core.go
+++ b/pkg/virt-operator/resource/apply/core.go
@@ -817,6 +817,7 @@ func (r *Reconciler) updateSynchronizationAddress() (err error) {
 	lease, err := r.k8sClient.CoordinationV1().Leases(r.kv.Namespace).Get(context.Background(), components.VirtSynchronizationControllerName, metav1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
+			r.kv.Status.SynchronizationAddresses = nil
 			return nil
 		}
 		return err
@@ -826,14 +827,20 @@ func (r *Reconciler) updateSynchronizationAddress() (err error) {
 		podName = *lease.Spec.HolderIdentity
 	}
 	if podName == "" {
+		r.kv.Status.SynchronizationAddresses = nil
 		return nil
 	}
 	pod, err := r.k8sClient.CoreV1().Pods(r.kv.Namespace).Get(context.Background(), podName, metav1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
+			r.kv.Status.SynchronizationAddresses = nil
 			return nil
 		}
 		return err
+	}
+	if pod.DeletionTimestamp != nil {
+		r.kv.Status.SynchronizationAddresses = nil
+		return nil
 	}
 
 	// Check for the migration network address in the pod annotations.

--- a/pkg/virt-operator/resource/apply/core_test.go
+++ b/pkg/virt-operator/resource/apply/core_test.go
@@ -971,6 +971,20 @@ var _ = Describe("Apply", func() {
 			}
 		},
 			Entry("should not populate synchronization address, if no pod found", nil, "", ""),
+			Entry("should not populate synchronization address, if pod is terminating", &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:              synchronizationControllerPodName,
+					Namespace:         kubevirtNamespace,
+					DeletionTimestamp: pointer.P(metav1.Now()),
+				},
+				Status: corev1.PodStatus{
+					PodIPs: []corev1.PodIP{
+						{
+							IP: "1.1.1.1",
+						},
+					},
+				},
+			}, "", ""),
 			Entry("if pod found without migration network, without ip address", &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      synchronizationControllerPodName,

--- a/tests/testsuite/fixture.go
+++ b/tests/testsuite/fixture.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"time"
 
@@ -44,6 +45,7 @@ import (
 	"kubevirt.io/client-go/log"
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
+	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"
 	"kubevirt.io/kubevirt/tests/flags"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
@@ -210,6 +212,16 @@ func EnsureKubevirtReadyWithTimeout(kv *v1.KubeVirt, timeout time.Duration) {
 				return kv.ObjectMeta.Generation == *kv.Status.ObservedGeneration
 			}),
 		), "One of the Kubevirt control-plane components is not ready.")
+
+	if kv.Spec.Configuration.DeveloperConfiguration != nil &&
+		slices.Contains(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates, featuregate.DecentralizedLiveMigration) {
+		Eventually(func() []string {
+			foundKV, err := virtClient.KubeVirt(kv.Namespace).Get(context.Background(), kv.Name, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			return foundKV.Status.SynchronizationAddresses
+		}, timeout, 1*time.Second).ShouldNot(BeEmpty(),
+			"SynchronizationAddresses should be populated when DecentralizedLiveMigration is enabled")
+	}
 }
 
 func shouldAllowEmulation(virtClient kubecli.KubevirtClient) bool {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
During rolling updates the operator could advertise stale IPs in the
KubeVirt CR status because it never checked whether the lease-holder pod
was terminating. Several early-return paths also left stale addresses in
place.

Clear addresses when the lease-holder pod is terminating or unavailable.
Gate test fixture readiness on non-empty addresses when decentralized
live migration is enabled.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

