### PR TITLE
tests: Move CPU manager wait from BeforeSuite to decorator-driven BeforeEach

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -564,16 +564,16 @@ if [[ -z ${KUBEVIRT_E2E_FOCUS} && -z ${KUBEVIRT_E2E_SKIP} && -z ${label_filter} 
     label_filter='(sig-compute-migrations && !(GPU,VGPU)) && !(SEV, SEVES, secure-execution)'
   elif [[ $TARGET =~ sig-compute-serial ]]; then
     export KUBEVIRT_E2E_PARALLEL=false
-    label_filter='((sig-compute && Serial) && !(GPU,VGPU,DRA-GPU,sig-compute-migrations) && !(SEV, SEVES, secure-execution))'
+    label_filter='((sig-compute && Serial) && !(GPU,VGPU,DRA-GPU,sig-compute-migrations,requires-two-worker-nodes-with-cpu-manager) && !(SEV, SEVES, secure-execution))'
   elif [[ $TARGET =~ sig-compute-parallel ]]; then
-    label_filter='(sig-compute && !(Serial,GPU,VGPU,sig-compute-migrations,sig-storage,storage-req) && !(SEV, SEVES, secure-execution))'
+    label_filter='(sig-compute && !(Serial,GPU,VGPU,sig-compute-migrations,sig-storage,storage-req,requires-two-worker-nodes-with-cpu-manager) && !(SEV, SEVES, secure-execution))'
   elif [[ $TARGET =~ sig-compute-conformance ]]; then
     label_filter='(sig-compute && conformance)'
   elif [[ $TARGET =~ sig-compute-dra-gpu ]]; then
     export KUBEVIRT_E2E_PARALLEL=false
     label_filter='(DRA-GPU)'
   elif [[ $TARGET =~ sig-compute ]]; then
-    label_filter='(sig-compute && !(GPU,VGPU,sig-compute-migrations,sig-storage,DRA-GPU) && !(SEV, SEVES, secure-execution))'
+    label_filter='(sig-compute && !(GPU,VGPU,sig-compute-migrations,sig-storage,DRA-GPU,requires-two-worker-nodes-with-cpu-manager) && !(SEV, SEVES, secure-execution))'
   elif [[ $TARGET =~ sig-monitoring ]]; then
     label_filter='(sig-monitoring)'
   elif [[ $TARGET =~ sig-operator ]]; then
@@ -637,7 +637,7 @@ fi
 # Single-node single-replica test lanes obviously can't run live migrations,
 # but also currently lack the requirements for SRIOV, GPU, Macvtap and MDEVs.
 if [[ $KUBEVIRT_NUM_NODES = "1" && $KUBEVIRT_INFRA_REPLICAS = "1" ]]; then
-  add_to_label_filter '(!(SRIOV,GPU,Macvtap,VGPU,sig-compute-migrations,requires-two-schedulable-nodes))' '&&'
+  add_to_label_filter '(!(SRIOV,GPU,Macvtap,VGPU,sig-compute-migrations,requires-two-schedulable-nodes,requires-two-worker-nodes-with-cpu-manager))' '&&'
   add_to_label_filter '!(multi-replica)' '&&'
 else
   add_to_label_filter '!(single-replica)' '&&'

--- a/tests/framework/checks/BUILD.bazel
+++ b/tests/framework/checks/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//pkg/virt-config/featuregate:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//tests/decorators:go_default_library",
         "//tests/framework/kubevirt:go_default_library",
         "//tests/libkubevirt:go_default_library",
         "//tests/libnode:go_default_library",

--- a/tests/framework/checks/expects.go
+++ b/tests/framework/checks/expects.go
@@ -21,22 +21,53 @@ package checks
 
 import (
 	"fmt"
-
-	"kubevirt.io/kubevirt/tests/libnode"
+	"slices"
+	"time"
 
 	"github.com/onsi/ginkgo/v2"
 	"github.com/onsi/gomega"
+
 	"kubevirt.io/client-go/kubecli"
+
+	"kubevirt.io/kubevirt/tests/decorators"
+	"kubevirt.io/kubevirt/tests/libnode"
 )
 
-const (
-	DescriptionTwoWorkerNodesWCPUManagerRequired = "at least two worker nodes with cpumanager are required for migration"
-)
+const cpuManagerNodeWaitTimeout = 360 * time.Second
 
-// ExpectAtLeastTwoWorkerNodesWithCPUManager uses gomega.Expect to verify that the node list returned by
-// libnode.GetWorkerNodesWithCPUManagerEnabled contains at least two elements.
-// DescriptionTwoWorkerNodesWCPUManagerRequired is added to the default description via ginkgo.By
-func ExpectAtLeastTwoWorkerNodesWithCPUManager(virtClient kubecli.KubevirtClient) {
-	ginkgo.By(fmt.Sprintf("expect at least 2 nodes - %s", DescriptionTwoWorkerNodesWCPUManagerRequired))
-	_ = gomega.Expect(len(libnode.GetWorkerNodesWithCPUManagerEnabled(virtClient))).To(gomega.BeNumerically(">=", 2), DescriptionTwoWorkerNodesWCPUManagerRequired)
+// EnforceDecoratedCPUManagerRequirements waits for virt-handler to label worker nodes
+// when the current spec carries a CPU manager requirement decorator.
+func EnforceDecoratedCPUManagerRequirements(virtClient kubecli.KubevirtClient) {
+	switch {
+	case specHasLabel(decorators.RequiresTwoWorkerNodesWithCPUManager):
+		waitForWorkerNodesWithCPUManager(virtClient, 2, "at least two worker nodes with cpumanager are required for migration")
+	case specHasLabel(decorators.RequiresNodeWithCPUManager):
+		waitForWorkerNodesWithCPUManager(virtClient, 1, "at least one worker node with cpumanager is required")
+	}
+}
+
+func specHasLabel(labels ginkgo.Labels) bool {
+	if len(labels) == 0 {
+		return false
+	}
+	specLabels := ginkgo.CurrentSpecReport().Labels()
+	for _, label := range labels {
+		if !slices.Contains(specLabels, label) {
+			return false
+		}
+	}
+	return true
+}
+
+func waitForWorkerNodesWithCPUManager(virtClient kubecli.KubevirtClient, minNodes int, description string) {
+	ginkgo.By(fmt.Sprintf("expect at least %d nodes with cpumanager - %s", minNodes, description))
+
+	workerNodes := libnode.GetWorkerNodes(virtClient)
+	if len(workerNodes) < minNodes {
+		ginkgo.Fail(fmt.Sprintf("not enough worker nodes: need at least %d to run this test but cluster has %d", minNodes, len(workerNodes)))
+	}
+
+	gomega.Eventually(func() int {
+		return len(libnode.GetWorkerNodesWithCPUManagerEnabled(virtClient))
+	}, cpuManagerNodeWaitTimeout, time.Second).Should(gomega.BeNumerically(">=", minNodes), description)
 }

--- a/tests/hotplug/BUILD.bazel
+++ b/tests/hotplug/BUILD.bazel
@@ -24,7 +24,6 @@ go_library(
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//tests/console:go_default_library",
         "//tests/decorators:go_default_library",
-        "//tests/framework/checks:go_default_library",
         "//tests/framework/kubevirt:go_default_library",
         "//tests/framework/matcher:go_default_library",
         "//tests/libinstancetype/builder:go_default_library",

--- a/tests/hotplug/cpu.go
+++ b/tests/hotplug/cpu.go
@@ -22,7 +22,6 @@ import (
 	"kubevirt.io/kubevirt/pkg/pointer"
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/decorators"
-	"kubevirt.io/kubevirt/tests/framework/checks"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	. "kubevirt.io/kubevirt/tests/framework/matcher"
 	"kubevirt.io/kubevirt/tests/libkubevirt"
@@ -209,7 +208,6 @@ var _ = Describe("[sig-compute]CPU Hotplug", decorators.SigCompute, decorators.S
 		})
 
 		It("[test_id:10822]should successfully plug guaranteed vCPUs", decorators.RequiresTwoWorkerNodesWithCPUManager, func() {
-			checks.ExpectAtLeastTwoWorkerNodesWithCPUManager(virtClient)
 			const maxSockets uint32 = 3
 
 			By("Creating a running VM with 1 socket and 2 max sockets")

--- a/tests/libnode/BUILD.bazel
+++ b/tests/libnode/BUILD.bazel
@@ -19,7 +19,6 @@ go_library(
         "//tests/framework/cleanup:go_default_library",
         "//tests/framework/kubevirt:go_default_library",
         "//tests/libkubevirt:go_default_library",
-        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",

--- a/tests/libnode/node.go
+++ b/tests/libnode/node.go
@@ -27,7 +27,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	k8sv1 "k8s.io/api/core/v1"
@@ -53,6 +52,22 @@ import (
 )
 
 const workerLabel = "node-role.kubernetes.io/worker"
+
+func GetWorkerNodes(virtClient kubecli.KubevirtClient) []k8sv1.Node {
+	// CPUManager is typically not enabled in the control-plane node(s)
+	nodeList, err := virtClient.CoreV1().Nodes().List(context.Background(), k8smetav1.ListOptions{
+		LabelSelector: "!node-role.kubernetes.io/control-plane",
+	})
+	Expect(err).ToNot(HaveOccurred())
+	// This case could happen in the case of single node clusters (like OpenShift SNO)
+	if len(nodeList.Items) == 0 {
+		nodeList, err = virtClient.CoreV1().Nodes().List(context.Background(), k8smetav1.ListOptions{
+			LabelSelector: workerLabel,
+		})
+		Expect(err).ToNot(HaveOccurred())
+	}
+	return nodeList.Items
+}
 
 var SchedulableNode = ""
 
@@ -377,9 +392,8 @@ func GetControlPlaneNodes(virtCli kubecli.KubevirtClient) *k8sv1.NodeList {
 }
 
 func GetWorkerNodesWithCPUManagerEnabled(virtClient kubecli.KubevirtClient) []k8sv1.Node {
-	ginkgo.By("getting the list of worker nodes that have cpumanager enabled")
 	nodeList, err := virtClient.CoreV1().Nodes().List(context.TODO(), k8smetav1.ListOptions{
-		LabelSelector: fmt.Sprintf("%s=,%s=%s", workerLabel, "cpumanager", "true"),
+		LabelSelector: fmt.Sprintf("%s=,%s=%s,%s=%s", workerLabel, v1.NodeSchedulable, "true", v1.CPUManager, "true"),
 	})
 	Expect(err).ToNot(HaveOccurred())
 	Expect(nodeList).ToNot(BeNil())

--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -2548,11 +2548,7 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 		}
 
 		BeforeEach(func() {
-			// We will get focused to run on migration test lanes because we contain the word "Migration".
-			// However, we need to be sig-something or we'll fail the check, even if we don't run on any sig- lane.
-			// So let's be sig-compute and skip ourselves on sig-compute always... (they have only 1 node with CPU manager)
 			nodes = libnode.GetWorkerNodesWithCPUManagerEnabled(virtClient)
-			Expect(len(nodes)).To(BeNumerically(">=", 2), "Need at least 2 nodes with CPU manager enabled")
 			By("creating a template for a pause pod with 1 dedicated CPU core")
 			pausePod = libpod.RenderPod("pause-", nil, nil)
 			pausePod.Spec.Containers[0].Name = "compute"

--- a/tests/realtime/realtime.go
+++ b/tests/realtime/realtime.go
@@ -65,7 +65,7 @@ func byStartingTheVMI(vmi *v1.VirtualMachineInstance, virtClient kubecli.Kubevir
 	return libwait.WaitForSuccessfulVMIStart(vmi)
 }
 
-var _ = Describe("[sig-compute-realtime]Realtime", Serial, decorators.SigComputeRealtime, func() {
+var _ = Describe("[sig-compute-realtime]Realtime", Serial, decorators.SigComputeRealtime, decorators.RequiresNodeWithCPUManager, func() {
 
 	var virtClient kubecli.KubevirtClient
 

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -31,6 +31,8 @@ import (
 
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/flags"
+	"kubevirt.io/kubevirt/tests/framework/checks"
+	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/libkubevirt/config"
 	"kubevirt.io/kubevirt/tests/libnode"
 	"kubevirt.io/kubevirt/tests/reporter"
@@ -105,6 +107,10 @@ func TestTests(t *testing.T) {
 var _ = SynchronizedBeforeSuite(testsuite.SynchronizedBeforeTestSetup, testsuite.BeforeTestSuiteSetup)
 
 var _ = SynchronizedAfterSuite(testsuite.AfterTestSuiteCleanup, testsuite.SynchronizedAfterTestSuiteCleanup)
+
+var _ = BeforeEach(func() {
+	checks.EnforceDecoratedCPUManagerRequirements(kubevirt.Client())
+})
 
 var _ = AfterEach(func() {
 	if !hasOncePerOrderedCleanupLabel() {

--- a/tests/testsuite/kubevirtresource.go
+++ b/tests/testsuite/kubevirtresource.go
@@ -37,7 +37,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	v1 "kubevirt.io/api/core/v1"
-	"kubevirt.io/client-go/log"
 
 	"kubevirt.io/kubevirt/pkg/pointer"
 	"kubevirt.io/kubevirt/pkg/storage/cbt"
@@ -152,27 +151,6 @@ func AdjustKubeVirtResource() {
 	adjustedKV, err := virtClient.KubeVirt(kv.Namespace).Patch(context.Background(), kv.Name, types.JSONPatchType, []byte(patchData), metav1.PatchOptions{})
 	Expect(err).ToNot(HaveOccurred())
 	KubeVirtDefaultConfig = adjustedKV.Spec.Configuration
-	if checks.HasFeature(featuregate.CPUManager) {
-		// CPUManager is typically not enabled in the control-plane node(s)
-		nodes, err := virtClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{LabelSelector: "!node-role.kubernetes.io/control-plane"})
-		Expect(err).NotTo(HaveOccurred())
-		// This case could happen in the case of single node clusters (like OpenShift SNO)
-		if len(nodes.Items) == 0 {
-			log.Log.Info("No non-control-plane nodes found. This shouldn't happen unless this is a single-node cluster. Falling back to listing nodes labeled as `worker`.")
-			nodes, err = virtClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{LabelSelector: "node-role.kubernetes.io/worker"})
-			Expect(err).NotTo(HaveOccurred())
-		}
-		waitForSchedulableNodesWithCPUManager(len(nodes.Items))
-	}
-}
-
-func waitForSchedulableNodesWithCPUManager(n int) {
-	virtClient := kubevirt.Client()
-	Eventually(func() bool {
-		nodes, err := virtClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{LabelSelector: v1.NodeSchedulable + "=" + "true," + v1.CPUManager + "=true"})
-		Expect(err).ToNot(HaveOccurred(), "Should list compute nodes")
-		return len(nodes.Items) == n
-	}, 360, 1*time.Second).Should(BeTrue())
 }
 
 func RestoreKubeVirtResource() {

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -1097,14 +1097,6 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 			return nodeHaveCpuManagerLabel
 		}
 
-		BeforeEach(func() {
-			nodes, err := virtClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			if len(nodes.Items) == 1 {
-				Fail(`CPU pinning test that requires multiple nodes when only one node is present. You can filter by "requires-two-worker-nodes-with-cpu-manager" label`)
-			}
-		})
-
 		Context("with cpu pinning enabled", Serial, func() {
 			It("[test_id:1685]non master node should have a cpumanager label", func() {
 				cpuManagerEnabled := false

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -1080,7 +1080,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 			Expect(vmiCondition.Reason).To(Equal("Synchronizing with the Domain failed."))
 		})
 	})
-	Describe("[rfe_id:897][crit:medium][vendor:cnv-qe@redhat.com][level:component]VirtualMachineInstance with CPU pinning", decorators.WgArm64, decorators.RequiresTwoWorkerNodesWithCPUManager, func() {
+	Describe("[rfe_id:897][crit:medium][vendor:cnv-qe@redhat.com][level:component]VirtualMachineInstance with CPU pinning", decorators.WgArm64, decorators.RequiresNodeWithCPUManager, decorators.RequiresTwoSchedulableNodes, func() {
 		isNodeHasCPUManagerLabel := func(nodeName string) bool {
 
 			nodeObject, err := virtClient.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})


### PR DESCRIPTION

### What this PR does

#### Before this PR:

- `AdjustKubeVirtResource` waited globally in `BeforeSuite` for every worker node to have `cpumanager=true` before any test could run
- On clusters without a static CPU manager policy (e.g. kubeadm with `none` policy), nodes get labeled `cpumanager=false`, so the suite hung indefinitely blocking the entire suite
- On single-node kubevirtci clusters, the node count logic introduced in #16781 mismatched: it found 1 worker node but the node doesn't have `cpumanager=true`, causing a 360s timeout (see https://github.com/kubevirt/kubevirt/pull/16781#issuecomment-4462165261)
- Individual CPU-manager tests duplicated their own node-count checks inline

#### After this PR:

- Remove the global CPU manager wait from `AdjustKubeVirtResource`
- Add a per-spec `BeforeEach` that only waits when the current spec carries a `RequiresTwoWorkerNodesWithCPUManager` or `RequiresNodeWithCPUManager` decorator -- tests without these decorators skip the wait entirely
- Fast-fail if the cluster doesn't have enough worker nodes (instead of a 360s timeout)
- Remove redundant inline checks from individual tests (e.g. `hotplug/cpu.go`, `vmi_configuration_test.go`)
- Exclude `requires-two-worker-nodes-with-cpu-manager` from single-node CI lanes

Non-CPU-manager tests now run immediately on any cluster. CPU-manager tests still require `cpumanager=true` nodes and are properly gated by their decorators.

### References

- Fixes regression from #16781 reported in https://github.com/kubevirt/kubevirt/pull/16781#issuecomment-4462165261
- Follows suggestion from @Barakmor1 to use decorators for CPU manager requirements

### Why we need it and why it was done in this way

The following tradeoffs were made:

- Deferring the wait to decorated specs avoids blocking the entire suite on clusters that lack CPU manager, while keeping strict `cpumanager=true` semantics where tests actually need it
- The global `BeforeEach` is a no-op for specs without CPU manager decorators, so there is no overhead for the common case

The following alternatives were considered:

- Existence-only label selector in `BeforeSuite` -- unblocks setup but still waits for all nodes and miscounts on SNO/kubevirtci single-node
- Keep global wait, skip via env var -- pushes burden to every developer
- Fixing the node count logic in the existing `BeforeSuite` (as #16781 attempted) -- fragile because the global wait can't know which tests will actually run

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)

### Release note
```
NONE
```
