### PR TITLE
linter: forbid Update/UpdateStatus in tests, prefer Patch

### DIFF
--- a/hack/linter/.golangci.yml
+++ b/hack/linter/.golangci.yml
@@ -45,6 +45,12 @@ linters:
             Runtime skips silently suppress tests, making it easy to
             unknowingly stop running tests you care about.
             Labeling shifts the choice of what to run to the test executor.
+        - pattern: \.(Update|UpdateStatus)$
+          pkg: ^(kubevirt\.io/client-go/|k8s\.io/client-go/|github\.com/openshift/client-go/|sigs\.k8s\.io/controller-runtime/)
+          msg: >-
+            Use Patch/PatchStatus instead of Update/UpdateStatus.
+            Most often, tests do not really need to use Update (for an
+            atomic change) and Patch would be quicker and more precise.
     funlen:
       lines: 100
       statements: 50
@@ -111,6 +117,10 @@ linters:
       - legacy
       - std-error-handling
     rules:
+      - linters:
+          - forbidigo
+        path-except: 'tests/'
+        text: 'Use Patch/PatchStatus instead of Update/UpdateStatus'
       - linters:
           - staticcheck
         text: 'SA1019: checks.SkipTestIfNoCPUManager'

--- a/tests/framework/checks/fails.go
+++ b/tests/framework/checks/fails.go
@@ -25,7 +25,7 @@ func RecycleImageOrFail(virtClient kubecli.KubevirtClient, imageName string) {
 		ginkgo.Fail(fmt.Sprintf("Skip tests that requires PV %s", imageName))
 	} else if windowsPv.Status.Phase == k8sv1.VolumeReleased {
 		windowsPv.Spec.ClaimRef = nil
-		_, err = virtClient.CoreV1().PersistentVolumes().Update(context.Background(), windowsPv, metav1.UpdateOptions{})
+		_, err = virtClient.CoreV1().PersistentVolumes().Update(context.Background(), windowsPv, metav1.UpdateOptions{}) //nolint:forbidigo
 		gomega.Expect(err).ToNot(gomega.HaveOccurred())
 	}
 }

