### PR TITLE
tests/hyperv: drop redundant hyperv tests

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -110,7 +110,6 @@ go_test(
         "//pkg/virt-controller/services:go_default_library",
         "//pkg/virt-controller/watch/topology:go_default_library",
         "//pkg/virt-handler/device-manager:go_default_library",
-        "//pkg/virt-handler/node-labeller/util:go_default_library",
         "//pkg/virt-operator/util:go_default_library",
         "//staging/src/kubevirt.io/api/clone/v1beta1:go_default_library",
         "//staging/src/kubevirt.io/api/core:go_default_library",

--- a/tests/hyperv_test.go
+++ b/tests/hyperv_test.go
@@ -2,7 +2,6 @@ package tests_test
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -103,71 +102,6 @@ var _ = Describe("[sig-compute] Hyper-V enlightenments", decorators.SigCompute, 
 				Expect(console.LoginToAlpine(reEnlightenmentVMI)).To(Succeed())
 				Eventually(matcher.ThisVMI(reEnlightenmentVMI)).WithTimeout(30 * time.Second).WithPolling(time.Second).Should(matcher.HaveConditionFalseWithMessage(v1.VirtualMachineInstanceIsMigratable, "HyperV Reenlightenment VMIs cannot migrate when TSC Frequency is not exposed on the cluster"))
 			})
-		})
-
-		It("the vmi with HyperV feature matching a nfd label on a node should be scheduled", func() {
-			enableHyperVInVMI := func(label string) v1.FeatureHyperv {
-				features := v1.FeatureHyperv{}
-				trueV := true
-				switch label {
-				case "vpindex":
-					features.VPIndex = &v1.FeatureState{
-						Enabled: &trueV,
-					}
-				case "runtime":
-					features.Runtime = &v1.FeatureState{
-						Enabled: &trueV,
-					}
-				case "reset":
-					features.Reset = &v1.FeatureState{
-						Enabled: &trueV,
-					}
-				case "synic":
-					features.SyNIC = &v1.FeatureState{
-						Enabled: &trueV,
-					}
-				case "frequencies":
-					features.Frequencies = &v1.FeatureState{
-						Enabled: &trueV,
-					}
-				case "reenlightenment":
-					features.Reenlightenment = &v1.FeatureState{
-						Enabled: &trueV,
-					}
-				}
-
-				return features
-			}
-			var supportedKVMInfoFeature []string
-			nodes := libnode.GetAllSchedulableNodes(virtClient)
-			Expect(nodes.Items).ToNot(BeEmpty(), "There should be some compute node")
-			node := &nodes.Items[0]
-			supportedCPUs := libnode.GetSupportedCPUModels(*nodes)
-			Expect(supportedCPUs).ToNot(BeEmpty(), "There should be some supported cpu models")
-
-			for key := range node.Labels {
-				if strings.Contains(key, v1.HypervLabel) &&
-					!strings.Contains(key, "tlbflush") &&
-					!strings.Contains(key, "ipi") &&
-					!strings.Contains(key, "synictimer") {
-					supportedKVMInfoFeature = append(supportedKVMInfoFeature, strings.TrimPrefix(key, v1.HypervLabel))
-				}
-			}
-
-			for _, label := range supportedKVMInfoFeature {
-				vmi := libvmifact.NewAlpine()
-				features := enableHyperVInVMI(label)
-				vmi.Spec.Domain.Features = &v1.Features{
-					Hyperv: &features,
-				}
-
-				vmi, err := virtClient.VirtualMachineInstance(testsuite.NamespaceTestDefault).Create(context.Background(), vmi, metav1.CreateOptions{})
-				Expect(err).ToNot(HaveOccurred(), "Should create VMI when using %v", label)
-				libwait.WaitForSuccessfulVMIStart(vmi)
-
-				_, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred(), "Should get VMI when using %v", label)
-			}
 		})
 
 		DescribeTable(" the vmi with EVMCS HyperV feature should have correct HyperV and cpu features auto filled", Serial, func(featureState *v1.FeatureState) {

--- a/tests/hyperv_test.go
+++ b/tests/hyperv_test.go
@@ -14,19 +14,15 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
 	virtpointer "kubevirt.io/kubevirt/pkg/pointer"
-	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
-	nodelabellerutil "kubevirt.io/kubevirt/pkg/virt-handler/node-labeller/util"
 
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/framework/matcher"
 	"kubevirt.io/kubevirt/tests/libinfra"
-	"kubevirt.io/kubevirt/tests/libkubevirt/config"
 	"kubevirt.io/kubevirt/tests/libmigration"
 	"kubevirt.io/kubevirt/tests/libnet"
 	"kubevirt.io/kubevirt/tests/libnode"
-	"kubevirt.io/kubevirt/tests/libpod"
 	"kubevirt.io/kubevirt/tests/libvmifact"
 	"kubevirt.io/kubevirt/tests/libvmops"
 	"kubevirt.io/kubevirt/tests/libwait"
@@ -104,40 +100,6 @@ var _ = Describe("[sig-compute] Hyper-V enlightenments", decorators.SigCompute, 
 			})
 		})
 
