### PR TITLE
[Release-1.4] Improve handling of Windows VSS fsfreeze limitations

### DIFF
--- a/cmd/virt-freezer/BUILD.bazel
+++ b/cmd/virt-freezer/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/cmd/virt-freezer",
     visibility = ["//visibility:private"],
     deps = [
+        "//pkg/storage/snapshot:go_default_library",
         "//pkg/virt-handler/cmd-client:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",

--- a/cmd/virt-freezer/virt-freezer.go
+++ b/cmd/virt-freezer/virt-freezer.go
@@ -30,6 +30,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
 
+	"kubevirt.io/kubevirt/pkg/storage/snapshot"
 	cmdclient "kubevirt.io/kubevirt/pkg/virt-handler/cmd-client"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )
@@ -37,7 +38,6 @@ import (
 const (
 	gaNotAvailableError = "Guest agent not available for now"
 	windowsOS           = "windows"
-	freezeLimitReached  = "fsfreeze is limited"
 )
 
 type FreezerConfig struct {
@@ -140,7 +140,7 @@ func run(config *FreezerConfig, client cmdclient.LauncherClient) error {
 	} else {
 		err = client.UnfreezeVirtualMachine(vmi)
 		if err != nil {
-			if strings.Contains(err.Error(), freezeLimitReached) {
+			if strings.Contains(err.Error(), snapshot.VSSFreezeLimitReached) {
 				log.Log.Reason(err).Error("Unfreezing VMI failed, please try again. If problem continues, stop the VM and backup while down")
 			} else {
 				log.Log.Reason(err).Error("Unfreezing VMI failed")

--- a/pkg/storage/pod/annotations/generator.go
+++ b/pkg/storage/pod/annotations/generator.go
@@ -39,6 +39,7 @@ func (g Generator) Generate(vmi *v1.VirtualMachineInstance) (map[string]string, 
 			vmi.Name,
 			vmi.Namespace,
 		),
+		velero.PreBackupHookTimeoutAnnotation:    "60s",
 		velero.PostBackupHookContainerAnnotation: computeContainerName,
 		velero.PostBackupHookCommandAnnotation: fmt.Sprintf(
 			"[\"/usr/bin/virt-freezer\", \"--unfreeze\", \"--name\", %q, \"--namespace\", %q]",

--- a/pkg/storage/pod/annotations/generator_test.go
+++ b/pkg/storage/pod/annotations/generator_test.go
@@ -46,6 +46,7 @@ var _ = Describe("Annotations Generator", func() {
 		expectedAnnotations := map[string]string{
 			"pre.hook.backup.velero.io/container":  "compute",
 			"pre.hook.backup.velero.io/command":    expectedPreHookBackupCommand,
+			"pre.hook.backup.velero.io/timeout":    "60s",
 			"post.hook.backup.velero.io/container": "compute",
 			"post.hook.backup.velero.io/command":   expectedPostHookBackupCommand,
 		}

--- a/pkg/storage/snapshot/snapshot.go
+++ b/pkg/storage/snapshot/snapshot.go
@@ -483,6 +483,14 @@ func (ctrl *VMSnapshotController) updateVMSnapshotContent(content *snapshotv1.Vi
 
 		err = ctrl.unfreezeSource(vmSnapshot)
 		if err != nil {
+			if strings.Contains(err.Error(), VSSFreezeLimitReached) {
+				contentCpy.Status.CreationTime = nil
+				contentCpy.Status.Error = &snapshotv1.Error{
+					Time:    currentTime(),
+					Message: pointer.P(err.Error()),
+				}
+				return 5 * time.Second, ctrl.updateVmSnapshotContentStatus(content, contentCpy)
+			}
 			return 0, err
 		}
 	}
@@ -878,8 +886,8 @@ func updateSnapshotIndications(snapshot *snapshotv1.VirtualMachineSnapshot, sour
 			indications = sets.Insert(indications, snapshotv1.VMSnapshotGuestAgentIndication)
 			snapErr := snapshot.Status.Error
 			if snapErr != nil && snapErr.Message != nil &&
-				strings.Contains(*snapErr.Message, failedFreezeMsg) {
-				indications = sets.Insert(indications, snapshotv1.VMSnapshotQuiesceFailedIndication)
+				strings.Contains(*snapErr.Message, VSSFreezeLimitReached) {
+				indications = sets.Insert(indications, snapshotv1.VMSnapshotQuiesceTimeoutIndication)
 			}
 		} else {
 			indications = sets.Insert(indications, snapshotv1.VMSnapshotNoGuestAgentIndication)

--- a/pkg/storage/snapshot/snapshot_test.go
+++ b/pkg/storage/snapshot/snapshot_test.go
@@ -1480,12 +1480,11 @@ var _ = Describe("Snapshot controlleer", func() {
 				updatedContent := vmSnapshotContent.DeepCopy()
 				updatedContent.ResourceVersion = "1"
 				errorMessage := "Guest agent is not responding"
-				formatedErr := fmt.Sprintf("%s %s: %v", failedFreezeMsg, vm.Name, errorMessage)
 				updatedContent.Status = &snapshotv1.VirtualMachineSnapshotContentStatus{
 					ReadyToUse: pointer.P(false),
 					Error: &snapshotv1.Error{
 						Time:    timeFunc(),
-						Message: &formatedErr,
+						Message: &errorMessage,
 					},
 				}
 
@@ -1499,7 +1498,7 @@ var _ = Describe("Snapshot controlleer", func() {
 				Expect(*updateStatusCalls).To(Equal(1))
 			})
 
-			It("should set QuiesceFailed indication if error in content says failed freeze vm", func() {
+			It("should set QuiesceTimeout indication if error contains VSS freeze timeout", func() {
 				vm := createLockedVM()
 				vmSource.Add(vm)
 				vmi := createVMI(vm)
@@ -1511,9 +1510,8 @@ var _ = Describe("Snapshot controlleer", func() {
 				vmi.Status.Conditions = append(vmi.Status.Conditions, agentCondition)
 				vmiSource.Add(vmi)
 
-				errorMessage := "Guest agent is not responding"
-				formatedErr := fmt.Sprintf("%s %s: %v", failedFreezeMsg, vm.Name, errorMessage)
-				vmSnapshotContent := createErrorVMSnapshotContent(formatedErr)
+				// VSS timeout error during unfreeze - this should trigger QuiesceTimeout
+				vmSnapshotContent := createErrorVMSnapshotContent(VSSFreezeLimitReached)
 				vmSnapshotContentSource.Add(vmSnapshotContent)
 
 				vmSnapshot := createVMSnapshotInProgress()
@@ -1525,7 +1523,7 @@ var _ = Describe("Snapshot controlleer", func() {
 				updatedSnapshot.Status.Indications = []snapshotv1.Indication{
 					snapshotv1.VMSnapshotGuestAgentIndication,
 					snapshotv1.VMSnapshotOnlineSnapshotIndication,
-					snapshotv1.VMSnapshotQuiesceFailedIndication,
+					snapshotv1.VMSnapshotQuiesceTimeoutIndication,
 				}
 				updatedSnapshot.Status.Conditions = []snapshotv1.Condition{
 					newProgressingCondition(corev1.ConditionFalse, "In error state"),
@@ -1539,7 +1537,7 @@ var _ = Describe("Snapshot controlleer", func() {
 				Expect(*updateStatusCalls).To(Equal(1))
 			})
 
-			It("should not unset QuiesceFailed indication if freeze succeeded afterwards", func() {
+			It("should not unset QuiesceTimeout indication once set", func() {
 				vm := createLockedVM()
 				vmSource.Add(vm)
 				vmi := createVMI(vm)
@@ -1559,7 +1557,7 @@ var _ = Describe("Snapshot controlleer", func() {
 				vmSnapshot.Status.Indications = []snapshotv1.Indication{
 					snapshotv1.VMSnapshotGuestAgentIndication,
 					snapshotv1.VMSnapshotOnlineSnapshotIndication,
-					snapshotv1.VMSnapshotQuiesceFailedIndication,
+					snapshotv1.VMSnapshotQuiesceTimeoutIndication,
 				}
 				addVirtualMachineSnapshot(vmSnapshot)
 

--- a/pkg/storage/snapshot/source.go
+++ b/pkg/storage/snapshot/source.go
@@ -49,7 +49,9 @@ import (
 
 const (
 	sourceFinalizer = "snapshot.kubevirt.io/snapshot-source-protection"
-	failedFreezeMsg = "Failed freezing vm"
+	// VSSFreezeLimitReached is the error substring returned by the QEMU guest agent
+	// when Windows VSS cannot hold the freeze long enough (10-second VSS limitation).
+	VSSFreezeLimitReached = "fsfreeze is limited"
 )
 
 type snapshotSource interface {
@@ -384,9 +386,8 @@ func (s *vmSnapshotSource) Freeze() error {
 	err = s.controller.Client.VirtualMachineInstance(s.vm.Namespace).Freeze(context.Background(), s.vm.Name, getFailureDeadline(s.snapshot))
 	timeTrack(startTime, fmt.Sprintf("Freezing vmi %s", s.vm.Name))
 	if err != nil {
-		formattedErr := fmt.Errorf("%s %s: %v", failedFreezeMsg, s.vm.Name, err)
-		log.Log.Errorf(formattedErr.Error())
-		return formattedErr
+		log.Log.Errorf("Failed freezing vm %s: %v", s.vm.Name, err)
+		return err
 	}
 
 	return nil
@@ -415,6 +416,7 @@ func (s *vmSnapshotSource) Unfreeze() error {
 	defer timeTrack(time.Now(), fmt.Sprintf("Unfreezing vmi %s", s.vm.Name))
 	err = s.controller.Client.VirtualMachineInstance(s.vm.Namespace).Unfreeze(context.Background(), s.vm.Name)
 	if err != nil {
+		log.Log.Errorf("Failed unfreezing vm %s: %v", s.vm.Name, err)
 		return err
 	}
 

--- a/pkg/storage/velero/annotations.go
+++ b/pkg/storage/velero/annotations.go
@@ -27,6 +27,9 @@ const (
 	// PreBackupHookCommandAnnotation specifies the command to execute.
 	PreBackupHookCommandAnnotation = "pre.hook.backup.velero.io/command"
 
+	// PreBackupHookTimeoutAnnotation specifies how long to wait for the pre-hook to complete.
+	PreBackupHookTimeoutAnnotation = "pre.hook.backup.velero.io/timeout"
+
 	// PostBackupHookContainerAnnotation specifies the container where the command should be executed.
 	PostBackupHookContainerAnnotation = "post.hook.backup.velero.io/container"
 

--- a/pkg/virt-handler/cmd-client/client.go
+++ b/pkg/virt-handler/cmd-client/client.go
@@ -122,8 +122,9 @@ type VirtLauncherClient struct {
 }
 
 const (
-	shortTimeout time.Duration = 5 * time.Second
-	longTimeout  time.Duration = 20 * time.Second
+	shortTimeout    time.Duration = 5 * time.Second
+	longTimeout     time.Duration = 20 * time.Second
+	extendedTimeout time.Duration = 60 * time.Second
 )
 
 func SetBaseDir(dir string) {
@@ -383,7 +384,8 @@ func (c *VirtLauncherClient) FreezeVirtualMachine(vmi *v1.VirtualMachineInstance
 		UnfreezeTimeoutSeconds: unfreezeTimeoutSeconds,
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), longTimeout)
+	// Use extended timeout as Windows VSS can take up to 60 seconds
+	ctx, cancel := context.WithTimeout(context.Background(), extendedTimeout)
 	defer cancel()
 	response, err := c.v1client.FreezeVirtualMachine(ctx, request)
 

--- a/pkg/virt-launcher/virtwrap/cli/generated_mock_libvirt.go
+++ b/pkg/virt-launcher/virtwrap/cli/generated_mock_libvirt.go
@@ -624,3 +624,23 @@ func (_m *MockVirDomain) SetLaunchSecurityState(params *libvirt.DomainLaunchSecu
 func (_mr *_MockVirDomainRecorder) SetLaunchSecurityState(arg0, arg1 interface{}) *gomock.Call {
 	return _mr.mock.ctrl.RecordCall(_mr.mock, "SetLaunchSecurityState", arg0, arg1)
 }
+
+func (_m *MockVirDomain) FSFreeze(mounts []string, flags uint32) error {
+	ret := _m.ctrl.Call(_m, "FSFreeze", mounts, flags)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockVirDomainRecorder) FSFreeze(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "FSFreeze", arg0, arg1)
+}
+
+func (_m *MockVirDomain) FSThaw(mounts []string, flags uint32) error {
+	ret := _m.ctrl.Call(_m, "FSThaw", mounts, flags)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+func (_mr *_MockVirDomainRecorder) FSThaw(arg0, arg1 interface{}) *gomock.Call {
+	return _mr.mock.ctrl.RecordCall(_mr.mock, "FSThaw", arg0, arg1)
+}

--- a/pkg/virt-launcher/virtwrap/cli/libvirt.go
+++ b/pkg/virt-launcher/virtwrap/cli/libvirt.go
@@ -534,6 +534,8 @@ type VirDomain interface {
 	SetVcpusFlags(vcpu uint, flags libvirt.DomainVcpuFlags) error
 	GetLaunchSecurityInfo(flags uint32) (*libvirt.DomainLaunchSecurityParameters, error)
 	SetLaunchSecurityState(params *libvirt.DomainLaunchSecurityStateParameters, flags uint32) error
+	FSFreeze(mounts []string, flags uint32) error
+	FSThaw(mounts []string, flags uint32) error
 }
 
 func NewConnection(uri string, user string, pass string, checkInterval time.Duration) (Connection, error) {

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -1754,8 +1754,15 @@ func (l *LibvirtDomainManager) FreezeVMI(vmi *v1.VirtualMachineInstance, unfreez
 			return err
 		}
 	}
-	_, err = l.virConn.QemuAgentCommand(`{"execute":"guest-fsfreeze-freeze"}`, domainName)
+
+	domain, err := l.virConn.LookupDomainByName(domainName)
 	if err != nil {
+		log.Log.Errorf("Domain lookup failed: %v", err)
+		return err
+	}
+	defer domain.Free()
+
+	if err := domain.FSFreeze(nil, 0); err != nil {
 		log.Log.Errorf("Failed to freeze vmi, %s", err.Error())
 		return err
 	}
@@ -1777,9 +1784,15 @@ func (l *LibvirtDomainManager) UnfreezeVMI(vmi *v1.VirtualMachineInstance) error
 			return nil
 		}
 	}
-	// even if failed we should still try to unfreeze the fs
-	_, err = l.virConn.QemuAgentCommand(`{"execute":"guest-fsfreeze-thaw"}`, domainName)
+
+	domain, err := l.virConn.LookupDomainByName(domainName)
 	if err != nil {
+		log.Log.Errorf("Domain lookup failed: %v", err)
+		return err
+	}
+	defer domain.Free()
+
+	if err := domain.FSThaw(nil, 0); err != nil {
 		log.Log.Errorf("Failed to unfreeze vmi, %s", err.Error())
 		return err
 	}

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -585,7 +585,9 @@ var _ = Describe("Manager", func() {
 			vmi := newVMI(testNamespace, testVmName)
 
 			mockConn.EXPECT().QemuAgentCommand(`{"execute":"`+string(agentpoller.GET_FSFREEZE_STATUS)+`"}`, testDomainName).Return(expectedThawedOutput, nil)
-			mockConn.EXPECT().QemuAgentCommand(`{"execute":"guest-fsfreeze-freeze"}`, testDomainName).Return("1", nil)
+			mockConn.EXPECT().LookupDomainByName(testDomainName).Return(mockDomain, nil).Times(1)
+			mockDomain.EXPECT().Free().Times(1)
+			mockDomain.EXPECT().FSFreeze(nil, uint32(0)).Times(1)
 			manager, _ := NewLibvirtDomainManager(mockConn, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock, metadataCache, nil)
 
 			Expect(manager.FreezeVMI(vmi, 0)).To(Succeed())
@@ -605,7 +607,9 @@ var _ = Describe("Manager", func() {
 			vmi := newVMI(testNamespace, testVmName)
 
 			mockConn.EXPECT().QemuAgentCommand(`{"execute":"`+string(agentpoller.GET_FSFREEZE_STATUS)+`"}`, testDomainName).Return(expectedFrozenOutput, nil)
-			mockConn.EXPECT().QemuAgentCommand(`{"execute":"guest-fsfreeze-thaw"}`, testDomainName).Return("1", nil)
+			mockConn.EXPECT().LookupDomainByName(testDomainName).Return(mockDomain, nil).Times(1)
+			mockDomain.EXPECT().Free().Times(1)
+			mockDomain.EXPECT().FSThaw(nil, uint32(0)).Times(1)
 			manager, _ := NewLibvirtDomainManager(mockConn, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock, metadataCache, nil)
 
 			Expect(manager.UnfreezeVMI(vmi)).To(Succeed())
@@ -614,9 +618,11 @@ var _ = Describe("Manager", func() {
 			vmi := newVMI(testNamespace, testVmName)
 
 			mockConn.EXPECT().QemuAgentCommand(`{"execute":"`+string(agentpoller.GET_FSFREEZE_STATUS)+`"}`, testDomainName).Return(expectedThawedOutput, nil)
-			mockConn.EXPECT().QemuAgentCommand(`{"execute":"guest-fsfreeze-freeze"}`, testDomainName).Return("1", nil)
 			mockConn.EXPECT().QemuAgentCommand(`{"execute":"`+string(agentpoller.GET_FSFREEZE_STATUS)+`"}`, testDomainName).Return(expectedFrozenOutput, nil)
-			mockConn.EXPECT().QemuAgentCommand(`{"execute":"guest-fsfreeze-thaw"}`, testDomainName).Return("1", nil)
+			mockConn.EXPECT().LookupDomainByName(testDomainName).Return(mockDomain, nil).Times(2)
+			mockDomain.EXPECT().Free().Times(2)
+			mockDomain.EXPECT().FSFreeze(nil, uint32(0)).Times(1)
+			mockDomain.EXPECT().FSThaw(nil, uint32(0)).Times(1)
 			manager, _ := NewLibvirtDomainManager(mockConn, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock, metadataCache, nil)
 
 			var unfreezeTimeout time.Duration = 3 * time.Second
@@ -628,9 +634,11 @@ var _ = Describe("Manager", func() {
 			vmi := newVMI(testNamespace, testVmName)
 
 			mockConn.EXPECT().QemuAgentCommand(`{"execute":"`+string(agentpoller.GET_FSFREEZE_STATUS)+`"}`, testDomainName).Return(expectedThawedOutput, nil)
-			mockConn.EXPECT().QemuAgentCommand(`{"execute":"guest-fsfreeze-freeze"}`, testDomainName).Return("1", nil)
 			mockConn.EXPECT().QemuAgentCommand(`{"execute":"`+string(agentpoller.GET_FSFREEZE_STATUS)+`"}`, testDomainName).Return(expectedFrozenOutput, nil)
-			mockConn.EXPECT().QemuAgentCommand(`{"execute":"guest-fsfreeze-thaw"}`, testDomainName).Return("1", nil)
+			mockConn.EXPECT().LookupDomainByName(testDomainName).Return(mockDomain, nil).Times(2)
+			mockDomain.EXPECT().Free().Times(2)
+			mockDomain.EXPECT().FSFreeze(nil, uint32(0)).Times(1)
+			mockDomain.EXPECT().FSThaw(nil, uint32(0)).Times(1)
 
 			manager, _ := NewLibvirtDomainManager(mockConn, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock, metadataCache, nil)
 

--- a/staging/src/kubevirt.io/api/snapshot/v1alpha1/types.go
+++ b/staging/src/kubevirt.io/api/snapshot/v1alpha1/types.go
@@ -80,6 +80,7 @@ const (
 	VMSnapshotOnlineSnapshotIndication Indication = "Online"
 	VMSnapshotNoGuestAgentIndication   Indication = "NoGuestAgent"
 	VMSnapshotGuestAgentIndication     Indication = "GuestAgent"
+	VMSnapshotQuiesceTimeoutIndication Indication = "QuiesceTimeout"
 )
 
 // VirtualMachineSnapshotPhase is the current phase of the VirtualMachineSnapshot

--- a/staging/src/kubevirt.io/api/snapshot/v1beta1/types.go
+++ b/staging/src/kubevirt.io/api/snapshot/v1beta1/types.go
@@ -80,7 +80,7 @@ const (
 	VMSnapshotOnlineSnapshotIndication Indication = "Online"
 	VMSnapshotNoGuestAgentIndication   Indication = "NoGuestAgent"
 	VMSnapshotGuestAgentIndication     Indication = "GuestAgent"
-	VMSnapshotQuiesceFailedIndication  Indication = "QuiesceFailed"
+	VMSnapshotQuiesceTimeoutIndication Indication = "QuiesceTimeout"
 	VMSnapshotPausedIndication         Indication = "Paused"
 )
 


### PR DESCRIPTION
Manual Backports of  #16653 and #14530 

these backports are in same PR as they are logically related/needed.
some missing/added files  required manual intervention.

PRs #14530 is included because release-1.5 uses QemuAgentCommand for freeze/thaw operations, which has a 5-second default timeout. This is too short for Windows VSS operations. The refactor switches to libvirt's domain API which waits indefinitely for the operation to complete, avoiding premature timeouts.

---

```release-note
Handle fsfreeze related timeout issues
```