--- a/tests/infrastructure/security.go
+++ b/tests/infrastructure/security.go
@@ -98,7 +98,7 @@ var _ = Describe(SIGSerial("Node Restriction", decorators.RequiresTwoSchedulable
 			g.Expect(err).ToNot(HaveOccurred())
 
 			vmiScoped.Labels["allowed.io"] = "value"
-			_, err = handlerClient.VirtualMachineInstance(vmi.Namespace).Update(context.TODO(), vmiScoped, metav1.UpdateOptions{})
+			_, err = handlerClient.VirtualMachineInstance(vmi.Namespace).Update(context.TODO(), vmiScoped, metav1.UpdateOptions{}) //nolint:forbidigo
 			return err
 		}, 10*time.Second, time.Second).Should(MatchError(
 			ContainSubstring("Node restriction, virt-handler is only allowed to modify VMIs it owns"),

--- a/tests/migration/namespace.go
+++ b/tests/migration/namespace.go
@@ -168,7 +168,7 @@ var _ = Describe(SIG("Live Migration across namespaces", decorators.RequiresDece
 	updateRunStrategy := func(vm *virtv1.VirtualMachine, strategy *virtv1.VirtualMachineRunStrategy) {
 		Eventually(func() error {
 			vm.Spec.RunStrategy = strategy
-			_, err = virtClient.VirtualMachine(vm.Namespace).Update(context.Background(), vm, metav1.UpdateOptions{})
+			_, err = virtClient.VirtualMachine(vm.Namespace).Update(context.Background(), vm, metav1.UpdateOptions{}) //nolint:forbidigo
 			if err != nil {
 				// Ignore the error from the get.
 				vm, _ = virtClient.VirtualMachine(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})

--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -373,7 +373,7 @@ var _ = Describe("[sig-operator]Operator", Serial, decorators.SigOperator, func(
 			service.Spec.Ports[0].Port = 123
 
 			By("Update service with undesired port")
-			service, err = virtClient.CoreV1().Services(originalKv.Namespace).Update(context.Background(), service, metav1.UpdateOptions{})
+			service, err = virtClient.CoreV1().Services(originalKv.Namespace).Update(context.Background(), service, metav1.UpdateOptions{}) //nolint:forbidigo
 			Expect(err).ToNot(HaveOccurred())
 			Expect(service.Spec.Ports[0].Port).To(Equal(int32(123)))
 
@@ -607,7 +607,7 @@ var _ = Describe("[sig-operator]Operator", Serial, decorators.SigOperator, func(
 			kv, err := virtClient.KubeVirt(originalKv.Namespace).Get(context.Background(), originalKv.Name, metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			kv.Spec.ImagePullSecrets = imagePullSecrets
-			kv, err = virtClient.KubeVirt(originalKv.Namespace).Update(context.Background(), kv, metav1.UpdateOptions{})
+			kv, err = virtClient.KubeVirt(originalKv.Namespace).Update(context.Background(), kv, metav1.UpdateOptions{}) //nolint:forbidigo
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for virt-operator to apply changes to component")
@@ -629,7 +629,7 @@ var _ = Describe("[sig-operator]Operator", Serial, decorators.SigOperator, func(
 			kv, err = virtClient.KubeVirt(originalKv.Namespace).Get(context.Background(), originalKv.Name, metav1.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			kv.Spec.ImagePullSecrets = []k8sv1.LocalObjectReference{}
-			kv, err = virtClient.KubeVirt(originalKv.Namespace).Update(context.Background(), kv, metav1.UpdateOptions{})
+			kv, err = virtClient.KubeVirt(originalKv.Namespace).Update(context.Background(), kv, metav1.UpdateOptions{}) //nolint:forbidigo
 			Expect(err).NotTo(HaveOccurred())
 
 			By("Waiting for virt-operator to apply changes to component")
@@ -2298,7 +2298,7 @@ var _ = Describe("[sig-operator]Operator", Serial, decorators.SigOperator, func(
 					},
 				}
 
-				instancetype, err = virtClient.VirtualMachineClusterInstancetype().Update(context.Background(), instancetype, metav1.UpdateOptions{})
+				instancetype, err = virtClient.VirtualMachineClusterInstancetype().Update(context.Background(), instancetype, metav1.UpdateOptions{}) //nolint:forbidigo
 				Expect(err).ToNot(HaveOccurred())
 				Expect(instancetype.Annotations).To(HaveKeyWithValue(keyTest, valModified))
 				Expect(instancetype.Labels).To(HaveKeyWithValue(keyTest, valModified))
@@ -2329,7 +2329,7 @@ var _ = Describe("[sig-operator]Operator", Serial, decorators.SigOperator, func(
 					},
 				}
 
-				preference, err = virtClient.VirtualMachineClusterPreference().Update(context.Background(), preference, metav1.UpdateOptions{})
+				preference, err = virtClient.VirtualMachineClusterPreference().Update(context.Background(), preference, metav1.UpdateOptions{}) //nolint:forbidigo
 				Expect(err).ToNot(HaveOccurred())
 				Expect(preference.Annotations).To(HaveKeyWithValue(keyTest, valModified))
 				Expect(preference.Labels).To(HaveKeyWithValue(keyTest, valModified))

--- a/tests/storage/export.go
+++ b/tests/storage/export.go
@@ -2272,7 +2272,7 @@ var _ = Describe(SIG("Export", func() {
 		vm, err = virtClient.VirtualMachine(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		libstorage.AddDataVolume(vm, "blank-disk", dv)
-		vm, err = virtClient.VirtualMachine(vm.Namespace).Update(context.Background(), vm, metav1.UpdateOptions{})
+		vm, err = virtClient.VirtualMachine(vm.Namespace).Update(context.Background(), vm, metav1.UpdateOptions{}) //nolint:forbidigo
 		Expect(err).ToNot(HaveOccurred())
 		if libstorage.IsStorageClassBindingModeWaitForFirstConsumer(sc) {
 			// With WFFC we expect the volume to not be populated and the condition to be not ready and reason populating

--- a/tests/storage/objectgraph_test.go
+++ b/tests/storage/objectgraph_test.go
@@ -243,7 +243,7 @@ var _ = Describe("[sig-storage]ObjectGraph", decorators.SigStorage, func() {
 					},
 				},
 			})
-			vm, err = virtClient.VirtualMachine(vm.Namespace).Update(context.Background(), vm, metav1.UpdateOptions{})
+			vm, err = virtClient.VirtualMachine(vm.Namespace).Update(context.Background(), vm, metav1.UpdateOptions{}) //nolint:forbidigo
 			Expect(err).ToNot(HaveOccurred())
 
 			vm = libvmops.StartVirtualMachine(vm)

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -1306,7 +1306,7 @@ var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 				} else {
 					pvc.OwnerReferences = nil
 				}
-				_, err = virtClient.CoreV1().PersistentVolumeClaims(vm.Namespace).Update(context.Background(), pvc, metav1.UpdateOptions{})
+				_, err = virtClient.CoreV1().PersistentVolumeClaims(vm.Namespace).Update(context.Background(), pvc, metav1.UpdateOptions{}) //nolint:forbidigo
 				Expect(err).ToNot(HaveOccurred())
 				doRestore("", console.LoginToAlpine, offlineSnaphot, getTargetVMName(restoreToNewVM, newVmName))
 				Expect(restore.Status.Restores).To(HaveLen(1))

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -889,7 +889,7 @@ var _ = Describe(SIG("VirtualMachineSnapshot Tests", func() {
 				// zero out the times to be able to compare after
 				clearConditionsTimestamps(origStatus.Conditions)
 				ss.Status = nil
-				ss, err = virtClient.VirtualMachineSnapshot(ss.Namespace).UpdateStatus(context.Background(), ss, metav1.UpdateOptions{})
+				ss, err = virtClient.VirtualMachineSnapshot(ss.Namespace).UpdateStatus(context.Background(), ss, metav1.UpdateOptions{}) //nolint:forbidigo
 				Expect(err).ToNot(HaveOccurred())
 				Expect(ss.Status).To(BeNil())
 

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -645,7 +645,7 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 						},
 					},
 				}
-				_, err = kubevirt.Client().KubeVirt(kv.Namespace).Update(context.Background(), kv, metav1.UpdateOptions{})
+				_, err = kubevirt.Client().KubeVirt(kv.Namespace).Update(context.Background(), kv, metav1.UpdateOptions{}) //nolint:forbidigo
 				Expect(err).ToNot(HaveOccurred(), "Should update kubevirt infra placement")
 
 				Eventually(func() error {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Most test code does not need the atomicity of Update (HTTP PUT), which
replaces the entire resource and risks racing with concurrent changes.
Patch is quicker and more precise, modifying only the specified fields.

Add a forbidigo rule to enforce this convention, which has been adopted
incrementally through many prior conversions:
- 885e883274 operator tests: use patch instead of update
- ecec3a3540 tests/operator, test_id:3145: Replace Update with Patch
- 1ca4b502e1 tests/instancetype/upgrade: Replace Update with Patch
- 8fa35eca05 e2e,storage migration,UpdateVMWithDV: Replace client update with patch
- 15007bb808 Refactor updateVMRunningStatus so it uses Patch instead of Update

Existing Update/UpdateStatus calls in tests are grandfathered with
//nolint:forbidigo. The rule is suppressed in cmd/ and pkg/ via an
exclusion rule.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

