### PR TITLE
Propagate imagePullPolicy to all virt-handler and virt-launcher containers

### DIFF
--- a/pkg/virt-controller/services/virtiofs.go
+++ b/pkg/virt-controller/services/virtiofs.go
@@ -32,7 +32,7 @@ func generateVirtioFSContainers(vmi *v1.VirtualMachineInstance, image string, co
 				continue
 			}
 			resources := virtiofs.ResourcesForVirtioFSContainer(vmi.IsCPUDedicated(), vmi.IsCPUDedicated() || vmi.WantsToHaveQOSGuaranteed(), config)
-			container := generateContainerFromVolume(&volume, image, resources)
+			container := generateContainerFromVolume(&volume, image, resources, config.GetImagePullPolicy())
 			containers = append(containers, container)
 
 		}
@@ -62,7 +62,7 @@ func virtioFSMountPoint(volume *v1.Volume) string {
 	return volumeMountPoint
 }
 
-func generateContainerFromVolume(volume *v1.Volume, image string, resources k8sv1.ResourceRequirements) k8sv1.Container {
+func generateContainerFromVolume(volume *v1.Volume, image string, resources k8sv1.ResourceRequirements, imagePullPolicy k8sv1.PullPolicy) k8sv1.Container {
 
 	socketPathArg := fmt.Sprintf("--socket-path=%s", virtiofs.VirtioFSSocketPath(volume.Name))
 	sourceArg := fmt.Sprintf("--shared-dir=%s", virtioFSMountPoint(volume))
@@ -114,7 +114,7 @@ func generateContainerFromVolume(volume *v1.Volume, image string, resources k8sv
 	return k8sv1.Container{
 		Name:            fmt.Sprintf("virtiofs-%s", volume.Name),
 		Image:           image,
-		ImagePullPolicy: k8sv1.PullIfNotPresent,
+		ImagePullPolicy: imagePullPolicy,
 		Command:         []string{"/usr/libexec/virtiofsd"},
 		Args:            args,
 		VolumeMounts:    volumeMounts,

--- a/pkg/virt-controller/services/virtiofs_test.go
+++ b/pkg/virt-controller/services/virtiofs_test.go
@@ -6,6 +6,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	k8sv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/api"
@@ -94,6 +95,53 @@ var _ = Describe("virtiofs container", func() {
 		// Secret
 		Expect(container[1].SecurityContext.RunAsNonRoot).To(HaveValue(BeTrue()))
 		Expect(container[1].SecurityContext.AllowPrivilegeEscalation).To(HaveValue(BeFalse()))
+	})
+
+	It("should default imagePullPolicy to PullIfNotPresent when not configured", func() {
+		vmi := api.NewMinimalVMI("testvm")
+		vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
+			Name: "sharedtestdisk",
+			VolumeSource: v1.VolumeSource{
+				PersistentVolumeClaim: testutils.NewFakePersistentVolumeSource(),
+			},
+		})
+		vmi.Spec.Domain.Devices.Filesystems = append(vmi.Spec.Domain.Devices.Filesystems, v1.Filesystem{
+			Name:     "sharedtestdisk",
+			Virtiofs: &v1.FilesystemVirtiofs{},
+		})
+
+		containers := generateVirtioFSContainers(vmi, "virtiofs-container", config)
+		Expect(containers).To(HaveLen(1))
+		Expect(containers[0].ImagePullPolicy).To(Equal(k8sv1.PullIfNotPresent))
+	})
+
+	It("should use the configured imagePullPolicy", func() {
+		testutils.UpdateFakeKubeVirtClusterConfig(kvStore, &v1.KubeVirt{
+			Spec: v1.KubeVirtSpec{
+				Configuration: v1.KubeVirtConfiguration{
+					DeveloperConfiguration: &v1.DeveloperConfiguration{
+						FeatureGates: []string{featuregate.VirtIOFSStorageVolumeGate},
+					},
+					ImagePullPolicy: k8sv1.PullAlways,
+				},
+			},
+		})
+
+		vmi := api.NewMinimalVMI("testvm")
+		vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
+			Name: "sharedtestdisk",
+			VolumeSource: v1.VolumeSource{
+				PersistentVolumeClaim: testutils.NewFakePersistentVolumeSource(),
+			},
+		})
+		vmi.Spec.Domain.Devices.Filesystems = append(vmi.Spec.Domain.Devices.Filesystems, v1.Filesystem{
+			Name:     "sharedtestdisk",
+			Virtiofs: &v1.FilesystemVirtiofs{},
+		})
+
+		containers := generateVirtioFSContainers(vmi, "virtiofs-container", config)
+		Expect(containers).To(HaveLen(1))
+		Expect(containers[0].ImagePullPolicy).To(Equal(k8sv1.PullAlways))
 	})
 
 	It("should skip ContainerPath volumes", func() {

--- a/pkg/virt-operator/resource/generate/components/daemonsets.go
+++ b/pkg/virt-operator/resource/generate/components/daemonsets.go
@@ -147,8 +147,9 @@ func NewHandlerDaemonSet(config *operatorutil.KubeVirtDeploymentConfig, productN
 				"/bin/sh",
 				"-c",
 			},
-			Image: launcherImage,
-			Name:  "virt-launcher",
+			Image:           launcherImage,
+			ImagePullPolicy: config.GetImagePullPolicy(),
+			Name:            "virt-launcher",
 			Args: []string{
 				"node-labeller.sh",
 			},
@@ -187,7 +188,7 @@ func NewHandlerDaemonSet(config *operatorutil.KubeVirtDeploymentConfig, productN
 		pod.Containers = append(pod.Containers, corev1.Container{
 			Name:            "virt-launcher-image-holder",
 			Image:           launcherImage,
-			ImagePullPolicy: corev1.PullIfNotPresent,
+			ImagePullPolicy: config.GetImagePullPolicy(),
 			Command:         []string{"/bin/sh", "-c"},
 			Args:            []string{"sleep infinity"},
 			Resources: corev1.ResourceRequirements{

--- a/pkg/virt-operator/resource/generate/components/daemonsets_test.go
+++ b/pkg/virt-operator/resource/generate/components/daemonsets_test.go
@@ -16,6 +16,51 @@ var _ = Describe("Handler DaemonSet", func() {
 		config = &operatorutil.KubeVirtDeploymentConfig{}
 	})
 
+	DescribeTable("should propagate imagePullPolicy to",
+		func(additionalProperties map[string]string, containerName string, isInitContainer bool, expectedPolicy corev1.PullPolicy) {
+			config.AdditionalProperties = additionalProperties
+			ds := NewHandlerDaemonSet(config, "", "", "")
+
+			containers := ds.Spec.Template.Spec.Containers
+			if isInitContainer {
+				containers = ds.Spec.Template.Spec.InitContainers
+			}
+
+			var target *corev1.Container
+			for i := range containers {
+				if containers[i].Name == containerName {
+					target = &containers[i]
+					break
+				}
+			}
+			Expect(target).NotTo(BeNil(), "container %s should exist", containerName)
+			Expect(target.ImagePullPolicy).To(Equal(expectedPolicy))
+		},
+		Entry("the virt-launcher init container when configured",
+			map[string]string{
+				operatorutil.AdditionalPropertiesNamePullPolicy: string(corev1.PullAlways),
+			},
+			"virt-launcher", true, corev1.PullAlways,
+		),
+		Entry("the virt-launcher init container by default",
+			map[string]string(nil),
+			"virt-launcher", true, corev1.PullIfNotPresent,
+		),
+		Entry("the virt-launcher-image-holder container when configured",
+			map[string]string{
+				operatorutil.AdditionalPropertiesNamePullPolicy: string(corev1.PullAlways),
+				operatorutil.AdditionalPropertiesPullSecrets:    `[{"name":"test-secret"}]`,
+			},
+			"virt-launcher-image-holder", false, corev1.PullAlways,
+		),
+		Entry("the virt-launcher-image-holder container by default",
+			map[string]string{
+				operatorutil.AdditionalPropertiesPullSecrets: `[{"name":"test-secret"}]`,
+			},
+			"virt-launcher-image-holder", false, corev1.PullIfNotPresent,
+		),
+	)
+
 	It("should not use bidirectional mount propagation for the kubelet volume", func() {
 		ds := NewHandlerDaemonSet(config, "", "", "")
 		container := ds.Spec.Template.Spec.Containers[0]


### PR DESCRIPTION
### What this PR does
#### Before this PR:

Three containers ignore the configured `imagePullPolicy`:
1. virt-handler DaemonSet init container `virt-launcher` (node-labeller) — no `imagePullPolicy` set, defaults to `IfNotPresent`
2. virt-handler DaemonSet container `virt-launcher-image-holder` — hardcoded to `IfNotPresent`
3. virt-launcher pod `virtiofs` sidecar containers — hardcoded to `IfNotPresent`

#### After this PR:

All three container types use the config-provided `imagePullPolicy` (`config.GetImagePullPolicy()`), consistent with how the main virt-handler, pr-helper, compute, and serial-console-log containers already handle it.

### References

- Fixes #18170
- Partially addresses #15218

### Why we need it and why it was done in this way

`cluster-sync.sh` sets `IMAGE_PULL_POLICY=Always` (added in #15220) and PR #15244 wired `spec.configuration.imagePullPolicy` into the KubeVirt CR. However these three containers were missed, causing stale `devel`-tagged images to persist on kubevirtci nodes after rebuilds.

The fix follows the existing pattern used by other containers in the same files — passing `config.GetImagePullPolicy()` instead of hardcoding. For virtiofs, the pull policy is passed as a parameter to `generateContainerFromVolume()` rather than the full config object, matching the function's current abstraction level.

The following tradeoffs were made:
- None significant — this is a mechanical fix following established patterns.

The following alternatives were considered:
- Passing the full `ClusterConfig` to `generateContainerFromVolume()` — rejected as it would over-couple a simple container construction function.

Links to places where the discussion took place:
- https://github.com/kubevirt/kubevirt/issues/15218#issuecomment-3085474880 (@oshoval flagging virt-launcher pods still using `IfNotPresent`)
- https://github.com/kubevirt/kubevirt/pull/15244#issuecomment-3097474944 (@0xFelix noting serial console log and sidecars still not respecting config)

### Special notes for your reviewer

No production impact — both `GetImagePullPolicy()` methods default to `PullIfNotPresent` when unconfigured, matching the previous hardcoded values. The fix only has observable effect during `cluster-sync` dev workflows.

### Checklist

- [x] Design: A VEP was not required (bug fix)
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: Boy Scout Rule applied
- [x] Upgrade: No upgrade impact — default behavior unchanged
- [x] Testing: Unit tests added for all three fixes
- [ ] Documentation: Not required (dev-workflow fix)
- [ ] Community: Not required
- [x] AI Contributions: The PR abides by the KubeVirt AI Contribution Policy.

### Release note
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Image pull policies configured for the cluster are now applied consistently to VirtIOFS and virtualization handler containers.
  * The default behavior remains `PullIfNotPresent` when no policy is configured.

* **Bug Fixes**
  * Fixed container image pull settings that previously ignored the configured cluster policy.

* **Tests**
  * Added coverage for configured and default image pull policy behavior across affected containers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->