### PR TITLE
tests, storage: Move objectgraph tests under storage package

### DIFF
--- a/hack/lint-newcirros-deprecation.sh
+++ b/hack/lint-newcirros-deprecation.sh
@@ -43,7 +43,7 @@ tests/vmi_sound_test.go
 
 CONTAINERDISK_BASELINE="
 tests/container_disk_test.go
-tests/objectgraph_test.go
+tests/storage/objectgraph_test.go
 tests/vmi_configuration_test.go
 tests/vmi_lifecycle_test.go
 "

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -51,7 +51,6 @@ go_test(
         "dryrun_test.go",
         "hyperv_test.go",
         "mdev_configuration_allocation_test.go",
-        "objectgraph_test.go",
         "plugin_test.go",
         "pool_test.go",
         "portforward_test.go",

--- a/tests/storage/BUILD.bazel
+++ b/tests/storage/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -109,5 +109,29 @@ go_library(
         "//vendor/k8s.io/client-go/rest:go_default_library",
         "//vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
         "//vendor/sigs.k8s.io/yaml:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["objectgraph_test.go"],
+    embed = [":go_default_library"],
+    deps = [
+        "//pkg/libdv:go_default_library",
+        "//pkg/libvmi:go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//tests/containerdisk:go_default_library",
+        "//tests/decorators:go_default_library",
+        "//tests/framework/kubevirt:go_default_library",
+        "//tests/framework/matcher:go_default_library",
+        "//tests/libsecret:go_default_library",
+        "//tests/libstorage:go_default_library",
+        "//tests/libvmops:go_default_library",
+        "//tests/testsuite:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
     ],
 )

--- a/tests/storage/objectgraph_test.go
+++ b/tests/storage/objectgraph_test.go
@@ -17,7 +17,7 @@
  *
  */
 
-package tests_test
+package storage
 
 import (
 	"context"


### PR DESCRIPTION
### What this PR does

Move objectgraph tests (file) under storage package

### References

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

### Special notes for your reviewer

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
NONE
```

