### PR TITLE
tests: fix graceful shutdown test flakes on arm64

### DIFF
--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -1637,7 +1637,7 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				event = watcher.New(vmi).Timeout(10*time.Second).SinceWatchedObjectResourceVersion().WaitFor(ctx, watcher.NormalEvent, "Deleted")
 				Expect(event).ToNot(BeNil(), "There should be a graceful shutdown")
 
-				Eventually(matcher.ThisVMI(vmi)).WithTimeout(15 * time.Second).WithPolling(time.Second).Should(matcher.BeGone())
+				Eventually(matcher.ThisVMI(vmi)).WithTimeout(60 * time.Second).WithPolling(time.Second).Should(matcher.BeGone())
 			})
 		})
 	})

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -1598,10 +1598,26 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 		Context("with grace period greater than 0", func() {
 			It("[test_id:1655]should run graceful shutdown", decorators.Conformance, decorators.WgS390x, func() {
 				By("Setting a VirtualMachineInstance termination grace period to 5")
-				vmi := libvmifact.NewAlpineWithTestTooling(libvmi.WithTerminationGracePeriod(5))
+				vmi := libvmifact.NewAlpineWithTestTooling(
+					libvmi.WithTerminationGracePeriod(5),
+				)
 
 				By("Creating the VirtualMachineInstance")
 				vmi = libvmops.RunVMIAndExpectLaunch(vmi, startupTimeout)
+
+				By("Logging into the VirtualMachineInstance")
+				Expect(console.LoginToAlpine(vmi)).To(Succeed())
+
+				By("Waiting for the guest agent to connect")
+				Eventually(matcher.ThisVMI(vmi), 60*time.Second, 2*time.Second).Should(
+					matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
+
+				By("Disabling the guest agent to ensure ACPI shutdown path")
+				Expect(console.RunCommand(vmi, "rc-service qemu-guest-agent stop", 10*time.Second)).To(Succeed())
+
+				By("Verifying the guest agent is not connected")
+				Eventually(matcher.ThisVMI(vmi), 60*time.Second, 2*time.Second).Should(
+					matcher.HaveConditionMissingOrFalse(v1.VirtualMachineInstanceAgentConnected))
 
 				// Delete the VirtualMachineInstance and wait for the confirmation of the delete
 				By("Deleting the VirtualMachineInstance")


### PR DESCRIPTION
### What this PR does

Fixes two issues causing [test_id:1655] to flake on arm64 (~5-10% rate per #15742).

The alpine-with-test-tooling image ships with qemu-guest-agent, so libvirt was silently using the guest agent channel instead of ACPI for shutdown — the test wasn't exercising the path it was meant to verify. First commit stops the agent before deletion to force ACPI.

Second commit bumps the BeGone timeout from 15s to 60s. The virt-launcher pod's termination grace period is `(5 + 15) + 15 = 35s`, so 15s was never enough to wait for the finalizer to clear. @lyarwood proposed 30s in #17342 but it was closed without merging — 60s gives proper headroom.

### References
- #15742 — arm64 flaky test tracking
- #17342 — prior timeout bump attempt (closed)
- #17193, #17943 — earlier fixes for this test (Alpine→Fedora→alpine-with-test-tooling)

### Release note
```release-note
NONE
```