### PR TITLE
Move decentralized live migration feature gate to beta.

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/migration-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/migration-create-admitter_test.go
@@ -65,12 +65,6 @@ var _ = Describe("Validating MigrationCreate Admitter", func() {
 	}
 	config, _, kvStore := testutils.NewFakeClusterConfigUsingKV(kv)
 
-	enableFeatureGate := func(featureGate string) {
-		kvConfig := kv.DeepCopy()
-		kvConfig.Spec.Configuration.DeveloperConfiguration.FeatureGates = []string{featureGate}
-		testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kvConfig)
-	}
-
 	disableFeatureGates := func() {
 		testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kv)
 	}
@@ -229,8 +223,10 @@ var _ = Describe("Validating MigrationCreate Admitter", func() {
 			modifyMigration(migration)
 			ar, err := newAdmissionReviewForVMIMCreation(migration)
 			Expect(err).ToNot(HaveOccurred())
-			if featureGateEnabled {
-				enableFeatureGate(featuregate.DecentralizedLiveMigration)
+			if !featureGateEnabled {
+				kvConfig := kv.DeepCopy()
+				kvConfig.Spec.Configuration.DeveloperConfiguration.DisabledFeatureGates = []string{featuregate.DecentralizedLiveMigration}
+				testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kvConfig)
 			}
 			admitter := admitters.NewMigrationCreateAdmitter(virtClient, config, nil)
 			resp := admitter.Admit(context.Background(), ar)

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter_test.go
@@ -79,10 +79,22 @@ var _ = Describe("Validating VM Admitter", func() {
 		}
 		testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kv)
 	}
+	disableFeatureGate := func(featureGate string) {
+		kv := testutils.GetFakeKubeVirtClusterConfig(kvStore)
+		if kv.Spec.Configuration.DeveloperConfiguration == nil {
+			kv.Spec.Configuration.DeveloperConfiguration = &v1.DeveloperConfiguration{}
+		}
+		kv.Spec.Configuration.DeveloperConfiguration.DisabledFeatureGates = append(
+			kv.Spec.Configuration.DeveloperConfiguration.DisabledFeatureGates,
+			featureGate,
+		)
+		testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kv)
+	}
 	disableFeatureGates := func() {
 		kv := testutils.GetFakeKubeVirtClusterConfig(kvStore)
 		if kv.Spec.Configuration.DeveloperConfiguration != nil {
 			kv.Spec.Configuration.DeveloperConfiguration.FeatureGates = make([]string, 0)
+			kv.Spec.Configuration.DeveloperConfiguration.DisabledFeatureGates = make([]string, 0)
 		}
 		testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kv)
 	}
@@ -1604,7 +1616,9 @@ var _ = Describe("Validating VM Admitter", func() {
 					},
 				},
 			}
-			enableFeatureGate(featureGate)
+			if featureGate != "" {
+				disableFeatureGate(featureGate)
+			}
 			resp := admitVm(vmsAdmitter, vm)
 			Expect(resp.Allowed).To(Equal(accepted))
 		},
@@ -1613,8 +1627,8 @@ var _ = Describe("Validating VM Admitter", func() {
 			Entry("allow runstrategy always", v1.RunStrategyAlways, "", true),
 			Entry("allow runstrategy rerun on failure", v1.RunStrategyRerunOnFailure, "", true),
 			Entry("allow runstrategy once", v1.RunStrategyOnce, "", true),
-			Entry("allow runstrategy wait as receiver", v1.RunStrategyWaitAsReceiver, featuregate.DecentralizedLiveMigration, true),
-			Entry("reject runstrategy wait as receiver, if feature gate not enabled", v1.RunStrategyWaitAsReceiver, "", false),
+			Entry("allow runstrategy wait as receiver", v1.RunStrategyWaitAsReceiver, "", true),
+			Entry("reject runstrategy wait as receiver, if feature gate not enabled", v1.RunStrategyWaitAsReceiver, featuregate.DecentralizedLiveMigration, false),
 			Entry("reject invalid runstrategy", v1.VirtualMachineRunStrategy("invalid"), "", false),
 		)
 	})

