### PR TITLE
Fix decentralized live migration failure when using persistent TPM+EFI enabled

### DIFF
--- a/pkg/virt-controller/watch/migration/BUILD.bazel
+++ b/pkg/virt-controller/watch/migration/BUILD.bazel
@@ -55,6 +55,7 @@ go_test(
         "//pkg/controller:go_default_library",
         "//pkg/controller/testing:go_default_library",
         "//pkg/pointer:go_default_library",
+        "//pkg/storage/backend-storage:go_default_library",
         "//pkg/testutils:go_default_library",
         "//pkg/util/migrations:go_default_library",
         "//pkg/virt-config:go_default_library",

--- a/pkg/virt-controller/watch/migration/migration.go
+++ b/pkg/virt-controller/watch/migration/migration.go
@@ -1436,8 +1436,9 @@ func (c *Controller) handleBackendStorage(migration *virtv1.VirtualMachineInstan
 	if migration.Status.MigrationState == nil {
 		migration.Status.MigrationState = &virtv1.VirtualMachineInstanceMigrationState{}
 	}
-	// Set source PVC when: not decentralized, or VMI is source for this migration, or a previous decentralized migration completed (so next migration can run MigrationHandoff).
-	if !vmi.IsDecentralizedMigration() || vmi.IsMigrationSource() || vmi.IsMigrationCompleted() {
+	// Set source PVC when: local migration, or a previous decentralized source migration completed (for MigrationHandoff).
+	// Decentralized target VMIs do not have the source backend PVC locally; it is created in the target namespace instead.
+	if !migration.IsDecentralizedTarget() || vmi.IsMigrationCompleted() {
 		migration.Status.MigrationState.SourcePersistentStatePVCName = backendstorage.CurrentPVCName(vmi)
 		if migration.Status.MigrationState.SourcePersistentStatePVCName == "" {
 			return fmt.Errorf("no backend-storage PVC found in VMI volume status")

--- a/pkg/virt-controller/watch/migration/migration_test.go
+++ b/pkg/virt-controller/watch/migration/migration_test.go
@@ -61,6 +61,7 @@ import (
 	virtcontroller "kubevirt.io/kubevirt/pkg/controller"
 	controllertesting "kubevirt.io/kubevirt/pkg/controller/testing"
 	"kubevirt.io/kubevirt/pkg/pointer"
+	backendstorage "kubevirt.io/kubevirt/pkg/storage/backend-storage"
 	"kubevirt.io/kubevirt/pkg/testutils"
 	migrationsutil "kubevirt.io/kubevirt/pkg/util/migrations"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
@@ -3043,6 +3044,103 @@ var _ = Describe("Migration watcher", func() {
 		})
 	})
 
+	Context("handleBackendStorage decentralized migrations", func() {
+		setupVMStateStorageClass := func() {
+			sc := &storagev1.StorageClass{
+				ObjectMeta: metav1.ObjectMeta{Name: "testsc123"},
+			}
+			sp := &cdiv1.StorageProfile{
+				ObjectMeta: metav1.ObjectMeta{Name: sc.Name},
+				Spec: cdiv1.StorageProfileSpec{
+					ClaimPropertySets: []cdiv1.ClaimPropertySet{
+						{AccessModes: []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce}, VolumeMode: pointer.P(k8sv1.PersistentVolumeFilesystem)},
+					},
+				},
+				Status: cdiv1.StorageProfileStatus{
+					StorageClass: pointer.P(sc.Name),
+					ClaimPropertySets: []cdiv1.ClaimPropertySet{
+						{AccessModes: []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce}, VolumeMode: pointer.P(k8sv1.PersistentVolumeFilesystem)},
+					},
+				},
+			}
+			Expect(controller.storageClassStore.Add(sc)).To(Succeed())
+			Expect(controller.storageProfileStore.Add(sp)).To(Succeed())
+			setConfig(&v1.KubeVirtConfiguration{
+				VMStateStorageClass: "testsc123",
+			})
+		}
+
+		It("should not require source backend PVC on decentralized target VMI waiting for sync", func() {
+			setupVMStateStorageClass()
+			vmi := newReceiverVirtualMachine("testvmi", v1.WaitingForSync, "testmigration")
+			vmi.Spec.Domain.Devices.TPM = &v1.TPMDevice{Persistent: pointer.P(true)}
+			vmi.Spec.Domain.Firmware = &v1.Firmware{
+				Bootloader: &v1.Bootloader{
+					EFI: &v1.EFI{Persistent: pointer.P(true)},
+				},
+			}
+			migration := newDecentralizedReceiverMigration("testmigration", vmi.Name, v1.MigrationPending)
+
+			err := controller.handleBackendStorage(migration, vmi)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(migration.Status.MigrationState.SourcePersistentStatePVCName).To(BeEmpty())
+
+			pvcs, listErr := kubeClient.CoreV1().PersistentVolumeClaims(vmi.Namespace).List(context.Background(), metav1.ListOptions{})
+			Expect(listErr).ToNot(HaveOccurred())
+			Expect(pvcs.Items).ToNot(BeEmpty())
+		})
+
+		It("should require source backend PVC for local migration", func() {
+			vmi := newVirtualMachine("testvmi", v1.Running)
+			vmi.Spec.Domain.Devices.TPM = &v1.TPMDevice{Persistent: pointer.P(true)}
+			migration := newMigration("testmigration", vmi.Name, v1.MigrationPending)
+
+			err := controller.handleBackendStorage(migration, vmi)
+			Expect(err).To(MatchError(ContainSubstring("no backend-storage PVC found")))
+		})
+
+		It("should require source backend PVC for decentralized source migration", func() {
+			vmi := newVirtualMachine("testvmi", v1.Running)
+			vmi.Spec.Domain.Devices.TPM = &v1.TPMDevice{Persistent: pointer.P(true)}
+			migration := newDecentralizedSenderMigration("testmigration", vmi.Name, v1.MigrationPending)
+
+			err := controller.handleBackendStorage(migration, vmi)
+			Expect(err).To(MatchError(ContainSubstring("no backend-storage PVC found")))
+			Expect(migration.Status.MigrationState.SourcePersistentStatePVCName).To(BeEmpty())
+		})
+
+		It("should set SourcePersistentStatePVCName for decentralized source migration when source PVC exists", func() {
+			const sourcePVCName = "source-backend-pvc"
+			vmi := newVirtualMachine("testvmi", v1.Running)
+			vmi.Spec.Domain.Devices.TPM = &v1.TPMDevice{Persistent: pointer.P(true)}
+			setBackendStorageVolumeStatus(vmi, sourcePVCName)
+			migration := newDecentralizedSenderMigration("testmigration", vmi.Name, v1.MigrationPending)
+			migration.Status.MigrationState = &v1.VirtualMachineInstanceMigrationState{
+				TargetPersistentStatePVCName: "existing-target-pvc",
+			}
+
+			err := controller.handleBackendStorage(migration, vmi)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(migration.Status.MigrationState.SourcePersistentStatePVCName).To(Equal(sourcePVCName))
+		})
+
+		It("should set SourcePersistentStatePVCName on decentralized target when previous migration completed", func() {
+			const sourcePVCName = "handoff-backend-pvc"
+			vmi := newReceiverVirtualMachine("testvmi", v1.Running, "testmigration")
+			vmi.Spec.Domain.Devices.TPM = &v1.TPMDevice{Persistent: pointer.P(true)}
+			setBackendStorageVolumeStatus(vmi, sourcePVCName)
+			vmi.Status.MigrationState.Completed = true
+			migration := newDecentralizedReceiverMigration("testmigration", vmi.Name, v1.MigrationPending)
+			migration.Status.MigrationState = &v1.VirtualMachineInstanceMigrationState{
+				TargetPersistentStatePVCName: "existing-target-pvc",
+			}
+
+			err := controller.handleBackendStorage(migration, vmi)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(migration.Status.MigrationState.SourcePersistentStatePVCName).To(Equal(sourcePVCName))
+		})
+	})
+
 	Context("Decentralized migration condition", func() {
 		var (
 			conditionManager *virtcontroller.VirtualMachineInstanceMigrationConditionManager
@@ -3146,6 +3244,24 @@ func newDecentralizedReceiverMigration(name string, vmiName string, phase v1.Vir
 		MigrationID: vmiName,
 	}
 	return migration
+}
+
+func newDecentralizedSenderMigration(name string, vmiName string, phase v1.VirtualMachineInstanceMigrationPhase) *v1.VirtualMachineInstanceMigration {
+	migration := newMigration(name, vmiName, phase)
+	migration.Spec.SendTo = &v1.VirtualMachineInstanceMigrationSource{
+		MigrationID: "remote-migration-id",
+		ConnectURL:  "10.0.0.1:9185",
+	}
+	return migration
+}
+
+func setBackendStorageVolumeStatus(vmi *v1.VirtualMachineInstance, claimName string) {
+	vmi.Status.VolumeStatus = append(vmi.Status.VolumeStatus, v1.VolumeStatus{
+		Name: backendstorage.VolumeName,
+		PersistentVolumeClaimInfo: &v1.PersistentVolumeClaimInfo{
+			ClaimName: claimName,
+		},
+	})
 }
 
 func newMigrationWithAddedNodeSelector(name string, vmiName string, phase v1.VirtualMachineInstanceMigrationPhase, addedNodeSelector map[string]string) *v1.VirtualMachineInstanceMigration {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Fixes a bug where the migration failure was saying that the TPM could not be found on the
target. This caused the migration to remain pending indefinitely. Changed the check to not
just check for the TPM, but also allow the target

#### Before this PR:
Functional test: Live Migration across namespaces container disk with RWOFs backend storage class should decentralized migrate a VMI with persistent TPM+EFI enabled would fail a lot of the time.

#### After this PR:
Functional test passes.
### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/192

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [X] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

