### PR TITLE
Split virt-launcher-monitor flags from Command to Args

### DIFF
--- a/pkg/virt-controller/services/rendercontainer.go
+++ b/pkg/virt-controller/services/rendercontainer.go
@@ -34,6 +34,7 @@ type ContainerSpecRenderer struct {
 	readinessProbe    *k8sv1.Probe
 	ports             []k8sv1.ContainerPort
 	capabilities      *k8sv1.Capabilities
+	command           []string
 	args              []string
 	extraEnvVars      []k8sv1.EnvVar
 }
@@ -52,13 +53,13 @@ func NewContainerSpecRenderer(containerName string, launcherImg string, imgPullP
 	return computeContainerSpec
 }
 
-func (csr *ContainerSpecRenderer) Render(cmd []string) k8sv1.Container {
+func (csr *ContainerSpecRenderer) Render() k8sv1.Container {
 	return k8sv1.Container{
 		Name:                     csr.name,
 		Image:                    csr.launcherImg,
 		ImagePullPolicy:          csr.imgPullPolicy,
 		SecurityContext:          securityContext(csr.userID, csr.capabilities),
-		Command:                  cmd,
+		Command:                  csr.command,
 		VolumeDevices:            csr.volumeDevices,
 		VolumeMounts:             csr.volumeMounts,
 		Resources:                csr.resources,
@@ -155,6 +156,12 @@ func WithResourceRequirements(resources k8sv1.ResourceRequirements) Option {
 func WithPorts(vmi *v1.VirtualMachineInstance) Option {
 	return func(renderer *ContainerSpecRenderer) {
 		renderer.ports = containerPortsFromVMI(vmi)
+	}
+}
+
+func WithCommand(command []string) Option {
+	return func(renderer *ContainerSpecRenderer) {
+		renderer.command = command
 	}
 }
 

--- a/pkg/virt-controller/services/rendercontainer_test.go
+++ b/pkg/virt-controller/services/rendercontainer_test.go
@@ -29,11 +29,11 @@ var _ = Describe("Container spec renderer", func() {
 
 	Context("with non root user option", func() {
 		BeforeEach(func() {
-			specRenderer = NewContainerSpecRenderer(containerName, img, pullPolicy, WithNonRoot(nonRootUser))
+			specRenderer = NewContainerSpecRenderer(containerName, img, pullPolicy, WithCommand(exampleCommand), WithNonRoot(nonRootUser))
 		})
 
 		It("should feature the XDG environment variables", func() {
-			Expect(specRenderer.Render(exampleCommand).Env).Should(
+			Expect(specRenderer.Render().Env).Should(
 				ConsistOf(
 					k8sv1.EnvVar{
 						Name:  cacheHomeEnvVarName,
@@ -56,11 +56,11 @@ var _ = Describe("Container spec renderer", func() {
 		}
 		Context("a VMI running as root", func() {
 			BeforeEach(func() {
-				specRenderer = NewContainerSpecRenderer(containerName, img, pullPolicy, WithCapabilities(simplestVMI()))
+				specRenderer = NewContainerSpecRenderer(containerName, img, pullPolicy, WithCommand(exampleCommand), WithCapabilities(simplestVMI()))
 			})
 
 			It("must request to add the NET_BIND_SERVICE and SYS_NICE capabilities", func() {
-				Expect(specRenderer.Render(exampleCommand).SecurityContext.Capabilities.Add).To(
+				Expect(specRenderer.Render().SecurityContext.Capabilities.Add).To(
 					ConsistOf(allowedCapabilities))
 			})
 
@@ -71,11 +71,11 @@ var _ = Describe("Container spec renderer", func() {
 						containerName,
 						img,
 						pullPolicy,
-						WithCapabilities(vmiWithVirtioFS(rootUser)))
+						WithCommand(exampleCommand), WithCapabilities(vmiWithVirtioFS(rootUser)))
 				})
 
 				It("cannot request additional capabilities", func() {
-					Expect(specRenderer.Render(exampleCommand).SecurityContext.Capabilities.Add).Should(
+					Expect(specRenderer.Render().SecurityContext.Capabilities.Add).Should(
 						ConsistOf(allowedCapabilities))
 				})
 			})
@@ -88,11 +88,11 @@ var _ = Describe("Container spec renderer", func() {
 					containerName,
 					img,
 					pullPolicy,
-					WithCapabilities(nonRootVMI(nonRootUser)))
+					WithCommand(exampleCommand), WithCapabilities(nonRootVMI(nonRootUser)))
 			})
 
 			It("must request the NET_BIND_SERVICE capability", func() {
-				Expect(specRenderer.Render(exampleCommand).SecurityContext.Capabilities.Add).Should(
+				Expect(specRenderer.Render().SecurityContext.Capabilities.Add).Should(
 					ConsistOf(k8sv1.Capability(CAP_NET_BIND_SERVICE)))
 			})
 		})
@@ -105,8 +105,8 @@ var _ = Describe("Container spec renderer", func() {
 		)
 
 		DescribeTable("the expected `VolumeDevice`s are rendered into the container", func(devices ...k8sv1.VolumeDevice) {
-			specRenderer = NewContainerSpecRenderer(containerName, img, pullPolicy, WithVolumeDevices(devices...))
-			Expect(specRenderer.Render(exampleCommand).VolumeDevices).To(ConsistOf(devices))
+			specRenderer = NewContainerSpecRenderer(containerName, img, pullPolicy, WithCommand(exampleCommand), WithVolumeDevices(devices...))
+			Expect(specRenderer.Render().VolumeDevices).To(ConsistOf(devices))
 		},
 			Entry("no volume devices are passed as options"),
 			Entry("one optional volume device is added to the renderer", volumeDevice(volumeName, volumePath)),
@@ -120,8 +120,8 @@ var _ = Describe("Container spec renderer", func() {
 		)
 
 		DescribeTable("the expected `VolumeMount`s are rendered into the container", func(mounts ...k8sv1.VolumeMount) {
-			specRenderer = NewContainerSpecRenderer(containerName, img, pullPolicy, WithVolumeMounts(mounts...))
-			Expect(specRenderer.Render(exampleCommand).VolumeMounts).To(ConsistOf(mounts))
+			specRenderer = NewContainerSpecRenderer(containerName, img, pullPolicy, WithCommand(exampleCommand), WithVolumeMounts(mounts...))
+			Expect(specRenderer.Render().VolumeMounts).To(ConsistOf(mounts))
 		},
 			Entry("no volume devices are passed as options"),
 			Entry("one optional volume device is added to the renderer", volumeMount(mountName, mountPath)),
@@ -134,27 +134,27 @@ var _ = Describe("Container spec renderer", func() {
 		BeforeEach(func() {
 			expectedResource = resources("10", "100")
 			specRenderer = NewContainerSpecRenderer(
-				containerName, img, pullPolicy, WithResourceRequirements(expectedResource))
+				containerName, img, pullPolicy, WithCommand(exampleCommand), WithResourceRequirements(expectedResource))
 		})
 
 		It("the resource requirements are rendered into the container", func() {
-			Expect(specRenderer.Render(exampleCommand).Resources).To(Equal(expectedResource))
+			Expect(specRenderer.Render().Resources).To(Equal(expectedResource))
 		})
 	})
 
 	Context("with no capabilities option", func() {
 		It("all capabilities should be dropped", func() {
-			specRenderer = NewContainerSpecRenderer(containerName, img, pullPolicy, WithNoCapabilities())
-			Expect(specRenderer.Render(exampleCommand).SecurityContext.Capabilities.Drop).To(Equal([]k8sv1.Capability{"ALL"}))
+			specRenderer = NewContainerSpecRenderer(containerName, img, pullPolicy, WithCommand(exampleCommand), WithNoCapabilities())
+			Expect(specRenderer.Render().SecurityContext.Capabilities.Drop).To(Equal([]k8sv1.Capability{"ALL"}))
 		})
 	})
 
 	Context("with drop-all capabilities option", func() {
 		It("all capabilities should be dropped, but added caps should be kept", func() {
 			vmi := simplestVMI()
-			specRenderer = NewContainerSpecRenderer(containerName, img, pullPolicy, WithCapabilities(vmi), WithDropALLCapabilities())
-			Expect(specRenderer.Render(exampleCommand).SecurityContext.Capabilities.Drop).To(Equal([]k8sv1.Capability{"ALL"}))
-			Expect(specRenderer.Render(exampleCommand).SecurityContext.Capabilities.Add).ToNot(BeEmpty())
+			specRenderer = NewContainerSpecRenderer(containerName, img, pullPolicy, WithCommand(exampleCommand), WithCapabilities(vmi), WithDropALLCapabilities())
+			Expect(specRenderer.Render().SecurityContext.Capabilities.Drop).To(Equal([]k8sv1.Capability{"ALL"}))
+			Expect(specRenderer.Render().SecurityContext.Capabilities.Add).ToNot(BeEmpty())
 		})
 	})
 
@@ -168,14 +168,14 @@ var _ = Describe("Container spec renderer", func() {
 				{Protocol: "UDP", Port: 80},
 				{Port: 90},
 				{Name: "other-http", Port: 80}}
-			specRenderer = NewContainerSpecRenderer(containerName, img, pullPolicy, WithPorts(
+			specRenderer = NewContainerSpecRenderer(containerName, img, pullPolicy, WithCommand(exampleCommand), WithPorts(
 				vmiWithInterfaceWithPortAllowList(ifaceName, ports...)))
 		})
 
 		It("the container should feature the same port list", func() {
-			Expect(specRenderer.Render(exampleCommand).Ports).To(HaveLen(len(ports)))
+			Expect(specRenderer.Render().Ports).To(HaveLen(len(ports)))
 			for i := range ports {
-				Expect(specRenderer.Render(exampleCommand).Ports[i]).To(
+				Expect(specRenderer.Render().Ports[i]).To(
 					Equal(vmPortToContainerPort(ports[i])))
 			}
 		})
@@ -183,9 +183,9 @@ var _ = Describe("Container spec renderer", func() {
 
 	Context("container command and arguments", func() {
 		DescribeTable("", func(args ...string) {
-			specRenderer = NewContainerSpecRenderer(containerName, img, pullPolicy, WithArgs(args))
-			Expect(specRenderer.Render(exampleCommand).Command).To(Equal(exampleCommand))
-			Expect(specRenderer.Render(exampleCommand).Args).To(Equal(args))
+			specRenderer = NewContainerSpecRenderer(containerName, img, pullPolicy, WithCommand(exampleCommand), WithArgs(args))
+			Expect(specRenderer.Render().Command).To(Equal(exampleCommand))
+			Expect(specRenderer.Render().Args).To(Equal(args))
 		},
 			Entry("without input args"),
 			Entry("with an input argument", "do-stuff"),
@@ -196,18 +196,18 @@ var _ = Describe("Container spec renderer", func() {
 		Context("readiness probe", func() {
 			It("its pod should feature the same probe but with an additional 10 seconds initial delay", func() {
 				probe := dummyProbe()
-				specRenderer = NewContainerSpecRenderer(containerName, img, pullPolicy, WithReadinessProbe(
+				specRenderer = NewContainerSpecRenderer(containerName, img, pullPolicy, WithCommand(exampleCommand), WithReadinessProbe(
 					vmiWithReadinessProbe(probe)))
-				Expect(specRenderer.Render(exampleCommand).ReadinessProbe).To(Equal(probeWithDelay(probe)))
+				Expect(specRenderer.Render().ReadinessProbe).To(Equal(probeWithDelay(probe)))
 			})
 		})
 
 		Context("liveness probe", func() {
 			It("its pod should feature the same probe but with an additional 10 seconds initial delay", func() {
 				probe := dummyProbe()
-				specRenderer = NewContainerSpecRenderer(containerName, img, pullPolicy, WithLivelinessProbe(
+				specRenderer = NewContainerSpecRenderer(containerName, img, pullPolicy, WithCommand(exampleCommand), WithLivelinessProbe(
 					vmiWithLivenessProbe(probe)))
-				Expect(specRenderer.Render(exampleCommand).LivenessProbe).To(Equal(probeWithDelay(probe)))
+				Expect(specRenderer.Render().LivenessProbe).To(Equal(probeWithDelay(probe)))
 			})
 		})
 
@@ -217,9 +217,9 @@ var _ = Describe("Container spec renderer", func() {
 				probe.Handler = v1.Handler{
 					Exec: &k8sv1.ExecAction{Command: []string{"dummy-cli"}},
 				}
-				specRenderer = NewContainerSpecRenderer(containerName, img, pullPolicy, WithLivelinessProbe(
+				specRenderer = NewContainerSpecRenderer(containerName, img, pullPolicy, WithCommand(exampleCommand), WithLivelinessProbe(
 					vmiWithLivenessProbe(probe)))
-				Expect(specRenderer.Render(exampleCommand).LivenessProbe.Exec.Command).To(HaveExactElements(
+				Expect(specRenderer.Render().LivenessProbe.Exec.Command).To(HaveExactElements(
 					"virt-probe",
 					"--domainName", "_",
 					"--timeoutSeconds", strconv.FormatInt(int64(dummyProbe().TimeoutSeconds), 10),
@@ -235,9 +235,9 @@ var _ = Describe("Container spec renderer", func() {
 				probe.Handler = v1.Handler{
 					Exec: &k8sv1.ExecAction{Command: expectedExecCmd},
 				}
-				specRenderer = NewContainerSpecRenderer(containerName, img, pullPolicy, WithLivelinessProbe(
+				specRenderer = NewContainerSpecRenderer(containerName, img, pullPolicy, WithCommand(exampleCommand), WithLivelinessProbe(
 					vmiWithLivenessProbe(probe)))
-				Expect(specRenderer.Render(exampleCommand).LivenessProbe.Exec.Command).To(Equal(expectedExecCmd))
+				Expect(specRenderer.Render().LivenessProbe.Exec.Command).To(Equal(expectedExecCmd))
 			})
 		})
 	})

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -420,14 +420,15 @@ func (t *TemplateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 	}
 
 	var command []string
+	var args []string
 	if tempPod {
 		logger := log.DefaultLogger()
 		logger.Infof("RUNNING doppleganger pod for %s", vmi.Name)
-		command = []string{"/bin/bash",
-			"-c",
-			"echo", "bound PVCs"}
+		command = []string{"/bin/bash"}
+		args = []string{"-c", "echo", "bound PVCs"}
 	} else {
-		command = []string{"/usr/bin/virt-launcher-monitor",
+		command = []string{"/usr/bin/virt-launcher-monitor"}
+		args = []string{
 			"--qemu-timeout", generateQemuTimeoutWithJitter(t.launcherQemuTimeout),
 			"--name", domain,
 			"--uid", string(vmi.UID),
@@ -442,43 +443,43 @@ func (t *TemplateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 			"--hypervisor", t.clusterConfig.GetHypervisor().Name,
 		}
 		if nonRoot {
-			command = append(command, "--run-as-nonroot")
+			args = append(args, "--run-as-nonroot")
 		}
 		if t.clusterConfig.ImageVolumeEnabled() {
-			command = append(command, "--image-volume")
+			args = append(args, "--image-volume")
 		}
 		if t.clusterConfig.LibvirtHooksServerAndClientEnabled() {
-			command = append(command, "--libvirt-hook-server-and-client")
+			args = append(args, "--libvirt-hook-server-and-client")
 		}
 		if t.clusterConfig.PodSecondaryInterfaceNamingUpgradeEnabled() {
-			command = append(command, "--upgrade-ordinal-ifaces")
+			args = append(args, "--upgrade-ordinal-ifaces")
 		}
 		if t.clusterConfig.VGPULiveMigrationEnabled() {
-			command = append(command, "--vgpu-dedicated-hook")
+			args = append(args, "--vgpu-dedicated-hook")
 		}
 		if t.clusterConfig.VMStatsCollectorEnabled() {
-			command = append(command, "--vm-stats-collector")
+			args = append(args, "--vm-stats-collector")
 		}
 		if t.clusterConfig.FirmwareAutoSelectionEnabled() {
-			command = append(command, "--firmware-auto-selection")
+			args = append(args, "--firmware-auto-selection")
 		}
 		if customDebugFilters, exists := vmi.Annotations[v1.CustomLibvirtLogFiltersAnnotation]; exists {
 			log.Log.Object(vmi).Infof("Applying custom debug filters for vmi %s: %s", vmi.Name, customDebugFilters)
-			command = append(command, "--libvirt-log-filters", customDebugFilters)
+			args = append(args, "--libvirt-log-filters", customDebugFilters)
 		}
 	}
 
 	if t.clusterConfig.AllowEmulation() {
-		command = append(command, "--allow-emulation")
+		args = append(args, "--allow-emulation")
 	}
 
 	if checkForKeepLauncherAfterFailure(vmi) {
-		command = append(command, "--keep-after-failure")
+		args = append(args, "--keep-after-failure")
 	}
 
 	_, ok := vmi.Annotations[v1.FuncTestLauncherFailFastAnnotation]
 	if ok {
-		command = append(command, "--simulate-crash")
+		args = append(args, "--simulate-crash")
 	}
 
 	volumeRenderer, err := t.newVolumeRenderer(vmi, imageIDs, namespace, requestedHookSidecarList, backendStoragePVCName)
@@ -486,7 +487,7 @@ func (t *TemplateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 		return nil, err
 	}
 
-	compute := t.newContainerSpecRenderer(vmi, volumeRenderer, resources, userId).Render(command)
+	compute := t.newContainerSpecRenderer(vmi, volumeRenderer, resources, userId, WithCommand(command), WithArgs(args)).Render()
 
 	virtLauncherLogVerbosity := t.clusterConfig.GetVirtLauncherVerbosity()
 
@@ -544,7 +545,7 @@ func (t *TemplateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 	var sidecarVolumes []k8sv1.Volume
 	for i, requestedHookSidecar := range requestedHookSidecarList {
 		sidecarContainer := newSidecarContainerRenderer(
-			sidecarContainerName(i), vmi, sidecarResources(vmi, t.clusterConfig), requestedHookSidecar, userId).Render(requestedHookSidecar.Command)
+			sidecarContainerName(i), vmi, sidecarResources(vmi, t.clusterConfig), requestedHookSidecar, userId).Render()
 
 		if requestedHookSidecar.ConfigMap != nil {
 			cm, err := t.virtClient.CoreV1().ConfigMaps(vmi.Namespace).Get(context.TODO(), requestedHookSidecar.ConfigMap.Name, metav1.GetOptions{})
@@ -606,17 +607,15 @@ func (t *TemplateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 	}
 
 	if !t.clusterConfig.ImageVolumeEnabled() && (HaveContainerDiskVolume(vmi.Spec.Volumes) || util.HasKernelBootContainerImage(vmi)) {
-		initContainerCommand := []string{"/usr/bin/cp", "--preserve=all",
-			"/usr/bin/container-disk",
-			"/init/usr/bin/container-disk",
-		}
-
 		initContainers = append(
 			initContainers,
 			t.newInitContainerRenderer(vmi,
 				initContainerVolumeMount(),
 				initContainerResourceRequirementsForVMI(vmi, v1.ContainerDisk, t.clusterConfig),
-				userId).Render(initContainerCommand))
+				userId,
+				WithCommand([]string{"/usr/bin/cp"}),
+				WithArgs([]string{"--preserve=all", "/usr/bin/container-disk", "/init/usr/bin/container-disk"}),
+			).Render())
 
 		// this causes containerDisks to be pre-pulled before virt-launcher starts.
 		initContainers = append(initContainers, containerdisk.GenerateInitContainers(vmi, t.clusterConfig, imageIDs, containerDisks, virtBinDir)...)
@@ -828,6 +827,7 @@ func initContainerVolumeMount() k8sv1.VolumeMount {
 
 func newSidecarContainerRenderer(sidecarName string, vmiSpec *v1.VirtualMachineInstance, resources k8sv1.ResourceRequirements, requestedHookSidecar hooks.HookSidecar, userId int64) *ContainerSpecRenderer {
 	sidecarOpts := []Option{
+		WithCommand(requestedHookSidecar.Command),
 		WithResourceRequirements(resources),
 		WithArgs(requestedHookSidecar.Args),
 		WithExtraEnvVars([]k8sv1.EnvVar{
@@ -865,7 +865,7 @@ func newSidecarContainerRenderer(sidecarName string, vmiSpec *v1.VirtualMachineI
 		sidecarOpts...)
 }
 
-func (t *TemplateService) newInitContainerRenderer(vmiSpec *v1.VirtualMachineInstance, initContainerVolumeMount k8sv1.VolumeMount, initContainerResources k8sv1.ResourceRequirements, userId int64) *ContainerSpecRenderer {
+func (t *TemplateService) newInitContainerRenderer(vmiSpec *v1.VirtualMachineInstance, initContainerVolumeMount k8sv1.VolumeMount, initContainerResources k8sv1.ResourceRequirements, userId int64, extraOpts ...Option) *ContainerSpecRenderer {
 	const containerDisk = "container-disk-binary"
 	cpInitContainerOpts := []Option{
 		WithVolumeMounts(initContainerVolumeMount),
@@ -877,10 +877,12 @@ func (t *TemplateService) newInitContainerRenderer(vmiSpec *v1.VirtualMachineIns
 		cpInitContainerOpts = append(cpInitContainerOpts, WithNonRoot(userId))
 	}
 
+	cpInitContainerOpts = append(cpInitContainerOpts, extraOpts...)
+
 	return NewContainerSpecRenderer(containerDisk, t.launcherImage, t.clusterConfig.GetImagePullPolicy(), cpInitContainerOpts...)
 }
 
-func (t *TemplateService) newContainerSpecRenderer(vmi *v1.VirtualMachineInstance, volumeRenderer *VolumeRenderer, resources k8sv1.ResourceRequirements, userId int64) *ContainerSpecRenderer {
+func (t *TemplateService) newContainerSpecRenderer(vmi *v1.VirtualMachineInstance, volumeRenderer *VolumeRenderer, resources k8sv1.ResourceRequirements, userId int64, extraOpts ...Option) *ContainerSpecRenderer {
 	computeContainerOpts := []Option{
 		WithVolumeDevices(volumeRenderer.VolumeDevices()...),
 		WithVolumeMounts(volumeRenderer.Mounts()...),
@@ -900,6 +902,8 @@ func (t *TemplateService) newContainerSpecRenderer(vmi *v1.VirtualMachineInstanc
 	if vmi.Spec.LivenessProbe != nil {
 		computeContainerOpts = append(computeContainerOpts, WithLivelinessProbe(vmi))
 	}
+
+	computeContainerOpts = append(computeContainerOpts, extraOpts...)
 
 	const computeContainerName = "compute"
 	containerRenderer := NewContainerSpecRenderer(

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -284,7 +284,7 @@ var _ = Describe("Template", func() {
 				containers := pod.Spec.Containers
 				Expect(containers[0].Name).To(Equal(computeContainerName))
 				Expect(*containers[0].Resources.Limits.Name(kvmResource, resource.DecimalSI)).To(Equal(resource.MustParse("1")))
-				Expect(containers[0].Command).NotTo(ContainElements(allowEmulationOption))
+				Expect(containers[0].Args).NotTo(ContainElements(allowEmulationOption))
 			})
 
 			It("should not add the kvm resource and add the allow-emulation option when emulation is enabled", func() {
@@ -299,7 +299,7 @@ var _ = Describe("Template", func() {
 				containers := pod.Spec.Containers
 				Expect(containers[0].Name).To(Equal(computeContainerName))
 				Expect(containers[0].Resources.Limits.Name(kvmResource, resource.DecimalSI)).To(Equal(resource.NewQuantity(0, resource.DecimalSI)))
-				Expect(containers[0].Command).To(ContainElements(allowEmulationOption))
+				Expect(containers[0].Args).To(ContainElements(allowEmulationOption))
 			})
 		})
 
@@ -536,8 +536,9 @@ var _ = Describe("Template", func() {
 					k8sv1.LabelArchStable: arch,
 				}))
 
-				Expect(pod.Spec.Containers[0].Command).To(Equal([]string{"/usr/bin/virt-launcher-monitor",
-					"--qemu-timeout", validateAndExtractQemuTimeoutArg(pod.Spec.Containers[0].Command),
+				Expect(pod.Spec.Containers[0].Command).To(Equal([]string{"/usr/bin/virt-launcher-monitor"}))
+				Expect(pod.Spec.Containers[0].Args).To(Equal([]string{
+					"--qemu-timeout", validateAndExtractQemuTimeoutArg(pod.Spec.Containers[0].Args),
 					"--name", "testvmi",
 					"--uid", "1234",
 					"--namespace", "testns",
@@ -1050,7 +1051,8 @@ var _ = Describe("Template", func() {
 				Expect(pod.Spec.InitContainers).To(HaveLen(3))
 				Expect(pod.Spec.InitContainers[0].VolumeMounts[0].MountPath).To(Equal("/init/usr/bin"))
 				Expect(pod.Spec.InitContainers[0].VolumeMounts[0].Name).To(Equal("virt-bin-share-dir"))
-				Expect(pod.Spec.InitContainers[0].Command).To(Equal([]string{"/usr/bin/cp", "--preserve=all",
+				Expect(pod.Spec.InitContainers[0].Command).To(Equal([]string{"/usr/bin/cp"}))
+				Expect(pod.Spec.InitContainers[0].Args).To(Equal([]string{"--preserve=all",
 					"/usr/bin/container-disk",
 					"/init/usr/bin/container-disk",
 				}))
@@ -1138,8 +1140,9 @@ var _ = Describe("Template", func() {
 					v1.NodeSchedulable:    "true",
 					k8sv1.LabelArchStable: arch,
 				}))
-				Expect(pod.Spec.Containers[0].Command).To(Equal([]string{"/usr/bin/virt-launcher-monitor",
-					"--qemu-timeout", validateAndExtractQemuTimeoutArg(pod.Spec.Containers[0].Command),
+				Expect(pod.Spec.Containers[0].Command).To(Equal([]string{"/usr/bin/virt-launcher-monitor"}))
+				Expect(pod.Spec.Containers[0].Args).To(Equal([]string{
+					"--qemu-timeout", validateAndExtractQemuTimeoutArg(pod.Spec.Containers[0].Args),
 					"--name", "testvmi",
 					"--uid", "1234",
 					"--namespace", "default",
@@ -4180,7 +4183,7 @@ var _ = Describe("Template", func() {
 				initContainers := pod.Spec.InitContainers
 				for _, container := range append(containers, initContainers...) {
 					if container.Name == "compute" {
-						Expect(container.Command).To(ContainElement("--image-volume"))
+						Expect(container.Args).To(ContainElement("--image-volume"))
 						break
 					}
 				}
@@ -4493,7 +4496,7 @@ var _ = Describe("Template", func() {
 
 				for _, container := range pod.Spec.Containers {
 					if container.Name == "compute" {
-						Expect(container.Command).To(ContainElement("--vm-stats-collector"))
+						Expect(container.Args).To(ContainElement("--vm-stats-collector"))
 						return
 					}
 				}
@@ -4508,7 +4511,7 @@ var _ = Describe("Template", func() {
 
 				for _, container := range pod.Spec.Containers {
 					if container.Name == "compute" {
-						Expect(container.Command).NotTo(ContainElement("--vm-stats-collector"))
+						Expect(container.Args).NotTo(ContainElement("--vm-stats-collector"))
 						return
 					}
 				}
@@ -6300,7 +6303,7 @@ var _ = Describe("Template", func() {
 			vmi := libvmi.New(libvmi.WithNamespace("default"))
 			pod, err := svc.RenderLaunchManifest(vmi)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(pod.Spec.Containers[0].Command).To(ContainElement("--firmware-auto-selection"))
+			Expect(pod.Spec.Containers[0].Args).To(ContainElement("--firmware-auto-selection"))
 		})
 
 		It("should not pass --firmware-auto-selection flag when disabled", func() {
@@ -6309,7 +6312,7 @@ var _ = Describe("Template", func() {
 			vmi := libvmi.New(libvmi.WithNamespace("default"))
 			pod, err := svc.RenderLaunchManifest(vmi)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(pod.Spec.Containers[0].Command).ToNot(ContainElement("--firmware-auto-selection"))
+			Expect(pod.Spec.Containers[0].Args).ToNot(ContainElement("--firmware-auto-selection"))
 		})
 	})
 })

--- a/pkg/virt-controller/watch/vmi/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi/vmi_test.go
@@ -354,7 +354,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				func(pod *k8sv1.Pod) string {
 					for _, c := range pod.Spec.Containers {
 						if c.Name == "compute" {
-							return strings.Join(c.Command, " ")
+							return strings.Join(append(c.Command, c.Args...), " ")
 						}
 					}
 
@@ -716,7 +716,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				func(pod *k8sv1.Pod) string {
 					for _, c := range pod.Spec.Containers {
 						if c.Name == "compute" {
-							return strings.Join(c.Command, " ")
+							return strings.Join(append(c.Command, c.Args...), " ")
 						}
 					}
 


### PR DESCRIPTION
### What this PR does
#### Before this PR:

The virt-launcher-monitor container specification puts both the executable path and all command-line flags into the `.Command` field of the Kubernetes container spec.

#### After this PR:

Only the executable path (`/usr/bin/virt-launcher-monitor`) is set in `.Command`, and all flags are moved to `.Args`. This follows the Kubernetes convention where `Command` is the entrypoint and `Args` are the arguments, consistent with how containerdisk containers already set these fields.

The same split is applied to the `cp` init container used for container disk setup.

### References

- Follow-up from https://github.com/kubevirt/kubevirt/pull/17199#discussion_r3462682593

### Why we need it and why it was done in this way

This is a cleanup to align with Kubernetes container spec conventions. The existing `WithArgs()` option and `ContainerSpecRenderer.args` field were already in place but unused by the compute container. The containerdisk package already follows this pattern (`.Command = ["/usr/bin/container-disk"]`, `.Args = ["--no-op"]`).

### Special notes for your reviewer

Functional behavior is unchanged — Kubernetes treats `Command + Args` the same as a single `Command` slice containing both executable and arguments.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
NONE
```