### PR TITLE
instancetype: Add Max field to SpreadOptions

### DIFF
--- a/pkg/instancetype/apply/cpu.go
+++ b/pkg/instancetype/apply/cpu.go
@@ -91,20 +91,43 @@ func applyGuestCPUTopology(vCPUs uint32, preferenceSpec *v1beta1.VirtualMachineP
 	case v1beta1.DeprecatedPreferThreads, v1beta1.Threads:
 		vmiSpec.Domain.CPU.Threads = vCPUs
 	case v1beta1.DeprecatedPreferSpread, v1beta1.Spread:
-		ratio, across := preferenceApply.GetSpreadOptions(preferenceSpec)
-		switch across {
-		case v1beta1.SpreadAcrossSocketsCores:
-			vmiSpec.Domain.CPU.Cores = ratio
-			vmiSpec.Domain.CPU.Sockets = vCPUs / ratio
-		case v1beta1.SpreadAcrossCoresThreads:
-			vmiSpec.Domain.CPU.Threads = ratio
-			vmiSpec.Domain.CPU.Cores = vCPUs / ratio
-		case v1beta1.SpreadAcrossSocketsCoresThreads:
-			const threadsPerCore = 2
-			vmiSpec.Domain.CPU.Threads = threadsPerCore
-			vmiSpec.Domain.CPU.Cores = ratio
-			vmiSpec.Domain.CPU.Sockets = vCPUs / threadsPerCore / ratio
+		ratio, max, across := preferenceApply.GetSpreadOptions(preferenceSpec)
+		if max != nil {
+			applySpreadMax(vCPUs, *max, across, vmiSpec)
+		} else {
+			switch across {
+			case v1beta1.SpreadAcrossSocketsCores:
+				vmiSpec.Domain.CPU.Cores = ratio
+				vmiSpec.Domain.CPU.Sockets = vCPUs / ratio
+			case v1beta1.SpreadAcrossCoresThreads:
+				vmiSpec.Domain.CPU.Threads = ratio
+				vmiSpec.Domain.CPU.Cores = vCPUs / ratio
+			case v1beta1.SpreadAcrossSocketsCoresThreads:
+				const threadsPerCore = 2
+				vmiSpec.Domain.CPU.Threads = threadsPerCore
+				vmiSpec.Domain.CPU.Cores = ratio
+				vmiSpec.Domain.CPU.Sockets = vCPUs / threadsPerCore / ratio
+			}
 		}
+	}
+}
+
+func applySpreadMax(vCPUs, max uint32, across v1beta1.SpreadAcross, vmiSpec *virtv1.VirtualMachineInstanceSpec) {
+	switch across {
+	case v1beta1.SpreadAcrossSocketsCores:
+		sockets := min(max, vCPUs)
+		vmiSpec.Domain.CPU.Sockets = sockets
+		vmiSpec.Domain.CPU.Cores = vCPUs / sockets
+	case v1beta1.SpreadAcrossCoresThreads:
+		cores := min(max, vCPUs)
+		vmiSpec.Domain.CPU.Cores = cores
+		vmiSpec.Domain.CPU.Threads = vCPUs / cores
+	case v1beta1.SpreadAcrossSocketsCoresThreads:
+		const threadsPerCore = 2
+		vmiSpec.Domain.CPU.Threads = threadsPerCore
+		sockets := min(max, vCPUs/threadsPerCore)
+		vmiSpec.Domain.CPU.Sockets = sockets
+		vmiSpec.Domain.CPU.Cores = vCPUs / threadsPerCore / sockets
 	}
 }
 

--- a/pkg/instancetype/apply/cpu_test.go
+++ b/pkg/instancetype/apply/cpu_test.go
@@ -448,6 +448,98 @@ var _ = Describe("instancetype.spec.CPU and preference.spec.CPU", func() {
 				},
 				virtv1.CPU{Sockets: 1, Cores: 4, Threads: 2},
 			),
