### PR TITLE
iothreads: fix nil dereference in GetIOThreadsCountType

### DIFF
--- a/pkg/virt-launcher/virtwrap/converter/iothreads/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/converter/iothreads/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -9,5 +9,22 @@ go_library(
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "iothreads_suite_test.go",
+        "iothreads_test.go",
+    ],
+    embed = [":go_default_library"],
+    race = "on",
+    deps = [
+        "//pkg/pointer:go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
     ],
 )

--- a/pkg/virt-launcher/virtwrap/converter/iothreads/iothreads.go
+++ b/pkg/virt-launcher/virtwrap/converter/iothreads/iothreads.go
@@ -45,6 +45,7 @@ func GetIOThreadsCountType(vmi *v1.VirtualMachineInstance) (ioThreadCount, autoT
 
 	if vmi.Spec.Domain.IOThreadsPolicy != nil &&
 		*vmi.Spec.Domain.IOThreadsPolicy == v1.IOThreadsPolicySupplementalPool &&
+		vmi.Spec.Domain.IOThreads != nil &&
 		vmi.Spec.Domain.IOThreads.SupplementalPoolThreadCount != nil {
 		return int(*vmi.Spec.Domain.IOThreads.SupplementalPoolThreadCount), 0
 	}

--- a/pkg/virt-launcher/virtwrap/converter/iothreads/iothreads_suite_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/iothreads/iothreads_suite_test.go
@@ -1,0 +1,30 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package iothreads
+
+import (
+	"testing"
+
+	"kubevirt.io/client-go/testutils"
+)
+
+func TestIOThreads(t *testing.T) {
+	testutils.KubeVirtTestSuiteSetup(t)
+}

--- a/pkg/virt-launcher/virtwrap/converter/iothreads/iothreads_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/iothreads/iothreads_test.go
@@ -1,0 +1,54 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package iothreads
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/pointer"
+)
+
+var _ = Describe("GetIOThreadsCountType", func() {
+	It("should not panic when IOThreadsPolicy is supplementalPool but IOThreads is nil", func() {
+		vmi := &v1.VirtualMachineInstance{
+			Spec: v1.VirtualMachineInstanceSpec{
+				Domain: v1.DomainSpec{
+					IOThreadsPolicy: pointer.P(v1.IOThreadsPolicySupplementalPool),
+					Devices: v1.Devices{
+						Disks: []v1.Disk{
+							{Name: "disk0", DedicatedIOThread: pointer.P(true)},
+						},
+					},
+				},
+			},
+		}
+
+		Expect(func() {
+			GetIOThreadsCountType(vmi)
+		}).NotTo(Panic())
+
+		ioThreadCount, autoThreads := GetIOThreadsCountType(vmi)
+		Expect(ioThreadCount).To(Equal(2))
+		Expect(autoThreads).To(Equal(1))
+	})
+})

--- a/pkg/virt-launcher/virtwrap/converter/vcpu/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/converter/vcpu/BUILD.bazel
@@ -28,6 +28,7 @@ go_test(
     race = "on",
     deps = [
         "//pkg/handler-launcher-com/cmd/v1:go_default_library",
+        "//pkg/pointer:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",

--- a/pkg/virt-launcher/virtwrap/converter/vcpu/vcpu_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/vcpu/vcpu_test.go
@@ -16,6 +16,7 @@ import (
 	"kubevirt.io/client-go/log"
 
 	v1 "kubevirt.io/kubevirt/pkg/handler-launcher-com/cmd/v1"
+	"kubevirt.io/kubevirt/pkg/pointer"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )
 
@@ -179,6 +180,49 @@ var _ = Describe("VCPU pinning", func() {
 	)
 
 	Describe("AdjustDomainForTopologyAndCPUSet", func() {
+		It("should pin IOThreads with dedicatedIOThread and dedicatedCPU but without isolateEmulatorThread", func() {
+			vmi := &corev1.VirtualMachineInstance{
+				Spec: corev1.VirtualMachineInstanceSpec{
+					Domain: corev1.DomainSpec{
+						CPU: &corev1.CPU{
+							Cores:                 1,
+							Sockets:               8,
+							Threads:               1,
+							DedicatedCPUPlacement: true,
+						},
+						Devices: corev1.Devices{
+							Disks: []corev1.Disk{{
+								Name:              "rootdisk",
+								DedicatedIOThread: pointer.P(true),
+								DiskDevice: corev1.DiskDevice{
+									Disk: &corev1.DiskTarget{Bus: corev1.DiskBusVirtio},
+								},
+							}},
+						},
+					},
+				},
+			}
+			domain := &api.Domain{
+				Spec: api.DomainSpec{
+					CPU: api.CPU{
+						Topology: &api.CPUTopology{
+							Sockets: 8,
+							Cores:   1,
+							Threads: 1,
+						},
+					},
+					IOThreads: &api.IOThreads{IOThreads: 1},
+				},
+			}
+			cpuset := []int{0, 1, 2, 3, 4, 5, 6, 7}
+			topology := hostTopology(1, 1, 0, 1, 2, 3, 4, 5, 6, 7)
+
+			err := AdjustDomainForTopologyAndCPUSet(domain, vmi, topology, cpuset)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(domain.Spec.CPUTune).ToNot(BeNil())
+			Expect(domain.Spec.CPUTune.IOThreadPin).To(HaveLen(1))
+			Expect(domain.Spec.CPUTune.EmulatorPin).To(BeNil())
+		})
 		It("should succeed without modifying topology when VCPU metadata is absent", func() {
 			domain := &api.Domain{
 				Spec: api.DomainSpec{


### PR DESCRIPTION
### What this PR does
GetIOThreadsCountType accessed IOThreads.SupplementalPoolThreadCount without first checking whether IOThreads itself was nil. When IOThreadsPolicy was set to supplementalPool but the IOThreads struct was absent, this caused a nil pointer dereference (SIGSEGV).

Add the missing nil guard and regression tests for both this fix and for the related scenario of dedicatedIOThread with dedicatedCPU but without isolateEmulatorThread, which historically crashed due to a pipeline ordering bug (fixed by 15ce746945).

Assisted-by: Claude

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```