### PR TITLE
virt-controller: Prevent reusing DataVolume by other VMs

### DIFF
--- a/pkg/controller/controller_ref_manager.go
+++ b/pkg/controller/controller_ref_manager.go
@@ -335,14 +335,10 @@ func (m *VirtualMachineControllerRefManager) ReleaseDetachedVirtualMachines(vms 
 //
 // If the error is nil, either the reconciliation succeeded, or no
 // reconciliation was necessary. The list of DataVolumes that you now own is returned.
-func (m *VirtualMachineControllerRefManager) ClaimMatchedDataVolumes(dataVolumes []*cdiv1.DataVolume) ([]*cdiv1.DataVolume, error) {
+func (m *VirtualMachineControllerRefManager) ClaimMatchedDataVolumes(dataVolumes []*cdiv1.DataVolume, match func(metav1.Object) bool) ([]*cdiv1.DataVolume, error) {
 	var claimed []*cdiv1.DataVolume
 	var errlist []error
 
-	match := func(obj metav1.Object) bool {
-		return true
-
-	}
 	adopt := func(obj metav1.Object) error {
 		return m.AdoptDataVolume(obj.(*cdiv1.DataVolume))
 	}

--- a/pkg/controller/controller_ref_manager_test.go
+++ b/pkg/controller/controller_ref_manager_test.go
@@ -188,10 +188,12 @@ func newDataVolume(name string, owner metav1.Object) *cdiv1.DataVolume {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: metav1.NamespaceDefault,
+			Labels:    make(map[string]string),
 		},
 	}
 	if owner != nil {
 		dataVolume.OwnerReferences = []metav1.OwnerReference{*newControllerRef(owner)}
+		dataVolume.ObjectMeta.Labels[virtv1.CreatedByLabel] = string(owner.GetUID())
 	}
 
 	return dataVolume
@@ -273,6 +275,26 @@ func TestClaimDataVolume(t *testing.T) {
 					func() error { return nil }),
 				datavolumes: []*cdiv1.DataVolume{datavolumeToDelete1, datavolumeToDelete2},
 				claimed:     []*cdiv1.DataVolume{datavolumeToDelete1},
+			}
+		}(),
+		func() test {
+			controller := v1.ReplicationController{}
+			controller.UID = types.UID(controllerUID)
+			standaloneDV := &cdiv1.DataVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "datavolume1",
+					Namespace: metav1.NamespaceDefault,
+				},
+			}
+			return test{
+				name: "Controller does not claim orphaned datavolumes without unknown creator",
+				manager: NewVirtualMachineControllerRefManager(&FakeVirtualMachineControl{},
+					&controller,
+					productionLabelSelector,
+					controllerKind,
+					func() error { return nil }),
+				datavolumes: []*cdiv1.DataVolume{standaloneDV},
+				claimed:     nil,
 			}
 		}(),
 	}

