### PR TITLE
expose cgroup memory metrics via DomainStats

### DIFF
--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -44,13 +44,18 @@
 | kubevirt_vmi_info | Metric | Gauge | Information about VirtualMachineInstances. |
 | kubevirt_vmi_last_api_connection_timestamp_seconds | Metric | Gauge | Virtual Machine Instance last API connection timestamp. Including VNC, console, portforward, SSH and usbredir connections. |
 | kubevirt_vmi_launcher_memory_overhead_bytes | Metric | Gauge | Estimation of the memory amount required for virt-launcher's infrastructure components (e.g. libvirt, QEMU). |
+| kubevirt_vmi_memory_active_anon_bytes | Metric | Gauge | Active anonymous memory in the container cgroup in bytes. Recently accessed pages are less likely to be reclaimed. |
 | kubevirt_vmi_memory_actual_balloon_bytes | Metric | Gauge | Current balloon size in bytes. |
+| kubevirt_vmi_memory_anon_bytes | Metric | Gauge | Anonymous memory usage of the container cgroup in bytes, from cgroup memory.stat. |
+| kubevirt_vmi_memory_anon_thp_bytes | Metric | Gauge | Anonymous memory backed by transparent huge pages in the container cgroup in bytes, from cgroup memory.stat. |
 | kubevirt_vmi_memory_available_bytes | Metric | Gauge | Amount of usable memory as seen by the domain. This value may not be accurate if a balloon driver is in use or if the guest OS does not initialize all assigned pages |
 | kubevirt_vmi_memory_cached_bytes | Metric | Gauge | The amount of memory that is being used to cache I/O and is available to be reclaimed, corresponds to the sum of `Buffers` + `Cached` + `SwapCached` in `/proc/meminfo`. |
 | kubevirt_vmi_memory_domain_bytes | Metric | Gauge | The amount of memory in bytes allocated to the domain. The `memory` value in domain xml file. |
+| kubevirt_vmi_memory_inactive_anon_bytes | Metric | Gauge | Inactive anonymous memory in the container cgroup in bytes. High values indicate reclaim-eligible pages that may be swapped under pressure. |
 | kubevirt_vmi_memory_pgmajfault_total | Metric | Counter | The number of page faults when disk IO was required. Page faults occur when a process makes a valid access to virtual memory that is not available. When servicing the page fault, if disk IO is required, it is considered as major fault. |
 | kubevirt_vmi_memory_pgminfault_total | Metric | Counter | The number of other page faults, when disk IO was not required. Page faults occur when a process makes a valid access to virtual memory that is not available. When servicing the page fault, if disk IO is NOT required, it is considered as minor fault. |
 | kubevirt_vmi_memory_resident_bytes | Metric | Gauge | Resident set size of the process running the domain. |
+| kubevirt_vmi_memory_shmem_thp_bytes | Metric | Gauge | Shared memory backed by transparent huge pages in the container cgroup in bytes. Relevant when QEMU uses memfd-backed guest memory. |
 | kubevirt_vmi_memory_swap_in_traffic_bytes | Metric | Gauge | The total amount of data read from swap space of the guest in bytes. |
 | kubevirt_vmi_memory_swap_out_traffic_bytes | Metric | Gauge | The total amount of memory written out to swap space of the guest in bytes. |
 | kubevirt_vmi_memory_unused_bytes | Metric | Gauge | The amount of memory left completely unused by the system. Memory that is available but used for reclaimable caches should NOT be reported as free. |

--- a/pkg/monitoring/metrics/virt-handler/domainstats/memory_metrics.go
+++ b/pkg/monitoring/metrics/virt-handler/domainstats/memory_metrics.go
@@ -112,6 +112,43 @@ var (
 			Help: "The amount of memory in bytes allocated to the domain. The `memory` value in domain xml file.",
 		},
 	)