+			Entry("to SocketsCores with 6 vCPUs and max of 2",
+				uint32(6),
+				v1beta1.VirtualMachinePreferenceSpec{
+					CPU: &v1beta1.CPUPreferences{
+						SpreadOptions: &v1beta1.SpreadOptions{
+							Max: pointer.P(uint32(2)),
+						},
+					},
+				},
+				virtv1.CPU{Sockets: 2, Cores: 3, Threads: 1},
+			),
+			Entry("to SocketsCores with 8 vCPUs and max of 2",
+				uint32(8),
+				v1beta1.VirtualMachinePreferenceSpec{
+					CPU: &v1beta1.CPUPreferences{
+						SpreadOptions: &v1beta1.SpreadOptions{
+							Max: pointer.P(uint32(2)),
+						},
+					},
+				},
+				virtv1.CPU{Sockets: 2, Cores: 4, Threads: 1},
+			),
+			Entry("to SocketsCores with 4 vCPUs and max of 2",
+				uint32(4),
+				v1beta1.VirtualMachinePreferenceSpec{
+					CPU: &v1beta1.CPUPreferences{
+						SpreadOptions: &v1beta1.SpreadOptions{
+							Max: pointer.P(uint32(2)),
+						},
+					},
+				},
+				virtv1.CPU{Sockets: 2, Cores: 2, Threads: 1},
+			),
+			Entry("to SocketsCores with 2 vCPUs and max of 4 (clamped)",
+				uint32(2),
+				v1beta1.VirtualMachinePreferenceSpec{
+					CPU: &v1beta1.CPUPreferences{
+						SpreadOptions: &v1beta1.SpreadOptions{
+							Max: pointer.P(uint32(4)),
+						},
+					},
+				},
+				virtv1.CPU{Sockets: 2, Cores: 1, Threads: 1},
+			),
+			Entry("to CoresThreads with 4 vCPUs and max of 2",
+				uint32(4),
+				v1beta1.VirtualMachinePreferenceSpec{
+					CPU: &v1beta1.CPUPreferences{
+						SpreadOptions: &v1beta1.SpreadOptions{
+							Across: pointer.P(v1beta1.SpreadAcrossCoresThreads),
+							Max:    pointer.P(uint32(2)),
+						},
+					},
+				},
+				virtv1.CPU{Sockets: 1, Cores: 2, Threads: 2},
+			),
+			Entry("to CoresThreads with 8 vCPUs and max of 2",
+				uint32(8),
+				v1beta1.VirtualMachinePreferenceSpec{
+					CPU: &v1beta1.CPUPreferences{
+						SpreadOptions: &v1beta1.SpreadOptions{
+							Across: pointer.P(v1beta1.SpreadAcrossCoresThreads),
+							Max:    pointer.P(uint32(2)),
+						},
+					},
+				},
+				virtv1.CPU{Sockets: 1, Cores: 2, Threads: 4},
+			),
+			Entry("to SocketsCoresThreads with 8 vCPUs and max of 2",
+				uint32(8),
+				v1beta1.VirtualMachinePreferenceSpec{
+					CPU: &v1beta1.CPUPreferences{
+						SpreadOptions: &v1beta1.SpreadOptions{
+							Across: pointer.P(v1beta1.SpreadAcrossSocketsCoresThreads),
+							Max:    pointer.P(uint32(2)),
+						},
+					},
+				},
+				virtv1.CPU{Sockets: 2, Cores: 2, Threads: 2},
+			),
+			Entry("to SocketsCoresThreads with 12 vCPUs and max of 2",
+				uint32(12),
+				v1beta1.VirtualMachinePreferenceSpec{
+					CPU: &v1beta1.CPUPreferences{
+						SpreadOptions: &v1beta1.SpreadOptions{
+							Across: pointer.P(v1beta1.SpreadAcrossSocketsCoresThreads),
+							Max:    pointer.P(uint32(2)),
+						},
+					},
+				},
+				virtv1.CPU{Sockets: 2, Cores: 3, Threads: 2},
+			),
 		)
 	})
 

--- a/pkg/instancetype/preference/apply/cpu.go
+++ b/pkg/instancetype/preference/apply/cpu.go
@@ -50,12 +50,13 @@ func GetPreferredTopology(preferenceSpec *v1beta1.VirtualMachinePreferenceSpec) 
 
 const defaultSpreadRatio uint32 = 2
 
