### PR TITLE
virt-handler: don't error when kernel-boot artifacts already unmounted

### DIFF
--- a/pkg/virt-handler/container-disk/mount.go
+++ b/pkg/virt-handler/container-disk/mount.go
@@ -624,7 +624,8 @@ func (m *mounter) unmountKernelArtifacts(vmi *v1.VirtualMachineInstance) error {
 		return nil
 	}
 
-	return fmt.Errorf("kernel artifacts record wasn't found")
+	log.DefaultLogger().Object(vmi).Warning("no kernel-boot entries found to unmount; already unmounted")
+	return nil
 }
 
 func (m *mounter) getContainerDiskPath(vmi *v1.VirtualMachineInstance, volume *v1.Volume, volumeIndex int) (*safepath.Path, error) {

--- a/pkg/virt-handler/container-disk/mount_test.go
+++ b/pkg/virt-handler/container-disk/mount_test.go
@@ -241,6 +241,38 @@ var _ = Describe("ContainerDisk", func() {
 					false,
 				),
 			)
+
+			It("treats an already-unmounted kernel-boot record as success when other mount entries remain", func() {
+				// Regression test: unmountKernelArtifacts returned
+				// "kernel artifacts record wasn't found" whenever the mount
+				// record still existed but no longer held a kernel-boot entry --
+				// e.g. the entry was removed on an earlier pass while a leftover
+				// containerDisk entry kept the record alive because its own
+				// unmount failed (an unresponsive virt-launcher socket). That
+				// error makes Unmount() return early on every retry, so the VMI's
+				// foregroundDeleteVirtualMachine finalizer is never removed and
+				// teardown wedges forever. A record with no kernel-boot entry
+				// means the artifacts are already unmounted.
+				record := &vmiMountTargetRecord{
+					MountTargetEntries: []vmiMountTargetEntry{{
+						TargetFile: "/var/run/kubevirt/container-disks/disk_0",
+						SocketFile: "somesocketfile",
+					}},
+				}
+				Expect(m.setMountTargetRecord(vmi, record)).To(Succeed())
+
+				Expect(m.unmountKernelArtifacts(vmi)).To(Succeed())
+			})
+
+			It("treats a kernel-boot record with no mount entries as already unmounted", func() {
+				// All entries (kernel-boot and otherwise) were already removed on
+				// earlier passes, leaving an empty-but-present record. This must
+				// also be treated as already unmounted rather than returning
+				// "kernel artifacts record wasn't found".
+				Expect(m.setMountTargetRecord(vmi, &vmiMountTargetRecord{})).To(Succeed())
+
+				Expect(m.unmountKernelArtifacts(vmi)).To(Succeed())
+			})
 		})
 
 		Context("with ImageVolume", func() {


### PR DESCRIPTION
### What this PR does
#### Before this PR:
A VMI using a `kernelBoot` container could get permanently stuck during teardown.
If the containerDisk unmount in `Unmount()` failed after `unmountKernelArtifacts()`
had already removed the kernel-boot entry from the mount record (e.g. an
unresponsive virt-launcher command socket once the guest stopped), the leftover
record had no kernel-boot entry. On every retry `unmountKernelArtifacts()`
returned `kernel artifacts record wasn't found`; since `Unmount()` returns early
on that error, the containerDisks were never unmounted, the record was never
deleted, and the `foregroundDeleteVirtualMachine` finalizer was never removed.
The VMI stayed `Succeeded` with a `Completed` virt-launcher pod and virt-handler
re-enqueued it forever.

#### After this PR:
`unmountKernelArtifacts()` treats "record exists but has no kernel-boot entry" as
success (already unmounted): it logs a warning and returns nil, mirroring the
existing `record == nil` branch. `Unmount()` then unmounts the remaining
containerDisks and deletes the record, the finalizer is removed, and teardown
completes.

### Why we need it and why it was done in this way
The following tradeoffs were made:
- Return nil with a warning log instead of an error. The mount record is the
  source of truth for what was mounted, so "no kernel-boot entry" reliably means
  "already unmounted / never mounted" — nothing to do. The warning keeps the
  state visible without blocking teardown.

The following alternatives were considered:
- Hardening `Unmount()` to not return early on a kernel-artifacts error: a broader
  change to the unmount control flow; the root cause is the misclassification in
  `unmountKernelArtifacts()`, so fixing it there is more targeted and consistent
  with the sibling `record == nil` branch.
 
### Special notes for your reviewer
Real-world trigger: a kernelBoot VMI whose guest stopped leaves the launcher
command socket unresponsive; the containerDisk unmount then fails right after the
kernel-boot entry was removed, hitting this path on every retry (virt-handler logs
`error unmounting kernel artifacts: kernel artifacts record wasn't found` in a
loop; VMI stuck `Succeeded`, `Completed` virt-launcher pod never collected).
Reachable on current `main`. A unit test is included; a deterministic e2e test is
difficult because it requires the launcher socket to fail mid-teardown.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test - unit test added; no e2e test (deadlock is hard to reproduce deterministically in e2e — see reviewer notes)
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
virt-handler: fixed a teardown deadlock where a VMI using a kernelBoot container could remain stuck terminating (VMI in phase Succeeded with a Completed virt-launcher pod and an unremoved finalizer) when the container-disk unmount failed after the kernel-boot mount entry had already been removed.
```