--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -248,3 +248,7 @@ func (config *ClusterConfig) IOMMUFDEnabled() bool {
 func (config *ClusterConfig) FirmwareAutoSelectionEnabled() bool {
 	return config.isFeatureGateEnabled(featuregate.FirmwareAutoSelection)
 }
+
+func (config *ClusterConfig) DataVolumeOwnershipProtectionEnabled() bool {
+	return config.isFeatureGateEnabled(featuregate.DataVolumeOwnershipProtection)
+}

--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -252,3 +252,7 @@ func (config *ClusterConfig) MigrationStallDetectionEnabled() bool {
 func (config *ClusterConfig) MigrationDowntimeTuningEnabled() bool {
 	return config.isFeatureGateEnabled(featuregate.MigrationDowntimeTuning)
 }
+
+func (config *ClusterConfig) DataVolumeOwnershipProtectionEnabled() bool {
+	return config.isFeatureGateEnabled(featuregate.DataVolumeOwnershipProtection)
+}

--- a/pkg/virt-config/featuregate/active.go
+++ b/pkg/virt-config/featuregate/active.go
@@ -271,6 +271,14 @@ const (
 	// FirmwareAutoSelection uses libvirt's firmware auto-selection feature for
 	// EFI Secure Boot instead of hardcoded OVMF firmware paths.
 	FirmwareAutoSelection = "FirmwareAutoSelection"
+
+	// Owner: sig-compute / @nhoriguchi
+	// Alpha: v1.10.0
+	//
+	// DataVolumeOwnershipProtection enables strict isolation of ownership handling
+	// for DataVolume, ensuring that existing DataVolumes are never reused by
+	// subsequent VM creation with dataVolumeTemplates.
+	DataVolumeOwnershipProtection = "DataVolumeOwnershipProtection"
 )
 
 func init() {
@@ -320,4 +328,5 @@ func init() {
 	RegisterFeatureGate(FeatureGate{Name: GraceIOVirtualization, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: IOMMUFDGate, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: FirmwareAutoSelection, State: Alpha})
+	RegisterFeatureGate(FeatureGate{Name: DataVolumeOwnershipProtection, State: Alpha})
 }

--- a/pkg/virt-config/featuregate/active.go
+++ b/pkg/virt-config/featuregate/active.go
@@ -283,6 +283,14 @@ const (
 	// PortRangesSpec enables the portRanges field, initially only on masquerade interfaces,
 	// allowing compact specification of contiguous port intervals to forward to the VM guest.
 	PortRangesSpec = "PortRangesSpec"
+
+	// Owner: sig-compute / @nhoriguchi
+	// Alpha: v1.10.0
+	//
+	// DataVolumeOwnershipProtection enables strict isolation of ownership handling
+	// for DataVolume, ensuring that existing DataVolumes are never reused by
+	// subsequent VM creation with dataVolumeTemplates.
+	DataVolumeOwnershipProtection = "DataVolumeOwnershipProtection"
 )
 
 func init() {
@@ -332,4 +340,5 @@ func init() {
 	RegisterFeatureGate(FeatureGate{Name: MigrationDowntimeTuning, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: CrossArchitectureVirtualization, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: PortRangesSpec, State: Alpha})
+	RegisterFeatureGate(FeatureGate{Name: DataVolumeOwnershipProtection, State: Alpha})
 }

--- a/pkg/virt-controller/watch/vm/vm.go
+++ b/pkg/virt-controller/watch/vm/vm.go
@@ -114,6 +114,10 @@ const (
 	// SourcePVCNotAvailabe is added in an event when the source PVC of a valid
 	// clone Datavolume doesn't exist
 	SourcePVCNotAvailabe = "SourcePVCNotAvailabe"
+
+	// DataVolumeNotOwnedByVM is added in an event when a VM's DVTemplate attempts to create
+	// a DataVolume that already exists and is not already owned by the VM.
+	DataVolumeNotOwnedByVM = "DataVolumeNotOwnedByVM"
 )
 
 const (
@@ -431,7 +435,16 @@ func (c *Controller) execute(key string) error {
 	}
 
 	if len(dataVolumes) != 0 {
-		dataVolumes, err = cm.ClaimMatchedDataVolumes(dataVolumes)
+		match := func(obj metav1.Object) bool {
+			if c.clusterConfig.DataVolumeOwnershipProtectionEnabled() {
+				dataVolume := obj.(*cdiv1.DataVolume)
+				_, ok := dataVolume.Labels[virtv1.CreatedByLabel]
+				return ok
+			} else {
+				return true
+			}
+		}
+		dataVolumes, err = cm.ClaimMatchedDataVolumes(dataVolumes, match)
 		if err != nil {
 			return err
 		}
@@ -509,6 +522,21 @@ func (c *Controller) authorizeDataVolume(vm *virtv1.VirtualMachine, dataVolume *
 	return nil
 }
 
+func (c *Controller) checkDataVolumeOwnership(vm *virtv1.VirtualMachine, curDataVolume *cdiv1.DataVolume) error {
+	if len(curDataVolume.OwnerReferences) == 0 {
+		c.recorder.Eventf(vm, k8score.EventTypeWarning, DataVolumeNotOwnedByVM, "Standalone DataVolume %s already exists", curDataVolume.Name)
+		return fmt.Errorf("requested DataVolume %s already exists as standalone one", curDataVolume.Name)
+	}
+
+	owner := curDataVolume.OwnerReferences[0]
+	if owner.Name != vm.Name {
+		c.recorder.Eventf(vm, k8score.EventTypeWarning, DataVolumeNotOwnedByVM, "DataVolume %s already exists and is not owned by another VM %s", curDataVolume.Name, owner.Name)
+		return fmt.Errorf("requested DataVolume %s is owned by another VM %s", curDataVolume.Name, owner.Name)
+	}
+
+	return nil
+}
+
 func (c *Controller) handleDataVolumes(vm *virtv1.VirtualMachine) (bool, error) {
 	ready := true
 	vmKey, err := controller.KeyFunc(vm)
@@ -554,6 +582,13 @@ func (c *Controller) handleDataVolumes(vm *virtv1.VirtualMachine) (bool, error) 
 			}
 			c.recorder.Eventf(vm, k8score.EventTypeNormal, SuccessfulDataVolumeCreateReason, "Created DataVolume %s", curDataVolume.Name)
 		} else {
+			if c.clusterConfig.DataVolumeOwnershipProtectionEnabled() {
+				err := c.checkDataVolumeOwnership(vm, curDataVolume)
+				if err != nil {
+					return false, err
+				}
+			}
+
 			switch curDataVolume.Status.Phase {
 			case cdiv1.Succeeded, cdiv1.WaitForFirstConsumer, cdiv1.PendingPopulation:
 				continue

--- a/pkg/virt-controller/watch/vm/vm_test.go
+++ b/pkg/virt-controller/watch/vm/vm_test.go
@@ -2820,6 +2820,56 @@ var _ = Describe("VirtualMachine", func() {
 			sanityExecute(vm)
 		})
 
+		It("should not adopt a DataVolume that was not created from the VM's template", func() {
+			vm, _ := watchtesting.DefaultVirtualMachine(false)
+			vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, v1.Volume{
+				Name: "test1",
+				VolumeSource: v1.VolumeSource{
+					DataVolume: &v1.DataVolumeSource{
+						Name: "dv1",
+					},
+				},
+			})
+
+			vm.Spec.DataVolumeTemplates = append(vm.Spec.DataVolumeTemplates, v1.DataVolumeTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "dv1",
+					Namespace: vm.Namespace,
+				},
+			})
+
+			vm, err := virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Create(context.TODO(), vm, metav1.CreateOptions{})
+			Expect(err).To(Succeed())
+			addVirtualMachine(vm)
+
+			standaloneDV := &cdiv1.DataVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "dv1",
+					Namespace: vm.Namespace,
+				},
+				Status: cdiv1.DataVolumeStatus{
+					Phase: cdiv1.Succeeded,
+				},
+			}
+			Expect(controller.dataVolumeStore.Add(standaloneDV)).To(Succeed())
+
+			sanityExecute(vm)
+
+			vm, err = virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
+			Expect(err).To(Succeed())
+
+			cond := virtcontroller.NewVirtualMachineConditionManager().GetCondition(vm, v1.VirtualMachineFailure)
+			Expect(cond).To(Not(BeNil()))
+			Expect(*cond).To(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+				"Type":    Equal(v1.VirtualMachineFailure),
+				"Reason":  Equal("FailedCreate"),
+				"Message": ContainSubstring("requested DataVolume dv1 already exists as standalone one"),
+				"Status":  Equal(k8sv1.ConditionTrue),
+			}))
+
+			testutils.ExpectEvent(recorder, DataVolumeNotOwnedByVM)
+		})
+
 		It("should detect that it has nothing to do beside updating the status", func() {
 			vm, vmi := watchtesting.DefaultVirtualMachine(true)
 


### PR DESCRIPTION
### What this PR does

This PR adds checks to detect and prevent reusing a DataVolume that was created statically via `spec.template.spec.volumes` or dynamically via `dataVolumeTemplates` by another VM.
Additionally, this modifies the behavior of `ClaimMatchedDataVolumes()` to avoid updating the `ownerReferences` of a static DataVolume when requested by a VM using `dataVolumeTemplates`, thereby preventing unexpected cascading deletion.

#### Before this PR:

There is no restriction preventing `dataVolumeTemplates` from allocating an existing DataVolume. As a result, an existing DataVolume can be overwritten and unexpectedly deleted when a VM requesting the DV with the same name is created and then deleted (resulting in data loss in some situation).

#### After this PR:

In the above situation, the VM is (properly) stuck in `WaitingForVolumeBinding` to avoid the data loss. End users have changes to find and fix their configuration.

### References

### Why we need it and why it was done in this way

We have 2 types of usage of DataVolume (DV):
1. create DV statically and let VM use it by specifying the name of DV in `spec.template.spec.volumes`. This approach is expected to persist and/or share data beyond the VM's lifecycle.
2. create VM and DV togather by configuring `spec.dataVolumeTemplates`. This approach aligns the DataVolume's lifecycle with the VM (dynamically created and deleted).

Considering that expected behaviors differ significantly between the two typical usages of DataVolumes, we cannot combine these two usages on one DataVolume. So we need some way to identify the usage of a DataVolume and make sure that a DV created in one way should not be used in another way.

We can use CreatedByLabel to judge in which way a DataVolume is created (CreatedByLabel is "none" for method 1 and vm.UID for method 2).
Similarly, we can also use ownerReferences (which is nil for method 1 and list of owners for method 2), but simply adding checks by ownerReferences on current code base does not work, becauses ownerReferences is not set at the time of DV creation and the setter function, ClaimMatchedDataVolumes, does not distinguish the way of creation.

So this PR first changes ClaimMatchedDataVolumes to prevent adopting static DataVolume to keep ownerReferences empty to avoid cascading delete.
Then, straightforwardly adding checks by ownerReferences do work.

### Special notes for your reviewer

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).


### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Prevent DataVolumes hijacking and deletion via dataVolumeTemplates behind DataVolumeOwnershipProtection feature gate (Alpha).
```