### PR TITLE
[release-1.5] send domain info update only when when change in domain info params

### DIFF
--- a/pkg/virt-launcher/virtwrap/agent-poller/agent_poller.go
+++ b/pkg/virt-launcher/virtwrap/agent-poller/agent_poller.go
@@ -77,18 +77,19 @@ func NewAsyncAgentStore() AsyncAgentStore {
 func (s *AsyncAgentStore) Store(key AgentCommand, value interface{}) {
 
 	oldData, _ := s.store.Load(key)
-	updated := (oldData == nil) || !equality.Semantic.DeepEqual(oldData, value)
 
 	s.store.Store(key, value)
 
-	if updated {
-		domainInfo := api.DomainGuestInfo{}
-		switch key {
-		case GET_OSINFO, GET_INTERFACES, GET_FSFREEZE_STATUS:
-			domainInfo.OSInfo = s.GetGuestOSInfo()
-			domainInfo.Interfaces = s.GetInterfaceStatus()
-			domainInfo.FSFreezeStatus = s.GetFSFreezeStatus()
+	domainInfo := api.DomainGuestInfo{}
+	switch key {
+	case GET_OSINFO, GET_INTERFACES, GET_FSFREEZE_STATUS:
+		updated := (oldData == nil) || !equality.Semantic.DeepEqual(oldData, value)
+		if !updated {
+			return
 		}
+		domainInfo.OSInfo = s.GetGuestOSInfo()
+		domainInfo.Interfaces = s.GetInterfaceStatus()
+		domainInfo.FSFreezeStatus = s.GetFSFreezeStatus()
 
 		s.AgentUpdated <- AgentUpdatedEvent{
 			DomainInfo: domainInfo,

--- a/pkg/virt-launcher/virtwrap/agent-poller/agent_poller_test.go
+++ b/pkg/virt-launcher/virtwrap/agent-poller/agent_poller_test.go
@@ -170,6 +170,20 @@ var _ = Describe("Qemu agent poller", func() {
 
 			Expect(*osInfo).To(Equal(fakeInfo))
 		})
+
+		It("should not fire an event for a new GET_FILESYSTEM", func() {
+			var agentStore = NewAsyncAgentStore()
+			fakeFileSystemInfo := []api.Filesystem{
+				{
+					Name: "test",
+				},
+			}
+			agentStore.Store(GET_FILESYSTEM, fakeFileSystemInfo)
+
+			Expect(agentStore.AgentUpdated).NotTo(Receive(Equal(AgentUpdatedEvent{
+				DomainInfo: api.DomainGuestInfo{},
+			})))
+		})
 	})
 
 	Context("PollerWorker", func() {


### PR DESCRIPTION
This is a manual backport of PR https://github.com/kubevirt/kubevirt/pull/13624.

Reason for backport: This PR backports the fix for a bug where the IP flaps between its correct value and nil on the VMI status, making it unreliable.  The bug was also reported on 1.5 and 1.4 - hence the backport. The change is fairly simple and is tested with an unit test.

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixes bug: IP flapping on VMI status due to a flaw in the Guest Agent logic
```

