### PR TITLE
use constant-time comparison for export token check

### DIFF
--- a/pkg/storage/export/virt-exportserver/exportserver.go
+++ b/pkg/storage/export/virt-exportserver/exportserver.go
@@ -22,6 +22,7 @@ package virtexportserver
 import (
 	"bytes"
 	"context"
+	"crypto/subtle"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
@@ -575,7 +576,7 @@ func tokenChecker(tokenGetter TokenGetterFunc, nextHandler http.Handler) http.Ha
 			return
 		}
 		for _, tok := range []string{getTokenQueryParam(r), getTokenHeader(r)} {
-			if tok == token {
+			if subtle.ConstantTimeCompare([]byte(tok), []byte(token)) == 1 {
 				nextHandler.ServeHTTP(w, r)
 				return
 			}


### PR DESCRIPTION
### What this PR does
#### Before this PR:
`tokenChecker` in the export server compares the client-supplied export token against the server secret with `tok == token`. Go's string equality returns on the first differing byte, so response time correlates with how many leading bytes matched. The export server is reachable over the network and this token is the only gate on the VM disk volume endpoints, so the timing oracle lets a client recover the token byte-by-byte rather than guessing it whole.

#### After this PR:
The comparison uses `crypto/subtle.ConstantTimeCompare`, which runs in time independent of where the mismatch is. Accept/reject behavior is unchanged. The check stays in the middleware since that is the trust boundary between the request handlers and the protected volume data.

### Why we need it and why it was done in this way
A constant-time compare is the standard fix for secret comparison and keeps the diff to the one line that matters.

### Checklist

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
Fixed a timing side channel in the export server token check by switching to a constant-time comparison.
```
