### PR TITLE
net, restart: Restart required for NAD hotswap on non migratable VMs

### DIFF
--- a/pkg/network/controllers/vm.go
+++ b/pkg/network/controllers/vm.go
@@ -120,7 +120,9 @@ func syncVMIInterfaces(
 	vmiCopy.Spec.Domain.Devices.Interfaces = ifaces
 	vmiCopy.Spec.Networks = networks
 
-	vmiCopy.Spec.Networks = syncNetworks(vm.Spec.Template.Spec.Networks, vmiCopy.Spec.Networks)
+	if vmi.IsMigratable() {
+		vmiCopy.Spec.Networks = syncNetworks(vm.Spec.Template.Spec.Networks, vmiCopy.Spec.Networks)
+	}
 
 	return vmiCopy
 }

--- a/pkg/network/controllers/vm_test.go
+++ b/pkg/network/controllers/vm_test.go
@@ -26,6 +26,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	k8sv1 "k8s.io/api/core/v1"
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/testing"
@@ -665,7 +666,7 @@ var _ = Describe("VM Network Controller", func() {
 		Expect(updatedVMI.Spec.Domain.Devices.Interfaces).To(Equal(originalVMI.Spec.Domain.Devices.Interfaces))
 	})
 
-	It("sync handles NAD reference updates by copying NAD reference to VMI", func() {
+	DescribeTable("sync handles NAD reference updates", func(migratableStatus k8sv1.ConditionStatus, expectedNADName string) {
 		clientset := fake.NewSimpleClientset()
 		c := controllers.NewVMController(clientset)
 
@@ -674,7 +675,16 @@ var _ = Describe("VM Network Controller", func() {
 			libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetName1)),
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
 			libvmi.WithNetwork(libvmi.MultusNetwork(secondaryNetName1, nadName)),
+			libvmistatus.WithStatus(
+				libvmistatus.New(
+					libvmistatus.WithCondition(v1.VirtualMachineInstanceCondition{
+						Type:   v1.VirtualMachineInstanceIsMigratable,
+						Status: migratableStatus,
+					}),
+				),
+			),
 		)
+
 		vm := libvmi.NewVirtualMachine(vmi.DeepCopy())
 
 		_, err := clientset.KubevirtV1().VirtualMachineInstances(vmi.Namespace).Create(context.Background(), vmi, k8smetav1.CreateOptions{})
@@ -691,8 +701,11 @@ var _ = Describe("VM Network Controller", func() {
 			Get(context.Background(), vmi.Name, k8smetav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
-		Expect(updatedVMI.Spec.Networks[1].Multus.NetworkName).To(Equal(updatedNADName1))
-	})
+		Expect(updatedVMI.Spec.Networks[1].Multus.NetworkName).To(Equal(expectedNADName))
+	},
+		Entry("by copying NAD reference to VMI for migratable VM", k8sv1.ConditionTrue, updatedNADName1),
+		Entry("by not copying NAD reference to VMI for non-migratable VM", k8sv1.ConditionFalse, nadName),
+	)
 
 	It("sync handles multiple NAD reference updates", func() {
 		clientset := fake.NewSimpleClientset()
@@ -708,7 +721,16 @@ var _ = Describe("VM Network Controller", func() {
 			libvmi.WithNetwork(libvmi.MultusNetwork(secondaryNetName1, nadName)),
 			libvmi.WithNetwork(libvmi.MultusNetwork(secondaryNetName2, nadName2)),
 			libvmi.WithNetwork(libvmi.MultusNetwork(secondaryNetName3, nadName3)),
+			libvmistatus.WithStatus(
+				libvmistatus.New(
+					libvmistatus.WithCondition(v1.VirtualMachineInstanceCondition{
+						Type:   v1.VirtualMachineInstanceIsMigratable,
+						Status: k8sv1.ConditionTrue,
+					}),
+				),
+			),
 		)
+
 		vm := libvmi.NewVirtualMachine(vmi.DeepCopy())
 
 		_, err := clientset.KubevirtV1().VirtualMachineInstances(vmi.Namespace).Create(context.Background(), vmi, k8smetav1.CreateOptions{})

--- a/pkg/network/vmliveupdate/BUILD.bazel
+++ b/pkg/network/vmliveupdate/BUILD.bazel
@@ -25,5 +25,6 @@ go_test(
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
     ],
 )

--- a/pkg/network/vmliveupdate/restart.go
+++ b/pkg/network/vmliveupdate/restart.go
@@ -38,7 +38,12 @@ func IsRestartRequired(vm *v1.VirtualMachine, vmi *v1.VirtualMachineInstance) bo
 	desiredNets := vm.Spec.Template.Spec.Networks
 	currentNets := vmi.Spec.Networks
 
-	netChangePredicates := []netChangePredicate{haveCurrentNetsBeenRemoved, haveNetsChangedIgnoringNADName}
+	netChangePredicates := []netChangePredicate{haveCurrentNetsBeenRemoved}
+	if vmi.IsMigratable() {
+		netChangePredicates = append(netChangePredicates, haveNetsChangedIgnoringNADName)
+	} else {
+		netChangePredicates = append(netChangePredicates, haveCurrentNetsChanged)
+	}
 
 	return shouldIfacesChangeRequireRestart(desiredIfaces, currentIfaces) ||
 		shouldNetsChangeRequireRestart(desiredNets, currentNets, netChangePredicates...)
@@ -114,6 +119,17 @@ func haveCurrentNetsBeenRemoved(desiredNetsByName, currentNetsByName map[string]
 		}
 	}
 
+	return false
+}
+
+func haveCurrentNetsChanged(desiredNetsByName, currentNetsByName map[string]v1.Network) bool {
+	for currentNetName, currentNet := range currentNetsByName {
+		desiredNet := desiredNetsByName[currentNetName]
+
+		if !reflect.DeepEqual(desiredNet, currentNet) {
+			return true
+		}
+	}
 	return false
 }
 

--- a/pkg/network/vmliveupdate/restart_test.go
+++ b/pkg/network/vmliveupdate/restart_test.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	k8sv1 "k8s.io/api/core/v1"
 	v1 "kubevirt.io/api/core/v1"
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
@@ -184,17 +185,27 @@ var _ = Describe("IsRestartRequired", func() {
 			*v1.DefaultPodNetwork()),
 	)
 
-	It("should not require restart when NAD name changes", func() {
-		vmi := libvmi.New(
-			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
-			libvmi.WithNetwork(libvmi.MultusNetwork(secondaryNetName1, secondaryNADName1)),
-		)
+	DescribeTable("should set restart requirement for NAD name changes based on migratability",
+		func(conditions []v1.VirtualMachineInstanceCondition, expectedRestart bool) {
+			vmi := libvmi.New(
+				libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetName1)),
+				libvmi.WithNetwork(libvmi.MultusNetwork(secondaryNetName1, secondaryNADName1)),
+			)
+			vmi.Status.Conditions = conditions
 
-		vm := libvmi.NewVirtualMachine(vmi).DeepCopy()
-		vm.Spec.Template.Spec.Networks[0] = *libvmi.MultusNetwork(secondaryNetName1, secondaryNADName2)
+			vm := libvmi.NewVirtualMachine(vmi).DeepCopy()
+			vm.Spec.Template.Spec.Networks[0] = *libvmi.MultusNetwork(secondaryNetName1, secondaryNADName2)
 
-		Expect(vmliveupdate.IsRestartRequired(vm, vmi)).To(BeFalse())
-	})
+			Expect(vmliveupdate.IsRestartRequired(vm, vmi)).To(Equal(expectedRestart))
+		},
+		Entry("when VM is migratable", []v1.VirtualMachineInstanceCondition{
+			{Type: v1.VirtualMachineInstanceIsMigratable, Status: k8sv1.ConditionTrue},
+		}, false),
+		Entry("when VM is non-migratable", []v1.VirtualMachineInstanceCondition{
+			{Type: v1.VirtualMachineInstanceIsMigratable, Status: k8sv1.ConditionFalse},
+		}, true),
+		Entry("when IsMigratable condition is absent", nil, true),
+	)
 
 	It("Should require restart when interfaces and networks are removed", func() {
 		vmi := libvmi.New(


### PR DESCRIPTION
The current logic does not handle NAD updates correctly for non-migratable VMs. The NAD reference is synced to the VMI spec (triggering MigrationRequired condition), but the change is not detected as requiring
restart. Since these VMs cannot migrate, the condition persists indefinitely and the NAD change never applies.

This PR fixes the issue by ensuring non-migratable VMs get RestartRequired condition for NAD changes and preventing the NAD reference from being synced to the VMI spec for non-migratable VMs .

 Fixes bug: https://redhat.atlassian.net/browse/CNV-87878


Note: VMs without the VirtualMachineInstanceIsMigratable condition are treated as non-migratable per
[IsMigratable()](https://github.com/kubevirt/kubevirt/blob/3150e5df489b74372b53cecd10728d804a11fb99/staging/src/kubevirt.io/api/core/v1/types.go#L532). 

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:

#### After this PR:

### References
- Fixes: https://redhat.atlassian.net/browse/CNV-87878
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

Tested locally with a VM that has
```
      networks:
        - name: net1
          multus:
            networkName: nad-first
...
      volumes:
...
        - persistentVolumeClaim:
            claimName: vm-non-mg-disk
          name: pvcdisk
```

Verified the status has 
```
    {
      "lastProbeTime": null,
      "lastTransitionTime": null,
      "message": "cannot migrate VMI: PVC vm-non-mg-disk is not shared, live migration requires that all PVCs must be shared (using ReadWriteMany access mode)",
      "reason": "DisksNotLiveMigratable",
      "status": "False",
      "type": "LiveMigratable"
    },
```
Changed the NAD to nad-second. Then in the VM status it has
```
    {
      "lastProbeTime": null,
      "lastTransitionTime": "2026-07-01T20:46:10Z",
      "message": "a non-live-updatable field was changed in the template spec",
      "status": "True",
      "type": "RestartRequired"
    }
```
and the VMi spec still has
```
    networks:
    - multus:
        networkName: nad-first
      name: net1
```

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Require restart for NAD swap for non-migratable VMs
```