+
+	memoryAnonBytes = operatormetrics.NewGauge(
+		operatormetrics.MetricOpts{
+			Name: "kubevirt_vmi_memory_anon_bytes",
+			Help: "Anonymous memory usage of the container cgroup in bytes, from cgroup memory.stat.",
+		},
+	)
+
+	memoryAnonTHPBytes = operatormetrics.NewGauge(
+		operatormetrics.MetricOpts{
+			Name: "kubevirt_vmi_memory_anon_thp_bytes",
+			Help: "Anonymous memory backed by transparent huge pages in the container cgroup in bytes, from cgroup memory.stat.",
+		},
+	)
+
+	memoryInactiveAnonBytes = operatormetrics.NewGauge(
+		operatormetrics.MetricOpts{
+			Name: "kubevirt_vmi_memory_inactive_anon_bytes",
+			Help: "Inactive anonymous memory in the container cgroup in bytes. " +
+				"High values indicate reclaim-eligible pages that may be swapped under pressure.",
+		},
+	)
+
+	memoryActiveAnonBytes = operatormetrics.NewGauge(
+		operatormetrics.MetricOpts{
+			Name: "kubevirt_vmi_memory_active_anon_bytes",
+			Help: "Active anonymous memory in the container cgroup in bytes. Recently accessed pages are less likely to be reclaimed.",
+		},
+	)
+
+	memoryShmemTHPBytes = operatormetrics.NewGauge(
+		operatormetrics.MetricOpts{
+			Name: "kubevirt_vmi_memory_shmem_thp_bytes",
+			Help: "Shared memory backed by transparent huge pages in the container cgroup in bytes. " +
+				"Relevant when QEMU uses memfd-backed guest memory.",
+		},
+	)
 )
 
 type memoryMetrics struct{}
@@ -129,6 +166,11 @@ func (memoryMetrics) Describe() []operatormetrics.Metric {
 		memoryActualBallon,
 		memoryUsableBytes,
 		memoryDomainBytes,
+		memoryAnonBytes,
+		memoryAnonTHPBytes,
+		memoryInactiveAnonBytes,
+		memoryActiveAnonBytes,
+		memoryShmemTHPBytes,
 	}
 }
 
@@ -185,5 +227,32 @@ func (memoryMetrics) Collect(vmiReport *VirtualMachineInstanceReport) []operator
 		crs = append(crs, vmiReport.newCollectorResult(memoryDomainBytes, kibibytesToBytes(mem.Total)))
 	}
 
+	crs = append(crs, collectCgroupMemoryMetrics(vmiReport)...)
+
+	return crs
+}
+
+func collectCgroupMemoryMetrics(vmiReport *VirtualMachineInstanceReport) []operatormetrics.CollectorResult {
+	cgMem := vmiReport.vmiStats.DomainStats.CgroupMemory
+	if cgMem == nil {
+		return nil
+	}
+
+	var crs []operatormetrics.CollectorResult
+	if cgMem.AnonSet {
+		crs = append(crs, vmiReport.newCollectorResult(memoryAnonBytes, float64(cgMem.Anon)))
+	}
+	if cgMem.AnonTHPSet {
+		crs = append(crs, vmiReport.newCollectorResult(memoryAnonTHPBytes, float64(cgMem.AnonTHP)))
+	}
+	if cgMem.InactiveAnonSet {
+		crs = append(crs, vmiReport.newCollectorResult(memoryInactiveAnonBytes, float64(cgMem.InactiveAnon)))
+	}
+	if cgMem.ActiveAnonSet {
+		crs = append(crs, vmiReport.newCollectorResult(memoryActiveAnonBytes, float64(cgMem.ActiveAnon)))
+	}
+	if cgMem.ShmemTHPSet {
+		crs = append(crs, vmiReport.newCollectorResult(memoryShmemTHPBytes, float64(cgMem.ShmemTHP)))
+	}
 	return crs
 }

--- a/pkg/monitoring/metrics/virt-handler/domainstats/memory_metrics_test.go
+++ b/pkg/monitoring/metrics/virt-handler/domainstats/memory_metrics_test.go
@@ -66,6 +66,18 @@ var _ = Describe("memory metrics", func() {
 					TotalSet:         true,
 					Total:            11,
 				},
+				CgroupMemory: &stats.CgroupMemoryStats{
+					AnonSet:         true,
+					Anon:            1073741824,
+					AnonTHPSet:      true,
+					AnonTHP:         1006632960,
+					ShmemTHPSet:     true,
+					ShmemTHP:        134217728,
+					InactiveAnonSet: true,
+					InactiveAnon:    805306368,
+					ActiveAnonSet:   true,
+					ActiveAnon:      268435456,
+				},
 			},
 		}
 
