### PR TITLE
tests/migration: use required affinity for eviction strategy test

### DIFF
--- a/pkg/libvmi/selector.go
+++ b/pkg/libvmi/selector.go
@@ -50,10 +50,14 @@ func WithToleration(toleration k8sv1.Toleration) Option {
 }
 
 func WithNodeAffinityForLabel(nodeLabelKey, nodeLabelValue string) Option {
+	return withRequiredNodeAffinityForLabel(nodeLabelKey, nodeLabelValue, k8sv1.NodeSelectorOpIn)
+}
+
+func withRequiredNodeAffinityForLabel(nodeLabelKey, nodeLabelValue string, op k8sv1.NodeSelectorOperator) Option {
 	return func(vmi *v1.VirtualMachineInstance) {
 		nodeSelectorTerm := k8sv1.NodeSelectorTerm{
 			MatchExpressions: []k8sv1.NodeSelectorRequirement{
-				{Key: nodeLabelKey, Operator: k8sv1.NodeSelectorOpIn, Values: []string{nodeLabelValue}},
+				{Key: nodeLabelKey, Operator: op, Values: []string{nodeLabelValue}},
 			},
 		}
 
@@ -110,6 +114,10 @@ func WithPreferredPodAffinity(term k8sv1.WeightedPodAffinityTerm) Option {
 			vmi.Spec.Affinity.PodAffinity.PreferredDuringSchedulingIgnoredDuringExecution, term,
 		)
 	}
+}
+
+func WithNodeAntiaffinityForLabel(nodeLabelKey, nodeLabelValue string) Option {
+	return withRequiredNodeAffinityForLabel(nodeLabelKey, nodeLabelValue, k8sv1.NodeSelectorOpNotIn)
 }
 
 func WithPreferredNodeAffinity(term k8sv1.PreferredSchedulingTerm) Option {

--- a/tests/migration/eviction_strategy.go
+++ b/tests/migration/eviction_strategy.go
@@ -318,30 +318,27 @@ var _ = Describe(SIG("Live Migration", decorators.RequiresTwoSchedulableNodes, f
 					const labelKey = "testkey"
 
 					// give an affinity rule to ensure the vmi's get placed on the same node.
-					podAffinityTerm := k8sv1.WeightedPodAffinityTerm{
-						Weight: int32(1),
-						PodAffinityTerm: k8sv1.PodAffinityTerm{
-							LabelSelector: &metav1.LabelSelector{
-								MatchExpressions: []metav1.LabelSelectorRequirement{
-									{
-										Key:      labelKey,
-										Operator: metav1.LabelSelectorOpIn,
-										Values:   []string{""}},
-								},
+					podAffinityTerm := k8sv1.PodAffinityTerm{
+						LabelSelector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      labelKey,
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{""}},
 							},
-							TopologyKey: k8sv1.LabelHostname,
 						},
+						TopologyKey: k8sv1.LabelHostname,
 					}
 					vmi_evict1 := alpineVMIWithEvictionStrategy(
 						libvmi.WithNamespace(testsuite.GetTestNamespace(nil)),
 						libvmi.WithLabel(labelKey, ""),
-						libvmi.WithPreferredPodAffinity(podAffinityTerm),
+						libvmi.WithRequiredPodAffinity(podAffinityTerm),
 						libvmi.WithPreferredNodeAffinity(nodeAffinityTerm),
 					)
 					vmi_evict2 := alpineVMIWithEvictionStrategy(
 						libvmi.WithNamespace(testsuite.GetTestNamespace(nil)),
 						libvmi.WithLabel(labelKey, ""),
-						libvmi.WithPreferredPodAffinity(podAffinityTerm),
+						libvmi.WithRequiredPodAffinity(podAffinityTerm),
 						libvmi.WithPreferredNodeAffinity(nodeAffinityTerm),
 					)
 					vmi_noevict := libvmifact.NewAlpine(
@@ -350,14 +347,14 @@ var _ = Describe(SIG("Live Migration", decorators.RequiresTwoSchedulableNodes, f
 						libvmi.WithNetwork(v1.DefaultPodNetwork()),
 						libvmi.WithEvictionStrategy(v1.EvictionStrategyNone),
 						libvmi.WithLabel(labelKey, ""),
-						libvmi.WithPreferredPodAffinity(podAffinityTerm),
+						libvmi.WithRequiredPodAffinity(podAffinityTerm),
 						libvmi.WithPreferredNodeAffinity(nodeAffinityTerm),
 					)
 
 					By("Starting the VirtualMachineInstance with eviction set to live migration")
-					vm_evict1 := libvmi.NewVirtualMachine(vmi_evict1)
-					vm_evict2 := libvmi.NewVirtualMachine(vmi_evict2)
-					vm_noevict := libvmi.NewVirtualMachine(vmi_noevict)
+					vm_evict1 := libvmi.NewVirtualMachine(vmi_evict1, libvmi.WithRunStrategy(v1.RunStrategyAlways))
+					vm_evict2 := libvmi.NewVirtualMachine(vmi_evict2, libvmi.WithRunStrategy(v1.RunStrategyAlways))
+					vm_noevict := libvmi.NewVirtualMachine(vmi_noevict, libvmi.WithRunStrategy(v1.RunStrategyAlways))
 
 					// post VMs
 					vm_evict1, err := virtClient.VirtualMachine(vm_evict1.Namespace).Create(context.Background(), vm_evict1, metav1.CreateOptions{})
@@ -367,10 +364,10 @@ var _ = Describe(SIG("Live Migration", decorators.RequiresTwoSchedulableNodes, f
 					vm_noevict, err = virtClient.VirtualMachine(vm_noevict.Namespace).Create(context.Background(), vm_noevict, metav1.CreateOptions{})
 					Expect(err).ToNot(HaveOccurred())
 
-					// Start VMs
-					vm_evict1 = libvmops.StartVirtualMachine(vm_evict1)
-					vm_evict2 = libvmops.StartVirtualMachine(vm_evict2)
-					vm_noevict = libvmops.StartVirtualMachine(vm_noevict)
+					// Wait for all three VMs to be ready before proceeding
+					Eventually(matcher.ThisVM(vm_evict1), libvmops.StartupTimeoutSecondsXHuge*time.Second, time.Second).Should(matcher.BeReady())
+					Eventually(matcher.ThisVM(vm_evict2), libvmops.StartupTimeoutSecondsXHuge*time.Second, time.Second).Should(matcher.BeReady())
+					Eventually(matcher.ThisVM(vm_noevict), libvmops.StartupTimeoutSecondsXHuge*time.Second, time.Second).Should(matcher.BeReady())
 
 					// Get VMIs
 					vmi_evict1, err = virtClient.VirtualMachineInstance(vmi_evict1.Namespace).Get(context.Background(), vmi_evict1.Name, metav1.GetOptions{})

--- a/tests/migration/eviction_strategy.go
+++ b/tests/migration/eviction_strategy.go
@@ -200,10 +200,7 @@ var _ = Describe(SIG("Live Migration", decorators.RequiresTwoSchedulableNodes, f
 
 			Context(" with node tainted during node drain", Serial, func() {
 
-				var (
-					nodeAffinity     *k8sv1.NodeAffinity
-					nodeAffinityTerm k8sv1.PreferredSchedulingTerm
-				)
+				var nodeAffinity *k8sv1.NodeAffinity
 
 				expectVMIMigratedToAnotherNode := func(vmiNamespace, vmiName, sourceNodeName string) {
 					EventuallyWithOffset(1, func() error {
@@ -233,21 +230,15 @@ var _ = Describe(SIG("Live Migration", decorators.RequiresTwoSchedulableNodes, f
 						config.UpdateKubeVirtConfigValueAndWait(cfg)
 					}
 
-					controlPlaneNodes := libnode.GetControlPlaneNodes(virtClient)
-
-					// This nodeAffinity will make sure the vmi, initially, will not be scheduled in the control-plane node in those clusters where there is only one.
-					// This is mandatory, since later the tests will drain the node where the vmi will be scheduled.
-					nodeAffinityTerm = k8sv1.PreferredSchedulingTerm{
-						Weight: int32(1),
-						Preference: k8sv1.NodeSelectorTerm{
-							MatchExpressions: []k8sv1.NodeSelectorRequirement{
-								{Key: k8sv1.LabelHostname, Operator: k8sv1.NodeSelectorOpNotIn, Values: []string{controlPlaneNodes.Items[0].Name}},
-							},
-						},
-					}
-
+					// Ensure VMIs don't land on the control-plane node, since the tests drain the node they start on.
 					nodeAffinity = &k8sv1.NodeAffinity{
-						PreferredDuringSchedulingIgnoredDuringExecution: []k8sv1.PreferredSchedulingTerm{nodeAffinityTerm},
+						RequiredDuringSchedulingIgnoredDuringExecution: &k8sv1.NodeSelector{
+							NodeSelectorTerms: []k8sv1.NodeSelectorTerm{{
+								MatchExpressions: []k8sv1.NodeSelectorRequirement{
+									{Key: "node-role.kubernetes.io/control-plane", Operator: k8sv1.NodeSelectorOpNotIn, Values: []string{""}},
+								},
+							}},
+						},
 					}
 				})
 
@@ -333,13 +324,13 @@ var _ = Describe(SIG("Live Migration", decorators.RequiresTwoSchedulableNodes, f
 						libvmi.WithNamespace(testsuite.GetTestNamespace(nil)),
 						libvmi.WithLabel(labelKey, ""),
 						libvmi.WithRequiredPodAffinity(podAffinityTerm),
-						libvmi.WithPreferredNodeAffinity(nodeAffinityTerm),
+						libvmi.WithNodeAntiaffinityForLabel("node-role.kubernetes.io/control-plane", ""),
 					)
 					vmi_evict2 := alpineVMIWithEvictionStrategy(
 						libvmi.WithNamespace(testsuite.GetTestNamespace(nil)),
 						libvmi.WithLabel(labelKey, ""),
 						libvmi.WithRequiredPodAffinity(podAffinityTerm),
-						libvmi.WithPreferredNodeAffinity(nodeAffinityTerm),
+						libvmi.WithNodeAntiaffinityForLabel("node-role.kubernetes.io/control-plane", ""),
 					)
 					vmi_noevict := libvmifact.NewAlpine(
 						libvmi.WithNamespace(testsuite.GetTestNamespace(nil)),
@@ -348,7 +339,7 @@ var _ = Describe(SIG("Live Migration", decorators.RequiresTwoSchedulableNodes, f
 						libvmi.WithEvictionStrategy(v1.EvictionStrategyNone),
 						libvmi.WithLabel(labelKey, ""),
 						libvmi.WithRequiredPodAffinity(podAffinityTerm),
-						libvmi.WithPreferredNodeAffinity(nodeAffinityTerm),
+						libvmi.WithNodeAntiaffinityForLabel("node-role.kubernetes.io/control-plane", ""),
 					)
 
 					By("Starting the VirtualMachineInstance with eviction set to live migration")

--- a/tests/migration/eviction_strategy.go
+++ b/tests/migration/eviction_strategy.go
@@ -377,8 +377,11 @@ var _ = Describe(SIG("Live Migration", decorators.RequiresTwoSchedulableNodes, f
 
 					// Get VMIs
 					vmi_evict1, err = virtClient.VirtualMachineInstance(vmi_evict1.Namespace).Get(context.Background(), vmi_evict1.Name, metav1.GetOptions{})
-					vmi_evict2, err = virtClient.VirtualMachineInstance(vmi_evict1.Namespace).Get(context.Background(), vmi_evict2.Name, metav1.GetOptions{})
-					vmi_noevict, err = virtClient.VirtualMachineInstance(vmi_evict1.Namespace).Get(context.Background(), vmi_noevict.Name, metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					vmi_evict2, err = virtClient.VirtualMachineInstance(vmi_evict2.Namespace).Get(context.Background(), vmi_evict2.Name, metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					vmi_noevict, err = virtClient.VirtualMachineInstance(vmi_noevict.Namespace).Get(context.Background(), vmi_noevict.Name, metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
 
 					By("Verifying all VMIs are collcated on the same node")
 					Expect(vmi_evict1.Status.NodeName).To(Equal(vmi_evict2.Status.NodeName))

--- a/tests/migration/eviction_strategy.go
+++ b/tests/migration/eviction_strategy.go
@@ -84,7 +84,11 @@ var _ = Describe(SIG("Live Migration", decorators.RequiresTwoSchedulableNodes, f
 		Context("[ref_id:2293] with a VMI running with an eviction strategy set", func() {
 
 			It("[test_id:3242]should block the eviction api and migrate", decorators.Conformance, func() {
-				vmi := libvmops.RunVMIAndExpectLaunch(alpineVMIWithEvictionStrategy(), libvmops.StartupTimeoutSecondsXLarge)
+				vmi := libvmops.RunVMIAndExpectLaunch(libvmifact.NewGuestless(
+					libnet.WithMasqueradeNetworking(),
+					libvmi.WithEvictionStrategy(v1.EvictionStrategyLiveMigrate),
+					libvmi.WithNamespace(testsuite.GetTestNamespace(nil)),
+				), libvmops.StartupTimeoutSecondsXLarge)
 
 				originalNode := vmi.Status.NodeName
 
@@ -111,7 +115,11 @@ var _ = Describe(SIG("Live Migration", decorators.RequiresTwoSchedulableNodes, f
 
 			It("[sig-compute][test_id:7680]should delete PDBs created by an old virt-controller", func() {
 				By("creating the VMI")
-				vmi := alpineVMIWithEvictionStrategy()
+				vmi := libvmifact.NewGuestless(
+					libnet.WithMasqueradeNetworking(),
+					libvmi.WithEvictionStrategy(v1.EvictionStrategyLiveMigrate),
+					libvmi.WithNamespace(testsuite.GetTestNamespace(nil)),
+				)
 				vmi, err := virtClient.VirtualMachineInstance(vmi.Namespace).Create(context.Background(), vmi, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				By("waiting for VMI")
@@ -289,7 +297,11 @@ var _ = Describe(SIG("Live Migration", decorators.RequiresTwoSchedulableNodes, f
 				})
 
 				It("[test_id:2222] should migrate a VMI when custom taint key is configured", func() {
-					vmi := alpineVMIWithEvictionStrategy()
+					vmi := libvmifact.NewGuestless(
+						libnet.WithMasqueradeNetworking(),
+						libvmi.WithEvictionStrategy(v1.EvictionStrategyLiveMigrate),
+						libvmi.WithNamespace(testsuite.GetTestNamespace(nil)),
+					)
 					vmi.Spec.Affinity = &k8sv1.Affinity{NodeAffinity: nodeAffinity}
 
 					By("Configuring a custom nodeDrainTaintKey in kubevirt configuration")
@@ -320,23 +332,26 @@ var _ = Describe(SIG("Live Migration", decorators.RequiresTwoSchedulableNodes, f
 						},
 						TopologyKey: k8sv1.LabelHostname,
 					}
-					vmi_evict1 := alpineVMIWithEvictionStrategy(
+					vmi_evict1 := libvmifact.NewGuestless(
+						libnet.WithMasqueradeNetworking(),
+						libvmi.WithEvictionStrategy(v1.EvictionStrategyLiveMigrate),
 						libvmi.WithNamespace(testsuite.GetTestNamespace(nil)),
 						libvmi.WithLabel(labelKey, ""),
 						libvmi.WithRequiredPodAffinity(podAffinityTerm),
 						libvmi.WithNodeAntiaffinityForLabel("node-role.kubernetes.io/control-plane", ""),
 					)
-					vmi_evict2 := alpineVMIWithEvictionStrategy(
+					vmi_evict2 := libvmifact.NewGuestless(
+						libnet.WithMasqueradeNetworking(),
+						libvmi.WithEvictionStrategy(v1.EvictionStrategyLiveMigrate),
 						libvmi.WithNamespace(testsuite.GetTestNamespace(nil)),
 						libvmi.WithLabel(labelKey, ""),
 						libvmi.WithRequiredPodAffinity(podAffinityTerm),
 						libvmi.WithNodeAntiaffinityForLabel("node-role.kubernetes.io/control-plane", ""),
 					)
-					vmi_noevict := libvmifact.NewAlpine(
-						libvmi.WithNamespace(testsuite.GetTestNamespace(nil)),
-						libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
-						libvmi.WithNetwork(v1.DefaultPodNetwork()),
+					vmi_noevict := libvmifact.NewGuestless(
+						libnet.WithMasqueradeNetworking(),
 						libvmi.WithEvictionStrategy(v1.EvictionStrategyNone),
+						libvmi.WithNamespace(testsuite.GetTestNamespace(nil)),
 						libvmi.WithLabel(labelKey, ""),
 						libvmi.WithRequiredPodAffinity(podAffinityTerm),
 						libvmi.WithNodeAntiaffinityForLabel("node-role.kubernetes.io/control-plane", ""),
@@ -412,7 +427,11 @@ var _ = Describe(SIG("Live Migration", decorators.RequiresTwoSchedulableNodes, f
 			It("[release-blocker][test_id:3245]should not migrate more than two VMIs at the same time from a node", func() {
 				var vmis []*v1.VirtualMachineInstance
 				for i := 0; i < 4; i++ {
-					vmi := alpineVMIWithEvictionStrategy()
+					vmi := libvmifact.NewGuestless(
+						libnet.WithMasqueradeNetworking(),
+						libvmi.WithEvictionStrategy(v1.EvictionStrategyLiveMigrate),
+						libvmi.WithNamespace(testsuite.GetTestNamespace(nil)),
+					)
 					vmi.Spec.NodeSelector = map[string]string{cleanup.TestLabelForNamespace(vmi.Namespace): "target"}
 					vmis = append(vmis, vmi)
 				}
@@ -507,10 +526,7 @@ var _ = Describe(SIG("Live Migration", decorators.RequiresTwoSchedulableNodes, f
 			Context("with no eviction strategy set", func() {
 				It("[test_id:10155]should block the eviction api and migrate", func() {
 					// no EvictionStrategy set
-					vmi := libvmifact.NewAlpine(
-						libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
-						libvmi.WithNetwork(v1.DefaultPodNetwork()),
-					)
+					vmi := libvmifact.NewGuestless(libnet.WithMasqueradeNetworking())
 
 					vmi = libvmops.RunVMIAndExpectLaunch(vmi, libvmops.StartupTimeoutSecondsXLarge)
 					vmiNodeOrig := vmi.Status.NodeName
@@ -548,9 +564,8 @@ var _ = Describe(SIG("Live Migration", decorators.RequiresTwoSchedulableNodes, f
 
 			Context("with eviction strategy set to 'None'", func() {
 				It("[test_id:10156]The VMI should get evicted", func() {
-					vmi := libvmifact.NewAlpine(
-						libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
-						libvmi.WithNetwork(v1.DefaultPodNetwork()),
+					vmi := libvmifact.NewGuestless(
+						libnet.WithMasqueradeNetworking(),
 						libvmi.WithEvictionStrategy(v1.EvictionStrategyNone),
 					)
 					vmi = libvmops.RunVMIAndExpectLaunch(vmi, libvmops.StartupTimeoutSecondsXLarge)
@@ -570,13 +585,6 @@ func fedoraVMIWithEvictionStrategy() *v1.VirtualMachineInstance {
 		libvmi.WithMemoryRequest(fedoraVMSize),
 		libvmi.WithEvictionStrategy(v1.EvictionStrategyLiveMigrate),
 		libvmi.WithNamespace(testsuite.GetTestNamespace(nil)))
-}
-
-func alpineVMIWithEvictionStrategy(additionalOpts ...libvmi.Option) *v1.VirtualMachineInstance {
-	opts := []libvmi.Option{libnet.WithMasqueradeNetworking(), libvmi.WithEvictionStrategy(v1.EvictionStrategyLiveMigrate), libvmi.WithNamespace(testsuite.GetTestNamespace(nil))}
-	opts = append(opts, additionalOpts...)
-
-	return libvmifact.NewAlpine(opts...)
 }
 
 func filterRunningMigrations(migrations []v1.VirtualMachineInstanceMigration) []v1.VirtualMachineInstanceMigration {

--- a/tests/migration/host_model.go
+++ b/tests/migration/host_model.go
@@ -41,10 +41,12 @@ import (
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/libinfra"
 	"kubevirt.io/kubevirt/tests/libmigration"
+	"kubevirt.io/kubevirt/tests/libnet"
 	"kubevirt.io/kubevirt/tests/libnode"
 	"kubevirt.io/kubevirt/tests/libpod"
 	"kubevirt.io/kubevirt/tests/libvmifact"
 	"kubevirt.io/kubevirt/tests/libvmops"
+	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
 var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes, func() {
@@ -110,7 +112,11 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 			BeforeEach(func() {
 				var err error
 				By("Creating a VMI with default CPU mode")
-				vmi = alpineVMIWithEvictionStrategy()
+				vmi = libvmifact.NewGuestless(
+					libnet.WithMasqueradeNetworking(),
+					libvmi.WithEvictionStrategy(v1.EvictionStrategyLiveMigrate),
+					libvmi.WithNamespace(testsuite.GetTestNamespace(nil)),
+				)
 				vmi.Spec.Domain.CPU = &v1.CPU{Model: v1.CPUModeHostModel}
 
 				By("Starting the VirtualMachineInstance")
@@ -170,7 +176,11 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 				}
 
 				By("Creating a VMI with default CPU mode")
-				vmi = alpineVMIWithEvictionStrategy()
+				vmi = libvmifact.NewGuestless(
+					libnet.WithMasqueradeNetworking(),
+					libvmi.WithEvictionStrategy(v1.EvictionStrategyLiveMigrate),
+					libvmi.WithNamespace(testsuite.GetTestNamespace(nil)),
+				)
 				vmi.Spec.Domain.CPU = &v1.CPU{Model: v1.CPUModeHostModel}
 
 				By("Starting the VirtualMachineInstance")


### PR DESCRIPTION
The eviction strategy test relies on multiple VMIs landing on the same node. With preferred pod affinity, the scheduler could theoretically place them on different nodes, making the test not actually validate what it claims to test. Switch to required pod affinity to guarantee co-location.

```release-note
NONE
```