-		DescribeTable(" the vmi with EVMCS HyperV feature should have correct HyperV and cpu features auto filled", Serial, func(featureState *v1.FeatureState) {
-			config.EnableFeatureGate(featuregate.HypervStrictCheckGate)
-			vmi := libvmifact.NewAlpine()
-			vmi.Spec.Domain.Features = &v1.Features{
-				Hyperv: &v1.FeatureHyperv{
-					EVMCS: featureState,
-				},
-			}
-			vmi = libvmops.RunVMIAndExpectLaunch(vmi, libvmops.StartupTimeoutSecondsMedium)
-
-			var err error
-			vmi, err = virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred(), "Should get VMI")
-			Expect(vmi.Spec.Domain.Features.Hyperv.EVMCS).ToNot(BeNil(), "evmcs should not be nil")
-			Expect(vmi.Spec.Domain.CPU).ToNot(BeNil(), "cpu topology can't be nil")
-			pod, err := libpod.GetPodByVirtualMachineInstance(vmi, vmi.Namespace)
-			Expect(err).ToNot(HaveOccurred())
-
-			if featureState.Enabled == nil || *featureState.Enabled == true {
-				Expect(vmi.Spec.Domain.Features.Hyperv.VAPIC).ToNot(BeNil(), "vapic should not be nil")
-				Expect(vmi.Spec.Domain.CPU.Features).To(HaveLen(1), "cpu topology has to contain 1 feature")
-				Expect(vmi.Spec.Domain.CPU.Features[0].Name).To(Equal(nodelabellerutil.VmxFeature), "vmx cpu feature should be requested")
-				Expect(pod.Spec.NodeSelector).Should(HaveKeyWithValue(v1.CPUModelVendorLabel+"Intel", "true"))
-			} else {
-				Expect(pod.Spec.NodeSelector).ShouldNot(HaveKeyWithValue(v1.CPUModelVendorLabel+"Intel", "true"))
-				Expect(vmi.Spec.Domain.Features.Hyperv.VAPIC).To(BeNil(), "vapic should be nil")
-				Expect(vmi.Spec.Domain.CPU.Features).To(BeEmpty())
-			}
-
-		},
-			Entry("hyperv and cpu features should be auto filled when EVMCS is enabled", decorators.VMX, &v1.FeatureState{Enabled: virtpointer.P(true)}),
-			Entry("EVMCS should be enabled when vmi.Spec.Domain.Features.Hyperv.EVMCS is set but the EVMCS.Enabled field is nil ", decorators.VMX, &v1.FeatureState{Enabled: nil}),
-			Entry("Verify that features aren't applied when enabled is false", &v1.FeatureState{Enabled: virtpointer.P(false)}),
-		)
 	})
 
 	Context("VMI with HyperV passthrough", func() {


### PR DESCRIPTION
The removed tests started VMs only to check that k8s scheduler adheres to label affinity, that kubevirt builds the virt-launcher pod as expected, and that libvirt/qemu can start a VM with this feature. virt-launcher building is well covered by unit tests, k8s scheduling and libvirt are well tested outside k6t.

/kind cleanup

```release-note
NONE
```

