### PR TITLE
Unquarantine decentralized live migration cancel tests

### DIFF
--- a/pkg/synchronization-controller/synchronization-controller.go
+++ b/pkg/synchronization-controller/synchronization-controller.go
@@ -376,6 +376,15 @@ func (s *SynchronizationController) execute(key string) error {
 		}
 		return nil
 	} else {
+		// After a target-initiated cancel the source migration object may be removed
+		// before the source VMI records abort completion. Push the final source state
+		// once more so the target VMI receives EndTimestamp and can finish abort cleanup.
+		if needsOrphanSourceAbortSync(vmi) {
+			log.Log.Object(vmi).Info("migration object gone after source abort, pushing final source state to target")
+			if err := s.handleSourceState(vmi.DeepCopy(), nil); err != nil {
+				return err
+			}
+		}
 		// No migration found don't do anything
 		// We should only clear the condition if we are not waiting for synchronization.
 		if err := s.clearDecentralizedLiveMigrationFailure(vmi); err != nil {
@@ -384,6 +393,17 @@ func (s *SynchronizationController) execute(key string) error {
 		log.Log.Object(vmi).V(4).Info("no active decentralized migration found for VMI")
 		return nil
 	}
+}
+
+func needsOrphanSourceAbortSync(vmi *virtv1.VirtualMachineInstance) bool {
+	ms := vmi.Status.MigrationState
+	if ms == nil || ms.SourceState == nil || ms.TargetState == nil {
+		return false
+	}
+	if ms.MigrationUID != ms.SourceState.MigrationUID {
+		return false
+	}
+	return ms.AbortRequested && ms.EndTimestamp != nil
 }
 
 func (s *SynchronizationController) updateDecentralizedFailureOnSource(vmi *virtv1.VirtualMachineInstance, migration *virtv1.VirtualMachineInstanceMigration, opErr error) error {
@@ -548,7 +568,29 @@ func (s *SynchronizationController) getOutboundSourceConnection(vmi *virtv1.Virt
 	if migrationState.TargetState == nil || migrationState.TargetState.SyncAddress == nil || *migrationState.TargetState.SyncAddress == "" {
 		return nil, nil
 	}
-	return s.getOutboundConnection(vmi, migrationState.SourceState.MigrationUID, *migrationState.TargetState.SyncAddress, s.syncOutboundConnectionMap)
+	migrationID, err := s.resolveSourceOutboundMigrationID(migrationState)
+	if err != nil {
+		return nil, err
+	}
+	if migrationID == "" {
+		return nil, nil
+	}
+	return s.getOutboundConnectionByMigrationID(vmi, migrationID, *migrationState.TargetState.SyncAddress, s.syncOutboundConnectionMap)
+}
+
+func (s *SynchronizationController) resolveSourceOutboundMigrationID(migrationState *virtv1.VirtualMachineInstanceMigrationState) (string, error) {
+	if migrationState == nil || migrationState.SourceState == nil {
+		return "", nil
+	}
+	migrationID, err := s.getMigrationIDFromUID(migrationState.SourceState.MigrationUID)
+	if err != nil || migrationID != "" {
+		return migrationID, err
+	}
+	// The source migration object may already be deleted after a target-initiated cancel.
+	if migrationState.TargetState != nil && migrationState.TargetState.MigrationUID != "" {
+		return s.getMigrationIDFromUID(migrationState.TargetState.MigrationUID)
+	}
+	return "", nil
 }
 
 func (s *SynchronizationController) getOutboundTargetConnection(vmi *virtv1.VirtualMachineInstance, migrationState *virtv1.VirtualMachineInstanceMigrationState) (*SynchronizationConnection, error) {
@@ -565,6 +607,13 @@ func (s *SynchronizationController) getOutboundConnection(vmi *virtv1.VirtualMac
 	migrationID, err := s.getMigrationIDFromUID(migrationUID)
 	if err != nil {
 		return nil, err
+	}
+	return s.getOutboundConnectionByMigrationID(vmi, migrationID, syncAddress, connectionMap)
+}
+
+func (s *SynchronizationController) getOutboundConnectionByMigrationID(vmi *virtv1.VirtualMachineInstance, migrationID string, syncAddress string, connectionMap *sync.Map) (*SynchronizationConnection, error) {
+	if migrationID == "" {
+		return nil, nil
 	}
 	log.Log.Object(vmi).V(4).Infof("found migration ID %s", migrationID)
 	obj, ok := connectionMap.Load(migrationID)
@@ -633,7 +682,7 @@ func (s *SynchronizationController) handleSourceState(vmi *virtv1.VirtualMachine
 	}); err != nil {
 		return err
 	}
-	if migration.IsFinal() {
+	if migration != nil && migration.IsFinal() {
 		if migration.Spec.SendTo != nil {
 			log.Log.Object(migration).Infof("completed migration for VMI %s/%s, closing outbound connections", migration.Namespace, migration.Spec.VMIName)
 			s.closeConnectionForMigrationID(s.syncOutboundConnectionMap, migration.Spec.SendTo.MigrationID)

--- a/pkg/synchronization-controller/synchronization-controller.go
+++ b/pkg/synchronization-controller/synchronization-controller.go
@@ -350,8 +350,10 @@ func (s *SynchronizationController) execute(key string) error {
 		}
 		if migration.IsDecentralizedSource() {
 			if migration.DeletionTimestamp != nil {
-				log.Log.V(2).Object(migration).Infof("migration is being deleted, informing the target that the migration is canceled")
-				// migration is being deleted, inform the target that the migration is canceled
+				log.Log.V(2).Object(migration).Infof("migration is being deleted, syncing source state before canceling target migration")
+				if err := s.handleSourceState(vmi.DeepCopy(), migration); err != nil {
+					return s.updateDecentralizedFailureOnSource(vmi, migration, err)
+				}
 				if err := s.cancelTargetRemoteMigration(vmi, migration); err != nil {
 					return err
 				}
@@ -1348,6 +1350,16 @@ func copyLegacySourceFields(vmi *virtv1.VirtualMachineInstance, migrationState *
 	}
 	vmi.Status.MigrationState.SourcePod = migrationState.SourceState.Pod
 	copyCommonLegacyFields(vmi.Status.MigrationState, migrationState)
+	if migrationState.AbortRequested && migrationState.EndTimestamp != nil {
+		vmi.Status.MigrationState.Failed = migrationState.Failed
+		vmi.Status.MigrationState.Completed = migrationState.Completed
+		if migrationState.AbortStatus != "" {
+			vmi.Status.MigrationState.AbortStatus = migrationState.AbortStatus
+		}
+		if migrationState.FailureReason != "" {
+			vmi.Status.MigrationState.FailureReason = migrationState.FailureReason
+		}
+	}
 }
 
 func copyCommonLegacyFields(targetMigrationState, sourceMigrationState *virtv1.VirtualMachineInstanceMigrationState) {

--- a/pkg/synchronization-controller/synchronization-controller_test.go
+++ b/pkg/synchronization-controller/synchronization-controller_test.go
@@ -905,6 +905,99 @@ var _ = Describe("VMI status synchronization controller", func() {
 			})
 		})
 
+		Context("decentralized migration abort cleanup", func() {
+			setupConnectedAbortMigration := func() {
+				sourceVMI.Status.MigrationState.MigrationUID = sourceTestMigrationUID
+				sourceVMI.Status.MigrationState.SourceState = &virtv1.VirtualMachineInstanceMigrationSourceState{
+					VirtualMachineInstanceCommonMigrationState: virtv1.VirtualMachineInstanceCommonMigrationState{
+						MigrationUID: sourceTestMigrationUID,
+						SyncAddress:  pointer.P(localTCPConn.Addr().String()),
+					},
+				}
+				sourceVMI.Status.MigrationState.TargetState = &virtv1.VirtualMachineInstanceMigrationTargetState{
+					VirtualMachineInstanceCommonMigrationState: virtv1.VirtualMachineInstanceCommonMigrationState{
+						MigrationUID: targetTestMigrationUID,
+						SyncAddress:  pointer.P(localTCPConn.Addr().String()),
+					},
+				}
+				targetVMI.Status.MigrationState.MigrationUID = targetTestMigrationUID
+				targetVMI.Status.MigrationState.TargetState = &virtv1.VirtualMachineInstanceMigrationTargetState{
+					VirtualMachineInstanceCommonMigrationState: virtv1.VirtualMachineInstanceCommonMigrationState{
+						MigrationUID: targetTestMigrationUID,
+					},
+				}
+				targetVMI.Status.MigrationState.SourceState = &virtv1.VirtualMachineInstanceMigrationSourceState{
+					VirtualMachineInstanceCommonMigrationState: virtv1.VirtualMachineInstanceCommonMigrationState{
+						SyncAddress: pointer.P(localTCPConn.Addr().String()),
+					},
+				}
+				err = controller.vmiInformer.GetStore().Update(sourceVMI)
+				Expect(err).ToNot(HaveOccurred())
+				_, err = controller.client.VirtualMachineInstance(sourceVMI.Namespace).Update(context.Background(), sourceVMI, metav1.UpdateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				err = controller.vmiInformer.GetStore().Update(targetVMI)
+				Expect(err).ToNot(HaveOccurred())
+				_, err = controller.client.VirtualMachineInstance(targetVMI.Namespace).Update(context.Background(), targetVMI, metav1.UpdateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+			}
+
+			setSourceAbortCompleted := func() {
+				endTimestamp := metav1.Now()
+				sourceVMI.Status.MigrationState.AbortRequested = true
+				sourceVMI.Status.MigrationState.EndTimestamp = &endTimestamp
+				sourceVMI.Status.MigrationState.Failed = true
+				sourceVMI.Status.MigrationState.Completed = true
+				sourceVMI.Status.MigrationState.AbortStatus = virtv1.MigrationAbortSucceeded
+				sourceVMI.Status.MigrationState.FailureReason = "Live migration has been aborted"
+				err = controller.vmiInformer.GetStore().Update(sourceVMI)
+				Expect(err).ToNot(HaveOccurred())
+				_, err = controller.client.VirtualMachineInstance(sourceVMI.Namespace).Update(context.Background(), sourceVMI, metav1.UpdateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+			}
+
+			verifyTargetAbortCompletion := func() {
+				updatedTargetVMI, err := controller.client.VirtualMachineInstance(targetVMI.Namespace).Get(context.Background(), targetVMI.Name, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(updatedTargetVMI.Status.MigrationState.EndTimestamp).ToNot(BeNil())
+				Expect(updatedTargetVMI.Status.MigrationState.Failed).To(BeTrue())
+				Expect(updatedTargetVMI.Status.MigrationState.Completed).To(BeTrue())
+				Expect(updatedTargetVMI.Status.MigrationState.AbortStatus).To(Equal(virtv1.MigrationAbortSucceeded))
+				Expect(updatedTargetVMI.Status.MigrationState.FailureReason).To(Equal("Live migration has been aborted"))
+			}
+
+			It("should push abort completion to target when source migration object is gone", func() {
+				setupConnectedAbortMigration()
+				setSourceAbortCompleted()
+
+				By("removing the source migration object as happens after target-initiated cancel")
+				err = migrationInformer.GetStore().Delete(sourceMigration)
+				Expect(err).ToNot(HaveOccurred())
+
+				sourceKey, err := kvcontroller.KeyFunc(sourceVMI)
+				Expect(err).ToNot(HaveOccurred())
+				err = controller.execute(sourceKey)
+				Expect(err).ToNot(HaveOccurred())
+
+				verifyTargetAbortCompletion()
+			})
+
+			It("should sync source abort state before canceling target migration on source migration deletion", func() {
+				setupConnectedAbortMigration()
+				setSourceAbortCompleted()
+
+				sourceMigration.DeletionTimestamp = pointer.P(metav1.Now())
+				err = migrationInformer.GetStore().Update(sourceMigration)
+				Expect(err).ToNot(HaveOccurred())
+
+				sourceKey, err := kvcontroller.KeyFunc(sourceVMI)
+				Expect(err).ToNot(HaveOccurred())
+				err = controller.execute(sourceKey)
+				Expect(err).ToNot(HaveOccurred())
+
+				verifyTargetAbortCompletion()
+			})
+		})
+
 		It("should properly update both source and target if both handlers are called", func() {
 			targetVMI.Status.MigrationState.TargetState = &virtv1.VirtualMachineInstanceMigrationTargetState{
 				VirtualMachineInstanceCommonMigrationState: virtv1.VirtualMachineInstanceCommonMigrationState{
@@ -1278,6 +1371,222 @@ var _ = Describe("VMI status synchronization controller", func() {
 			})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(res.Message).To(Equal("migration canceled"))
+		})
+
+		It("should not orphan-sync when source abort has not completed yet", func() {
+			sourceVMI.Status.MigrationState = &virtv1.VirtualMachineInstanceMigrationState{
+				MigrationUID:   sourceTestMigrationUID,
+				AbortRequested: true,
+				SourceState: &virtv1.VirtualMachineInstanceMigrationSourceState{
+					VirtualMachineInstanceCommonMigrationState: virtv1.VirtualMachineInstanceCommonMigrationState{
+						MigrationUID: sourceTestMigrationUID,
+					},
+				},
+				TargetState: &virtv1.VirtualMachineInstanceMigrationTargetState{
+					VirtualMachineInstanceCommonMigrationState: virtv1.VirtualMachineInstanceCommonMigrationState{
+						MigrationUID: targetTestMigrationUID,
+					},
+				},
+			}
+			Expect(needsOrphanSourceAbortSync(sourceVMI)).To(BeFalse())
+		})
+
+		It("should request source cancel when target migration is deleted", func() {
+			targetVMI.Status.MigrationState.TargetState = &virtv1.VirtualMachineInstanceMigrationTargetState{
+				VirtualMachineInstanceCommonMigrationState: virtv1.VirtualMachineInstanceCommonMigrationState{
+					MigrationUID: targetTestMigrationUID,
+				},
+			}
+			targetVMI.Status.MigrationState.SourceState = &virtv1.VirtualMachineInstanceMigrationSourceState{
+				VirtualMachineInstanceCommonMigrationState: virtv1.VirtualMachineInstanceCommonMigrationState{
+					SyncAddress: pointer.P(localURL),
+				},
+			}
+			sourceVMI.Status.MigrationState.SourceState = &virtv1.VirtualMachineInstanceMigrationSourceState{
+				VirtualMachineInstanceCommonMigrationState: virtv1.VirtualMachineInstanceCommonMigrationState{
+					MigrationUID: sourceTestMigrationUID,
+				},
+			}
+			sourceVMI.Status.MigrationState.TargetState = &virtv1.VirtualMachineInstanceMigrationTargetState{
+				VirtualMachineInstanceCommonMigrationState: virtv1.VirtualMachineInstanceCommonMigrationState{
+					SyncAddress: pointer.P(remoteURL),
+				},
+			}
+			err = remoteController.vmiInformer.GetStore().Update(targetVMI)
+			Expect(err).ToNot(HaveOccurred())
+			_, err = remoteController.client.VirtualMachineInstance(targetVMI.Namespace).Update(context.Background(), targetVMI, metav1.UpdateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			err = controller.vmiInformer.GetStore().Update(sourceVMI)
+			Expect(err).ToNot(HaveOccurred())
+			_, err = controller.client.VirtualMachineInstance(sourceVMI.Namespace).Update(context.Background(), sourceVMI, metav1.UpdateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			targetMigration.DeletionTimestamp = pointer.P(metav1.Now())
+			err = remoteController.migrationInformer.GetStore().Update(targetMigration)
+			Expect(err).ToNot(HaveOccurred())
+
+			targetKey, err := kvcontroller.KeyFunc(targetVMI)
+			Expect(err).ToNot(HaveOccurred())
+			err = remoteController.execute(targetKey)
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Context("needsOrphanSourceAbortSync", func() {
+		It("should return true for completed decentralized source abort without migration object", func() {
+			endTimestamp := metav1.Now()
+			vmi := &virtv1.VirtualMachineInstance{
+				Status: virtv1.VirtualMachineInstanceStatus{
+					MigrationState: &virtv1.VirtualMachineInstanceMigrationState{
+						MigrationUID:   sourceTestMigrationUID,
+						AbortRequested: true,
+						EndTimestamp:   &endTimestamp,
+						SourceState: &virtv1.VirtualMachineInstanceMigrationSourceState{
+							VirtualMachineInstanceCommonMigrationState: virtv1.VirtualMachineInstanceCommonMigrationState{
+								MigrationUID: sourceTestMigrationUID,
+							},
+						},
+						TargetState: &virtv1.VirtualMachineInstanceMigrationTargetState{
+							VirtualMachineInstanceCommonMigrationState: virtv1.VirtualMachineInstanceCommonMigrationState{
+								MigrationUID: targetTestMigrationUID,
+							},
+						},
+					},
+				},
+			}
+			Expect(needsOrphanSourceAbortSync(vmi)).To(BeTrue())
+		})
+
+		It("should return false when abort is still in progress", func() {
+			vmi := &virtv1.VirtualMachineInstance{
+				Status: virtv1.VirtualMachineInstanceStatus{
+					MigrationState: &virtv1.VirtualMachineInstanceMigrationState{
+						MigrationUID:   sourceTestMigrationUID,
+						AbortRequested: true,
+						SourceState: &virtv1.VirtualMachineInstanceMigrationSourceState{
+							VirtualMachineInstanceCommonMigrationState: virtv1.VirtualMachineInstanceCommonMigrationState{
+								MigrationUID: sourceTestMigrationUID,
+							},
+						},
+						TargetState: &virtv1.VirtualMachineInstanceMigrationTargetState{
+							VirtualMachineInstanceCommonMigrationState: virtv1.VirtualMachineInstanceCommonMigrationState{
+								MigrationUID: targetTestMigrationUID,
+							},
+						},
+					},
+				},
+			}
+			Expect(needsOrphanSourceAbortSync(vmi)).To(BeFalse())
+		})
+
+		It("should return false for target-side VMIs", func() {
+			endTimestamp := metav1.Now()
+			vmi := &virtv1.VirtualMachineInstance{
+				Status: virtv1.VirtualMachineInstanceStatus{
+					MigrationState: &virtv1.VirtualMachineInstanceMigrationState{
+						MigrationUID:   targetTestMigrationUID,
+						AbortRequested: true,
+						EndTimestamp:   &endTimestamp,
+						SourceState: &virtv1.VirtualMachineInstanceMigrationSourceState{
+							VirtualMachineInstanceCommonMigrationState: virtv1.VirtualMachineInstanceCommonMigrationState{
+								MigrationUID: sourceTestMigrationUID,
+							},
+						},
+						TargetState: &virtv1.VirtualMachineInstanceMigrationTargetState{
+							VirtualMachineInstanceCommonMigrationState: virtv1.VirtualMachineInstanceCommonMigrationState{
+								MigrationUID: targetTestMigrationUID,
+							},
+						},
+					},
+				},
+			}
+			Expect(needsOrphanSourceAbortSync(vmi)).To(BeFalse())
+		})
+	})
+
+	Context("resolveSourceOutboundMigrationID", func() {
+		It("should fall back to target migration UID when source migration object is gone", func() {
+			targetMigration := createTargetMigration(testMigrationID, "test-vmi", targetNamespace)
+			err := migrationInformer.GetStore().Add(targetMigration)
+			Expect(err).ToNot(HaveOccurred())
+
+			migrationState := &virtv1.VirtualMachineInstanceMigrationState{
+				SourceState: &virtv1.VirtualMachineInstanceMigrationSourceState{
+					VirtualMachineInstanceCommonMigrationState: virtv1.VirtualMachineInstanceCommonMigrationState{
+						MigrationUID: sourceTestMigrationUID,
+					},
+				},
+				TargetState: &virtv1.VirtualMachineInstanceMigrationTargetState{
+					VirtualMachineInstanceCommonMigrationState: virtv1.VirtualMachineInstanceCommonMigrationState{
+						MigrationUID: targetTestMigrationUID,
+					},
+				},
+			}
+
+			migrationID, err := controller.resolveSourceOutboundMigrationID(migrationState)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(migrationID).To(Equal(testMigrationID))
+		})
+	})
+
+	Context("copyLegacySourceFields", func() {
+		It("should copy abort completion fields when abort was requested", func() {
+			endTimestamp := metav1.Now()
+			vmi := &virtv1.VirtualMachineInstance{
+				Status: virtv1.VirtualMachineInstanceStatus{
+					MigrationState: &virtv1.VirtualMachineInstanceMigrationState{},
+				},
+			}
+			remoteState := &virtv1.VirtualMachineInstanceMigrationState{
+				AbortRequested: true,
+				EndTimestamp:   &endTimestamp,
+				Failed:         true,
+				Completed:      true,
+				AbortStatus:    virtv1.MigrationAbortSucceeded,
+				FailureReason:  "Live migration has been aborted",
+				SourceState: &virtv1.VirtualMachineInstanceMigrationSourceState{
+					VirtualMachineInstanceCommonMigrationState: virtv1.VirtualMachineInstanceCommonMigrationState{
+						Node: "node03",
+						Pod:  "source-pod",
+					},
+				},
+			}
+
+			copyLegacySourceFields(vmi, remoteState)
+
+			Expect(vmi.Status.MigrationState.EndTimestamp).To(Equal(&endTimestamp))
+			Expect(vmi.Status.MigrationState.Failed).To(BeTrue())
+			Expect(vmi.Status.MigrationState.Completed).To(BeTrue())
+			Expect(vmi.Status.MigrationState.AbortStatus).To(Equal(virtv1.MigrationAbortSucceeded))
+			Expect(vmi.Status.MigrationState.FailureReason).To(Equal("Live migration has been aborted"))
+			Expect(vmi.Status.MigrationState.SourceNode).To(Equal("node03"))
+			Expect(vmi.Status.MigrationState.SourcePod).To(Equal("source-pod"))
+		})
+
+		It("should not copy failed/completed abort fields without EndTimestamp", func() {
+			vmi := &virtv1.VirtualMachineInstance{
+				Status: virtv1.VirtualMachineInstanceStatus{
+					MigrationState: &virtv1.VirtualMachineInstanceMigrationState{},
+				},
+			}
+			remoteState := &virtv1.VirtualMachineInstanceMigrationState{
+				AbortRequested: true,
+				Failed:         true,
+				Completed:      true,
+				AbortStatus:    virtv1.MigrationAbortSucceeded,
+				SourceState: &virtv1.VirtualMachineInstanceMigrationSourceState{
+					VirtualMachineInstanceCommonMigrationState: virtv1.VirtualMachineInstanceCommonMigrationState{
+						Node: "node03",
+					},
+				},
+			}
+
+			copyLegacySourceFields(vmi, remoteState)
+
+			Expect(vmi.Status.MigrationState.EndTimestamp).To(BeNil())
+			Expect(vmi.Status.MigrationState.Failed).To(BeFalse())
+			Expect(vmi.Status.MigrationState.Completed).To(BeFalse())
+			Expect(vmi.Status.MigrationState.AbortStatus).To(BeEmpty())
 		})
 	})
 

--- a/pkg/virt-handler/migration-target.go
+++ b/pkg/virt-handler/migration-target.go
@@ -261,9 +261,15 @@ func (c *MigrationTargetController) handleDecentralizedMigrationAbort(vmi *v1.Vi
 			return nil
 		}
 
+		// The target migration proxy must stay up while the source migration is still
+		// running. Wait until the source reports completion (EndTimestamp synced onto
+		// the target VMI) before marking the target migration failed and cleaning up.
 		if migrationState.EndTimestamp == nil {
-			migrationState.EndTimestamp = pointer.P(metav1.Now())
+			c.logger.Object(vmi).V(5).Info("waiting for source migration abort to complete before finalizing target abort")
+			c.queue.AddAfter(controller.VirtualMachineInstanceKey(vmi), time.Second)
+			return nil
 		}
+
 		migrationState.Failed = true
 		migrationState.Completed = true
 		if migrationState.AbortStatus == "" {
@@ -866,13 +872,16 @@ func (c *MigrationTargetController) processVMI(vmi *v1.VirtualMachineInstance) (
 
 	// Once the migration target has been fully prepared (indicated by the
 	// migration proxy listening), there is nothing left for processVMI to
-	// do until the migration completes. Return early to avoid re-running
-	// the full preparation while QEMU is actively migrating.
+	// do until the migration completes or abort finalization runs.
+	// Return early to avoid re-running the full preparation while QEMU is
+	// actively migrating or while waiting for a decentralized abort to finish
+	// on the source (handleDecentralizedMigrationAbort requeues via AddAfter).
+	// Centralized aborts still fall through so checkLauncherClient can run.
 	// Return skipExpectations=true so the caller does not block the
 	// controller from processing external events (domain updates, sync
 	// controller VMI patches).
 	if len(c.migrationProxy.GetTargetListenerPorts(migrationProxyKey(vmi))) > 0 {
-		if !abortInProgress(vmi) {
+		if !abortInProgress(vmi) || vmi.IsDecentralizedMigration() {
 			c.logger.Object(vmi).V(4).Info("migration target already prepared, nothing to do")
 			return nil, true
 		}

--- a/pkg/virt-handler/migration-target_test.go
+++ b/pkg/virt-handler/migration-target_test.go
@@ -745,85 +745,99 @@ var _ = Describe("VirtualMachineInstance migration target", func() {
 		sanityExecute()
 	})
 
-	DescribeTable("should mark migration failed when abort is requested on target",
-		func(withDomain bool) {
-			const (
-				targetMigrationUID  = types.UID("target-migration-uid")
-				domainFailureReason = "target domain reported migration abort via libvirt"
-			)
+	It("should wait for source abort completion before marking migration failed on target", func() {
+		const targetMigrationUID = types.UID("target-migration-uid")
 
-			vmi := api2.NewMinimalVMI("testvmi")
-			vmi.UID = vmiTestUUID
-			vmi.ObjectMeta.ResourceVersion = "1"
-			vmi.Status.Phase = v1.Scheduled
-			vmi.Labels = make(map[string]string)
-			vmi.Status.NodeName = host
-			vmi.Labels[v1.MigrationTargetNodeNameLabel] = host
-			start := metav1.Now()
-			vmi.Status.MigrationState = decentralizedTargetAbortMigrationState(targetMigrationUID, host, "othernode", start, true)
-			vmi = addActivePods(vmi, podTestUUID, host)
+		start := metav1.Now()
+		vmi := api2.NewMinimalVMI("testvmi")
+		vmi.UID = vmiTestUUID
+		vmi.ObjectMeta.ResourceVersion = "1"
+		vmi.Status.Phase = v1.Scheduled
+		vmi.Labels = make(map[string]string)
+		vmi.Status.NodeName = host
+		vmi.Labels[v1.MigrationTargetNodeNameLabel] = host
+		vmi.Status.MigrationState = decentralizedTargetAbortMigrationState(targetMigrationUID, host, "othernode", start, true)
+		vmi = addActivePods(vmi, podTestUUID, host)
+		createVMI(vmi)
 
-			var domainEnd *metav1.Time
-			if withDomain {
-				domainEnd = pointer.P(metav1.Now())
-				domain := api.NewMinimalDomainWithUUID("testvmi", vmiTestUUID)
-				domain.Status.Status = api.Shutoff
-				domain.Spec.Metadata.KubeVirt.Migration = &api.MigrationMetadata{
-					UID:            targetMigrationUID,
-					StartTimestamp: &start,
-					EndTimestamp:   domainEnd,
-					Failed:         true,
-					AbortStatus:    string(v1.MigrationAbortSucceeded),
-					FailureReason:  domainFailureReason,
-				}
-				addVMI(vmi, domain)
-			} else {
-				createVMI(vmi)
+		controller.Execute()
 
-				controller.Execute()
+		inProgressVMI, err := virtfakeClient.KubevirtV1().VirtualMachineInstances(metav1.NamespaceDefault).Get(context.TODO(), vmi.Name, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(inProgressVMI.Status.MigrationState.EndTimestamp).To(BeNil())
+		Expect(inProgressVMI.Status.MigrationState.Completed).To(BeFalse())
 
-				inProgressVMI, err := virtfakeClient.KubevirtV1().VirtualMachineInstances(metav1.NamespaceDefault).Get(context.TODO(), vmi.Name, metav1.GetOptions{})
-				Expect(err).NotTo(HaveOccurred())
-				Expect(inProgressVMI.Status.MigrationState.EndTimestamp).To(BeNil())
-				Expect(inProgressVMI.Status.MigrationState.Completed).To(BeFalse())
+		// Simulate the sync controller copying source abort completion onto the target VMI.
+		sourceEnd := metav1.Now()
+		inProgressVMI.Status.MigrationState.EndTimestamp = &sourceEnd
+		_, err = virtfakeClient.KubevirtV1().VirtualMachineInstances(metav1.NamespaceDefault).Update(context.TODO(), inProgressVMI, metav1.UpdateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(controller.vmiStore.Update(inProgressVMI)).To(Succeed())
+		key, err := virtcontroller.KeyFunc(inProgressVMI)
+		Expect(err).NotTo(HaveOccurred())
+		// Re-enqueue the VMI as the informer would after the status patch. The first
+		// Execute() returned early and only scheduled a delayed retry via AddAfter;
+		// without this the queue would be empty until that timer fires.
+		controller.queue.Add(key)
 
-				sourceEnd := metav1.Now()
-				inProgressVMI.Status.MigrationState.EndTimestamp = &sourceEnd
-				_, err = virtfakeClient.KubevirtV1().VirtualMachineInstances(metav1.NamespaceDefault).Update(context.TODO(), inProgressVMI, metav1.UpdateOptions{})
-				Expect(err).NotTo(HaveOccurred())
-				Expect(controller.vmiStore.Update(inProgressVMI)).To(Succeed())
-				key, err := virtcontroller.KeyFunc(inProgressVMI)
-				Expect(err).NotTo(HaveOccurred())
-				controller.queue.Add(key)
-			}
+		client.EXPECT().SignalTargetPodCleanup(gomock.Any())
+		controller.Execute()
 
-			client.EXPECT().SignalTargetPodCleanup(gomock.Any())
-			controller.Execute()
+		testutils.ExpectEvent(recorder, VMIAbortingMigration)
 
-			expectedFailureReason := "Live migration has been aborted"
-			if withDomain {
-				testutils.ExpectEvent(recorder, domainFailureReason)
-				Expect(recorder.Events).NotTo(Receive(ContainSubstring(VMIAbortingMigration)))
-				expectedFailureReason = domainFailureReason
-			} else {
-				testutils.ExpectEvent(recorder, VMIAbortingMigration)
-			}
+		updatedVMI, err := virtfakeClient.KubevirtV1().VirtualMachineInstances(metav1.NamespaceDefault).Get(context.TODO(), vmi.Name, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(updatedVMI.Status.MigrationState.Failed).To(BeTrue())
+		Expect(updatedVMI.Status.MigrationState.Completed).To(BeTrue())
+		Expect(updatedVMI.Status.MigrationState.EndTimestamp).NotTo(BeNil())
+		Expect(updatedVMI.Status.MigrationState.AbortStatus).To(Equal(v1.MigrationAbortSucceeded))
+		Expect(updatedVMI.Status.MigrationState.FailureReason).To(Equal("Live migration has been aborted"))
+	})
 
-			updatedVMI, err := virtfakeClient.KubevirtV1().VirtualMachineInstances(metav1.NamespaceDefault).Get(context.TODO(), vmi.Name, metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(updatedVMI.Status.MigrationState.Failed).To(BeTrue())
-			Expect(updatedVMI.Status.MigrationState.Completed).To(BeTrue())
-			if withDomain {
-				Expect(updatedVMI.Status.MigrationState.EndTimestamp).To(Equal(domainEnd))
-			} else {
-				Expect(updatedVMI.Status.MigrationState.EndTimestamp).NotTo(BeNil())
-			}
-			Expect(updatedVMI.Status.MigrationState.AbortStatus).To(Equal(v1.MigrationAbortSucceeded))
-			Expect(updatedVMI.Status.MigrationState.FailureReason).To(Equal(expectedFailureReason))
-		},
-		Entry("when domain is not active on target yet", false),
-		Entry("when abort status is synced from domain metadata", true),
-	)
+	It("should mark migration failed from domain metadata when abort is requested on target", func() {
+		const (
+			targetMigrationUID  = types.UID("target-migration-uid")
+			domainFailureReason = "target domain reported migration abort via libvirt"
+		)
+
+		start := metav1.Now()
+		domainEnd := metav1.Now()
+		vmi := api2.NewMinimalVMI("testvmi")
+		vmi.UID = vmiTestUUID
+		vmi.ObjectMeta.ResourceVersion = "1"
+		vmi.Status.Phase = v1.Scheduled
+		vmi.Labels = make(map[string]string)
+		vmi.Status.NodeName = host
+		vmi.Labels[v1.MigrationTargetNodeNameLabel] = host
+		vmi.Status.MigrationState = decentralizedTargetAbortMigrationState(targetMigrationUID, host, "othernode", start, true)
+		vmi = addActivePods(vmi, podTestUUID, host)
+
+		domain := api.NewMinimalDomainWithUUID("testvmi", vmiTestUUID)
+		domain.Status.Status = api.Shutoff
+		domain.Spec.Metadata.KubeVirt.Migration = &api.MigrationMetadata{
+			UID:            targetMigrationUID,
+			StartTimestamp: &start,
+			EndTimestamp:   &domainEnd,
+			Failed:         true,
+			AbortStatus:    string(v1.MigrationAbortSucceeded),
+			FailureReason:  domainFailureReason,
+		}
+		addVMI(vmi, domain)
+
+		client.EXPECT().SignalTargetPodCleanup(gomock.Any())
+		controller.Execute()
+
+		testutils.ExpectEvent(recorder, domainFailureReason)
+		Expect(recorder.Events).NotTo(Receive(ContainSubstring(VMIAbortingMigration)))
+
+		updatedVMI, err := virtfakeClient.KubevirtV1().VirtualMachineInstances(metav1.NamespaceDefault).Get(context.TODO(), vmi.Name, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(updatedVMI.Status.MigrationState.Failed).To(BeTrue())
+		Expect(updatedVMI.Status.MigrationState.Completed).To(BeTrue())
+		Expect(updatedVMI.Status.MigrationState.EndTimestamp).To(Equal(&domainEnd))
+		Expect(updatedVMI.Status.MigrationState.AbortStatus).To(Equal(v1.MigrationAbortSucceeded))
+		Expect(updatedVMI.Status.MigrationState.FailureReason).To(Equal(domainFailureReason))
+	})
 
 	It("should not mark migration failed while domain is still active on target", func() {
 		const targetMigrationUID = types.UID("target-migration-uid")

--- a/pkg/virt-handler/migration-target_test.go
+++ b/pkg/virt-handler/migration-target_test.go
@@ -779,6 +779,22 @@ var _ = Describe("VirtualMachineInstance migration target", func() {
 				addVMI(vmi, domain)
 			} else {
 				createVMI(vmi)
+
+				controller.Execute()
+
+				inProgressVMI, err := virtfakeClient.KubevirtV1().VirtualMachineInstances(metav1.NamespaceDefault).Get(context.TODO(), vmi.Name, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(inProgressVMI.Status.MigrationState.EndTimestamp).To(BeNil())
+				Expect(inProgressVMI.Status.MigrationState.Completed).To(BeFalse())
+
+				sourceEnd := metav1.Now()
+				inProgressVMI.Status.MigrationState.EndTimestamp = &sourceEnd
+				_, err = virtfakeClient.KubevirtV1().VirtualMachineInstances(metav1.NamespaceDefault).Update(context.TODO(), inProgressVMI, metav1.UpdateOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(controller.vmiStore.Update(inProgressVMI)).To(Succeed())
+				key, err := virtcontroller.KeyFunc(inProgressVMI)
+				Expect(err).NotTo(HaveOccurred())
+				controller.queue.Add(key)
 			}
 
 			client.EXPECT().SignalTargetPodCleanup(gomock.Any())
@@ -876,6 +892,157 @@ var _ = Describe("VirtualMachineInstance migration target", func() {
 		Expect(controller.handleDecentralizedMigrationAbort(vmi, domain)).To(Succeed())
 		Expect(vmi.Status.MigrationState).To(Equal(stateBefore))
 		Expect(recorder.Events).NotTo(Receive())
+	})
+
+	Context("when decentralized target migration is cancelled while source is still migrating", func() {
+		const (
+			targetMigrationUID        = types.UID("target-migration-uid")
+			decentralizedSourceVMIUID = types.UID("source-vmi-uid")
+		)
+
+		setupDecentralizedTargetAbortWithProxy := func() string {
+			vmi := api2.NewMinimalVMI("testvmi")
+			vmi.UID = vmiTestUUID
+			vmi.ObjectMeta.ResourceVersion = "1"
+			vmi.Annotations = map[string]string{v1.CreateMigrationTarget: "true"}
+			vmi.Status.Phase = v1.WaitingForSync
+			vmi.Labels = make(map[string]string)
+			vmi.Status.NodeName = host
+			vmi.Labels[v1.MigrationTargetNodeNameLabel] = host
+			vmi.Status.MigrationTransport = v1.MigrationTransportUnix
+
+			start := metav1.Now()
+			vmi.Status.MigrationState = decentralizedTargetAbortMigrationState(targetMigrationUID, host, "othernode", start, true)
+			Expect(vmi.Status.MigrationState.EndTimestamp).To(BeNil())
+
+			vmi = addActivePods(vmi, podTestUUID, host)
+			createVMI(vmi)
+
+			Expect(os.MkdirAll(cmdclient.SocketDirectoryOnHost(string(podTestUUID)), os.ModePerm)).To(Succeed())
+			socketFile := cmdclient.SocketFilePathOnHost(string(podTestUUID))
+			Expect(os.RemoveAll(socketFile)).To(Succeed())
+			socket, err := net.Listen("unix", socketFile)
+			Expect(err).NotTo(HaveOccurred())
+			GinkgoT().Cleanup(func() { socket.Close() })
+
+			Expect(controller.handleTargetMigrationProxy(vmi)).To(Succeed())
+			proxyKey := string(decentralizedSourceVMIUID)
+			Expect(controller.migrationProxy.GetTargetListenerPorts(proxyKey)).NotTo(BeEmpty())
+
+			return proxyKey
+		}
+
+		// Target VMIM deleted while source migration is still running. The target must
+		// not tear down the migration proxy until source abort completion is synced.
+		It("does not finalize target abort until source migration has completed", func() {
+			proxyKey := setupDecentralizedTargetAbortWithProxy()
+
+			controller.Execute()
+
+			updatedVMI, err := virtfakeClient.KubevirtV1().VirtualMachineInstances(metav1.NamespaceDefault).Get(context.TODO(), "testvmi", metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(updatedVMI.Status.MigrationState.EndTimestamp).To(BeNil())
+			Expect(updatedVMI.Status.MigrationState.Completed).To(BeFalse())
+			Expect(controller.migrationProxy.GetTargetListenerPorts(proxyKey)).NotTo(BeEmpty())
+
+			sourceEnd := metav1.Now()
+			updatedVMI.Status.MigrationState.EndTimestamp = &sourceEnd
+			_, err = virtfakeClient.KubevirtV1().VirtualMachineInstances(metav1.NamespaceDefault).Update(context.TODO(), updatedVMI, metav1.UpdateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(controller.vmiStore.Update(updatedVMI)).To(Succeed())
+			key, err := virtcontroller.KeyFunc(updatedVMI)
+			Expect(err).NotTo(HaveOccurred())
+			controller.queue.Add(key)
+
+			client.EXPECT().SignalTargetPodCleanup(gomock.Any())
+			sanityExecute()
+
+			updatedVMI, err = virtfakeClient.KubevirtV1().VirtualMachineInstances(metav1.NamespaceDefault).Get(context.TODO(), "testvmi", metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(updatedVMI.Status.MigrationState.Failed).To(BeTrue())
+			Expect(updatedVMI.Status.MigrationState.Completed).To(BeTrue())
+			Expect(updatedVMI.Status.MigrationState.AbortStatus).To(Equal(v1.MigrationAbortSucceeded))
+			Expect(updatedVMI.Status.MigrationState.FailureReason).To(Equal("Live migration has been aborted"))
+			Expect(controller.migrationProxy.GetTargetListenerPorts(proxyKey)).To(BeEmpty())
+		})
+
+		It("should keep the migration proxy listening until the source abort has completed", func() {
+			proxyKey := setupDecentralizedTargetAbortWithProxy()
+
+			controller.Execute()
+
+			Expect(controller.migrationProxy.GetTargetListenerPorts(proxyKey)).NotTo(BeEmpty())
+
+			updatedVMI, err := virtfakeClient.KubevirtV1().VirtualMachineInstances(metav1.NamespaceDefault).Get(context.TODO(), "testvmi", metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(updatedVMI.Status.MigrationState.EndTimestamp).To(BeNil())
+			Expect(updatedVMI.Status.MigrationState.Completed).To(BeFalse())
+		})
+	})
+
+	Describe("processVMI when migration proxy is listening during abort", func() {
+		setupTargetAbortMigrationProxy := func(vmi *v1.VirtualMachineInstance) string {
+			vmi = addActivePods(vmi, podTestUUID, host)
+
+			Expect(os.MkdirAll(cmdclient.SocketDirectoryOnHost(string(podTestUUID)), os.ModePerm)).To(Succeed())
+			socketFile := cmdclient.SocketFilePathOnHost(string(podTestUUID))
+			Expect(os.RemoveAll(socketFile)).To(Succeed())
+			socket, err := net.Listen("unix", socketFile)
+			Expect(err).NotTo(HaveOccurred())
+			GinkgoT().Cleanup(func() { socket.Close() })
+
+			Expect(controller.handleTargetMigrationProxy(vmi)).To(Succeed())
+			proxyKey := migrationProxyKey(vmi)
+			Expect(controller.migrationProxy.GetTargetListenerPorts(proxyKey)).NotTo(BeEmpty())
+			return proxyKey
+		}
+
+		It("returns early for decentralized abort so source-abort wait stays in handleDecentralizedMigrationAbort", func() {
+			const targetMigrationUID = types.UID("target-migration-uid")
+
+			start := metav1.Now()
+			vmi := api2.NewMinimalVMI("testvmi")
+			vmi.UID = vmiTestUUID
+			vmi.Annotations = map[string]string{v1.CreateMigrationTarget: "true"}
+			vmi.Status.MigrationTransport = v1.MigrationTransportUnix
+			vmi.Labels = map[string]string{v1.MigrationTargetNodeNameLabel: host}
+			vmi.Status.MigrationState = decentralizedTargetAbortMigrationState(targetMigrationUID, host, "othernode", start, true)
+			Expect(vmi.IsDecentralizedMigration()).To(BeTrue())
+
+			setupTargetAbortMigrationProxy(vmi)
+
+			launcherClients := controller.launcherClients.(*launcherclients.MockLauncherClientManager)
+			launcherClients.UnResponsive = true
+
+			err, skipExpectations := controller.processVMI(vmi)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(skipExpectations).To(BeTrue(), "decentralized abort must take the prepared-target early return")
+		})
+
+		It("falls through for centralized abort so checkLauncherClient runs", func() {
+			start := metav1.Now()
+			vmi := api2.NewMinimalVMI("testvmi")
+			vmi.UID = vmiTestUUID
+			vmi.Status.Phase = v1.Running
+			vmi.Labels = map[string]string{v1.MigrationTargetNodeNameLabel: host}
+			vmi.Status.MigrationState = &v1.VirtualMachineInstanceMigrationState{
+				TargetNode:     host,
+				SourceNode:     "othernode",
+				MigrationUID:   "centralized-migration-uid",
+				StartTimestamp: &start,
+				AbortRequested: true,
+			}
+			Expect(vmi.IsDecentralizedMigration()).To(BeFalse())
+
+			setupTargetAbortMigrationProxy(vmi)
+
+			launcherClients := controller.launcherClients.(*launcherclients.MockLauncherClientManager)
+			launcherClients.UnResponsive = true
+
+			err, skipExpectations := controller.processVMI(vmi)
+			Expect(err).To(MatchError(ContainSubstring("unresponsive command server")))
+			Expect(skipExpectations).To(BeFalse(), "centralized abort must not take the prepared-target early return")
+		})
 	})
 
 	It("should not accidentally update VMI spec on cleanup", func() {

--- a/pkg/virt-launcher/virtwrap/live-migration-source_test.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source_test.go
@@ -164,6 +164,20 @@ var _ = Describe("Live migration source", func() {
 			Entry("marking the migration as failed should finalize", true),
 			Entry("marking the migration as completed should finalize", false),
 		)
+
+		// When the target migration proxy is torn down before source abort completes,
+		// libvirt reports "client socket is closed". setMigrationResult does not map
+		// that to abortStatus=Succeeded, which is why ConfirmVMIPostMigrationAborted
+		// fails on the source VMI in the decentralized delete-target-migration test.
+		It("records failed migration with blank AbortStatus when libvirt fails with client socket is closed", func() {
+			libvirtDomainManager.setMigrationResult(true, "client socket is closed")
+
+			migrationMetadata, exists := libvirtDomainManager.metadataCache.Migration.Load()
+			Expect(exists).To(BeTrue(), "migrationMetadata not found")
+			Expect(migrationMetadata.Failed).To(BeTrue())
+			Expect(migrationMetadata.FailureReason).To(Equal("client socket is closed"))
+			Expect(migrationMetadata.AbortStatus).To(BeEmpty())
+		})
 	})
 
 	Context("Migration abort status", func() {

--- a/tests/migration/namespace.go
+++ b/tests/migration/namespace.go
@@ -593,7 +593,7 @@ var _ = Describe(SIG("Live Migration across namespaces", decorators.RequiresDece
 			targetVMI.Namespace = testsuite.NamespaceTestAlternative
 		})
 
-		DescribeTable("should be able to cancel a migration by deleting the migration resource", decorators.SigStorage, Serial, func(deleteSource bool) {
+		DescribeTable("should be able to cancel a migration by deleting the migration resource", Serial, func(deleteSource bool) {
 			const timeout = 180
 			migrationID := fmt.Sprintf("mig-%s", rand.String(5))
 
@@ -653,8 +653,8 @@ var _ = Describe(SIG("Live Migration across namespaces", decorators.RequiresDece
 			}).WithTimeout(time.Minute).WithPolling(2 * time.Second).Should(Equal(virtv1.WaitingForSync))
 			stopStressTest(sourceVMI)
 		},
-			Entry("[QUARANTINE] delete source migration", decorators.Quarantine, true),
-			Entry("[QUARANTINE]delete target migration", decorators.Quarantine, false),
+			Entry("delete source migration", true),
+			Entry("delete target migration", false),
 		)
 
 		It("should properly propagate failure from target to source", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Once https://github.com/kubevirt/kubevirt/pull/18216 is merged, all the flakiness in the test should be solved. This PR unquarantines the flaky tests as they are useful.
#### Before this PR:

#### After this PR:

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
-->  
- Fixes #18302
<!--
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/24
### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