-func GetSpreadOptions(preferenceSpec *v1beta1.VirtualMachinePreferenceSpec) (uint32, v1beta1.SpreadAcross) {
+func GetSpreadOptions(preferenceSpec *v1beta1.VirtualMachinePreferenceSpec) (uint32, *uint32, v1beta1.SpreadAcross) {
 	ratio := defaultSpreadRatio
 	if preferenceSpec.PreferSpreadSocketToCoreRatio != 0 {
 		ratio = preferenceSpec.PreferSpreadSocketToCoreRatio
 	}
 	across := v1beta1.SpreadAcrossSocketsCores
+	var max *uint32
 	if preferenceSpec.CPU != nil && preferenceSpec.CPU.SpreadOptions != nil {
 		if preferenceSpec.CPU.SpreadOptions.Across != nil {
 			across = *preferenceSpec.CPU.SpreadOptions.Across
@@ -63,6 +64,7 @@ func GetSpreadOptions(preferenceSpec *v1beta1.VirtualMachinePreferenceSpec) (uin
 		if preferenceSpec.CPU.SpreadOptions.Ratio != nil {
 			ratio = *preferenceSpec.CPU.SpreadOptions.Ratio
 		}
+		max = preferenceSpec.CPU.SpreadOptions.Max
 	}
-	return ratio, across
+	return ratio, max, across
 }

--- a/pkg/instancetype/preference/requirements/cpu.go
+++ b/pkg/instancetype/preference/requirements/cpu.go
@@ -102,7 +102,7 @@ func checkSpread(
 		conflicts conflict.Conflicts
 	)
 	baseConflict := conflict.New("spec", "template", "spec", "domain", "cpu")
-	_, across := preferenceApply.GetSpreadOptions(preferenceSpec)
+	_, _, across := preferenceApply.GetSpreadOptions(preferenceSpec)
 	switch across {
 	case v1beta1.SpreadAcrossSocketsCores:
 		vCPUs = vmiSpec.Domain.CPU.Sockets * vmiSpec.Domain.CPU.Cores

--- a/pkg/instancetype/preference/validation/cpu.go
+++ b/pkg/instancetype/preference/validation/cpu.go
@@ -51,6 +51,9 @@ const (
 	spreadAcrossCoresThreadsErrFmt        = "%d vCPUs provided by the instance type are not divisible by the number of threads per core %d"
 	spreadAcrossSocketsCoresThreadsErrFmt = "%d vCPUs provided by the instance type are not divisible by the number of threads per core " +
 		"%d and Spec.PreferSpreadSocketToCoreRatio or Spec.CPU.PreferSpreadOptions.Ratio of %d"
+	spreadAcrossMaxErrFmt                    = "%d vCPUs provided by the instance type are not evenly divisible with a max of %d"
+	spreadAcrossSocketsCoresThreadsMaxErrFmt = "%d vCPUs provided by the instance type are not evenly divisible by the number of threads " +
+		"per core %d with a max of %d"
 )
 
 func CheckSpreadCPUTopology(
@@ -62,7 +65,10 @@ func CheckSpreadCPUTopology(
 		return nil
 	}
 
-	ratio, across := apply.GetSpreadOptions(preferenceSpec)
+	ratio, max, across := apply.GetSpreadOptions(preferenceSpec)
+	if max != nil {
+		return checkSpreadMax(instancetypeSpec.CPU.Guest, *max, across)
+	}
 	switch across {
 	case v1beta1.SpreadAcrossSocketsCores:
 		if (instancetypeSpec.CPU.Guest % ratio) > 0 {
@@ -83,6 +89,36 @@ func CheckSpreadCPUTopology(
 		if (instancetypeSpec.CPU.Guest%threadsPerCore) > 0 || ((instancetypeSpec.CPU.Guest/threadsPerCore)%ratio) > 0 {
 			return conflict.NewWithMessage(
 				fmt.Sprintf(spreadAcrossSocketsCoresThreadsErrFmt, instancetypeSpec.CPU.Guest, threadsPerCore, ratio),
+				instancetypeCPUGuestPath,
+			)
+		}
+	}
+	return nil
+}
+
+func checkSpreadMax(vCPUs, max uint32, across v1beta1.SpreadAcross) *conflict.Conflict {
+	switch across {
+	case v1beta1.SpreadAcrossSocketsCores, v1beta1.SpreadAcrossCoresThreads:
+		effective := min(max, vCPUs)
+		if (vCPUs % effective) > 0 {
+			return conflict.NewWithMessage(
+				fmt.Sprintf(spreadAcrossMaxErrFmt, vCPUs, max),
+				instancetypeCPUGuestPath,
+			)
+		}
+	case v1beta1.SpreadAcrossSocketsCoresThreads:
+		const threadsPerCore = 2
+		if (vCPUs % threadsPerCore) > 0 {
+			return conflict.NewWithMessage(
+				fmt.Sprintf(spreadAcrossSocketsCoresThreadsMaxErrFmt, vCPUs, threadsPerCore, max),
+				instancetypeCPUGuestPath,
+			)
+		}
+		adjusted := vCPUs / threadsPerCore
+		effective := min(max, adjusted)
+		if (adjusted % effective) > 0 {
+			return conflict.NewWithMessage(
+				fmt.Sprintf(spreadAcrossSocketsCoresThreadsMaxErrFmt, vCPUs, threadsPerCore, max),
 				instancetypeCPUGuestPath,
 			)
 		}

--- a/pkg/instancetype/preference/webhooks/admitter.go
+++ b/pkg/instancetype/preference/webhooks/admitter.go
@@ -76,6 +76,7 @@ func validatePreferredCPUTopology(field *k8sfield.Path, spec *instancetypeapiv1b
 const (
 	spreadAcrossCoresThreadsRatioErr = "only a ratio of 2 (1 core 2 threads) is allowed when spreading vCPUs over cores and threads"
 	spreadAcrossUnsupportedErrFmt    = "across %s is not supported"
+	spreadRatioMaxMutuallyExclusive  = "ratio and max are mutually exclusive"
 )
 
 func hasSpreadTopology(spec *instancetypeapiv1beta1.VirtualMachinePreferenceSpec) bool {
@@ -90,7 +91,7 @@ func validateSpreadOptions(field *k8sfield.Path, spec *instancetypeapiv1beta1.Vi
 	if !hasSpreadTopology(spec) {
 		return nil
 	}
-	ratio, across := apply.GetSpreadOptions(spec)
+	ratio, max, across := apply.GetSpreadOptions(spec)
 
 	supportedSpreadAcross := []instancetypeapiv1beta1.SpreadAcross{
 		instancetypeapiv1beta1.SpreadAcrossCoresThreads,
@@ -105,7 +106,16 @@ func validateSpreadOptions(field *k8sfield.Path, spec *instancetypeapiv1beta1.Vi
 		}}
 	}
 
-	if across == instancetypeapiv1beta1.SpreadAcrossCoresThreads && ratio != 2 {
+	if spec.CPU != nil && spec.CPU.SpreadOptions != nil &&
+		spec.CPU.SpreadOptions.Ratio != nil && spec.CPU.SpreadOptions.Max != nil {
+		return []metav1.StatusCause{{
+			Type:    metav1.CauseTypeFieldValueInvalid,
+			Message: spreadRatioMaxMutuallyExclusive,
+			Field:   field.Child("cpu", "spreadOptions").String(),
+		}}
+	}
+
+	if max == nil && across == instancetypeapiv1beta1.SpreadAcrossCoresThreads && ratio != 2 {
 		return []metav1.StatusCause{{
 			Type:    metav1.CauseTypeFieldValueInvalid,
 			Message: spreadAcrossCoresThreadsRatioErr,

--- a/pkg/instancetype/preference/webhooks/admitter_test.go
+++ b/pkg/instancetype/preference/webhooks/admitter_test.go
@@ -175,6 +175,51 @@ var _ = Describe("Validating Preference Admitter", func() {
 		),
 	)
 
+	DescribeTable("should reject when ratio and max are both set", func(preferredCPUTopology instancetypev1beta1.PreferredCPUTopology) {
+		preferenceObj = &instancetypev1beta1.VirtualMachinePreference{
+			Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{
+				CPU: &instancetypev1beta1.CPUPreferences{
+					PreferredCPUTopology: &preferredCPUTopology,
+					SpreadOptions: &instancetypev1beta1.SpreadOptions{
+						Ratio: pointer.P(uint32(2)),
+						Max:   pointer.P(uint32(2)),
+					},
+				},
+			},
+		}
+		ar := createPreferenceAdmissionReview(preferenceObj, instancetypev1beta1.SchemeGroupVersion.Version)
+		response := admitter.Admit(context.Background(), ar)
+
+		Expect(response.Allowed).To(BeFalse(), "Expected preference to not be allowed")
+		Expect(response.Result.Details.Causes).To(HaveLen(1))
+		Expect(response.Result.Details.Causes[0].Type).To(Equal(metav1.CauseTypeFieldValueInvalid))
+		Expect(response.Result.Details.Causes[0].Message).To(Equal("ratio and max are mutually exclusive"))
+		Expect(response.Result.Details.Causes[0].Field).To(Equal(k8sfield.NewPath("spec", "cpu", "spreadOptions").String()))
+	},
+		Entry("with spread", instancetypev1beta1.Spread),
+		Entry("with preferSpread", instancetypev1beta1.DeprecatedPreferSpread),
+	)
+
+	DescribeTable("should allow CoresThreads with max", func(preferredCPUTopology instancetypev1beta1.PreferredCPUTopology) {
+		preferenceObj = &instancetypev1beta1.VirtualMachinePreference{
+			Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{
+				CPU: &instancetypev1beta1.CPUPreferences{
+					PreferredCPUTopology: &preferredCPUTopology,
+					SpreadOptions: &instancetypev1beta1.SpreadOptions{
+						Across: pointer.P(instancetypev1beta1.SpreadAcrossCoresThreads),
+						Max:    pointer.P(uint32(4)),
+					},
+				},
+			},
+		}
+		ar := createPreferenceAdmissionReview(preferenceObj, instancetypev1beta1.SchemeGroupVersion.Version)
+		response := admitter.Admit(context.Background(), ar)
+		Expect(response.Allowed).To(BeTrue(), "Expected preference with CoresThreads and max to be allowed")
+	},
+		Entry("with spread", instancetypev1beta1.Spread),
+		Entry("with preferSpread", instancetypev1beta1.DeprecatedPreferSpread),
+	)
+
 	DescribeTable("should raise warning for", func(deprecatedTopology, expectedAlternativeTopology instancetypev1beta1.PreferredCPUTopology) {
 		preferenceObj := &instancetypev1beta1.VirtualMachinePreference{
 			Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{

--- a/pkg/instancetype/webhooks/vm/admitter_test.go
+++ b/pkg/instancetype/webhooks/vm/admitter_test.go
@@ -242,6 +242,9 @@ var _ = Describe("Instance type and Preference VirtualMachine Admitter", func() 
 			spreadAcrossCoresThreadsErrFmt        = "%d vCPUs provided by the instance type are not divisible by the number of threads per core %d"
 			spreadAcrossSocketsCoresThreadsErrFmt = "%d vCPUs provided by the instance type are not divisible by the number of threads per core " +
 				"%d and Spec.PreferSpreadSocketToCoreRatio or Spec.CPU.PreferSpreadOptions.Ratio of %d"
+			spreadAcrossMaxErrFmt                    = "%d vCPUs provided by the instance type are not evenly divisible with a max of %d"
+			spreadAcrossSocketsCoresThreadsMaxErrFmt = "%d vCPUs provided by the instance type are not evenly divisible by the number of threads " +
+				"per core %d with a max of %d"
 		)
 
 		DescribeTable("should reject if PreferSpread requested with",
@@ -502,6 +505,57 @@ var _ = Describe("Instance type and Preference VirtualMachine Admitter", func() 
 					},
 				},
 				fmt.Sprintf(spreadAcrossSocketsCoresThreadsErrFmt, 6, 2, 4),
+			),
+			Entry("5 vCPUs, SpreadAcrossSocketsCores and max of 3 with spread",
+				uint32(5),
+				v1beta1.VirtualMachinePreferenceSpec{
+					CPU: &v1beta1.CPUPreferences{
+						PreferredCPUTopology: pointer.P(v1beta1.Spread),
+						SpreadOptions: &v1beta1.SpreadOptions{
+							Max: pointer.P(uint32(3)),
+						},
+					},
+				},
+				fmt.Sprintf(spreadAcrossMaxErrFmt, 5, 3),
+			),
+			Entry("7 vCPUs, SpreadAcrossCoresThreads and max of 3 with spread",
+				uint32(7),
+				v1beta1.VirtualMachinePreferenceSpec{
+					CPU: &v1beta1.CPUPreferences{
+						PreferredCPUTopology: pointer.P(v1beta1.Spread),
+						SpreadOptions: &v1beta1.SpreadOptions{
+							Across: pointer.P(v1beta1.SpreadAcrossCoresThreads),
+							Max:    pointer.P(uint32(3)),
+						},
+					},
+				},
+				fmt.Sprintf(spreadAcrossMaxErrFmt, 7, 3),
+			),
+			Entry("5 vCPUs, SpreadAcrossSocketsCoresThreads and max of 2 with spread",
+				uint32(5),
+				v1beta1.VirtualMachinePreferenceSpec{
+					CPU: &v1beta1.CPUPreferences{
+						PreferredCPUTopology: pointer.P(v1beta1.Spread),
+						SpreadOptions: &v1beta1.SpreadOptions{
+							Across: pointer.P(v1beta1.SpreadAcrossSocketsCoresThreads),
+							Max:    pointer.P(uint32(2)),
+						},
+					},
+				},
+				fmt.Sprintf(spreadAcrossSocketsCoresThreadsMaxErrFmt, 5, 2, 2),
+			),
+			Entry("10 vCPUs, SpreadAcrossSocketsCoresThreads and max of 3 with spread",
+				uint32(10),
+				v1beta1.VirtualMachinePreferenceSpec{
+					CPU: &v1beta1.CPUPreferences{
+						PreferredCPUTopology: pointer.P(v1beta1.Spread),
+						SpreadOptions: &v1beta1.SpreadOptions{
+							Across: pointer.P(v1beta1.SpreadAcrossSocketsCoresThreads),
+							Max:    pointer.P(uint32(3)),
+						},
+					},
+				},
+				fmt.Sprintf(spreadAcrossSocketsCoresThreadsMaxErrFmt, 10, 2, 3),
 			),
 		)
 

--- a/staging/src/kubevirt.io/api/instancetype/v1beta1/deepcopy_generated.go
+++ b/staging/src/kubevirt.io/api/instancetype/v1beta1/deepcopy_generated.go
@@ -439,6 +439,11 @@ func (in *SpreadOptions) DeepCopyInto(out *SpreadOptions) {
 		*out = new(uint32)
 		**out = **in
 	}
+	if in.Max != nil {
+		in, out := &in.Max, &out.Max
+		*out = new(uint32)
+		**out = **in
+	}
 	return
 }
 

--- a/staging/src/kubevirt.io/api/instancetype/v1beta1/types.go
+++ b/staging/src/kubevirt.io/api/instancetype/v1beta1/types.go
@@ -400,7 +400,8 @@ type SpreadOptions struct {
 	//+optional
 	Across *SpreadAcross `json:"across,omitempty"`
 
-	// Ratio optionally defines the ratio to spread vCPUs across the guest visible topology:
+	// Ratio optionally defines the ratio to spread vCPUs across the guest visible topology.
+	// Mutually exclusive with Max.
 	//
 	// CoresThreads        - 1:2   - Controls the ratio of cores to threads. Only a ratio of 2 is currently accepted.
 	// SocketsCores        - 1:N   - Controls the ratio of socket to cores.
@@ -410,6 +411,16 @@ type SpreadOptions struct {
 	//
 	//+optional
 	Ratio *uint32 `json:"ratio,omitempty"`
+
+	// Max optionally defines the maximum number of the outer scaling topology dimension.
+	// Mutually exclusive with Ratio.
+	//
+	// SocketsCores        - Limits the number of sockets. Cores are computed as vCPUs / sockets.
+	// CoresThreads        - Limits the number of cores. Threads are computed as vCPUs / cores.
+	// SocketsCoresThreads - Limits the number of sockets. Each core provides 2 threads. Cores are computed as vCPUs / (2 * sockets).
+	//
+	//+optional
+	Max *uint32 `json:"max,omitempty"`
 }
 
 // DevicePreferences contains various optional Device preferences.

--- a/staging/src/kubevirt.io/api/instancetype/v1beta1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/instancetype/v1beta1/types_swagger_generated.go
@@ -133,7 +133,8 @@ func (CPUPreferences) SwaggerDoc() map[string]string {
 func (SpreadOptions) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"across": "Across optionally defines how to spread vCPUs across the guest visible topology.\nDefault: SocketsCores\n\n+optional",
-		"ratio":  "Ratio optionally defines the ratio to spread vCPUs across the guest visible topology:\n\nCoresThreads        - 1:2   - Controls the ratio of cores to threads. Only a ratio of 2 is currently accepted.\nSocketsCores        - 1:N   - Controls the ratio of socket to cores.\nSocketsCoresThreads - 1:N:2 - Controls the ratio of socket to cores. Each core providing 2 threads.\n\nDefault: 2\n\n+optional",
+		"ratio": "Ratio optionally defines the ratio to spread vCPUs across the guest visible topology.\nMutually exclusive with Max.\n\nCoresThreads        - 1:2   - Controls the ratio of cores to threads. Only a ratio of 2 is currently accepted.\nSocketsCores        - 1:N   - Controls the ratio of socket to cores.\nSocketsCoresThreads - 1:N:2 - Controls the ratio of socket to cores. Each core providing 2 threads.\n\nDefault: 2\n\n+optional",
+		"max":   "Max optionally defines the maximum number of the outer scaling topology dimension.\nMutually exclusive with Ratio.\n\nSocketsCores        - Limits the number of sockets. Cores are computed as vCPUs / sockets.\nCoresThreads        - Limits the number of cores. Threads are computed as vCPUs / cores.\nSocketsCoresThreads - Limits the number of sockets. Each core provides 2 threads. Cores are computed as vCPUs / (2 * sockets).\n\n+optional",
 	}
 }
 


### PR DESCRIPTION
### What this PR does
#### Before this PR:

`SpreadOptions.Ratio` fixes the inner topology dimension (e.g. cores per socket) and the outer dimension (e.g. sockets) scales linearly with vCPU count. There is no way to cap the outer dimension. For example, with `SocketsCores` and `ratio=2`, 6 vCPUs produces 3 sockets with 2 cores.

#### After this PR:

A new `Max` field (mutually exclusive with `Ratio`) caps the outer scaling dimension and computes the inner dimension as `vCPUs / max`. For example, with `SocketsCores` and `max=2`, 6 vCPUs produces 2 sockets with 3 cores.

| `Across` | `Max` caps | Computed |
|---|---|---|
| `SocketsCores` | sockets | `cores = vCPUs / sockets` |
| `CoresThreads` | cores | `threads = vCPUs / cores` |
| `SocketsCoresThreads` | sockets | `threads=2, cores = vCPUs / (2 * sockets)` |

### References

- This will need a VEP to land in v1.10.0

### Why we need it and why it was done in this way

Users want to limit the number of sockets (or cores) presented to a guest while still spreading vCPUs, rather than fixing the inner dimension ratio. The `Max` field inverts the `Ratio` computation — the user caps the outer dimension and the inner dimension adapts to the vCPU count.

The following tradeoffs were made:
- `Max` and `Ratio` are mutually exclusive since they invert each other's computation and composing them would require overflow/remainder handling.
- When `max >= vCPUs`, it clamps down so the result is equivalent to a single-dimension topology (e.g. all cores in one socket).

The following alternatives were considered:
- Making `Max` a cap that searches for the largest divisor ≤ max — rejected for simplicity and consistency with how `Ratio` works (exact value, validation rejects non-divisible vCPU counts).

### Special notes for your reviewer

- The swagger, deepcopy, and openapi generated files were manually updated. A full `make generate` should be run before merging.

### Checklist

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

```release-note
Add Max field to SpreadOptions allowing users to cap the outer topology dimension when spreading vCPUs, mutually exclusive with the existing Ratio field.
```