### PR TITLE
e2e: Replace Cirros with Alpine/AlpineWithTestTooling across e2e tests in sig-compute and sig-storage

### DIFF
--- a/tests/hotplug/pci-ports.go
+++ b/tests/hotplug/pci-ports.go
@@ -32,7 +32,8 @@ var _ = Describe("[sig-compute]VM Hotplug PCI Port Allocation", decorators.SigCo
 		// 5. Memory Balloon
 		// 6. Root Disk
 		// 7. Cloudinit Disk
-		cirrosDefaultPortsUsed = 7
+		// 8. RNG
+		alpineDefaultPortsUsed = 8
 	)
 
 	var (
@@ -53,25 +54,25 @@ var _ = Describe("[sig-compute]VM Hotplug PCI Port Allocation", decorators.SigCo
 					libvmi.WithEmptyDisk(fmt.Sprintf("emptydisk%d", i), v1.VirtIO, resource.MustParse("10Mi")),
 				)
 			}
-			vmi := libvmifact.NewCirros(options...)
+			vmi := libvmifact.NewAlpineWithTestTooling(options...)
 			vmi, err := virtClient.VirtualMachineInstance(testsuite.NamespaceTestDefault).Create(context.Background(), vmi, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
-			totalPorts := cirrosDefaultPortsUsed + additionalDevs + expectedFreePorts
+			totalPorts := alpineDefaultPortsUsed + additionalDevs + expectedFreePorts
 			By(fmt.Sprintf("Expecting VM to have %d total ports", totalPorts))
 
-			vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToCirros)
+			vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToAlpine)
 
 			err = console.SafeExpectBatch(vmi, []expect.Batcher{
-				&expect.BSnd{S: fmt.Sprintf("lspci | grep %s | wc -l\n", pciRootPortID)},
+				&expect.BSnd{S: fmt.Sprintf("lspci -nn | grep %s | wc -l\n", pciRootPortID)},
 				&expect.BExp{R: console.RetValue(fmt.Sprintf("%d", totalPorts))},
 			}, 15)
 			Expect(err).ToNot(HaveOccurred())
 		},
 		// min required free ports for <= 2G memory is 3
 		Entry("with 1Gi memory and 0 additional devs", "1Gi", 0, 3),
-		// 16 total ports default for > 2G and that will leave 9 free
-		Entry("with 2.1Gi memory and 0 additional devs", "2.1Gi", 0, 9),
+		// 16 total ports default for > 2G and that will leave 8 free
+		Entry("with 2.1Gi memory and 0 additional devs", "2.1Gi", 0, 8),
 		// min required free ports for > 2G memory is 6
 		Entry("with 2.1Gi memory and 6 additional devs", "2.1Gi", 6, 6),
 	)

