### PR TITLE
backend-storage: add retry cap to migration recovery job

### DIFF
--- a/pkg/storage/backend-storage/backend-storage.go
+++ b/pkg/storage/backend-storage/backend-storage.go
@@ -155,24 +155,12 @@ func RecoverFromBrokenMigration(client kubecli.KubevirtClient, migration *corev1
 			}
 		case batchv1.JobFailed:
 			if c.Status == v1.ConditionTrue {
-				if c.Reason == batchv1.JobReasonPodFailurePolicy {
-					// The job ran properly but didn't find /meta/migrated, meaning the migration failed
-					err = MigrationAbort(client, migration)
-					if err == nil {
-						migration.Status.Phase = corev1.MigrationFailed
-					}
-					return err
-				} else {
-					// The job failed to run properly. Deleting it to retry asap.
-					// Ignoring the deletion error because the job may already be gone, or will get auto-removed anyway.
-					_ = client.BatchV1().Jobs(job.Namespace).Delete(context.Background(), job.Name, metav1.DeleteOptions{
-						PropagationPolicy: pointer.P(metav1.DeletePropagationBackground),
-					})
-					return fmt.Errorf("%s", c.Message)
+				err = MigrationAbort(client, migration)
+				if err == nil {
+					migration.Status.Phase = corev1.MigrationFailed
 				}
+				return err
 			}
-		default:
-			break
 		}
 	}
 
@@ -188,8 +176,8 @@ func buildRecoveryJob(jobName, launcherImage string, migration *corev1.VirtualMa
 			},
 		},
 		Spec: batchv1.JobSpec{
-			ActiveDeadlineSeconds:   pointer.P(int64(30)),
-			BackoffLimit:            pointer.P(int32(0)),
+			ActiveDeadlineSeconds:   pointer.P(int64(120)),
+			BackoffLimit:            pointer.P(int32(3)),
 			TTLSecondsAfterFinished: pointer.P(int32(30)),
 			PodFailurePolicy: &batchv1.PodFailurePolicy{
 				Rules: []batchv1.PodFailurePolicyRule{{


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
infrastructure failures in the migration recovery job (permissions, image pull, scheduling) cause an infinite retry loop as the controller deletes the failed job and re-creates it endlessly (which eventually can block node drains and cluster upgrades as seen is some cases).
#### After this PR:
The job retries up to 3 times within a 2-minute window (BackoffLimit=3, ActiveDeadlineSeconds=120). If all attempts fail, the migration is aborted.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.


- Fixes #
- 
- Partially addresses #
-->

<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

Jira: https://redhat.atlassian.net/browse/CNV-80517  

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

