### PR TITLE
tests/migration: replace Alpine VMIs with guestless VMIs

### DIFF
--- a/tests/migration/eviction_strategy.go
+++ b/tests/migration/eviction_strategy.go
@@ -84,7 +84,11 @@ var _ = Describe(SIG("Live Migration", decorators.RequiresTwoSchedulableNodes, f
 		Context("[ref_id:2293] with a VMI running with an eviction strategy set", func() {
 
 			It("[test_id:3242]should block the eviction api and migrate", decorators.Conformance, func() {
-				vmi := libvmops.RunVMIAndExpectLaunch(alpineVMIWithEvictionStrategy(), libvmops.StartupTimeoutSecondsXLarge)
+				vmi := libvmops.RunVMIAndExpectLaunch(libvmifact.NewGuestless(
+					libnet.WithMasqueradeNetworking(),
+					libvmi.WithEvictionStrategy(v1.EvictionStrategyLiveMigrate),
+					libvmi.WithNamespace(testsuite.GetTestNamespace(nil)),
+				), libvmops.StartupTimeoutSecondsXLarge)
 
 				originalNode := vmi.Status.NodeName
 
@@ -111,7 +115,11 @@ var _ = Describe(SIG("Live Migration", decorators.RequiresTwoSchedulableNodes, f
 
 			It("[sig-compute][test_id:7680]should delete PDBs created by an old virt-controller", func() {
 				By("creating the VMI")
-				vmi := alpineVMIWithEvictionStrategy()
+				vmi := libvmifact.NewGuestless(
+					libnet.WithMasqueradeNetworking(),
+					libvmi.WithEvictionStrategy(v1.EvictionStrategyLiveMigrate),
+					libvmi.WithNamespace(testsuite.GetTestNamespace(nil)),
+				)
 				vmi, err := virtClient.VirtualMachineInstance(vmi.Namespace).Create(context.Background(), vmi, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				By("waiting for VMI")
@@ -298,7 +306,11 @@ var _ = Describe(SIG("Live Migration", decorators.RequiresTwoSchedulableNodes, f
 				})
 
 				It("[test_id:2222] should migrate a VMI when custom taint key is configured", func() {
-					vmi := alpineVMIWithEvictionStrategy()
+					vmi := libvmifact.NewGuestless(
+						libnet.WithMasqueradeNetworking(),
+						libvmi.WithEvictionStrategy(v1.EvictionStrategyLiveMigrate),
+						libvmi.WithNamespace(testsuite.GetTestNamespace(nil)),
+					)
 					vmi.Spec.Affinity = &k8sv1.Affinity{NodeAffinity: nodeAffinity}
 
 					By("Configuring a custom nodeDrainTaintKey in kubevirt configuration")
@@ -332,23 +344,26 @@ var _ = Describe(SIG("Live Migration", decorators.RequiresTwoSchedulableNodes, f
 							TopologyKey: k8sv1.LabelHostname,
 						},
 					}
-					vmi_evict1 := alpineVMIWithEvictionStrategy(
+					vmi_evict1 := libvmifact.NewGuestless(
+						libnet.WithMasqueradeNetworking(),
+						libvmi.WithEvictionStrategy(v1.EvictionStrategyLiveMigrate),
 						libvmi.WithNamespace(testsuite.GetTestNamespace(nil)),
 						libvmi.WithLabel(labelKey, ""),
 						libvmi.WithPreferredPodAffinity(podAffinityTerm),
 						libvmi.WithPreferredNodeAffinity(nodeAffinityTerm),
 					)
-					vmi_evict2 := alpineVMIWithEvictionStrategy(
+					vmi_evict2 := libvmifact.NewGuestless(
+						libnet.WithMasqueradeNetworking(),
+						libvmi.WithEvictionStrategy(v1.EvictionStrategyLiveMigrate),
 						libvmi.WithNamespace(testsuite.GetTestNamespace(nil)),
 						libvmi.WithLabel(labelKey, ""),
 						libvmi.WithPreferredPodAffinity(podAffinityTerm),
 						libvmi.WithPreferredNodeAffinity(nodeAffinityTerm),
 					)
-					vmi_noevict := libvmifact.NewAlpine(
-						libvmi.WithNamespace(testsuite.GetTestNamespace(nil)),
-						libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
-						libvmi.WithNetwork(v1.DefaultPodNetwork()),
+					vmi_noevict := libvmifact.NewGuestless(
+						libnet.WithMasqueradeNetworking(),
 						libvmi.WithEvictionStrategy(v1.EvictionStrategyNone),
+						libvmi.WithNamespace(testsuite.GetTestNamespace(nil)),
 						libvmi.WithLabel(labelKey, ""),
 						libvmi.WithPreferredPodAffinity(podAffinityTerm),
 						libvmi.WithPreferredNodeAffinity(nodeAffinityTerm),
@@ -424,7 +439,11 @@ var _ = Describe(SIG("Live Migration", decorators.RequiresTwoSchedulableNodes, f
 			It("[release-blocker][test_id:3245]should not migrate more than two VMIs at the same time from a node", func() {
 				var vmis []*v1.VirtualMachineInstance
 				for i := 0; i < 4; i++ {
-					vmi := alpineVMIWithEvictionStrategy()
+					vmi := libvmifact.NewGuestless(
+						libnet.WithMasqueradeNetworking(),
+						libvmi.WithEvictionStrategy(v1.EvictionStrategyLiveMigrate),
+						libvmi.WithNamespace(testsuite.GetTestNamespace(nil)),
+					)
 					vmi.Spec.NodeSelector = map[string]string{cleanup.TestLabelForNamespace(vmi.Namespace): "target"}
 					vmis = append(vmis, vmi)
 				}
@@ -519,10 +538,7 @@ var _ = Describe(SIG("Live Migration", decorators.RequiresTwoSchedulableNodes, f
 			Context("with no eviction strategy set", func() {
 				It("[test_id:10155]should block the eviction api and migrate", func() {
 					// no EvictionStrategy set
-					vmi := libvmifact.NewAlpine(
-						libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
-						libvmi.WithNetwork(v1.DefaultPodNetwork()),
-					)
+					vmi := libvmifact.NewGuestless(libnet.WithMasqueradeNetworking())
 
 					vmi = libvmops.RunVMIAndExpectLaunch(vmi, libvmops.StartupTimeoutSecondsXLarge)
 					vmiNodeOrig := vmi.Status.NodeName
@@ -560,9 +576,8 @@ var _ = Describe(SIG("Live Migration", decorators.RequiresTwoSchedulableNodes, f
 
 			Context("with eviction strategy set to 'None'", func() {
 				It("[test_id:10156]The VMI should get evicted", func() {
-					vmi := libvmifact.NewAlpine(
-						libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
-						libvmi.WithNetwork(v1.DefaultPodNetwork()),
+					vmi := libvmifact.NewGuestless(
+						libnet.WithMasqueradeNetworking(),
 						libvmi.WithEvictionStrategy(v1.EvictionStrategyNone),
 					)
 					vmi = libvmops.RunVMIAndExpectLaunch(vmi, libvmops.StartupTimeoutSecondsXLarge)
@@ -582,13 +597,6 @@ func fedoraVMIWithEvictionStrategy() *v1.VirtualMachineInstance {
 		libvmi.WithMemoryRequest(fedoraVMSize),
 		libvmi.WithEvictionStrategy(v1.EvictionStrategyLiveMigrate),
 		libvmi.WithNamespace(testsuite.GetTestNamespace(nil)))
-}
-
-func alpineVMIWithEvictionStrategy(additionalOpts ...libvmi.Option) *v1.VirtualMachineInstance {
-	opts := []libvmi.Option{libnet.WithMasqueradeNetworking(), libvmi.WithEvictionStrategy(v1.EvictionStrategyLiveMigrate), libvmi.WithNamespace(testsuite.GetTestNamespace(nil))}
-	opts = append(opts, additionalOpts...)
-
-	return libvmifact.NewAlpine(opts...)
 }
 
 func filterRunningMigrations(migrations []v1.VirtualMachineInstanceMigration) []v1.VirtualMachineInstanceMigration {

--- a/tests/migration/host_model.go
+++ b/tests/migration/host_model.go
@@ -41,10 +41,12 @@ import (
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/libinfra"
 	"kubevirt.io/kubevirt/tests/libmigration"
+	"kubevirt.io/kubevirt/tests/libnet"
 	"kubevirt.io/kubevirt/tests/libnode"
 	"kubevirt.io/kubevirt/tests/libpod"
 	"kubevirt.io/kubevirt/tests/libvmifact"
 	"kubevirt.io/kubevirt/tests/libvmops"
+	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
 var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes, func() {
@@ -110,7 +112,11 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 			BeforeEach(func() {
 				var err error
 				By("Creating a VMI with default CPU mode")
-				vmi = alpineVMIWithEvictionStrategy()
+				vmi = libvmifact.NewGuestless(
+					libnet.WithMasqueradeNetworking(),
+					libvmi.WithEvictionStrategy(v1.EvictionStrategyLiveMigrate),
+					libvmi.WithNamespace(testsuite.GetTestNamespace(nil)),
+				)
 				vmi.Spec.Domain.CPU = &v1.CPU{Model: v1.CPUModeHostModel}
 
 				By("Starting the VirtualMachineInstance")
@@ -170,7 +176,11 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 				}
 
 				By("Creating a VMI with default CPU mode")
-				vmi = alpineVMIWithEvictionStrategy()
+				vmi = libvmifact.NewGuestless(
+					libnet.WithMasqueradeNetworking(),
+					libvmi.WithEvictionStrategy(v1.EvictionStrategyLiveMigrate),
+					libvmi.WithNamespace(testsuite.GetTestNamespace(nil)),
+				)
 				vmi.Spec.Domain.CPU = &v1.CPU{Model: v1.CPUModeHostModel}
 
 				By("Starting the VirtualMachineInstance")


### PR DESCRIPTION
None of the eviction strategy tests interact with the guest OS — they only inspect VMI status, migration state, and Kubernetes API objects. Replace all Alpine-based VMIs with guestless VMIs so the tests start faster and don't pull an unnecessary image.

Also eliminate the alpineVMIWithEvictionStrategy() helper by inlining its construction at each call site, using the libvmi builder pattern.

/kind cleanup

```release-note
NONE
```