--- a/tests/hotplug/pci_topology.go
+++ b/tests/hotplug/pci_topology.go
@@ -53,14 +53,14 @@ var _ = Describe("[sig-compute]PCI Topology", decorators.SigCompute, func() {
 
 	Context("v3 annotation", func() {
 		It("should be set on a new VMI", func() {
-			vmi := libvmifact.NewCirros()
+			vmi := libvmifact.NewAlpineWithTestTooling()
 			vmi, err := virtClient.VirtualMachineInstance(testsuite.NamespaceTestDefault).Create(context.Background(), vmi, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(vmi.Annotations).To(HaveKeyWithValue(v1.PciTopologyVersionAnnotation, v1.PciTopologyVersionV3))
 		})
 
 		It("should be set on a new VM template", func() {
-			vmi := libvmifact.NewCirros()
+			vmi := libvmifact.NewAlpineWithTestTooling()
 			vm := libvmi.NewVirtualMachine(vmi, libvmi.WithRunStrategy(v1.RunStrategyHalted))
 			vm, err := virtClient.VirtualMachine(testsuite.NamespaceTestDefault).Create(context.Background(), vm, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
@@ -70,7 +70,7 @@ var _ = Describe("[sig-compute]PCI Topology", decorators.SigCompute, func() {
 
 	Context("v3 PCI address stability", func() {
 		It("should preserve PCI addresses across VM restart", func() {
-			vmi := libvmifact.NewCirros()
+			vmi := libvmifact.NewAlpineWithTestTooling()
 			vm := libvmi.NewVirtualMachine(vmi, libvmi.WithRunStrategy(v1.RunStrategyAlways))
 			vm, err := virtClient.VirtualMachine(testsuite.NamespaceTestDefault).Create(context.Background(), vm, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
@@ -79,7 +79,7 @@ var _ = Describe("[sig-compute]PCI Topology", decorators.SigCompute, func() {
 			Eventually(matcher.ThisVMIWith(vm.Namespace, vm.Name), 360, 1).Should(matcher.Exist())
 			runningVMI, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			runningVMI = libwait.WaitUntilVMIReady(runningVMI, console.LoginToCirros)
+			runningVMI = libwait.WaitUntilVMIReady(runningVMI, console.LoginToAlpine)
 
 			By("Recording PCI fingerprint before restart")
 			fingerprintBefore := guestPCIFingerprint(runningVMI)
@@ -91,7 +91,7 @@ var _ = Describe("[sig-compute]PCI Topology", decorators.SigCompute, func() {
 			By("Waiting for VMI to be ready after restart")
 			runningVMI, err = virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			runningVMI = libwait.WaitUntilVMIReady(runningVMI, console.LoginToCirros)
+			runningVMI = libwait.WaitUntilVMIReady(runningVMI, console.LoginToAlpine)
 
 			By("Verifying PCI addresses are unchanged")
 			fingerprintAfter := guestPCIFingerprint(runningVMI)
@@ -102,7 +102,7 @@ var _ = Describe("[sig-compute]PCI Topology", decorators.SigCompute, func() {
 	Context("v2 frozen interface slot count", func() {
 		It("should use the frozen slot count and preserve addresses across restart", func() {
 			By("Creating a stopped VM with v2 annotations")
-			vmi := libvmifact.NewCirros()
+			vmi := libvmifact.NewAlpineWithTestTooling()
 			vm := libvmi.NewVirtualMachine(vmi, libvmi.WithRunStrategy(v1.RunStrategyHalted))
 			vm, err := virtClient.VirtualMachine(testsuite.NamespaceTestDefault).Create(context.Background(), vm, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
@@ -122,7 +122,7 @@ var _ = Describe("[sig-compute]PCI Topology", decorators.SigCompute, func() {
 			By("Waiting for VMI to be ready")
 			runningVMI, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			runningVMI = libwait.WaitUntilVMIReady(runningVMI, console.LoginToCirros)
+			runningVMI = libwait.WaitUntilVMIReady(runningVMI, console.LoginToAlpine)
 
 			By("Verifying VMI has v2 annotations")
 			Expect(runningVMI.Annotations).To(HaveKeyWithValue(v1.PciTopologyVersionAnnotation, v1.PciTopologyVersionV2))
@@ -138,7 +138,7 @@ var _ = Describe("[sig-compute]PCI Topology", decorators.SigCompute, func() {
 			By("Waiting for VMI to be ready after restart")
 			runningVMI, err = virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			runningVMI = libwait.WaitUntilVMIReady(runningVMI, console.LoginToCirros)
+			runningVMI = libwait.WaitUntilVMIReady(runningVMI, console.LoginToAlpine)
 
 			By("Verifying v2 annotations are preserved after restart")
 			Expect(runningVMI.Annotations).To(HaveKeyWithValue(v1.PciTopologyVersionAnnotation, v1.PciTopologyVersionV2))
@@ -151,20 +151,20 @@ var _ = Describe("[sig-compute]PCI Topology", decorators.SigCompute, func() {
 
 		It("should produce different PCI addresses than v3", func() {
 			By("Creating a v3 VMI")
-			v3VMI := libvmifact.NewCirros()
+			v3VMI := libvmifact.NewAlpineWithTestTooling()
 			v3VMI, err := virtClient.VirtualMachineInstance(testsuite.NamespaceTestDefault).Create(context.Background(), v3VMI, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			v3VMI = libwait.WaitUntilVMIReady(v3VMI, console.LoginToCirros)
+			v3VMI = libwait.WaitUntilVMIReady(v3VMI, console.LoginToAlpine)
 			v3Fingerprint := guestPCIFingerprint(v3VMI)
 
 			By("Creating a v2 VMI with frozen slot count of 9 (8 placeholders + 1 interface)")
-			v2VMI := libvmifact.NewCirros(
+			v2VMI := libvmifact.NewAlpineWithTestTooling(
 				libvmi.WithAnnotation(v1.PciTopologyVersionAnnotation, v1.PciTopologyVersionV2),
 				libvmi.WithAnnotation(v1.PciInterfaceSlotCountAnnotation, "9"),
 			)
 			v2VMI, err = virtClient.VirtualMachineInstance(testsuite.NamespaceTestDefault).Create(context.Background(), v2VMI, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			v2VMI = libwait.WaitUntilVMIReady(v2VMI, console.LoginToCirros)
+			v2VMI = libwait.WaitUntilVMIReady(v2VMI, console.LoginToAlpine)
 			v2Fingerprint := guestPCIFingerprint(v2VMI)
 
 			By("Verifying v2 PCI addresses differ from v3")
@@ -176,7 +176,7 @@ var _ = Describe("[sig-compute]PCI Topology", decorators.SigCompute, func() {
 	Context("annotation propagation", func() {
 		It("should propagate PCI topology annotations from VMI to VM template", func() {
 			By("Creating a stopped VM and removing the v3 annotation from the template")
-			vmi := libvmifact.NewCirros()
+			vmi := libvmifact.NewAlpineWithTestTooling()
 			vm := libvmi.NewVirtualMachine(vmi, libvmi.WithRunStrategy(v1.RunStrategyHalted))
 			vm, err := virtClient.VirtualMachine(testsuite.NamespaceTestDefault).Create(context.Background(), vm, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())

--- a/tests/libvmifact/factory.go
+++ b/tests/libvmifact/factory.go
@@ -182,3 +182,9 @@ func WithDummyCloudForFastBoot() libvmici.NoCloudOption {
 		source.UserDataBase64 = base64.StdEncoding.EncodeToString([]byte("#!/bin/bash\necho 'hello'\n"))
 	}
 }
+
+func WithDummyConfigDriveCloudForFastBoot() libvmici.ConfigDriveOption {
+	return func(source *kvirtv1.CloudInitConfigDriveSource) {
+		source.UserData = "#!/bin/bash\necho 'hello'\n"
+	}
+}

--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -377,7 +377,7 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 					libdv.WithRegistrySource(libdv.WithURL(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine)), libdv.WithPullMethod(cdiv1.RegistryPullNode), libdv.WithPlatformArch(defaultArch)),
 					libdv.WithStorage(
 						libdv.StorageWithStorageClass(sc),
-						libdv.StorageWithVolumeSize(cd.CirrosVolumeSize),
+						libdv.StorageWithVolumeSize(cd.AlpineVolumeSize),
 						libdv.StorageWithAccessMode(k8sv1.ReadWriteMany),
 						libdv.StorageWithVolumeMode(k8sv1.PersistentVolumeBlock),
 					),

--- a/tests/migration/namespace.go
+++ b/tests/migration/namespace.go
@@ -394,7 +394,7 @@ var _ = Describe(SIG("Live Migration across namespaces", decorators.RequiresDece
 			By("Writing data to extra disk")
 			Expect(console.LoginToAlpine(sourceVMI)).To(Succeed())
 			// I am aware I should not use the device name since it is not guaranteed to be the same as the one in the VMI
-			// I should be using the serial number, but not sure how to access that in cirros.
+			// I should be using the serial number, but not sure how to access that in alpine.
 			Expect(console.RunCommand(sourceVMI, fmt.Sprintf("mkfs.ext4 /dev/%s", deviceName), 30*time.Second)).To(Succeed())
 			Expect(console.RunCommand(sourceVMI, "mkdir /home/alpine/test", 30*time.Second)).To(Succeed())
 			Expect(console.RunCommand(sourceVMI, fmt.Sprintf("mount -t ext4 /dev/%s /home/alpine/test", deviceName), 30*time.Second)).To(Succeed())

--- a/tests/stability_test.go
+++ b/tests/stability_test.go
@@ -19,7 +19,7 @@ var _ = PDescribe("Ensure stable functionality", func() {
 
 		experiment.Sample(func(idx int) {
 			experiment.MeasureDuration("Create VM", func() {
-				libvmops.RunVMIAndExpectLaunch(libvmifact.NewCirros(), libvmops.StartupTimeoutSecondsTiny)
+				libvmops.RunVMIAndExpectLaunch(libvmifact.NewAlpine(), libvmops.StartupTimeoutSecondsTiny)
 			})
 		}, gmeasure.SamplingConfig{N: 15, Duration: 10 * time.Minute})
 	})

--- a/tests/storage/objectgraph_test.go
+++ b/tests/storage/objectgraph_test.go
@@ -199,7 +199,7 @@ var _ = Describe("[sig-storage]ObjectGraph", decorators.SigStorage, func() {
 		It("Object Graph should detect newly added resources", func() {
 			By("Creating DataVolume")
 			dv := libdv.NewDataVolume(
-				libdv.WithRegistryURLSource(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskCirros)),
+				libdv.WithRegistryURLSource(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine)),
 				libdv.WithStorage(),
 				libdv.WithForceBindAnnotation(),
 			)

--- a/tests/vmi_cloudinit_hook_sidecar_test.go
+++ b/tests/vmi_cloudinit_hook_sidecar_test.go
@@ -98,7 +98,7 @@ var _ = Describe("[sig-compute]CloudInitHookSidecars", decorators.SigCompute, fu
 
 	BeforeEach(func() {
 		virtClient = kubevirt.Client()
-		vmi = libvmifact.NewCirros(
+		vmi = libvmifact.NewAlpineWithTestTooling(
 			libvmi.WithAnnotation("hooks.kubevirt.io/hookSidecars",
 				fmt.Sprintf(`[{"args": ["--version", "v1alpha2"], "image": "%s", "imagePullPolicy": "IfNotPresent"}]`,
 					libregistry.GetUtilityImageFromRegistry(cloudinitHookSidecarImage))))
@@ -131,7 +131,7 @@ var _ = Describe("[sig-compute]CloudInitHookSidecars", decorators.SigCompute, fu
 			It("[test_id:3169]should have cloud-init user-data from sidecar", func() {
 				vmi, err = virtClient.VirtualMachineInstance(testsuite.NamespaceTestDefault).Create(context.Background(), vmi, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
-				libwait.WaitUntilVMIReady(vmi, console.LoginToCirros)
+				libwait.WaitUntilVMIReady(vmi, console.LoginToAlpine)
 				By("mouting cloudinit iso")
 				MountCloudInit(vmi)
 				By("checking cloudinit user-data")

--- a/tests/vmi_cloudinit_test.go
+++ b/tests/vmi_cloudinit_test.go
@@ -316,7 +316,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			It("[test_id:3184]should have cloud-init network-config with NetworkData source", func() {
 				vmi := libvmifact.NewAlpineWithTestTooling(
 					libvmi.WithCloudInitConfigDrive(libcloudinit.WithConfigDriveNetworkData(testConfigDriveNetworkData),
-						libcloudinit.WithConfigDriveUserData("#!/bin/bash\necho 'hello'\n")))
+						libvmifact.WithDummyConfigDriveCloudForFastBoot()))
 				vmi = libvmops.RunVMIAndExpectLaunch(vmi, startupTime)
 				vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToAlpine)
 
@@ -335,8 +335,9 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 					tag        = "specialNet"
 				)
 				testInstancetype := "testInstancetype"
-				vmi := libvmifact.NewCirros(
-					libvmi.WithCloudInitConfigDrive(libcloudinit.WithConfigDriveNetworkData(testNoCloudNetworkData)),
+				vmi := libvmifact.NewAlpineWithTestTooling(
+					libvmi.WithCloudInitConfigDrive(libcloudinit.WithConfigDriveNetworkData(testConfigDriveNetworkData),
+						libvmifact.WithDummyConfigDriveCloudForFastBoot()),
 					libvmi.WithInterface(v1.Interface{
 						Name: "default",
 						Tag:  tag,
@@ -350,7 +351,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 					libvmi.WithAnnotation(v1.InstancetypeAnnotation, testInstancetype),
 				)
 				vmi = libvmops.RunVMIAndExpectLaunch(vmi, startupTime)
-				vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToCirros)
+				vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToAlpine)
 				checkCloudInitIsoSize(vmi, cloudinit.DataSourceConfigDrive)
 
 				metadataStruct := cloudinit.ConfigDriveMetadata{
@@ -374,7 +375,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				Expect(mountGuestDevice(vmi, dataSourceConfigDriveVolumeID)).To(Succeed())
 
 				By("checking cloudinit network-config")
-				checkCloudInitFile(vmi, "openstack/latest/network_data.json", testNoCloudNetworkData)
+				checkCloudInitFile(vmi, "openstack/latest/network_data.json", testConfigDriveNetworkData)
 
 				By("checking cloudinit meta-data")
 				const consoleCmd = `cat /mnt/openstack/latest/meta_data.json; printf "@@"`
@@ -389,7 +390,7 @@ var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			It("[test_id:3185]should have cloud-init network-config with NetworkDataBase64 source", func() {
 				vmi := libvmifact.NewAlpineWithTestTooling(
 					libvmi.WithCloudInitConfigDrive(libcloudinit.WithConfigDriveEncodedNetworkData(testConfigDriveNetworkData),
-						libcloudinit.WithConfigDriveUserData("#!/bin/bash\necho 'hello'\n")),
+						libvmifact.WithDummyConfigDriveCloudForFastBoot()),
 				)
 				vmi = libvmops.RunVMIAndExpectLaunch(vmi, startupTime)
 				vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToAlpine)

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -1005,10 +1005,10 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 		// ordering:
 		// use a small disk for the other ones
 		testVMI := func() *v1.VirtualMachineInstance {
-			// virtio - added by NewCirros
-			return libvmifact.NewCirros(
+			// virtio - added by NewAlpine
+			return libvmifact.NewAlpine(
 				// add sata disk
-				libvmi.WithContainerSATADisk("disk2", cd.ContainerDiskFor(cd.ContainerDiskCirros)),
+				libvmi.WithContainerSATADisk("disk2", cd.ContainerDiskFor(cd.ContainerDiskAlpine)),
 			)
 			// NOTE: we have one disk per bus, so we expect vda, sda
 		}
@@ -1028,11 +1028,11 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 			Expect(err).ToNot(HaveOccurred())
 			libwait.WaitForSuccessfulVMIStart(vmi)
 
-			Expect(console.LoginToCirros(vmi)).To(Succeed())
+			Expect(console.LoginToAlpine(vmi)).To(Succeed())
 
 			Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
 				// keep the ordering!
-				&expect.BSnd{S: "ls /dev/vda  /dev/vdb\n"},
+				&expect.BSnd{S: "ls /dev/vda  /dev/sda\n"},
 				&expect.BExp{R: ""},
 				&expect.BSnd{S: "echo $?\n"},
 				&expect.BExp{R: console.RetValue("0")},
@@ -1046,7 +1046,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 			vmi.Spec.Domain.Devices.Disks[0].Disk.Bus = v1.DiskBusVirtio
 			vmi, err := virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			libwait.WaitUntilVMIReady(vmi, console.LoginToCirros)
+			libwait.WaitUntilVMIReady(vmi, console.LoginToAlpine)
 
 			checkPciAddress(vmi, vmi.Spec.Domain.Devices.Disks[0].Disk.PciAddress)
 		})

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -315,7 +315,7 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 
 				It("[test_id:1630]should log warning and proceed once the secret is there", func() {
 					userData64 := ""
-					vmi := libvmifact.NewCirros()
+					vmi := libvmifact.NewAlpineWithTestTooling()
 
 					for _, volume := range vmi.Spec.Volumes {
 						if volume.CloudInitNoCloud != nil {

--- a/tests/vmi_sound_test.go
+++ b/tests/vmi_sound_test.go
@@ -44,14 +44,14 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 	Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component] A VirtualMachineInstance with default sound support", func() {
 
 		It("should create an ich9 sound device on empty model", func() {
-			vmi := libvmifact.NewCirros()
+			vmi := libvmifact.NewAlpineWithTestTooling()
 			vmi.Spec.Domain.Devices.Sound = &v1.SoundDevice{
 				Name: "test-audio-device",
 			}
 			vmi, err := kubevirt.Client().VirtualMachineInstance(testsuite.NamespaceTestDefault).Create(context.Background(), vmi, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
-			vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToCirros)
+			vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToAlpine)
 			err = checkICH9AudioDeviceInGuest(vmi)
 			Expect(err).ToNot(HaveOccurred(), "ICH9 sound device was no found")
 		})
@@ -66,7 +66,7 @@ func checkICH9AudioDeviceInGuest(vmi *v1.VirtualMachineInstance) error {
 	return console.SafeExpectBatch(vmi, []expect.Batcher{
 		&expect.BSnd{S: "\n"},
 		&expect.BExp{R: ""},
-		&expect.BSnd{S: fmt.Sprintf("lspci | grep %s\n", deviceId)},
+		&expect.BSnd{S: fmt.Sprintf("lspci -nn | grep %s\n", deviceId)},
 		&expect.BExp{R: ".*8086.*"},
 	}, 15)
 }


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

This PR replaces Cirros container disk images with Alpine or AlpineWithTestTooling images across multiple e2e test files as part of the ongoing effort to deprecate Cirros from the KubeVirt test suite.

#### Before this PR:

- Multiple e2e tests in sig-compute, sig-compute-migrations, and sig-storage use NewCirros() with LoginToCirros and Cirros-specific volume sizes and data sources.
- PCI device listing uses lspci which relies on Cirros's built-in pciutils

#### After this PR:

- Tests use NewAlpineWithTestTooling() or NewAlpine() with LoginToAlpine
- Volume sizes and data sources reference Alpine instead of Cirros
- PCI device listing uses lspci -nn to match Alpine's busybox implementation which requires the -nn flag to display device IDs

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->
Partially addresses https://github.com/kubevirt/kubevirt/issues/15043

### Why we need it and why it was done in this way

Cirros is being deprecated from the KubeVirt test suite. Alpine is a lightweight, actively maintained alternative that provides better tooling support and is already widely used across KubeVirt tests. This PR migrates additional test files that were still using Cirros to Alpine or AlpineWithTestTooling images.

The following tradeoffs were made:

- NewAlpineWithTestTooling() is used instead of NewAlpine() in tests that require guest-agent capabilities or richer shell tooling (e.g., cloudinit hook sidecar, PCI topology, lifecycle tests)
- NewAlpine() is used in tests that only need a basic bootable VM (e.g., stability test, disk configuration test)
- lspci commands were updated to lspci -nn because Alpine's busybox-based lspci requires the -nn flag to display numeric PCI device IDs, unlike Cirros's full pciutils

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

