### PR TITLE
Fix finalizer not being properly removed from target when cancelling decentralized live migration

### DIFF
--- a/pkg/virt-handler/migration-target.go
+++ b/pkg/virt-handler/migration-target.go
@@ -695,7 +695,7 @@ func (c *MigrationTargetController) execute(key string) error {
 		domain.Status.Status != ""
 
 	if domainExists && !domainAlive {
-		if !abortInProgress(vmi) && !needsCleanup(vmi) {
+		if !abortInProgress(vmi) && !(vmi.IsDecentralizedMigration() && needsCleanup(vmi)) {
 			c.logger.V(4).Object(vmi).Info("domain is not alive")
 			return nil
 		}

--- a/pkg/virt-handler/migration-target.go
+++ b/pkg/virt-handler/migration-target.go
@@ -204,6 +204,86 @@ func domainIsActiveOnTarget(domain *api.Domain) bool {
 	return false
 }
 
+func isTargetMigrationAbortCompleted(state *v1.VirtualMachineInstanceMigrationState) bool {
+	return state != nil && state.EndTimestamp != nil && (state.Completed || state.Failed)
+}
+
+func (c *MigrationTargetController) decentralizedMigrationMetadataUIDMatchesVMI(vmi *v1.VirtualMachineInstance, migrationMetadata *api.MigrationMetadata) bool {
+	state := vmi.Status.MigrationState
+	if state == nil {
+		return false
+	}
+	uid := migrationMetadata.UID
+	return vmi.IsDecentralizedMigration() &&
+		state.TargetState != nil && uid == state.TargetState.MigrationUID
+}
+
+func (c *MigrationTargetController) setDecentralizedMigrationProgressStatus(vmi *v1.VirtualMachineInstance, domain *api.Domain) {
+	if domain == nil ||
+		domain.Spec.Metadata.KubeVirt.Migration == nil ||
+		vmi.Status.MigrationState == nil ||
+		!c.isMigrationTarget(vmi) {
+		c.logger.Object(vmi).V(5).Info("not setting decentralized migration progress status, domain is nil or migration metadata is nil or migration state is nil or not a migration target")
+		return
+	}
+
+	migrationMetadata := domain.Spec.Metadata.KubeVirt.Migration
+	if !c.decentralizedMigrationMetadataUIDMatchesVMI(vmi, migrationMetadata) {
+		c.logger.Object(vmi).V(5).Info("not setting decentralized migration progress status, metadata UID does not match")
+		return
+	}
+	if migrationMetadata.StartTimestamp != nil {
+		vmi.Status.MigrationState.StartTimestamp = migrationMetadata.StartTimestamp
+	}
+
+	if migrationMetadata.Failed {
+		vmi.Status.MigrationState.Failed = true
+		vmi.Status.MigrationState.Completed = true
+		vmi.Status.MigrationState.EndTimestamp = migrationMetadata.EndTimestamp
+		vmi.Status.MigrationState.AbortStatus = v1.MigrationAbortStatus(migrationMetadata.AbortStatus)
+		vmi.Status.MigrationState.FailureReason = migrationMetadata.FailureReason
+		c.recorder.Event(vmi, k8sv1.EventTypeWarning, v1.Migrated.String(), fmt.Sprintf("VirtualMachineInstance migration uid %s failed. reason:%s", string(migrationMetadata.UID), migrationMetadata.FailureReason))
+		c.logger.Object(vmi).V(5).Infof("migration failed, completed: true, end timestamp: %v, abort status: %s, failure reason: %s", migrationMetadata.EndTimestamp, migrationMetadata.AbortStatus, migrationMetadata.FailureReason)
+	}
+
+	vmi.Status.MigrationState.Mode = migrationMetadata.Mode
+}
+
+func (c *MigrationTargetController) handleDecentralizedMigrationAbort(vmi *v1.VirtualMachineInstance, domain *api.Domain) error {
+	migrationState := vmi.Status.MigrationState
+	if !vmi.IsDecentralizedMigration() || migrationState == nil || !migrationState.AbortRequested || isTargetMigrationAbortCompleted(migrationState) {
+		c.logger.Object(vmi).V(5).Info("not aborting migration, not a decentralized migration or migration state is nil or not abort requested or abort completed")
+		return nil
+	}
+
+	// set status from domain metadata
+	c.setDecentralizedMigrationProgressStatus(vmi, domain)
+
+	if !isTargetMigrationAbortCompleted(migrationState) {
+		if domainIsActiveOnTarget(domain) {
+			c.logger.Object(vmi).Info("not aborting migration, domain is active on target")
+			return nil
+		}
+
+		if migrationState.EndTimestamp == nil {
+			migrationState.EndTimestamp = pointer.P(metav1.Now())
+		}
+		migrationState.Failed = true
+		migrationState.Completed = true
+		if migrationState.AbortStatus == "" {
+			migrationState.AbortStatus = v1.MigrationAbortSucceeded
+		}
+		if migrationState.FailureReason == "" {
+			migrationState.FailureReason = "Live migration has been aborted"
+		}
+		c.recorder.Event(vmi, k8sv1.EventTypeWarning, v1.Migrated.String(), VMIAbortingMigration)
+	} else {
+		c.logger.Object(vmi).V(5).Info("migration abort completed")
+	}
+
+	return nil
+}
+
 func (c *MigrationTargetController) ackMigrationCompletion(vmi *v1.VirtualMachineInstance, domain *api.Domain) {
 	// as fallback set the target migration start timestamp
 	if vmi.Status.MigrationState.StartTimestamp == nil && domain.Spec.Metadata.KubeVirt.Migration.StartTimestamp != nil {
@@ -234,11 +314,18 @@ func (c *MigrationTargetController) ackMigrationCompletion(vmi *v1.VirtualMachin
 	c.logger.Object(vmi).Info("The target node detected that the migration has completed")
 }
 
+func abortInProgress(vmi *v1.VirtualMachineInstance) bool {
+	migrationState := vmi.Status.MigrationState
+	return migrationState != nil && migrationState.AbortRequested && !isTargetMigrationAbortCompleted(migrationState)
+}
+
 func (c *MigrationTargetController) updateStatus(vmi *v1.VirtualMachineInstance, domain *api.Domain) (error, bool) {
 	if migrations.MigrationFailed(vmi) {
 		c.logger.Object(vmi).V(4).Info("migration has failed, nothing to report on the target node")
 		return nil, false
 	}
+
+	c.setDecentralizedMigrationProgressStatus(vmi, domain)
 
 	domainExists := domain != nil
 
@@ -296,7 +383,7 @@ func (c *MigrationTargetController) updateStatus(vmi *v1.VirtualMachineInstance,
 		}
 	}
 
-	if migrations.IsMigrating(vmi) {
+	if migrations.IsMigrating(vmi) && !abortInProgress(vmi) {
 		c.logger.Object(vmi).V(4).Info("migration is already in progress")
 		return nil, false
 	}
@@ -497,6 +584,10 @@ func (c *MigrationTargetController) sync(vmi *v1.VirtualMachineInstance, domain 
 	oldLabels := vmi.Labels
 	vmi = vmi.DeepCopy()
 
+	if err := c.handleDecentralizedMigrationAbort(vmi, domain); err != nil {
+		return err
+	}
+
 	// post-migration clean up
 	if vmi.Status.MigrationState != nil && vmi.Status.MigrationState.EndTimestamp != nil &&
 		(vmi.Status.MigrationState.Completed || vmi.Status.MigrationState.Failed) {
@@ -600,8 +691,12 @@ func (c *MigrationTargetController) execute(key string) error {
 		domain.Status.Status != ""
 
 	if domainExists && !domainAlive {
-		c.logger.V(4).Object(vmi).Info("domain is not alive")
-		return nil
+		migrationState := vmi.Status.MigrationState
+		needsCleanup := migrationState != nil && migrationState.EndTimestamp != nil && (migrationState.Completed || migrationState.Failed)
+		if !abortInProgress(vmi) && !needsCleanup {
+			c.logger.V(4).Object(vmi).Info("domain is not alive")
+			return nil
+		}
 	}
 
 	if vmi.Status.MigrationState == nil {
@@ -775,8 +870,10 @@ func (c *MigrationTargetController) processVMI(vmi *v1.VirtualMachineInstance) (
 	// controller from processing external events (domain updates, sync
 	// controller VMI patches).
 	if len(c.migrationProxy.GetTargetListenerPorts(migrationProxyKey(vmi))) > 0 {
-		c.logger.Object(vmi).V(4).Info("migration target already prepared, nothing to do")
-		return nil, true
+		if !abortInProgress(vmi) {
+			c.logger.Object(vmi).V(4).Info("migration target already prepared, nothing to do")
+			return nil, true
+		}
 	}
 
 	// In decentralized migrations the target VMI is created before the

--- a/pkg/virt-handler/migration-target.go
+++ b/pkg/virt-handler/migration-target.go
@@ -204,11 +204,7 @@ func domainIsActiveOnTarget(domain *api.Domain) bool {
 	return false
 }
 
-func isTargetMigrationAbortCompleted(state *v1.VirtualMachineInstanceMigrationState) bool {
-	return state != nil && state.EndTimestamp != nil && (state.Completed || state.Failed)
-}
-
-func (c *MigrationTargetController) decentralizedMigrationMetadataUIDMatchesVMI(vmi *v1.VirtualMachineInstance, migrationMetadata *api.MigrationMetadata) bool {
+func decentralizedMigrationMetadataUIDMatchesVMI(vmi *v1.VirtualMachineInstance, migrationMetadata *api.MigrationMetadata) bool {
 	state := vmi.Status.MigrationState
 	if state == nil {
 		return false
@@ -228,7 +224,7 @@ func (c *MigrationTargetController) setDecentralizedMigrationProgressStatus(vmi 
 	}
 
 	migrationMetadata := domain.Spec.Metadata.KubeVirt.Migration
-	if !c.decentralizedMigrationMetadataUIDMatchesVMI(vmi, migrationMetadata) {
+	if !decentralizedMigrationMetadataUIDMatchesVMI(vmi, migrationMetadata) {
 		c.logger.Object(vmi).V(5).Info("not setting decentralized migration progress status, metadata UID does not match")
 		return
 	}
@@ -251,15 +247,15 @@ func (c *MigrationTargetController) setDecentralizedMigrationProgressStatus(vmi 
 
 func (c *MigrationTargetController) handleDecentralizedMigrationAbort(vmi *v1.VirtualMachineInstance, domain *api.Domain) error {
 	migrationState := vmi.Status.MigrationState
-	if !vmi.IsDecentralizedMigration() || migrationState == nil || !migrationState.AbortRequested || isTargetMigrationAbortCompleted(migrationState) {
-		c.logger.Object(vmi).V(5).Info("not aborting migration, not a decentralized migration or migration state is nil or not abort requested or abort completed")
+	if !vmi.IsDecentralizedMigration() || migrationState == nil || !migrationState.AbortRequested || isMigrationDone(migrationState) {
+		c.logger.Object(vmi).V(5).Info("not aborting migration, not a decentralized migration or migration is done")
 		return nil
 	}
 
 	// set status from domain metadata
 	c.setDecentralizedMigrationProgressStatus(vmi, domain)
 
-	if !isTargetMigrationAbortCompleted(migrationState) {
+	if !isMigrationDone(migrationState) {
 		if domainIsActiveOnTarget(domain) {
 			c.logger.Object(vmi).Info("not aborting migration, domain is active on target")
 			return nil
@@ -316,7 +312,7 @@ func (c *MigrationTargetController) ackMigrationCompletion(vmi *v1.VirtualMachin
 
 func abortInProgress(vmi *v1.VirtualMachineInstance) bool {
 	migrationState := vmi.Status.MigrationState
-	return migrationState != nil && migrationState.AbortRequested && !isTargetMigrationAbortCompleted(migrationState)
+	return migrationState != nil && migrationState.AbortRequested && !isMigrationDone(migrationState)
 }
 
 func (c *MigrationTargetController) updateStatus(vmi *v1.VirtualMachineInstance, domain *api.Domain) (error, bool) {
@@ -325,7 +321,10 @@ func (c *MigrationTargetController) updateStatus(vmi *v1.VirtualMachineInstance,
 		return nil, false
 	}
 
-	c.setDecentralizedMigrationProgressStatus(vmi, domain)
+	if !abortInProgress(vmi) {
+		// Only call this if abort is not in progress, the abort handler calls this function
+		c.setDecentralizedMigrationProgressStatus(vmi, domain)
+	}
 
 	domainExists := domain != nil
 
@@ -645,6 +644,11 @@ func (c *MigrationTargetController) isMigrationTarget(vmi *v1.VirtualMachineInst
 	return migrationTargetNodeName == c.host
 }
 
+func needsCleanup(vmi *v1.VirtualMachineInstance) bool {
+	migrationState := vmi.Status.MigrationState
+	return migrationState != nil && isMigrationDone(migrationState)
+}
+
 func (c *MigrationTargetController) execute(key string) error {
 	vmi, vmiExists, err := c.getVMIFromCache(key)
 	if err != nil {
@@ -691,9 +695,7 @@ func (c *MigrationTargetController) execute(key string) error {
 		domain.Status.Status != ""
 
 	if domainExists && !domainAlive {
-		migrationState := vmi.Status.MigrationState
-		needsCleanup := migrationState != nil && migrationState.EndTimestamp != nil && (migrationState.Completed || migrationState.Failed)
-		if !abortInProgress(vmi) && !needsCleanup {
+		if !abortInProgress(vmi) && !needsCleanup(vmi) {
 			c.logger.V(4).Object(vmi).Info("domain is not alive")
 			return nil
 		}

--- a/pkg/virt-handler/migration-target_test.go
+++ b/pkg/virt-handler/migration-target_test.go
@@ -71,6 +71,31 @@ import (
 	"kubevirt.io/kubevirt/tests/framework/matcher"
 )
 
+func decentralizedTargetAbortMigrationState(targetMigrationUID types.UID, targetNode, sourceNode string, start metav1.Time, abortRequested bool) *v1.VirtualMachineInstanceMigrationState {
+	syncAddress := "10.0.0.1:9185"
+	sourceVMIUID := types.UID("source-vmi-uid")
+	return &v1.VirtualMachineInstanceMigrationState{
+		TargetNode:     targetNode,
+		SourceNode:     sourceNode,
+		MigrationUID:   targetMigrationUID,
+		StartTimestamp: &start,
+		AbortRequested: abortRequested,
+		SourceState: &v1.VirtualMachineInstanceMigrationSourceState{
+			VirtualMachineInstanceCommonMigrationState: v1.VirtualMachineInstanceCommonMigrationState{
+				Node:                      sourceNode,
+				SyncAddress:               &syncAddress,
+				VirtualMachineInstanceUID: pointer.P(sourceVMIUID),
+			},
+		},
+		TargetState: &v1.VirtualMachineInstanceMigrationTargetState{
+			VirtualMachineInstanceCommonMigrationState: v1.VirtualMachineInstanceCommonMigrationState{
+				Node:         targetNode,
+				MigrationUID: targetMigrationUID,
+			},
+		},
+	}
+}
+
 var _ = Describe("VirtualMachineInstance migration target", func() {
 	var (
 		client         *cmdclient.MockLauncherClient
@@ -718,6 +743,139 @@ var _ = Describe("VirtualMachineInstance migration target", func() {
 
 		client.EXPECT().SignalTargetPodCleanup(vmi)
 		sanityExecute()
+	})
+
+	DescribeTable("should mark migration failed when abort is requested on target",
+		func(withDomain bool) {
+			const (
+				targetMigrationUID  = types.UID("target-migration-uid")
+				domainFailureReason = "target domain reported migration abort via libvirt"
+			)
+
+			vmi := api2.NewMinimalVMI("testvmi")
+			vmi.UID = vmiTestUUID
+			vmi.ObjectMeta.ResourceVersion = "1"
+			vmi.Status.Phase = v1.Scheduled
+			vmi.Labels = make(map[string]string)
+			vmi.Status.NodeName = host
+			vmi.Labels[v1.MigrationTargetNodeNameLabel] = host
+			start := metav1.Now()
+			vmi.Status.MigrationState = decentralizedTargetAbortMigrationState(targetMigrationUID, host, "othernode", start, true)
+			vmi = addActivePods(vmi, podTestUUID, host)
+
+			var domainEnd *metav1.Time
+			if withDomain {
+				domainEnd = pointer.P(metav1.Now())
+				domain := api.NewMinimalDomainWithUUID("testvmi", vmiTestUUID)
+				domain.Status.Status = api.Shutoff
+				domain.Spec.Metadata.KubeVirt.Migration = &api.MigrationMetadata{
+					UID:            targetMigrationUID,
+					StartTimestamp: &start,
+					EndTimestamp:   domainEnd,
+					Failed:         true,
+					AbortStatus:    string(v1.MigrationAbortSucceeded),
+					FailureReason:  domainFailureReason,
+				}
+				addVMI(vmi, domain)
+			} else {
+				createVMI(vmi)
+			}
+
+			client.EXPECT().SignalTargetPodCleanup(gomock.Any())
+			controller.Execute()
+
+			expectedFailureReason := "Live migration has been aborted"
+			if withDomain {
+				testutils.ExpectEvent(recorder, domainFailureReason)
+				Expect(recorder.Events).NotTo(Receive(ContainSubstring(VMIAbortingMigration)))
+				expectedFailureReason = domainFailureReason
+			} else {
+				testutils.ExpectEvent(recorder, VMIAbortingMigration)
+			}
+
+			updatedVMI, err := virtfakeClient.KubevirtV1().VirtualMachineInstances(metav1.NamespaceDefault).Get(context.TODO(), vmi.Name, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(updatedVMI.Status.MigrationState.Failed).To(BeTrue())
+			Expect(updatedVMI.Status.MigrationState.Completed).To(BeTrue())
+			if withDomain {
+				Expect(updatedVMI.Status.MigrationState.EndTimestamp).To(Equal(domainEnd))
+			} else {
+				Expect(updatedVMI.Status.MigrationState.EndTimestamp).NotTo(BeNil())
+			}
+			Expect(updatedVMI.Status.MigrationState.AbortStatus).To(Equal(v1.MigrationAbortSucceeded))
+			Expect(updatedVMI.Status.MigrationState.FailureReason).To(Equal(expectedFailureReason))
+		},
+		Entry("when domain is not active on target yet", false),
+		Entry("when abort status is synced from domain metadata", true),
+	)
+
+	It("should not mark migration failed while domain is still active on target", func() {
+		const targetMigrationUID = types.UID("target-migration-uid")
+
+		vmi := api2.NewMinimalVMI("testvmi")
+		vmi.UID = vmiTestUUID
+		vmi.ObjectMeta.ResourceVersion = "1"
+		vmi.Status.Phase = v1.Running
+		vmi.Labels = make(map[string]string)
+		vmi.Status.NodeName = host
+		vmi.Labels[v1.MigrationTargetNodeNameLabel] = host
+		start := metav1.Now()
+		vmi.Status.MigrationState = decentralizedTargetAbortMigrationState(targetMigrationUID, host, "othernode", start, true)
+		vmi = addActivePods(vmi, podTestUUID, host)
+
+		domain := api.NewMinimalDomainWithUUID("testvmi", vmiTestUUID)
+		domain.Status.Status = api.Running
+		addVMI(vmi, domain)
+
+		controller.Execute()
+
+		updatedVMI, err := virtfakeClient.KubevirtV1().VirtualMachineInstances(metav1.NamespaceDefault).Get(context.TODO(), vmi.Name, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(updatedVMI.Status.MigrationState.Failed).To(BeFalse())
+		Expect(updatedVMI.Status.MigrationState.Completed).To(BeFalse())
+		Expect(updatedVMI.Status.MigrationState.EndTimestamp).To(BeNil())
+		Expect(recorder.Events).NotTo(Receive(ContainSubstring(VMIAbortingMigration)))
+	})
+
+	It("should not re-handle abort when migration is already marked failed", func() {
+		const (
+			targetMigrationUID  = types.UID("target-migration-uid")
+			domainFailureReason = "target domain reported migration abort via libvirt"
+		)
+
+		start := metav1.Now()
+		end := metav1.Now()
+		vmi := api2.NewMinimalVMI("testvmi")
+		vmi.UID = vmiTestUUID
+		vmi.ObjectMeta.ResourceVersion = "1"
+		vmi.Status.Phase = v1.Scheduled
+		vmi.Labels = make(map[string]string)
+		vmi.Status.NodeName = host
+		vmi.Labels[v1.MigrationTargetNodeNameLabel] = host
+		vmi.Status.MigrationState = decentralizedTargetAbortMigrationState(targetMigrationUID, host, "othernode", start, true)
+		vmi.Status.MigrationState.Failed = true
+		vmi.Status.MigrationState.Completed = true
+		vmi.Status.MigrationState.EndTimestamp = &end
+		vmi.Status.MigrationState.AbortStatus = v1.MigrationAbortSucceeded
+		vmi.Status.MigrationState.FailureReason = domainFailureReason
+		vmi = addActivePods(vmi, podTestUUID, host)
+
+		domain := api.NewMinimalDomainWithUUID("testvmi", vmiTestUUID)
+		domain.Status.Status = api.Shutoff
+		domain.Spec.Metadata.KubeVirt.Migration = &api.MigrationMetadata{
+			UID:            targetMigrationUID,
+			StartTimestamp: &start,
+			EndTimestamp:   &end,
+			Failed:         true,
+			AbortStatus:    string(v1.MigrationAbortSucceeded),
+			FailureReason:  domainFailureReason,
+		}
+		addVMI(vmi, domain)
+
+		stateBefore := vmi.Status.MigrationState.DeepCopy()
+		Expect(controller.handleDecentralizedMigrationAbort(vmi, domain)).To(Succeed())
+		Expect(vmi.Status.MigrationState).To(Equal(stateBefore))
+		Expect(recorder.Events).NotTo(Receive())
 	})
 
 	It("should not accidentally update VMI spec on cleanup", func() {

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -2036,6 +2036,12 @@ func (c *VirtualMachineController) handleStartingVMI(
 ) (bool, error) {
 	// give containerDisks some time to become ready before throwing errors on retries
 	info := c.launcherClients.GetLauncherClientInfo(vmi)
+	if info == nil {
+		c.logger.Object(vmi).V(5).Info("not handling starting VMI, launcher client info is nil, requeuing")
+		c.queue.AddRateLimited(controller.VirtualMachineInstanceKey(vmi))
+		return false, nil
+	}
+
 	if ready, err := c.containerDiskMounter.ContainerDisksReady(vmi, info.NotInitializedSince); !ready {
 		if err != nil {
 			return false, err

--- a/tests/libmigration/migration.go
+++ b/tests/libmigration/migration.go
@@ -482,7 +482,7 @@ func ConfirmVMIPostMigrationAborted(vmi *v1.VirtualMachineInstance, migrationUID
 	ExpectWithOffset(1, vmi.Status.MigrationState.Failed).To(BeTrue())
 	ExpectWithOffset(1, vmi.Status.MigrationState.Completed).To(BeTrue())
 	ExpectWithOffset(1, vmi.Status.MigrationState.AbortRequested).To(BeTrue())
-	ExpectWithOffset(1, vmi.Status.MigrationState.AbortStatus).To(BeElementOf(v1.MigrationAbortSucceeded, v1.MigrationAbortFailed))
+	ExpectWithOffset(1, vmi.Status.MigrationState.AbortStatus).To(Equal(v1.MigrationAbortSucceeded))
 
 	By("Verifying the VMI's is in the running state")
 	ExpectWithOffset(1, vmi).To(matcher.BeInPhase(v1.Running))

--- a/tests/libmigration/migration.go
+++ b/tests/libmigration/migration.go
@@ -480,8 +480,9 @@ func ConfirmVMIPostMigrationAborted(vmi *v1.VirtualMachineInstance, migrationUID
 	ExpectWithOffset(1, vmi.Status.MigrationState.TargetNodeAddress).ToNot(Equal(""))
 	ExpectWithOffset(1, string(vmi.Status.MigrationState.MigrationUID)).To(Equal(migrationUID))
 	ExpectWithOffset(1, vmi.Status.MigrationState.Failed).To(BeTrue())
+	ExpectWithOffset(1, vmi.Status.MigrationState.Completed).To(BeTrue())
 	ExpectWithOffset(1, vmi.Status.MigrationState.AbortRequested).To(BeTrue())
-	ExpectWithOffset(1, vmi.Status.MigrationState.AbortStatus).To(Equal(v1.MigrationAbortSucceeded))
+	ExpectWithOffset(1, vmi.Status.MigrationState.AbortStatus).To(BeElementOf(v1.MigrationAbortSucceeded, v1.MigrationAbortFailed))
 
 	By("Verifying the VMI's is in the running state")
 	ExpectWithOffset(1, vmi).To(matcher.BeInPhase(v1.Running))

--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -3079,6 +3079,14 @@ func runStressTest(vmi *v1.VirtualMachineInstance, vmsize string) {
 	time.Sleep(stressDefaultSleepDuration * time.Second)
 }
 
+func stopStressTest(vmi *v1.VirtualMachineInstance) {
+	By("Stopping the stress test")
+	Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
+		&expect.BSnd{S: "pkill -f stress-ng\n"},
+		&expect.BExp{R: ""},
+	}, 15)).To(Succeed(), "should stop a stress test")
+}
+
 func getIdOfLauncher(vmi *v1.VirtualMachineInstance) string {
 	vmi, err := kubevirt.Client().VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
 	Expect(err).ToNot(HaveOccurred())

--- a/tests/migration/namespace.go
+++ b/tests/migration/namespace.go
@@ -580,10 +580,11 @@ var _ = Describe(SIG("Live Migration across namespaces", decorators.RequiresDece
 		)
 
 		BeforeEach(func() {
-			sourceVMI = libvmifact.NewAlpine(
+			sourceVMI = libvmifact.NewAlpineWithTestTooling(
 				libvmi.WithNamespace(testsuite.NamespaceTestDefault),
 				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
+				libvmi.WithMemoryRequest("1Gi"),
 			)
 			By("limiting the bandwidth of migrations")
 			Expect(CreateMigrationPolicy(virtClient, PreparePolicyAndVMIWithBandwidthLimitation(sourceVMI, resource.MustParse("1Ki")))).ToNot(BeNil())
@@ -598,6 +599,10 @@ var _ = Describe(SIG("Live Migration across namespaces", decorators.RequiresDece
 
 			By("starting the VirtualMachine")
 			createAndStartVMFromVMISpec(sourceVMI)
+			sourceVMI, err = virtClient.VirtualMachineInstance(sourceVMI.Namespace).Get(context.Background(), sourceVMI.Name, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(console.LoginToAlpine(sourceVMI)).To(Succeed())
+			runStressTest(sourceVMI, stressLargeVMSize)
 			By("creating a receiver VM")
 			createReceiverVMFromVMISpec(targetVMI)
 			By("creating the migration")
@@ -646,6 +651,7 @@ var _ = Describe(SIG("Live Migration across namespaces", decorators.RequiresDece
 				Expect(err).ToNot(HaveOccurred())
 				return targetVMI.Status.Phase
 			}).WithTimeout(time.Minute).WithPolling(2 * time.Second).Should(Equal(virtv1.WaitingForSync))
+			stopStressTest(sourceVMI)
 		},
 			Entry("[QUARANTINE] delete source migration", decorators.Quarantine, true),
 			Entry("[QUARANTINE]delete target migration", decorators.Quarantine, false),

--- a/tests/migration/namespace.go
+++ b/tests/migration/namespace.go
@@ -580,7 +580,7 @@ var _ = Describe(SIG("Live Migration across namespaces", decorators.RequiresDece
 		)
 
 		BeforeEach(func() {
-			sourceVMI = libvmifact.NewAlpineWithTestTooling(
+			sourceVMI = libvmifact.NewFedora(
 				libvmi.WithNamespace(testsuite.NamespaceTestDefault),
 				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
@@ -601,7 +601,7 @@ var _ = Describe(SIG("Live Migration across namespaces", decorators.RequiresDece
 			createAndStartVMFromVMISpec(sourceVMI)
 			sourceVMI, err = virtClient.VirtualMachineInstance(sourceVMI.Namespace).Get(context.Background(), sourceVMI.Name, metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
-			Expect(console.LoginToAlpine(sourceVMI)).To(Succeed())
+			Expect(console.LoginToFedora(sourceVMI)).To(Succeed())
 			runStressTest(sourceVMI, stressLargeVMSize)
 			By("creating a receiver VM")
 			createReceiverVMFromVMISpec(targetVMI)
@@ -644,7 +644,7 @@ var _ = Describe(SIG("Live Migration across namespaces", decorators.RequiresDece
 			By("Waiting for the target migration object to disappear")
 			Expect(libwait.WaitForMigrationToDisappearWithTimeout(targetMigration, timeout*time.Second)).To(Succeed())
 			By("Logging in and ensuring the source VM is still running")
-			Expect(console.LoginToAlpine(sourceVMI)).To(Succeed())
+			Expect(console.LoginToFedora(sourceVMI)).To(Succeed())
 			By("Checking that the receiving VM is in WaitingAsReceiver phase")
 			Eventually(func() virtv1.VirtualMachineInstancePhase {
 				targetVMI, err := virtClient.VirtualMachineInstance(targetVMI.Namespace).Get(context.Background(), targetVMI.Name, metav1.GetOptions{})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Sometimes when cancelling a decentralized migration, the source would get properly cancelled, but the target would not. This commit fixes the migration-target to properly handle the migration being cancelled.

#### Before this PR:
Cancelling a decentralized live migration would sometimes cause the migration resource to keep the finalizer and not be removed.

#### After this PR:
Cancelling a decentralized live migration properly removes the finalizer and everything is cleaned up properly.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/24

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [X] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: Fixes bug in cancelling of decentralized live migration not removing finalizer from migration resource
```

