### PR TITLE
tests: replace JSON dumps with compact logging in fuzzing tests

### DIFF
--- a/pkg/virt-api/webhooks/fuzz/fuzz_test.go
+++ b/pkg/virt-api/webhooks/fuzz/fuzz_test.go
@@ -22,7 +22,6 @@ package fuzz
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"reflect"
 	"testing"
 	"time"
@@ -151,41 +150,30 @@ func FuzzAdmitter(f *testing.F) {
 				randfill.NewWithSeed(seed).NilChance(0.1).NumElements(0, 15).Funcs(
 					tc.fuzzFuncs...,
 				).Fill(obj)
-				request := toAdmissionReview(obj, tc.gvk)
+				raw, err := json.Marshal(obj)
+				if err != nil {
+					t.Fatalf("seed %d: json.Marshal failed: %v", seed, err)
+				}
+				request := toAdmissionReviewRaw(raw, tc.gvk)
 				config := fuzzKubeVirtConfig(seed)
 				startTime := time.Now()
 				response := tc.admit(config, request)
-				endTime := time.Now()
-				if startTime.Add(timeoutDuration).Before(endTime) {
-					fmt.Printf("Execution time %v is more than %v\n", endTime.Sub(startTime), timeoutDuration)
-					fmt.Println(response.Result.Message)
-					j, err := json.MarshalIndent(obj, "", "  ")
-					if err != nil {
-						panic(err)
-					}
-					fmt.Println(string(j))
-					t.Fail()
+				elapsed := time.Since(startTime)
+				if elapsed > timeoutDuration {
+					t.Errorf("SLOW seed=%d case=%s elapsed=%v threshold=%v objBytes=%d response=%q",
+						seed, tc.name, elapsed, timeoutDuration, len(raw), truncateMessage(response))
 				}
 
 				if tc.debug && !response.Allowed {
-					fmt.Println(response.Result.Message)
-					j, err := json.MarshalIndent(obj, "", "  ")
-					if err != nil {
-						panic(err)
-					}
-					fmt.Println(string(j))
+					t.Logf("REJECTED seed=%d case=%s objBytes=%d response=%q",
+						seed, tc.name, len(raw), truncateMessage(response))
 				}
 			})
 		}
 	})
 }
 
-func toAdmissionReview(obj interface{}, gvr metav1.GroupVersionResource) *admissionv1.AdmissionReview {
-	raw, err := json.Marshal(obj)
-	if err != nil {
-		panic(err)
-	}
-
+func toAdmissionReviewRaw(raw []byte, gvr metav1.GroupVersionResource) *admissionv1.AdmissionReview {
 	return &admissionv1.AdmissionReview{
 		Request: &admissionv1.AdmissionRequest{
 			Resource: gvr,
@@ -233,6 +221,19 @@ func fuzzKubeVirtConfig(seed int64) *virtconfig.ClusterConfig {
 	).Fill(kv)
 	config, _, _ := testutils.NewFakeClusterConfigUsingKV(kv)
 	return config
+}
+
+const maxMessageLen = 1000
+
+func truncateMessage(resp *admissionv1.AdmissionResponse) string {
+	if resp == nil || resp.Result == nil {
+		return "<nil>"
+	}
+	msg := resp.Result.Message
+	if len(msg) > maxMessageLen {
+		return msg[:maxMessageLen] + "..."
+	}
+	return msg
 }
 
 func fuzzFuncs(options ...fuzzOption) []interface{} {


### PR DESCRIPTION
The fuzz test was dumping full pretty-printed JSON of every timed-out object to raw stdout via fmt.Printf, producing ~15MB of output that Bazel silently truncated at its 1MB limit, leaving zero diagnostic information after CI failures.

Replace with compact t.Errorf one-liners reporting the seed number, test case name, elapsed time, object size, and a truncated admission response. The seed is sufficient to reproduce any failure locally.


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:

#### After this PR:
instead of nothing, we can see (example with lowered threshold):
```
    --- FAIL: FuzzAdmitter/seed#496 (0.17s)
        --- FAIL: FuzzAdmitter/seed#496/SemanticVirtualMachineFuzzing (0.06s)
            fuzz_test.go:163: SLOW seed=496 case=SemanticVirtualMachineFuzzing elapsed=54.004776ms threshold=50ms objBytes=365891 response="spec.dataVolumeTemplates.spec.pvc.accessModes in body should be one of [ReadOnlyMany ReadWriteMany ReadWriteOnce ReadWriteOncePod], spec.dataVolumeTemplates.spec.storage.accessModes in body should be one of [ReadOnlyMany ReadWriteMany ReadWriteOnce ReadWriteOncePod], spec.template.spec.accessCredentials.sshPublicKey.propagationMethod.qemuGuestAgent.users in body must be of type array: \"null\", spec.template.spec.domain.devices.filesystems.virtiofs in body must be of type object: \"null\", status.volumeUpdateState.volumeMigrationState.migratedVolumes.sourcePVCInfo.accessModes in body should be one of [ReadOnlyMany ReadWriteMany ReadWriteOnce ReadWriteOncePod], status.volumeUpdateState.volumeMigrationState.migratedVolumes.destinationPVCInfo.accessModes in body should be one of [ReadOnlyMany ReadWriteMany ReadWriteOnce ReadWriteOncePod], status.volumeRequests.addVolumeOptions.volumeSource in body must be of type object: \"null\""
    --- FAIL: FuzzAdmitter/seed#497 (0.19s)
        --- FAIL: FuzzAdmitter/seed#497/SyntacticVirtualMachineFuzzing (0.06s)
            fuzz_test.go:163: SLOW seed=497 case=SyntacticVirtualMachineFuzzing elapsed=50.872422ms threshold=50ms objBytes=339249 response="spec.template.spec.affinity.nodeAffinity.preferredDuringSchedulingIgnoredDuringExecution.preference.matchExpressions.operator in body should be one of [DoesNotExist Exists Gt In Lt NotIn], spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms in body must be of type array: \"null\", spec.template.spec.dnsPolicy in body should be one of [ClusterFirst ClusterFirstWithHostNet Default None], spec.template.spec.domain.devices.disks.blockSize.custom.discardGranularity in body must be of type int32: \"float64\", spec.template.spec.domain.devices.disks.blockSize.custom.logical in body must be of type int32: \"float64\", spec.template.spec.domain.devices.disks.blockSize.custom.physical in body must be of type int32: \"float64\", spec.template.spec.domain.devices.disks.bootOrder in body must be of type int32: \"float64\", spec.template.spec.domain.devices.interfaces.acpiIndex in body must be of type int32: \"float64\", spec.template.spec.domain.devices.int..."
```

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->


### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