@@ -86,6 +98,11 @@ var _ = Describe("memory metrics", func() {
 			Entry("kubevirt_vmi_memory_actual_ballon_bytes", memoryActualBallon, kibibytesToBytes(9)),
 			Entry("kubevirt_vmi_memory_usable_bytes", memoryUsableBytes, kibibytesToBytes(10)),
 			Entry("kubevirt_vmi_memory_domain_bytes", memoryDomainBytes, kibibytesToBytes(11)),
+			Entry("kubevirt_vmi_memory_anon_bytes", memoryAnonBytes, float64(1073741824)),
+			Entry("kubevirt_vmi_memory_anon_thp_bytes", memoryAnonTHPBytes, float64(1006632960)),
+			Entry("kubevirt_vmi_memory_inactive_anon_bytes", memoryInactiveAnonBytes, float64(805306368)),
+			Entry("kubevirt_vmi_memory_active_anon_bytes", memoryActiveAnonBytes, float64(268435456)),
+			Entry("kubevirt_vmi_memory_shmem_thp_bytes", memoryShmemTHPBytes, float64(134217728)),
 		)
 
 		It("result should be empty if stat not populated or set is false", func() {
@@ -94,6 +111,7 @@ var _ = Describe("memory metrics", func() {
 				MinorFaultSet: false,
 				TotalSet:      false,
 			}
+			vmiStats.DomainStats.CgroupMemory = nil
 			crs := memoryMetrics{}.Collect(vmiReport)
 			Expect(crs).To(BeEmpty())
 		})

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -237,6 +237,7 @@ type LibvirtDomainManager struct {
 	domainStatsCache          *virtcache.TimeDefinedCache[*stats.DomainStats]
 	domainDirtyRateStatsCache *virtcache.TimeDefinedCache[*stats.DomainStatsDirtyRate]
 	agentDataCaches           map[string]*virtcache.TimeDefinedCache[string]
+	cgroupMemStatReader       *stats.CgroupMemoryStatReader
 
 	// Device aliasas are updated only through hotplug events and SyncVMI
 	devAliasMap  map[string]string
@@ -400,6 +401,7 @@ func newLibvirtDomainManager(
 	manager.hotplugHostDevicesInProgress = make(chan struct{}, maxConcurrentHotplugHostDevices)
 	manager.storageManager = storage.NewStorageManager(connection, metadataCache, registerNBD)
 	manager.credManager = accesscredentials.NewManager(connection, &manager.domainModifyLock, metadataCache, eventSender)
+	manager.cgroupMemStatReader = stats.NewCgroupMemoryStatReader()
 
 	reCalcDomainStats := func() (*stats.DomainStats, error) {
 		list, err := manager.getDomainStats()
@@ -2404,6 +2406,11 @@ func (l *LibvirtDomainManager) getDomainStats() ([]*stats.DomainStats, error) {
 		}
 		if l.agentData != nil {
 			ds.Load = l.agentData.GetLoad()
+		}
+		if cgroupMem, err := l.cgroupMemStatReader.Read(); err == nil {
+			ds.CgroupMemory = cgroupMem
+		} else {
+			log.Log.Reason(err).V(4).Info("Failed to read cgroup memory stats")
 		}
 	}
 

--- a/pkg/virt-launcher/virtwrap/stats/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/stats/BUILD.bazel
@@ -1,8 +1,26 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["types.go"],
+    srcs = [
+        "cgroup.go",
+        "types.go",
+    ],
     importpath = "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/stats",
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "cgroup_test.go",
+        "stats_suite_test.go",
+    ],
+    embed = [":go_default_library"],
+    race = "on",
+    deps = [
+        "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+    ],
 )

--- a/pkg/virt-launcher/virtwrap/stats/cgroup.go
+++ b/pkg/virt-launcher/virtwrap/stats/cgroup.go
@@ -1,0 +1,86 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ */
+
+package stats
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+// CgroupMemoryStatReader reads selected fields from cgroup v2 memory.stat.
+// This is a temporary measure until container runtimes expose these values
+// natively (see https://github.com/cri-o/cri-o/pull/10143). Once runtime
+// support is available, these metrics can be replaced by Prometheus recording
+// rules over the runtime-provided container_memory_* metrics, and this reader
+// can be removed.
+const defaultCgroupMemoryStatPath = "/sys/fs/cgroup/memory.stat"
+
+type CgroupMemoryStatReader struct {
+	path string
+}
+
+func NewCgroupMemoryStatReader() *CgroupMemoryStatReader {
+	return &CgroupMemoryStatReader{path: defaultCgroupMemoryStatPath}
+}
+
+func NewCgroupMemoryStatReaderWithPath(path string) *CgroupMemoryStatReader {
+	return &CgroupMemoryStatReader{path: path}
+}
+
+func (r *CgroupMemoryStatReader) Read() (*CgroupMemoryStats, error) {
+	f, err := os.Open(r.path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open cgroup memory.stat: %w", err)
+	}
+	defer f.Close()
+
+	result := &CgroupMemoryStats{}
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) != 2 {
+			continue
+		}
+		val, err := strconv.ParseUint(fields[1], 10, 64)
+		if err != nil {
+			continue
+		}
+		switch fields[0] {
+		case "anon":
+			result.Anon = val
+			result.AnonSet = true
+		case "anon_thp":
+			result.AnonTHP = val
+			result.AnonTHPSet = true
+		case "shmem_thp":
+			result.ShmemTHP = val
+			result.ShmemTHPSet = true
+		case "inactive_anon":
+			result.InactiveAnon = val
+			result.InactiveAnonSet = true
+		case "active_anon":
+			result.ActiveAnon = val
+			result.ActiveAnonSet = true
+		}
+	}
+	return result, scanner.Err()
+}

--- a/pkg/virt-launcher/virtwrap/stats/cgroup_test.go
+++ b/pkg/virt-launcher/virtwrap/stats/cgroup_test.go
@@ -1,0 +1,59 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ */
+
+package stats
+
+import (
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("CgroupMemoryStatReader", func() {
+	It("should parse all memory.stat fields correctly", func() {
+		content := "anon 1073741824\nfile 536870912\nanon_thp 1006632960\nshmem_thp 134217728\ninactive_anon 805306368\nactive_anon 268435456\n"
+		dir := GinkgoT().TempDir()
+		path := filepath.Join(dir, "memory.stat")
+		Expect(os.WriteFile(path, []byte(content), 0644)).To(Succeed())
+
+		result, err := NewCgroupMemoryStatReaderWithPath(path).Read()
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(result.AnonSet).To(BeTrue())
+		Expect(result.Anon).To(Equal(uint64(1073741824)))
+
+		Expect(result.AnonTHPSet).To(BeTrue())
+		Expect(result.AnonTHP).To(Equal(uint64(1006632960)))
+
+		Expect(result.ShmemTHPSet).To(BeTrue())
+		Expect(result.ShmemTHP).To(Equal(uint64(134217728)))
+
+		Expect(result.InactiveAnonSet).To(BeTrue())
+		Expect(result.InactiveAnon).To(Equal(uint64(805306368)))
+
+		Expect(result.ActiveAnonSet).To(BeTrue())
+		Expect(result.ActiveAnon).To(Equal(uint64(268435456)))
+	})
+
+	It("should return an error for a missing file", func() {
+		_, err := NewCgroupMemoryStatReaderWithPath("/nonexistent").Read()
+		Expect(err).To(HaveOccurred())
+	})
+})

--- a/pkg/virt-launcher/virtwrap/stats/stats_suite_test.go
+++ b/pkg/virt-launcher/virtwrap/stats/stats_suite_test.go
@@ -1,0 +1,29 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ */
+
+package stats
+
+import (
+	"testing"
+
+	"kubevirt.io/client-go/testutils"
+)
+
+func TestStats(t *testing.T) {
+	testutils.KubeVirtTestSuiteSetup(t)
+}

--- a/pkg/virt-launcher/virtwrap/stats/types.go
+++ b/pkg/virt-launcher/virtwrap/stats/types.go
@@ -68,10 +68,11 @@ type DomainStats struct {
 	Block []DomainStatsBlock
 	// omitted from libvirt-go: Perf
 	// extra stats
-	CPUMapSet bool
-	CPUMap    [][]bool
-	DirtyRate *DomainStatsDirtyRate
-	Load      *DomainStatsLoad
+	CPUMapSet    bool
+	CPUMap       [][]bool
+	DirtyRate    *DomainStatsDirtyRate
+	Load         *DomainStatsLoad
+	CgroupMemory *CgroupMemoryStats
 }
 
 type DomainStatsLoad struct {
@@ -211,6 +212,20 @@ type DomainStatsDirtyRate struct {
 	CalcPeriod            int
 	MegabytesPerSecondSet bool
 	MegabytesPerSecond    int64
+}
+
+// CgroupMemoryStats holds cgroup v2 memory.stat fields (values in bytes).
+type CgroupMemoryStats struct {
+	AnonSet         bool
+	Anon            uint64
+	AnonTHPSet      bool
+	AnonTHP         uint64
+	ShmemTHPSet     bool
+	ShmemTHP        uint64
+	InactiveAnonSet bool
+	InactiveAnon    uint64
+	ActiveAnonSet   bool
+	ActiveAnon      uint64
 }
 
 type VMStats struct {

--- a/pkg/virt-launcher/virtwrap/statsconv/util/domstats_utils.go
+++ b/pkg/virt-launcher/virtwrap/statsconv/util/domstats_utils.go
@@ -284,7 +284,8 @@ var Testdataexpected = `{
      "MegabytesPerSecondSet": false,
      "MegabytesPerSecond": 0
    },
-   "Load": null
+   "Load": null,
+   "CgroupMemory": null
  }`
 
 func LoadStats() ([]libvirt.DomainStats, error) {


### PR DESCRIPTION
Read `anon`, `anon_thp`, `shmem_thp`, `inactive_anon` and `active_anon` from the virt-launcher cgroup v2 `memory.stat` and expose them as Prometheus gauges via `DomainStats`. These provide host-side visibility into THP coverage and reclaim risk of the VM pod.

### New metrics

| Metric | Description |
|--------|-------------|
| `kubevirt_vmi_memory_anon_bytes` | Anonymous memory usage of the container cgroup |
| `kubevirt_vmi_memory_anon_thp_bytes` | Anonymous memory backed by transparent huge pages |
| `kubevirt_vmi_memory_shmem_thp_bytes` | Shared memory backed by transparent huge pages (relevant for memfd-backed guest memory) |
| `kubevirt_vmi_memory_inactive_anon_bytes` | Inactive anonymous memory (reclaim-eligible) |
| `kubevirt_vmi_memory_active_anon_bytes` | Active anonymous memory (recently accessed) |

### Why shmem_thp and not file_thp

KubeVirt normally backs guest memory with plain anonymous memory, so THP shows up as `anon_thp`. However, when QEMU uses memfd-backed guest memory, hugepages are counted under `shmem_thp` instead. Both are needed for complete THP visibility.

`file_thp` is omitted because KubeVirt does not use file-backed guest memory.

### Relationship to CRI-O runtime metrics

This work is aligned with [cri-o/cri-o#10143](https://github.com/cri-o/cri-o/pull/10143), which proposes exposing the same `memory.stat` fields as `container_memory_*` metrics from the container runtime. The overlap is intentional and the transition path is straightforward:

1. **Today**: virt-launcher reads `/sys/fs/cgroup/memory.stat` directly because no container runtime exposes these fields yet.
2. **Once runtime support lands**: the same data becomes available as `container_memory_*` gauges (e.g. `container_memory_anon_hugepages_bytes`, `container_memory_shmem_hugepages_bytes`).
3. **Transition**: the `kubevirt_vmi_memory_*` metric names can be preserved via Prometheus recording rules over the runtime-provided `container_memory_*` metrics, following the same pattern KubeVirt already uses for `container_memory_rss` and `container_memory_working_set_bytes`. At that point the direct cgroup reader can be removed entirely.

This keeps the implementation self-contained for now while ensuring a clean upgrade path that doesn't depend on any specific runtime version.

### What this PR does

#### Before this PR:
No visibility into cgroup-level anonymous memory breakdown or THP coverage for VM pods.

#### After this PR:
Five new Prometheus gauges expose the relevant `memory.stat` fields, giving operators insight into THP backing ratio, active/inactive memory split, and swap pressure risk.

### References
- CRI-O runtime metrics: [cri-o/cri-o#10143](https://github.com/cri-o/cri-o/pull/10143)
- cAdvisor upstream: [google/cadvisor#3915](https://github.com/google/cadvisor/issues/3915)

### Special notes for your reviewer
- cgroup v2 only — cgroup v1 is not needed
- `file_thp` is intentionally omitted (not relevant for VM workloads)
- The code comment in `cgroup.go` documents the planned transition once runtime support is available

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough).
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
New Prometheus metrics for host-side visibility into cgroup memory breakdown and THP coverage of VM pods:
    kubevirt_vmi_memory_anon_bytes
    kubevirt_vmi_memory_anon_thp_bytes
    kubevirt_vmi_memory_shmem_thp_bytes
    kubevirt_vmi_memory_inactive_anon_bytes
    kubevirt_vmi_memory_active_anon_bytes
```
