### PR TITLE
Recover VMI from hotplug attachment pod annotations

### DIFF
--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1041,6 +1041,10 @@ func (t *TemplateService) RenderHotplugAttachmentPodTemplate(volumes []*v1.Volum
 			Labels: map[string]string{
 				v1.AppLabel: hotplugDisk,
 			},
+			Annotations: map[string]string{
+				v1.OwnerVMINameAnnotation: vmi.Name,
+				v1.OwnerVMIUIDAnnotation:  string(vmi.UID),
+			},
 		},
 		Spec: k8sv1.PodSpec{
 			Containers: []k8sv1.Container{
@@ -1161,7 +1165,10 @@ func (t *TemplateService) RenderHotplugAttachmentTriggerPodTemplate(volume *v1.V
 		command = []string{"/bin/sh", "-c", "/usr/bin/container-disk --copy-path /path/hp"}
 	}
 
-	annotationsList := make(map[string]string)
+	annotationsList := map[string]string{
+		v1.OwnerVMINameAnnotation: vmi.Name,
+		v1.OwnerVMIUIDAnnotation:  string(vmi.UID),
+	}
 	if tempPod {
 		// mark pod as temp - only used for provisioning
 		annotationsList[v1.EphemeralProvisioningObject] = "true"

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -4664,10 +4664,11 @@ var _ = Describe("Template", func() {
 		It("should render owner VMI annotations on hotplug attachment pod", func() {
 			vmi := api.NewMinimalVMI("fake-vmi")
 			vmi.UID = "fake-vmi-uid"
-			vmi.Status.SelinuxContext = "test_u:test_r:test_t:s0"
 			ownerPod, err := svc.RenderLaunchManifest(vmi)
 			Expect(err).ToNot(HaveOccurred())
 
+			// Hotplug pod rendering requires an SELinux context; the value is not relevant to this annotation test.
+			vmi.Status.SelinuxContext = "test_u:test_r:test_t:s0"
 			pod, err := svc.RenderHotplugAttachmentPodTemplate([]*v1.Volume{}, ownerPod, vmi, map[string]*k8sv1.PersistentVolumeClaim{})
 			Expect(err).ToNot(HaveOccurred())
 
@@ -4678,10 +4679,11 @@ var _ = Describe("Template", func() {
 		It("should render owner VMI annotations on hotplug attachment trigger pods", func() {
 			vmi := api.NewMinimalVMI("fake-vmi")
 			vmi.UID = "fake-vmi-uid"
-			vmi.Status.SelinuxContext = "test_u:test_r:test_t:s0"
 			ownerPod, err := svc.RenderLaunchManifest(vmi)
 			Expect(err).ToNot(HaveOccurred())
 
+			// Hotplug pod rendering requires an SELinux context; the value is not relevant to this annotation test.
+			vmi.Status.SelinuxContext = "test_u:test_r:test_t:s0"
 			pod, err := svc.RenderHotplugAttachmentTriggerPodTemplate(&v1.Volume{}, ownerPod, vmi, "test", true, false)
 			Expect(err).ToNot(HaveOccurred())
 

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -4661,6 +4661,34 @@ var _ = Describe("Template", func() {
 			}))
 		})
 
+		It("should render owner VMI annotations on hotplug attachment pod", func() {
+			vmi := api.NewMinimalVMI("fake-vmi")
+			vmi.UID = "fake-vmi-uid"
+			vmi.Status.SelinuxContext = "test_u:test_r:test_t:s0"
+			ownerPod, err := svc.RenderLaunchManifest(vmi)
+			Expect(err).ToNot(HaveOccurred())
+
+			pod, err := svc.RenderHotplugAttachmentPodTemplate([]*v1.Volume{}, ownerPod, vmi, map[string]*k8sv1.PersistentVolumeClaim{})
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(pod.Annotations).To(HaveKeyWithValue(v1.OwnerVMINameAnnotation, vmi.Name))
+			Expect(pod.Annotations).To(HaveKeyWithValue(v1.OwnerVMIUIDAnnotation, string(vmi.UID)))
+		})
+
+		It("should render owner VMI annotations on hotplug attachment trigger pods", func() {
+			vmi := api.NewMinimalVMI("fake-vmi")
+			vmi.UID = "fake-vmi-uid"
+			vmi.Status.SelinuxContext = "test_u:test_r:test_t:s0"
+			ownerPod, err := svc.RenderLaunchManifest(vmi)
+			Expect(err).ToNot(HaveOccurred())
+
+			pod, err := svc.RenderHotplugAttachmentTriggerPodTemplate(&v1.Volume{}, ownerPod, vmi, "test", true, false)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(pod.Annotations).To(HaveKeyWithValue(v1.OwnerVMINameAnnotation, vmi.Name))
+			Expect(pod.Annotations).To(HaveKeyWithValue(v1.OwnerVMIUIDAnnotation, string(vmi.UID)))
+		})
+
 		It("should compute the correct tolerations when rendering hotplug attachment pods", func() {
 			vmi := api.NewMinimalVMI("fake-vmi")
 			duplicateToleration := []k8sv1.Toleration{{Key: "test", Operator: k8sv1.TolerationOpExists, Effect: k8sv1.TaintEffectNoSchedule},

--- a/pkg/virt-controller/watch/vmi/vmi.go
+++ b/pkg/virt-controller/watch/vmi/vmi.go
@@ -470,7 +470,6 @@ func (c *Controller) onPodDelete(obj interface{}) {
 		// Not all pods can have VMI ref at annotations, this is ok.
 		vmi = c.recoverVMIFromPodAnnotations(pod)
 		if vmi == nil {
-			log.Log.Object(pod).Warning("failed to recover owner VMI from annotations for pod; deletion sync may be delayed")
 			return
 		}
 		log.Log.Object(pod).V(3).Infof("recovered owner VMI %s from pod annotations", vmi.Name)

--- a/pkg/virt-controller/watch/vmi/vmi.go
+++ b/pkg/virt-controller/watch/vmi/vmi.go
@@ -466,7 +466,14 @@ func (c *Controller) onPodDelete(obj interface{}) {
 	controllerRef := v1.GetControllerOf(pod)
 	vmi := c.resolveControllerRef(pod.Namespace, controllerRef)
 	if vmi == nil {
-		return
+		// Recover the VMI from the owner annotations as a fallback strategy.
+		// Not all pods can have VMI ref at annotations, this is ok.
+		vmi = c.recoverVMIFromPodAnnotations(pod)
+		if vmi == nil {
+			log.Log.Object(pod).Warning("failed to recover owner VMI from annotations for pod; deletion sync may be delayed")
+			return
+		}
+		log.Log.Object(pod).V(3).Infof("recovered owner VMI %s from pod annotations", vmi.Name)
 	}
 	vmiKey, err := controller.KeyFunc(vmi)
 	if err != nil {
@@ -474,6 +481,29 @@ func (c *Controller) onPodDelete(obj interface{}) {
 	}
 	c.podExpectations.DeletionObserved(vmiKey, controller.PodKey(pod))
 	c.enqueueVirtualMachine(vmi)
+}
+
+// recoverVMIFromPodAnnotations is the fallback for when the owner chain cannot be
+// resolved; it recovers the VMI from the owner identity annotations on the pod.
+func (c *Controller) recoverVMIFromPodAnnotations(pod *k8sv1.Pod) *virtv1.VirtualMachineInstance {
+	name := pod.Annotations[virtv1.OwnerVMINameAnnotation]
+	uid := pod.Annotations[virtv1.OwnerVMIUIDAnnotation]
+	if name == "" || uid == "" {
+		return nil
+	}
+	obj, exists, err := c.vmiIndexer.GetByKey(controller.NamespacedKey(pod.Namespace, name))
+	if err != nil {
+		log.Log.Object(pod).Reason(err).Error("failed to look up owner VMI from indexer")
+		return nil
+	}
+	if !exists {
+		return nil
+	}
+	vmi := obj.(*virtv1.VirtualMachineInstance)
+	if string(vmi.UID) != uid {
+		return nil
+	}
+	return vmi
 }
 
 func (c *Controller) addVirtualMachineInstance(obj interface{}) {

--- a/pkg/virt-controller/watch/vmi/vmi.go
+++ b/pkg/virt-controller/watch/vmi/vmi.go
@@ -501,6 +501,7 @@ func (c *Controller) recoverVMIFromPodAnnotations(pod *k8sv1.Pod) *virtv1.Virtua
 	}
 	vmi := obj.(*virtv1.VirtualMachineInstance)
 	if string(vmi.UID) != uid {
+		log.Log.Object(pod).Warningf("owner VMI UID mismatch while recovering from pod annotations: expected %s, got %s", uid, vmi.UID)
 		return nil
 	}
 	return vmi

--- a/pkg/virt-controller/watch/vmi/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi/vmi_test.go
@@ -306,6 +306,69 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 		Expect(controller.dataVolumeIndexer.Add(dv)).To(Succeed())
 	}
 
+	Describe("recovering a VMI from pod owner annotations", func() {
+		It("should recover the VMI when the annotated owner identity matches", func() {
+			vmi := newPendingVirtualMachine("testvmi")
+			Expect(controller.vmiIndexer.Add(vmi)).To(Succeed())
+
+			pod := &k8sv1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "attachment-pod",
+					Namespace: vmi.Namespace,
+					Annotations: map[string]string{
+						virtv1.OwnerVMINameAnnotation: vmi.Name,
+						virtv1.OwnerVMIUIDAnnotation:  string(vmi.UID),
+					},
+				},
+			}
+
+			Expect(controller.recoverVMIFromPodAnnotations(pod)).To(Equal(vmi))
+		})
+
+		It("should not recover the VMI when the annotated owner UID does not match", func() {
+			vmi := newPendingVirtualMachine("testvmi")
+			Expect(controller.vmiIndexer.Add(vmi)).To(Succeed())
+
+			pod := &k8sv1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "attachment-pod",
+					Namespace: vmi.Namespace,
+					Annotations: map[string]string{
+						virtv1.OwnerVMINameAnnotation: vmi.Name,
+						virtv1.OwnerVMIUIDAnnotation:  "other-uid",
+					},
+				},
+			}
+
+			Expect(controller.recoverVMIFromPodAnnotations(pod)).To(BeNil())
+		})
+
+		It("should observe an attachment pod deletion when the virt-launcher pod is gone from the cache", func() {
+			vmi := newPendingVirtualMachine("testvmi")
+			Expect(controller.vmiIndexer.Add(vmi)).To(Succeed())
+			vmiKey := kvcontroller.VirtualMachineInstanceKey(vmi)
+
+			virtlauncherPod := newPodForVirtualMachine(vmi, k8sv1.PodRunning)
+			attachmentPod := newPodForVirtlauncher(virtlauncherPod, "attachment-pod", "attachment-uid", k8sv1.PodRunning)
+			attachmentPod.Annotations = map[string]string{
+				virtv1.OwnerVMINameAnnotation: vmi.Name,
+				virtv1.OwnerVMIUIDAnnotation:  string(vmi.UID),
+			}
+
+			controller.podExpectations.ExpectDeletions(vmiKey, []string{kvcontroller.PodKey(attachmentPod)})
+			Expect(controller.podExpectations.SatisfiedExpectations(vmiKey)).To(BeFalse())
+
+			controller.onPodDelete(attachmentPod)
+
+			Expect(controller.podExpectations.SatisfiedExpectations(vmiKey)).To(BeTrue())
+			Expect(mockQueue.Len()).To(Equal(1))
+			key, shutdown := mockQueue.Get()
+			Expect(shutdown).To(BeFalse())
+			Expect(key).To(Equal(vmiKey))
+			mockQueue.Done(key)
+		})
+	})
+
 	Context("On valid VirtualMachineInstance given with DataVolume source", func() {
 
 		dvVolumeSource := virtv1.VolumeSource{

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -1158,6 +1158,11 @@ const (
 	// Similar to kubevirt.io/domain. Used on Pod.
 	// Internal use only.
 	CreatedByLabel string = "kubevirt.io/created-by"
+	// Owner VMI name/UID recorded on a pod, used to recover the VMI when the
+	// owner chain cannot be resolved. Used on Pod.
+	// Internal use only.
+	OwnerVMINameAnnotation string = "kubevirt.io/owner-vmi-name"
+	OwnerVMIUIDAnnotation  string = "kubevirt.io/owner-vmi-uid"
 	// This label is used to indicate that this pod is the target of a migration job.
 	MigrationJobLabel string = "kubevirt.io/migrationJobUID"
 	// This label indicates the migration name that a PDB is protecting.


### PR DESCRIPTION
A hotplug attachment pod is owned by the virt-launcher pod, so its deletion can't be mapped back to the VMI once that pod leaves the cache. Stamp the owner VMI name/UID on hotplug pods and use them as a fallback.

### What this PR does
#### Before this PR:

If pod expectations are not met, the VMI sync stops early and runs again only on the next event. If no event wakes the VMI, the next check may happen only a few minutes later. This can delay VM/VMI deletion.

Today the owner is resolved through the k8s `controllerRef` chain:

`attachment pod` -> `virt-launcher pod` -> `VMI`

When the informer processes the attachment pod event, this chain may fail to resolve, because the virt-launcher pod can already be deleted. In that case the VMI is not notified.

#### After this PR:

The owner reference is stored directly in the attachment pod annotations and is used as a fallback when the chain cannot be resolved.

### References

- Partially addresses #18177

### Why we need it and why it was done in this way
The following tradeoffs were made:

- Two extra annotations on each attachment pod.
- The fallback has the same trust level as the existing `controllerRef` resolution: the value can be changed by anyone with permission to edit the pod.

The following alternatives were considered:

- Keeping a bidirectional `attachment pod <-> VMI` map inside `virt-controller`. This adds extra in-memory state and is more invasive.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

- Issue: https://github.com/kubevirt/kubevirt/issues/18177
- Re-enqueueing VMI sync PR: https://github.com/kubevirt/kubevirt/pull/18206

### Special notes for your reviewer

This PR is meant to start the discussion in issue #18177. If the approach looks valuable, I am ready to add tests.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed VMI owner resolution when an attachment pod is deleted while the virt-launcher pod is gone
```

