### PR TITLE
linter: suppress mnd for Log.V calls via exclusion rule

### DIFF
--- a/hack/linter/.golangci.yml
+++ b/hack/linter/.golangci.yml
@@ -112,6 +112,9 @@ linters:
       - linters:
           - staticcheck
         text: 'SA1019: checks.SkipTestIfNoCPUManager'
+      - linters:
+          - mnd
+        source: 'Log\.V\('
     paths:
       - third_party$
       - builtin$

--- a/pkg/network/setup/launcher/configurator.go
+++ b/pkg/network/setup/launcher/configurator.go
@@ -153,7 +153,7 @@ func (n *VMNetworkConfigurator) ensureDHCP(iface *v1.Interface, network *v1.Netw
 		log.Log.Reason(err).Errorf("failed to get a dhcp configuration for: %s", podIfaceName)
 		return err
 	}
-	log.Log.V(4).Infof("The imported dhcpConfig: %s", dhcpConfig.String()) //nolint:mnd
+	log.Log.V(4).Infof("The imported dhcpConfig: %s", dhcpConfig.String())
 	if err := configurator.EnsureDHCPServerStarted(podIfaceName, *dhcpConfig, iface.DHCPOptions); err != nil {
 		log.Log.Reason(err).Criticalf("failed to ensure dhcp service running for: %s", podIfaceName)
 		panic(err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
The mnd linter's ignored-functions cannot match chained selectors like log.Log.V because go-mnd only handles single-level package.Function patterns. Use a source-based exclusion rule instead of a per-line nolint directive.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->
https://github.com/kubevirt/kubevirt/pull/17940#discussion_r3395101302

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

