### PR TITLE
Requeue VMI sync after expectations timeout

### DIFF
--- a/pkg/virt-controller/watch/vmi/vmi.go
+++ b/pkg/virt-controller/watch/vmi/vmi.go
@@ -343,6 +343,9 @@ func (c *Controller) execute(key string) error {
 	needsSync := c.podExpectations.SatisfiedExpectations(key) && c.vmiExpectations.SatisfiedExpectations(key) && c.pvcExpectations.SatisfiedExpectations(key)
 
 	if !needsSync {
+		// Re-enqueue so a missed expectation event (for example an attachment pod deletion)
+		// can't delay the sync until the next informer resync.
+		c.Queue.AddAfter(key, controller.ExpectationsTimeout)
 		return nil
 	}
 

--- a/pkg/virt-controller/watch/vmi/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi/vmi_test.go
@@ -56,7 +56,7 @@ import (
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
 	backendstorage "kubevirt.io/kubevirt/pkg/storage/backend-storage"
-	velero "kubevirt.io/kubevirt/pkg/storage/velero"
+	"kubevirt.io/kubevirt/pkg/storage/velero"
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
 
@@ -1216,6 +1216,20 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				})),
 			)
 		})
+		It("should requeue after the expectations timeout when expectations are not met", func() {
+			vmi := newPendingVirtualMachine("testvmi")
+			addVirtualMachine(vmi)
+			key, err := kvcontroller.KeyFunc(vmi)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(mockQueue.GetAddAfterEnqueueCount()).To(BeZero())
+
+			// A pending creation expectation that no event will satisfy.
+			controller.podExpectations.SetExpectations(key, 1, 0)
+
+			sanityExecute()
+			Expect(mockQueue.GetAddAfterEnqueueCount()).To(Equal(1))
+		})
+
 		It("should remove the error condition if the sync finally succeeds", func() {
 			vmi := newPendingVirtualMachine("testvmi")
 


### PR DESCRIPTION
### What this PR does
#### Before this PR:

If pod, VMI or PVC expectations are not met, the VMI sync stops early and runs again only on the next event. If no event wakes the VMI, the timeout is not checked until the next informer resync, which is hours by default. This can delay VM/VMI deletion.

This could happen with hotplug attachment pods. An attachment pod is owned by the virt-launcher pod, not by the VMI. If the virt-launcher pod is already gone from the cache, the controller cannot find the VMI and cannot wake it up.

#### After this PR:

If a pod event does not wake the VMI, the VMI is re-enqueued automatically after the expectations timeout (5 minutes by default). The sync no longer waits for the next informer resync.

### References

- Fixes https://github.com/kubevirt/kubevirt/issues/18177

### Why we need it and why it was done in this way
The following tradeoffs were made:

VMI is re-enqueued once after the timeout when expectations are pending. This adds at most one extra sync per VMI every few minutes, which is cheap (almost noop).

The following alternatives were considered:

Recover the VMI directly from the attachment pod (for example, via owner annotations), or track pod deletions by pod key. This PR adds the simple, general safety net first. The faster recovery path is planned as a follow-up PR.

More details could be found in issue: https://github.com/kubevirt/kubevirt/issues/18177

### Special notes for your reviewer

This is the first of two PRs. Also it can be nice example in addition to the issue.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed a delay in VM/VMI deletion that could happen when the VMI controller missed a pod event.
```

