### PR TITLE
api: clarify ImagePullPolicy field comments in KubeVirt CR

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -16073,7 +16073,7 @@
       "x-kubernetes-list-type": "atomic"
      },
      "imagePullPolicy": {
-      "description": "Possible enum values:\n - `\"Always\"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.\n - `\"IfNotPresent\"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.\n - `\"Never\"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present",
+      "description": "The ImagePullPolicy to use for user workload pods and their containers (launcher pods, exporter pods, etc.). For KubeVirt infrastructure images, use spec.imagePullPolicy instead.\n\nPossible enum values:\n - `\"Always\"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.\n - `\"IfNotPresent\"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.\n - `\"Never\"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present",
       "type": "string",
       "enum": [
        "Always",
@@ -16262,7 +16262,7 @@
       "$ref": "#/definitions/v1.CustomizeComponents"
      },
      "imagePullPolicy": {
-      "description": "The ImagePullPolicy to use.\n\nPossible enum values:\n - `\"Always\"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.\n - `\"IfNotPresent\"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.\n - `\"Never\"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present",
+      "description": "The ImagePullPolicy to use for KubeVirt operator-managed infrastructure images (virt-api, virt-controller, virt-handler, virt-exportproxy, etc.). For pull policy of user workload pods, see spec.configuration.imagePullPolicy.\n\nPossible enum values:\n - `\"Always\"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.\n - `\"IfNotPresent\"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.\n - `\"Never\"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present",
       "type": "string",
       "enum": [
        "Always",

--- a/manifests/generated/kv-resource.yaml
+++ b/manifests/generated/kv-resource.yaml
@@ -600,8 +600,10 @@ spec:
                     type: array
                     x-kubernetes-list-type: atomic
                   imagePullPolicy:
-                    description: PullPolicy describes a policy for if/when to pull
-                      a container image
+                    description: |-
+                      The ImagePullPolicy to use for user workload pods and their containers
+                      (launcher pods, exporter pods, etc.).
+                      For KubeVirt infrastructure images, use spec.imagePullPolicy instead.
                     type: string
                   instancetype:
                     description: Instancetype configuration
@@ -1288,7 +1290,11 @@ spec:
                     x-kubernetes-list-type: atomic
                 type: object
               imagePullPolicy:
-                description: The ImagePullPolicy to use.
+                description: |-
+                  The ImagePullPolicy to use for KubeVirt operator-managed infrastructure
+                  images (virt-api, virt-controller, virt-handler, virt-exportproxy, etc.).
+                  For pull policy of user workload pods, see
+                  spec.configuration.imagePullPolicy.
                 type: string
               imagePullSecrets:
                 description: |-
@@ -4086,8 +4092,10 @@ spec:
                     type: array
                     x-kubernetes-list-type: atomic
                   imagePullPolicy:
-                    description: PullPolicy describes a policy for if/when to pull
-                      a container image
+                    description: |-
+                      The ImagePullPolicy to use for user workload pods and their containers
+                      (launcher pods, exporter pods, etc.).
+                      For KubeVirt infrastructure images, use spec.imagePullPolicy instead.
                     type: string
                   instancetype:
                     description: Instancetype configuration
@@ -4774,7 +4782,11 @@ spec:
                     x-kubernetes-list-type: atomic
                 type: object
               imagePullPolicy:
-                description: The ImagePullPolicy to use.
+                description: |-
+                  The ImagePullPolicy to use for KubeVirt operator-managed infrastructure
+                  images (virt-api, virt-controller, virt-handler, virt-exportproxy, etc.).
+                  For pull policy of user workload pods, see
+                  spec.configuration.imagePullPolicy.
                 type: string
               imagePullSecrets:
                 description: |-

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -1203,8 +1203,10 @@ var CRDsValidation map[string]string = map[string]string{
               type: array
               x-kubernetes-list-type: atomic
             imagePullPolicy:
-              description: PullPolicy describes a policy for if/when to pull a container
-                image
+              description: |-
+                The ImagePullPolicy to use for user workload pods and their containers
+                (launcher pods, exporter pods, etc.).
+                For KubeVirt infrastructure images, use spec.imagePullPolicy instead.
               type: string
             instancetype:
               description: Instancetype configuration
@@ -1889,7 +1891,11 @@ var CRDsValidation map[string]string = map[string]string{
               x-kubernetes-list-type: atomic
           type: object
         imagePullPolicy:
-          description: The ImagePullPolicy to use.
+          description: |-
+            The ImagePullPolicy to use for KubeVirt operator-managed infrastructure
+            images (virt-api, virt-controller, virt-handler, virt-exportproxy, etc.).
+            For pull policy of user workload pods, see
+            spec.configuration.imagePullPolicy.
           type: string
         imagePullSecrets:
           description: |-

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -2531,7 +2531,10 @@ type KubeVirtSpec struct {
 	// Defaults to the same registry the operator's container image is pulled from.
 	ImageRegistry string `json:"imageRegistry,omitempty"`
 
-	// The ImagePullPolicy to use.
+	// The ImagePullPolicy to use for KubeVirt operator-managed infrastructure
+	// images (virt-api, virt-controller, virt-handler, virt-exportproxy, etc.).
+	// For pull policy of user workload pods, see
+	// spec.configuration.imagePullPolicy.
 	ImagePullPolicy k8sv1.PullPolicy `json:"imagePullPolicy,omitempty" valid:"required"`
 
 	// The imagePullSecrets to pull the container images from
@@ -3060,7 +3063,10 @@ type KubeVirtConfiguration struct {
 	CPURequest             *resource.Quantity      `json:"cpuRequest,omitempty"`
 	DeveloperConfiguration *DeveloperConfiguration `json:"developerConfiguration,omitempty"`
 	// Deprecated. Use architectureConfiguration instead.
-	EmulatedMachines       []string                `json:"emulatedMachines,omitempty"`
+	EmulatedMachines []string `json:"emulatedMachines,omitempty"`
+	// The ImagePullPolicy to use for user workload pods and their containers
+	// (launcher pods, exporter pods, etc.).
+	// For KubeVirt infrastructure images, use spec.imagePullPolicy instead.
 	ImagePullPolicy        k8sv1.PullPolicy        `json:"imagePullPolicy,omitempty"`
 	MigrationConfiguration *MigrationConfiguration `json:"migrations,omitempty"`
 	// Deprecated. Use architectureConfiguration instead.

--- a/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
@@ -630,7 +630,7 @@ func (KubeVirtSpec) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"imageTag":                "The image tag to use for the continer images installed.\nDefaults to the same tag as the operator's container image.",
 		"imageRegistry":           "The image registry to pull the container images from\nDefaults to the same registry the operator's container image is pulled from.",
-		"imagePullPolicy":         "The ImagePullPolicy to use.",
+		"imagePullPolicy":         "The ImagePullPolicy to use for KubeVirt operator-managed infrastructure\nimages (virt-api, virt-controller, virt-handler, virt-exportproxy, etc.).\nFor pull policy of user workload pods, see\nspec.configuration.imagePullPolicy.",
 		"imagePullSecrets":        "The imagePullSecrets to pull the container images from\nDefaults to none\n+listType=atomic",
 		"monitorNamespace":        "The namespace Prometheus is deployed in\nDefaults to openshift-monitor",
 		"serviceMonitorNamespace": "The namespace the service monitor will be deployed\n When ServiceMonitorNamespace is set, then we'll install the service monitor object in that namespace\notherwise we will use the monitoring namespace.",
@@ -879,6 +879,7 @@ func (KubeVirtConfiguration) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"":                                   "KubeVirtConfiguration holds all kubevirt configurations",
 		"emulatedMachines":                   "Deprecated. Use architectureConfiguration instead.",
+		"imagePullPolicy":                    "The ImagePullPolicy to use for user workload pods and their containers\n(launcher pods, exporter pods, etc.).\nFor KubeVirt infrastructure images, use spec.imagePullPolicy instead.",
 		"machineType":                        "Deprecated. Use architectureConfiguration instead.",
 		"ovmfPath":                           "Deprecated. Use architectureConfiguration instead.",
 		"evictionStrategy":                   "EvictionStrategy defines at the cluster level if the VirtualMachineInstance should be\nmigrated instead of shut-off in case of a node drain. If the VirtualMachineInstance specific\nfield is set it overrides the cluster level one.",

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -22712,7 +22712,7 @@ func schema_kubevirtio_api_core_v1_KubeVirtConfiguration(ref common.ReferenceCal
 					},
 					"imagePullPolicy": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Possible enum values:\n - `\"Always\"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.\n - `\"IfNotPresent\"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.\n - `\"Never\"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present",
+							Description: "The ImagePullPolicy to use for user workload pods and their containers (launcher pods, exporter pods, etc.). For KubeVirt infrastructure images, use spec.imagePullPolicy instead.\n\nPossible enum values:\n - `\"Always\"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.\n - `\"IfNotPresent\"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.\n - `\"Never\"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present",
 							Type:        []string{"string"},
 							Format:      "",
 							Enum:        []interface{}{"Always", "IfNotPresent", "Never"},
@@ -23111,7 +23111,7 @@ func schema_kubevirtio_api_core_v1_KubeVirtSpec(ref common.ReferenceCallback) co
 					},
 					"imagePullPolicy": {
 						SchemaProps: spec.SchemaProps{
-							Description: "The ImagePullPolicy to use.\n\nPossible enum values:\n - `\"Always\"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.\n - `\"IfNotPresent\"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.\n - `\"Never\"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present",
+							Description: "The ImagePullPolicy to use for KubeVirt operator-managed infrastructure images (virt-api, virt-controller, virt-handler, virt-exportproxy, etc.). For pull policy of user workload pods, see spec.configuration.imagePullPolicy.\n\nPossible enum values:\n - `\"Always\"` means that kubelet always attempts to pull the latest image. Container will fail If the pull fails.\n - `\"IfNotPresent\"` means that kubelet pulls if the image isn't present on disk. Container will fail if the image isn't present and the pull fails.\n - `\"Never\"` means that kubelet never pulls an image, but only uses a local image. Container will fail if the image isn't present",
 							Type:        []string{"string"},
 							Format:      "",
 							Enum:        []interface{}{"Always", "IfNotPresent", "Never"},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
The KubeVirt CR has two separate ImagePullPolicy fields that were
poorly documented. Clarify that spec.imagePullPolicy governs
operator-managed infrastructure images, while
spec.configuration.imagePullPolicy governs user workload pods.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
Should I get an issue going about a possible API refactor or is this sort of desired?

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