--- a/pkg/virt-config/featuregate/active.go
+++ b/pkg/virt-config/featuregate/active.go
@@ -120,6 +120,12 @@ const (
 	// resources to be attached to VMs using the natural networks API.
 	NetworkDevicesWithDRAGate = "NetworkDevicesWithDRA"
 
+	// Owner: sig-compute / @awels
+	// Alpha: v1.6.0
+	// Beta: v1.10.0
+	//
+	// DecentralizedLiveMigration enables live migration across namespaces
+	// with separate source and target VirtualMachineInstanceMigration resources.
 	DecentralizedLiveMigration = "DecentralizedLiveMigration"
 
 	// Owner: sig-storage / @alromeros
@@ -312,7 +318,7 @@ func init() {
 	RegisterFeatureGate(FeatureGate{Name: HostDevicesWithDRAGate, State: Beta})
 	RegisterFeatureGate(FeatureGate{Name: PCINUMAAwareTopologyEnabled, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: NetworkDevicesWithDRAGate, State: Alpha})
-	RegisterFeatureGate(FeatureGate{Name: DecentralizedLiveMigration, State: Alpha})
+	RegisterFeatureGate(FeatureGate{Name: DecentralizedLiveMigration, State: Beta})
 	RegisterFeatureGate(FeatureGate{Name: DeclarativeHotplugVolumesGate, State: Beta})
 	RegisterFeatureGate(FeatureGate{Name: ObjectGraph, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: UtilityVolumesGate, State: Alpha})

--- a/pkg/virt-operator/kubevirt_test.go
+++ b/pkg/virt-operator/kubevirt_test.go
@@ -1221,6 +1221,29 @@ func (k *KubeVirtTestData) generateRandomResources() int {
 	return len(all)
 }
 
+func disableFeatureGate(kv *v1.KubeVirt, fg string) {
+	if kv.Spec.Configuration.DeveloperConfiguration == nil {
+		kv.Spec.Configuration.DeveloperConfiguration = &v1.DeveloperConfiguration{}
+	}
+	kv.Spec.Configuration.DeveloperConfiguration.DisabledFeatureGates = append(
+		kv.Spec.Configuration.DeveloperConfiguration.DisabledFeatureGates,
+		fg,
+	)
+}
+
+func disableTemplateFeatureGate(kv *v1.KubeVirt) {
+	disableFeatureGate(kv, featuregate.Template)
+}
+
+func disableDecentralizedLiveMigrationFeatureGate(kv *v1.KubeVirt) {
+	disableFeatureGate(kv, featuregate.DecentralizedLiveMigration)
+}
+
+func configureTestFeatureGates(kv *v1.KubeVirt) {
+	enableContainerPathVolumesFeatureGate(kv)
+	disableDecentralizedLiveMigrationFeatureGate(kv)
+}
+
 func enableFeatureGate(kv *v1.KubeVirt, fg string) {
 	if kv.Spec.Configuration.DeveloperConfiguration == nil {
 		kv.Spec.Configuration.DeveloperConfiguration = &v1.DeveloperConfiguration{}
@@ -1862,7 +1885,7 @@ func (k *KubeVirtTestData) getConfig(registry, version string) *util.KubeVirtDep
 			ImageTag:      version,
 		},
 	}
-	enableContainerPathVolumesFeatureGate(kv)
+	configureTestFeatureGates(kv)
 	return util.GetTargetConfigFromKVWithEnvVarManager(kv, k.mockEnvVarManager)
 }
 
@@ -1901,7 +1924,7 @@ var _ = Describe("KubeVirt Operator", func() {
 					ObservedGeneration: pointer.P(int64(1)),
 				},
 			}
-			enableContainerPathVolumesFeatureGate(kv)
+			configureTestFeatureGates(kv)
 			// Add kubevirt deployment and mark everything as ready
 			kvTestData.addKubeVirt(kv)
 			kubecontroller.SetLatestApiVersionAnnotation(kv)
@@ -1934,7 +1957,7 @@ var _ = Describe("KubeVirt Operator", func() {
 					Phase: v1.KubeVirtPhaseDeleted,
 				},
 			}
-			enableContainerPathVolumesFeatureGate(kv)
+			configureTestFeatureGates(kv)
 			kv.DeletionTimestamp = now()
 			util.UpdateConditionsDeleting(kv)
 
@@ -1972,7 +1995,7 @@ var _ = Describe("KubeVirt Operator", func() {
 					ObservedGeneration: pointer.P(int64(1)),
 				},
 			}
-			enableContainerPathVolumesFeatureGate(kv)
+			configureTestFeatureGates(kv)
 
 			// create all resources which should already exist
 			kubecontroller.SetLatestApiVersionAnnotation(kv)
@@ -2015,7 +2038,7 @@ var _ = Describe("KubeVirt Operator", func() {
 					ObservedGeneration: pointer.P(int64(1)),
 				},
 			}
-			enableContainerPathVolumesFeatureGate(kv)
+			configureTestFeatureGates(kv)
 			kvTestData.defaultConfig.SetTargetDeploymentConfig(kv)
 			kvTestData.defaultConfig.SetObservedDeploymentConfig(kv)
 			util.UpdateConditionsCreated(kv)
@@ -2060,7 +2083,7 @@ var _ = Describe("KubeVirt Operator", func() {
 					OperatorVersion: version.Get().String(),
 				},
 			}
-			enableContainerPathVolumesFeatureGate(kv)
+			configureTestFeatureGates(kv)
 			kvTestData.defaultConfig.SetTargetDeploymentConfig(kv)
 			kvTestData.defaultConfig.SetObservedDeploymentConfig(kv)
 			util.UpdateConditionsCreated(kv)
@@ -2131,7 +2154,7 @@ var _ = Describe("KubeVirt Operator", func() {
 					OperatorVersion: version.Get().String(),
 				},
 			}
-			enableContainerPathVolumesFeatureGate(kv)
+			configureTestFeatureGates(kv)
 			kvTestData.defaultConfig.SetTargetDeploymentConfig(kv)
 			kvTestData.defaultConfig.SetObservedDeploymentConfig(kv)
 			util.UpdateConditionsCreated(kv)
@@ -2189,6 +2212,10 @@ var _ = Describe("KubeVirt Operator", func() {
 			Expect(oldConfig.SetObservedDeploymentConfig(kv)).To(Succeed())
 			util.UpdateConditionsCreated(kv)
 			util.UpdateConditionsAvailable(kv)
+
+			// Disable before copying so kvNoTemplate does not wait on sync-controller
+			// deployments that are not part of this test scenario.
+			disableDecentralizedLiveMigrationFeatureGate(kv)
 
 			// Save a copy before toggling -- used below to skip virt-template
 			// pods in the first cycle (simulating them still starting).
@@ -2262,7 +2289,7 @@ var _ = Describe("KubeVirt Operator", func() {
 					ObservedGeneration: pointer.P(int64(1)),
 				},
 			}
-			enableContainerPathVolumesFeatureGate(kv)
+			configureTestFeatureGates(kv)
 			kvTestData.defaultConfig.SetTargetDeploymentConfig(kv)
 			kvTestData.defaultConfig.SetObservedDeploymentConfig(kv)
 			util.UpdateConditionsCreated(kv)
@@ -2327,7 +2354,7 @@ var _ = Describe("KubeVirt Operator", func() {
 					ObservedGeneration: pointer.P(int64(1)),
 				},
 			}
-			enableContainerPathVolumesFeatureGate(kv)
+			configureTestFeatureGates(kv)
 			kvTestData.defaultConfig.SetTargetDeploymentConfig(kv)
 			kvTestData.defaultConfig.SetObservedDeploymentConfig(kv)
 			util.UpdateConditionsDeploying(kv)
@@ -2374,6 +2401,7 @@ var _ = Describe("KubeVirt Operator", func() {
 					OperatorVersion: "v0.0.0-master+$Format:%h$",
 				},
 			}
+			configureTestFeatureGates(kv1)
 
 			kv2 := &v1.KubeVirt{
 				ObjectMeta: metav1.ObjectMeta{
@@ -2383,6 +2411,7 @@ var _ = Describe("KubeVirt Operator", func() {
 				},
 				Status: v1.KubeVirtStatus{},
 			}
+			configureTestFeatureGates(kv2)
 
 			kubecontroller.SetLatestApiVersionAnnotation(kv1)
 			util.UpdateConditionsCreated(kv1)
@@ -2420,7 +2449,7 @@ var _ = Describe("KubeVirt Operator", func() {
 					OperatorVersion: version.Get().String(),
 				},
 			}
-			enableContainerPathVolumesFeatureGate(kv)
+			configureTestFeatureGates(kv)
 			kvTestData.defaultConfig.SetTargetDeploymentConfig(kv)
 			kvTestData.defaultConfig.SetObservedDeploymentConfig(kv)
 			util.UpdateConditionsCreated(kv)
@@ -2536,7 +2565,7 @@ var _ = Describe("KubeVirt Operator", func() {
 				},
 				Status: v1.KubeVirtStatus{},
 			}
-			enableContainerPathVolumesFeatureGate(kv)
+			configureTestFeatureGates(kv)
 
 			// create all resources which should already exist
 			kubecontroller.SetLatestApiVersionAnnotation(kv)
@@ -2665,7 +2694,7 @@ var _ = Describe("KubeVirt Operator", func() {
 				},
 				Status: v1.KubeVirtStatus{},
 			}
-			enableContainerPathVolumesFeatureGate(kv)
+			configureTestFeatureGates(kv)
 
 			job, err := kvTestData.controller.generateInstallStrategyJob(&v1.ComponentConfig{}, util.GetTargetConfigFromKV(kv))
 			Expect(err).ToNot(HaveOccurred())
@@ -2703,7 +2732,7 @@ var _ = Describe("KubeVirt Operator", func() {
 				},
 				Status: v1.KubeVirtStatus{},
 			}
-			enableContainerPathVolumesFeatureGate(kv)
+			configureTestFeatureGates(kv)
 
 			job, err := kvTestData.controller.generateInstallStrategyJob(kv.Spec.Infra, util.GetTargetConfigFromKV(kv))
 			Expect(err).ToNot(HaveOccurred())
@@ -2733,7 +2762,7 @@ var _ = Describe("KubeVirt Operator", func() {
 					Namespace: NAMESPACE,
 				},
 			}
-			enableContainerPathVolumesFeatureGate(kv)
+			configureTestFeatureGates(kv)
 			kubecontroller.SetLatestApiVersionAnnotation(kv)
 			kvTestData.addKubeVirt(kv)
 			kvTestData.addInstallStrategy(kvTestData.defaultConfig)
@@ -2801,7 +2830,7 @@ var _ = Describe("KubeVirt Operator", func() {
 					Finalizers: []string{"foregroundDeleteKubeVirt"},
 				},
 			}
-			enableContainerPathVolumesFeatureGate(kv)
+			configureTestFeatureGates(kv)
 			kubecontroller.SetLatestApiVersionAnnotation(kv)
 			kvTestData.addKubeVirt(kv)
 			kvTestData.addInstallStrategy(kvTestData.defaultConfig)
@@ -2848,7 +2877,7 @@ var _ = Describe("KubeVirt Operator", func() {
 					OperatorVersion: version.Get().String(),
 				},
 			}
-			enableContainerPathVolumesFeatureGate(kv)
+			configureTestFeatureGates(kv)
 			kvTestData.defaultConfig.SetTargetDeploymentConfig(kv)
 			kvTestData.defaultConfig.SetObservedDeploymentConfig(kv)
 			util.UpdateConditionsCreated(kv)
@@ -2919,7 +2948,7 @@ var _ = Describe("KubeVirt Operator", func() {
 					OperatorVersion: version.Get().String(),
 				},
 			}
-			enableContainerPathVolumesFeatureGate(kv)
+			configureTestFeatureGates(kv)
 			kvTestData.defaultConfig.SetTargetDeploymentConfig(kv)
 			kvTestData.defaultConfig.SetObservedDeploymentConfig(kv)
 			util.UpdateConditionsCreated(kv)
@@ -2989,7 +3018,7 @@ var _ = Describe("KubeVirt Operator", func() {
 					OperatorVersion: version.Get().String(),
 				},
 			}
-			enableContainerPathVolumesFeatureGate(kv)
+			configureTestFeatureGates(kv)
 			kvTestData.defaultConfig.SetTargetDeploymentConfig(kv)
 			kvTestData.defaultConfig.SetObservedDeploymentConfig(kv)
 			util.UpdateConditionsCreated(kv)
@@ -3100,7 +3129,7 @@ var _ = Describe("KubeVirt Operator", func() {
 						},
 					},
 				}
-				enableContainerPathVolumesFeatureGate(kv)
+				configureTestFeatureGates(kv)
 
 				kubecontroller.SetLatestApiVersionAnnotation(kv)
 				kvTestData.addKubeVirt(kv)
@@ -3166,7 +3195,7 @@ var _ = Describe("KubeVirt Operator", func() {
 						Namespace: NAMESPACE,
 					},
 				}
-				enableContainerPathVolumesFeatureGate(kv)
+				configureTestFeatureGates(kv)
 
 				kubecontroller.SetLatestApiVersionAnnotation(kv)
 				kvTestData.addKubeVirt(kv)
@@ -3255,7 +3284,7 @@ var _ = Describe("KubeVirt Operator", func() {
 						OperatorVersion: version.Get().String(),
 					},
 				}
-				enableContainerPathVolumesFeatureGate(kv)
+				configureTestFeatureGates(kv)
 				customConfig := util.GetTargetConfigFromKVWithEnvVarManager(kv, kvTestData.mockEnvVarManager)
 
 				kubecontroller.SetLatestApiVersionAnnotation(kv)
@@ -3406,6 +3435,7 @@ var _ = Describe("KubeVirt Operator", func() {
 						OperatorVersion: version.Get().String(),
 					},
 				}
+				disableDecentralizedLiveMigrationFeatureGate(kv)
 				customConfig := util.GetTargetConfigFromKVWithEnvVarManager(&v1.KubeVirt{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: NAMESPACE,
@@ -3508,7 +3538,7 @@ var _ = Describe("KubeVirt Operator", func() {
 					OperatorVersion: version.Get().String(),
 				},
 			}
-			enableContainerPathVolumesFeatureGate(kv)
+			configureTestFeatureGates(kv)
 			kvTestData.defaultConfig.SetTargetDeploymentConfig(kv)
 			kvTestData.defaultConfig.SetObservedDeploymentConfig(kv)
 			util.UpdateConditionsCreated(kv)
@@ -3581,7 +3611,7 @@ var _ = Describe("KubeVirt Operator", func() {
 					OperatorVersion: version.Get().String(),
 				},
 			}
-			enableContainerPathVolumesFeatureGate(kv)
+			configureTestFeatureGates(kv)
 			kvTestData.defaultConfig.SetTargetDeploymentConfig(kv)
 			kvTestData.defaultConfig.SetObservedDeploymentConfig(kv)
 			util.UpdateConditionsCreated(kv)
@@ -3669,7 +3699,7 @@ var _ = Describe("KubeVirt Operator", func() {
 					OperatorVersion: version.Get().String(),
 				},
 			}
-			enableContainerPathVolumesFeatureGate(kv)
+			configureTestFeatureGates(kv)
 			kvTestData.defaultConfig.SetTargetDeploymentConfig(kv)
 			kvTestData.defaultConfig.SetObservedDeploymentConfig(kv)
 
@@ -3712,7 +3742,7 @@ var _ = Describe("KubeVirt Operator", func() {
 					Namespace: NAMESPACE,
 				},
 			}
-			enableContainerPathVolumesFeatureGate(kv)
+			configureTestFeatureGates(kv)
 			kv.DeletionTimestamp = now()
 			kubecontroller.SetLatestApiVersionAnnotation(kv)
 			kvTestData.addKubeVirt(kv)
@@ -3754,7 +3784,7 @@ var _ = Describe("KubeVirt Operator", func() {
 					Namespace: NAMESPACE,
 				},
 			}
-			enableContainerPathVolumesFeatureGate(kv)
+			configureTestFeatureGates(kv)
 
 			kv.DeletionTimestamp = now()
 
@@ -3856,7 +3886,7 @@ var _ = Describe("KubeVirt Operator", func() {
 					Configuration: v1.KubeVirtConfiguration{
 						DeveloperConfiguration: &v1.DeveloperConfiguration{
 							FeatureGates:         []string{featuregate.ContainerPathVolumesGate},
-							DisabledFeatureGates: []string{featuregate.Template},
+							DisabledFeatureGates: []string{featuregate.Template, featuregate.DecentralizedLiveMigration},
 						},
 						VirtTemplateDeployment: &v1.VirtTemplateDeployment{
 							Enabled: pointer.P(true),
@@ -3872,7 +3902,8 @@ var _ = Describe("KubeVirt Operator", func() {
 				Spec: v1.KubeVirtSpec{
 					Configuration: v1.KubeVirtConfiguration{
 						DeveloperConfiguration: &v1.DeveloperConfiguration{
-							FeatureGates: []string{featuregate.ContainerPathVolumesGate},
+							FeatureGates:         []string{featuregate.ContainerPathVolumesGate},
+							DisabledFeatureGates: []string{featuregate.DecentralizedLiveMigration},
 						},
 						VirtTemplateDeployment: &v1.VirtTemplateDeployment{
 							Enabled: pointer.P(false),
@@ -3898,7 +3929,7 @@ var _ = Describe("KubeVirt Operator", func() {
 					},
 				},
 			}
-			enableContainerPathVolumesFeatureGate(kv)
+			configureTestFeatureGates(kv)
 			config := util.GetTargetConfigFromKVWithEnvVarManager(kv, kvTestData.mockEnvVarManager)
 
 			// Create new KV with virt-template disabled
@@ -3954,7 +3985,7 @@ var _ = Describe("KubeVirt Operator", func() {
 					},
 				},
 			}
-			enableContainerPathVolumesFeatureGate(kv)
+			configureTestFeatureGates(kv)
 			config := util.GetTargetConfigFromKVWithEnvVarManager(kv, kvTestData.mockEnvVarManager)
 
 			// Create new KV with virt-template enabled
@@ -4015,6 +4046,8 @@ var _ = Describe("KubeVirt Operator", func() {
 					Namespace: NAMESPACE,
 				},
 			}
+			disableTemplateFeatureGate(kv)
+			disableDecentralizedLiveMigrationFeatureGate(kv)
 			// ContainerPathVolumes NOT enabled
 			config := util.GetTargetConfigFromKVWithEnvVarManager(kv, kvTestData.mockEnvVarManager)
 
@@ -4050,13 +4083,15 @@ var _ = Describe("KubeVirt Operator", func() {
 					Finalizers: []string{util.KubeVirtFinalizer},
 				},
 			}
-			enableContainerPathVolumesFeatureGate(kv)
+			configureTestFeatureGates(kv)
 			config := util.GetTargetConfigFromKVWithEnvVarManager(kv, kvTestData.mockEnvVarManager)
 
 			// Create new KV with ContainerPathVolumes disabled
 			newKv := kv.DeepCopy()
 			newKv.ObjectMeta.Generation = 2
-			newKv.Spec.Configuration.DeveloperConfiguration = &v1.DeveloperConfiguration{}
+			newKv.Spec.Configuration.DeveloperConfiguration = &v1.DeveloperConfiguration{
+				DisabledFeatureGates: []string{featuregate.DecentralizedLiveMigration},
+			}
 			newConfig := util.GetTargetConfigFromKVWithEnvVarManager(newKv, kvTestData.mockEnvVarManager)
 
 			kvTestData.deleteFromCache = true
@@ -4096,6 +4131,8 @@ var _ = Describe("KubeVirt Operator", func() {
 					Finalizers: []string{util.KubeVirtFinalizer},
 				},
 			}
+			disableTemplateFeatureGate(kv)
+			disableDecentralizedLiveMigrationFeatureGate(kv)
 			// ContainerPathVolumes NOT enabled
 			config := util.GetTargetConfigFromKVWithEnvVarManager(kv, kvTestData.mockEnvVarManager)
 
@@ -4103,6 +4140,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			newKv := kv.DeepCopy()
 			newKv.ObjectMeta.Generation = 2
 			enableContainerPathVolumesFeatureGate(newKv)
+			disableDecentralizedLiveMigrationFeatureGate(newKv)
 			newConfig := util.GetTargetConfigFromKVWithEnvVarManager(newKv, kvTestData.mockEnvVarManager)
 
 			kubecontroller.SetLatestApiVersionAnnotation(newKv)
@@ -4147,7 +4185,7 @@ var _ = Describe("KubeVirt Operator", func() {
 					Finalizers: []string{util.KubeVirtFinalizer},
 				},
 			}
-			enableContainerPathVolumesFeatureGate(kv)
+			configureTestFeatureGates(kv)
 			kubecontroller.SetLatestApiVersionAnnotation(kv)
 			kvTestData.addKubeVirt(kv)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Move the feature gate to beta which means it is enabled by default.

#### Before this PR:
Feature gate is alpha and disabled by default

#### After this PR:
Feature gate is beta and enabled by default

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/24

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Decentralized live migration to beta
```

