### PR TITLE
Default KUBEVIRT_CS10_BUILDER_VERSION in hack/dockerized

### DIFF
--- a/hack/dockerized
+++ b/hack/dockerized
@@ -13,7 +13,7 @@ fi
 fail_if_cri_bin_missing
 
 kubevirt_builder_version="2606231619-4fe2cd536f"
-kubevirt_cs10_builder_version=${KUBEVIRT_CS10_BUILDER_VERSION:-""}
+kubevirt_cs10_builder_version=${KUBEVIRT_CS10_BUILDER_VERSION:-"2606291605-cd18b3548f"}
 
 # CentOS Stream 9 builder images (default)
 default_kubevirt_builder_image="quay.io/kubevirt/builder:${kubevirt_builder_version}"
@@ -28,13 +28,6 @@ kubevirt_cs10_cross_compile_image="quay.io/kubevirt/builder-cs10-cross:${kubevir
 if [ -n "${KUBEVIRT_BUILDER_IMAGE}" ]; then
     : # User has specified a custom builder image
 elif [ "${KUBEVIRT_CENTOS_STREAM_VERSION}" == "10" ]; then
-    if [ -z "${kubevirt_cs10_builder_version}" ]; then
-        echo "ERROR: KUBEVIRT_CENTOS_STREAM_VERSION=10 requires KUBEVIRT_CS10_BUILDER_VERSION to be set" >&2
-        echo "Build a CS10 builder image with: hack/builder/build-cs10.sh" >&2
-        echo "Then set: export KUBEVIRT_CS10_BUILDER_VERSION=<version>" >&2
-        echo "Or set KUBEVIRT_BUILDER_IMAGE directly to your local CS10 builder image" >&2
-        exit 1
-    fi
     KUBEVIRT_BUILDER_IMAGE="${default_kubevirt_cs10_builder_image}"
     kubevirt_cross_compile_image="${kubevirt_cs10_cross_compile_image}"
 else


### PR DESCRIPTION
### What this PR does
#### Before this PR:

`hack/dockerized` required callers to explicitly set `KUBEVIRT_CS10_BUILDER_VERSION` when using `KUBEVIRT_CENTOS_STREAM_VERSION=10`, erroring out if it was missing.

#### After this PR:

`hack/dockerized` hardcodes a default CS10 builder version (`2605290816-89fad9a940`), matching the existing pattern for the CS9 builder on line 15. Callers can still override via the environment variable.

### References

- Partially addresses https://github.com/kubevirt/project-infra/pull/5158

### Why we need it and why it was done in this way

The `bump-kubevirt-rpms-cs10-weekly` periodic job and CS10 presubmit jobs in project-infra currently need to carry `KUBEVIRT_CS10_BUILDER_VERSION` explicitly in their Prow job configs. This is inconsistent with the CS9 builder which has a hardcoded default, and creates maintenance burden when the version is bumped (it must be updated in multiple places across repos).

Once this lands, `KUBEVIRT_CS10_BUILDER_VERSION` can be dropped from the project-infra Prow job definitions.

### Special notes for your reviewer

This is the same pattern already used for the CS9 builder version on line 15 of `hack/dockerized`.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
NONE
```