### PR TITLE
libvmi: add Interface builder with option pattern

### DIFF
--- a/pkg/libvmi/network.go
+++ b/pkg/libvmi/network.go
@@ -138,93 +138,62 @@ func WithState(state kvirtv1.InterfaceState) InterfaceOption {
 
 // InterfaceDeviceWithMasqueradeBinding returns an Interface named "default" with masquerade binding.
 func InterfaceDeviceWithMasqueradeBinding(ports ...kvirtv1.Port) kvirtv1.Interface {
-	return kvirtv1.Interface{
-		Name: kvirtv1.DefaultPodNetwork().Name,
-		InterfaceBindingMethod: kvirtv1.InterfaceBindingMethod{
-			Masquerade: &kvirtv1.InterfaceMasquerade{},
-		},
-		Ports: ports,
-	}
+	return NewInterface(kvirtv1.DefaultPodNetwork().Name, WithMasqueradeBinding(), WithPorts(ports...))
 }
 
 // InterfaceDeviceWithBridgeBinding returns an Interface with bridge binding.
 func InterfaceDeviceWithBridgeBinding(name string) kvirtv1.Interface {
-	return kvirtv1.Interface{
-		Name: name,
-		InterfaceBindingMethod: kvirtv1.InterfaceBindingMethod{
-			Bridge: &kvirtv1.InterfaceBridge{},
-		},
-	}
+	return NewInterface(name, WithBridgeBinding())
 }
 
 // InterfaceDeviceWithSRIOVBinding returns an Interface with SRIOV binding.
 func InterfaceDeviceWithSRIOVBinding(name string) kvirtv1.Interface {
-	return kvirtv1.Interface{
-		Name: name,
-		InterfaceBindingMethod: kvirtv1.InterfaceBindingMethod{
-			SRIOV: &kvirtv1.InterfaceSRIOV{},
-		},
-	}
+	return NewInterface(name, WithSRIOVBinding())
 }
 
 // InterfaceDeviceWithPasstBinding returns an Interface with passtBinding.
 func InterfaceDeviceWithPasstBinding(name string) kvirtv1.Interface {
-	return kvirtv1.Interface{
-		Name: name,
-		InterfaceBindingMethod: kvirtv1.InterfaceBindingMethod{
-			PasstBinding: &kvirtv1.InterfacePasstBinding{},
-		},
-	}
+	return NewInterface(name, WithPasstBinding())
 }
 
 // InterfaceWithPasstBinding returns an Interface named "default" with passt binding plugin.
 func InterfaceWithPasstBindingPlugin(ports ...kvirtv1.Port) kvirtv1.Interface {
 	const passtBindingName = "passt"
-	return kvirtv1.Interface{
-		Name:    kvirtv1.DefaultPodNetwork().Name,
-		Binding: &kvirtv1.PluginBinding{Name: passtBindingName},
-		Ports:   ports,
-	}
+	return NewInterface(kvirtv1.DefaultPodNetwork().Name,
+		WithBindingPlugin(kvirtv1.PluginBinding{Name: passtBindingName}), WithPorts(ports...))
 }
 
 // InterfaceWithMacvtapBindingPlugin returns an Interface named "default" with "macvtap" binding plugin.
 func InterfaceWithMacvtapBindingPlugin(name string) kvirtv1.Interface {
 	const macvtapBindingName = "macvtap"
-	return kvirtv1.Interface{
-		Name:    name,
-		Binding: &kvirtv1.PluginBinding{Name: macvtapBindingName},
-	}
+	return NewInterface(name, WithBindingPlugin(kvirtv1.PluginBinding{Name: macvtapBindingName}))
 }
 
 func InterfaceWithBindingPlugin(name string, binding kvirtv1.PluginBinding, ports ...kvirtv1.Port) kvirtv1.Interface {
-	return kvirtv1.Interface{
-		Name:    name,
-		Binding: &binding,
-		Ports:   ports,
-	}
+	return NewInterface(name, WithBindingPlugin(binding), WithPorts(ports...))
 }
 
 // InterfaceWithMac decorates an existing Interface with a MAC address.
 func InterfaceWithMac(iface kvirtv1.Interface, macAddress string) kvirtv1.Interface {
-	iface.MacAddress = macAddress
+	WithMac(macAddress)(&iface)
 	return iface
 }
 
 // InterfaceWithPciAddress decorates an existing Interface with a guest PCI address.
 func InterfaceWithPciAddress(iface kvirtv1.Interface, pciAddress string) kvirtv1.Interface {
-	iface.PciAddress = pciAddress
+	WithPciAddress(pciAddress)(&iface)
 	return iface
 }
 
 // InterfaceWithTag decorates an existing Interface with a tag.
 func InterfaceWithTag(iface kvirtv1.Interface, tag string) kvirtv1.Interface {
-	iface.Tag = tag
+	WithTag(tag)(&iface)
 	return iface
 }
 
 // InterfaceWithModel decorates an existing Interface with a model.
 func InterfaceWithModel(iface kvirtv1.Interface, model string) kvirtv1.Interface {
-	iface.Model = model
+	WithModel(model)(&iface)
 	return iface
 }
 

--- a/pkg/libvmi/network.go
+++ b/pkg/libvmi/network.go
@@ -39,6 +39,103 @@ func WithNetwork(network *kvirtv1.Network) Option {
 	}
 }
 
+// InterfaceOption represents an action that configures an Interface.
+type InterfaceOption func(iface *kvirtv1.Interface)
+
+// NewInterface instantiates a new Interface, building its properties based on the specified options.
+func NewInterface(name string, opts ...InterfaceOption) kvirtv1.Interface {
+	iface := kvirtv1.Interface{Name: name}
+	for _, opt := range opts {
+		opt(&iface)
+	}
+	return iface
+}
+
+// WithMasqueradeBinding sets the masquerade binding method.
+func WithMasqueradeBinding() InterfaceOption {
+	return func(iface *kvirtv1.Interface) {
+		iface.InterfaceBindingMethod = kvirtv1.InterfaceBindingMethod{
+			Masquerade: &kvirtv1.InterfaceMasquerade{},
+		}
+	}
+}
+
+// WithBridgeBinding sets the bridge binding method.
+func WithBridgeBinding() InterfaceOption {
+	return func(iface *kvirtv1.Interface) {
+		iface.InterfaceBindingMethod = kvirtv1.InterfaceBindingMethod{
+			Bridge: &kvirtv1.InterfaceBridge{},
+		}
+	}
+}
+
+// WithSRIOVBinding sets the SRIOV binding method.
+func WithSRIOVBinding() InterfaceOption {
+	return func(iface *kvirtv1.Interface) {
+		iface.InterfaceBindingMethod = kvirtv1.InterfaceBindingMethod{
+			SRIOV: &kvirtv1.InterfaceSRIOV{},
+		}
+	}
+}
+
+// WithPasstBinding sets the passt binding method.
+func WithPasstBinding() InterfaceOption {
+	return func(iface *kvirtv1.Interface) {
+		iface.InterfaceBindingMethod = kvirtv1.InterfaceBindingMethod{
+			PasstBinding: &kvirtv1.InterfacePasstBinding{},
+		}
+	}
+}
+
+// WithBindingPlugin sets a plugin binding.
+func WithBindingPlugin(binding kvirtv1.PluginBinding) InterfaceOption {
+	return func(iface *kvirtv1.Interface) {
+		iface.Binding = &binding
+	}
+}
+
+// WithMac sets the MAC address.
+func WithMac(macAddress string) InterfaceOption {
+	return func(iface *kvirtv1.Interface) {
+		iface.MacAddress = macAddress
+	}
+}
+
+// WithPorts sets the ports.
+func WithPorts(ports ...kvirtv1.Port) InterfaceOption {
+	return func(iface *kvirtv1.Interface) {
+		iface.Ports = ports
+	}
+}
+
+// WithPciAddress sets the guest PCI address.
+func WithPciAddress(pciAddress string) InterfaceOption {
+	return func(iface *kvirtv1.Interface) {
+		iface.PciAddress = pciAddress
+	}
+}
+
+// WithTag sets a tag.
+func WithTag(tag string) InterfaceOption {
+	return func(iface *kvirtv1.Interface) {
+		iface.Tag = tag
+	}
+}
+
+// WithModel sets the interface model.
+func WithModel(model string) InterfaceOption {
+	return func(iface *kvirtv1.Interface) {
+		iface.Model = model
+	}
+}
+
+// WithState sets the interface state.
+func WithState(state kvirtv1.InterfaceState) InterfaceOption {
+	return func(iface *kvirtv1.Interface) {
+		iface.State = state
+	}
+}
+
 // InterfaceDeviceWithMasqueradeBinding returns an Interface named "default" with masquerade binding.
 func InterfaceDeviceWithMasqueradeBinding(ports ...kvirtv1.Port) kvirtv1.Interface {
 	return kvirtv1.Interface{

--- a/tests/network/hotplug_bridge.go
+++ b/tests/network/hotplug_bridge.go
@@ -169,22 +169,6 @@ var _ = Describe(SIG("bridge nic-hotplug", Serial, func() {
 			Expect(libnet.SetInterfaceUp(hotPluggedVMI, guestSecondaryIfaceName)).To(Succeed())
 
 			By("creating another VM connected to the same secondary network")
-			net := v1.Network{
-				Name: ifaceName,
-				NetworkSource: v1.NetworkSource{
-					Multus: &v1.MultusNetwork{
-						NetworkName: nadName,
-					},
-				},
-			}
-
-			iface := v1.Interface{
-				Name: ifaceName,
-				InterfaceBindingMethod: v1.InterfaceBindingMethod{
-					Bridge: &v1.InterfaceBridge{},
-				},
-			}
-
 			networkData, err := cloudinit.NewNetworkData(
 				cloudinit.WithEthernet("eth1",
 					cloudinit.WithAddresses(ip2+subnetMask),
@@ -193,10 +177,10 @@ var _ = Describe(SIG("bridge nic-hotplug", Serial, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			anotherVmi := libvmifact.NewFedora(
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+				libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithMasqueradeBinding())),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
-				libvmi.WithInterface(iface),
-				libvmi.WithNetwork(&net),
+				libvmi.WithInterface(libvmi.NewInterface(ifaceName, libvmi.WithBridgeBinding())),
+				libvmi.WithNetwork(libvmi.MultusNetwork(ifaceName, nadName)),
 				libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(networkData)),
 				libvmi.WithNodeAffinityFor(hotPluggedVMI.Status.NodeName),
 			)
@@ -225,11 +209,11 @@ var _ = Describe(SIG("bridge nic-hotplug", Serial, func() {
 			secondIfaceMac, err := libnet.GenerateRandomMac()
 			Expect(err).NotTo(HaveOccurred())
 
-			secondHotpluggedIface := libvmi.InterfaceWithMac(
-				libvmi.InterfaceDeviceWithBridgeBinding(secondHotpluggedIfaceName),
-				secondIfaceMac.String(),
+			secondHotpluggedIface := libvmi.NewInterface(secondHotpluggedIfaceName,
+				libvmi.WithBridgeBinding(),
+				libvmi.WithMac(secondIfaceMac.String()),
+				libvmi.WithState(v1.InterfaceStateLinkDown),
 			)
-			secondHotpluggedIface.State = v1.InterfaceStateLinkDown
 
 			Expect(
 				libnet.PatchVMWithNewInterface(hotPluggedVM,
@@ -316,13 +300,11 @@ var _ = Describe(SIG("bridge nic-hotunplug", Serial, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			By("running a VM")
-			ifaceWithStateDown := libvmi.InterfaceDeviceWithBridgeBinding(linuxBridgeNetworkName2)
-			ifaceWithStateDown.State = v1.InterfaceStateLinkDown
 			vmi = libvmifact.NewAlpineWithTestTooling(libnet.WithMasqueradeNetworking(),
 				libvmi.WithNetwork(libvmi.MultusNetwork(linuxBridgeNetworkName1, nadName)),
 				libvmi.WithNetwork(libvmi.MultusNetwork(linuxBridgeNetworkName2, nadName)),
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(linuxBridgeNetworkName1)),
-				libvmi.WithInterface(ifaceWithStateDown))
+				libvmi.WithInterface(libvmi.NewInterface(linuxBridgeNetworkName1, libvmi.WithBridgeBinding())),
+				libvmi.WithInterface(libvmi.NewInterface(linuxBridgeNetworkName2, libvmi.WithBridgeBinding(), libvmi.WithState(v1.InterfaceStateLinkDown))))
 			vm = libvmi.NewVirtualMachine(vmi, libvmi.WithRunStrategy(v1.RunStrategyAlways))
 
 			vm, err = kubevirt.Client().VirtualMachine(testsuite.GetTestNamespace(nil)).Create(context.Background(), vm, metav1.CreateOptions{})
@@ -369,19 +351,7 @@ var _ = Describe(SIG("bridge nic-hotunplug", Serial, func() {
 }))
 
 func newBridgeNetworkInterface(name, netAttachDefName string) (v1.Network, v1.Interface) {
-	network := v1.Network{
-		Name: name,
-		NetworkSource: v1.NetworkSource{
-			Multus: &v1.MultusNetwork{
-				NetworkName: netAttachDefName,
-			},
-		},
-	}
-	iface := v1.Interface{
-		Name:                   name,
-		InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}},
-	}
-	return network, iface
+	return *libvmi.MultusNetwork(name, netAttachDefName), libvmi.NewInterface(name, libvmi.WithBridgeBinding())
 }
 
 func addBridgeInterface(vm *v1.VirtualMachine, name, netAttachDefName string) error {

--- a/tests/network/passt.go
+++ b/tests/network/passt.go
@@ -59,14 +59,13 @@ var _ = Describe(SIG(" VirtualMachineInstance with passt network binding", func(
 	It("should apply the interface configuration", func() {
 		const testMACAddr = "02:02:02:02:02:02"
 		const testPCIAddr = "0000:01:00.0"
-		passtIface := libvmi.InterfaceWithMac(
-			libvmi.InterfaceDeviceWithPasstBinding(v1.DefaultPodNetwork().Name),
-			testMACAddr,
-		)
-		passtIface.Ports = []v1.Port{{Port: 1234, Protocol: "TCP"}}
-		passtIface.PciAddress = testPCIAddr
 		vmi := libvmifact.NewAlpineWithTestTooling(
-			libvmi.WithInterface(passtIface),
+			libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name,
+				libvmi.WithPasstBinding(),
+				libvmi.WithMac(testMACAddr),
+				libvmi.WithPorts(v1.Port{Port: 1234, Protocol: "TCP"}),
+				libvmi.WithPciAddress(testPCIAddr),
+			)),
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
 		)
 
@@ -104,7 +103,7 @@ var _ = Describe(SIG(" VirtualMachineInstance with passt network binding", func(
 			Expect(err).ToNot(HaveOccurred())
 
 			serverVMI = libvmifact.NewAlpineWithTestTooling(
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithPasstBinding(v1.DefaultPodNetwork().Name)),
+				libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithPasstBinding())),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 			)
 			serverVMI, err = kubevirt.Client().VirtualMachineInstance(namespace).Create(
@@ -164,16 +163,15 @@ var _ = Describe(SIG(" VirtualMachineInstance with passt network binding", func(
 		BeforeAll(func() {
 			namespace := testsuite.GetTestNamespace(nil)
 
-			ports := []v1.Port{
-				{Port: udpPortForIPv4, Protocol: "UDP"},
-				{Port: udpPortForIPv6, Protocol: "UDP"},
-			}
-			passtIface := libvmi.InterfaceDeviceWithPasstBinding(v1.DefaultPodNetwork().Name)
-			passtIface.Ports = ports
-
 			By("Starting server VMI")
 			serverVMI = libvmifact.NewAlpineWithTestTooling(
-				libvmi.WithInterface(passtIface),
+				libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name,
+					libvmi.WithPasstBinding(),
+					libvmi.WithPorts(
+						v1.Port{Port: udpPortForIPv4, Protocol: "UDP"},
+						v1.Port{Port: udpPortForIPv6, Protocol: "UDP"},
+					),
+				)),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 			)
 			serverVMI, err = kubevirt.Client().VirtualMachineInstance(namespace).Create(
@@ -182,7 +180,7 @@ var _ = Describe(SIG(" VirtualMachineInstance with passt network binding", func(
 
 			By("Starting client VMI")
 			clientVMI = libvmifact.NewAlpineWithTestTooling(
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithPasstBinding(v1.DefaultPodNetwork().Name)),
+				libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithPasstBinding())),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 			)
 			clientVMI, err = kubevirt.Client().VirtualMachineInstance(namespace).Create(
@@ -319,9 +317,10 @@ var _ = Describe(SIG(" VirtualMachineInstance with passt network binding", func(
 )
 
 func withPasstInterfaceWithPort() libvmi.Option {
-	iface := libvmi.InterfaceDeviceWithPasstBinding(v1.DefaultPodNetwork().Name)
-	iface.Ports = []v1.Port{{Port: 1234, Protocol: "TCP"}}
-	return libvmi.WithInterface(iface)
+	return libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name,
+		libvmi.WithPasstBinding(),
+		libvmi.WithPorts(v1.Port{Port: 1234, Protocol: "TCP"}),
+	))
 }
 
 func assertSourcePodContainersTerminate(labelSelector, fieldSelector string, vmi *v1.VirtualMachineInstance) bool {
@@ -345,7 +344,7 @@ func startPasstVMI() *v1.VirtualMachineInstance {
 	)
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 	vmi := libvmifact.NewFedora(
-		libvmi.WithInterface(libvmi.InterfaceDeviceWithPasstBinding(v1.DefaultPodNetwork().Name)),
+		libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithPasstBinding())),
 		libvmi.WithNetwork(v1.DefaultPodNetwork()),
 		libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(networkData)),
 	)
@@ -369,11 +368,11 @@ func createClientServerPasstVMIsWithTCPServer(tcpPort int) (client, server *v1.V
 		return nil, nil, err
 	}
 
-	ports := []v1.Port{{Name: "http", Port: int32(tcpPort), Protocol: "TCP"}} //nolint:gosec // tcpPort is a test constant
-	passtIface := libvmi.InterfaceDeviceWithPasstBinding(v1.DefaultPodNetwork().Name)
-	passtIface.Ports = ports
 	serverVMI := libvmifact.NewAlpineWithTestTooling(
-		libvmi.WithInterface(passtIface),
+		libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name,
+			libvmi.WithPasstBinding(),
+			libvmi.WithPorts(v1.Port{Name: "http", Port: int32(tcpPort), Protocol: "TCP"}), //nolint:gosec // tcpPort is a test constant
+		)),
 		libvmi.WithNetwork(v1.DefaultPodNetwork()),
 	)
 	serverVMI, err = kubevirt.Client().VirtualMachineInstance(namespace).Create(


### PR DESCRIPTION
### What this PR does
#### Before this PR:
Interface construction in tests uses a mix of `InterfaceDeviceWith*()` constructors, `InterfaceWith*()` decorators, and post-construction struct mutations (`.Ports`, `.PciAddress`, `.State`). When multiple decorators are needed, they nest deeply and become hard to read.

#### After this PR:
Introduces `InterfaceOption` type and `NewInterface(name, ...InterfaceOption)` constructor, mirroring the existing VMI `Option` pattern. Callers compose interface configuration declaratively:

```go
libvmi.NewInterface(v1.DefaultPodNetwork().Name,
    libvmi.WithPasstBinding(),
    libvmi.WithMac(testMACAddr),
    libvmi.WithPorts(v1.Port{Port: 1234, Protocol: "TCP"}),
    libvmi.WithPciAddress(testPCIAddr),
)
```

Converts `tests/network/passt.go` and `tests/network/hotplug_bridge.go` as first adopters. Existing `InterfaceDeviceWith*` and `InterfaceWith*` functions are kept for backwards compatibility — other callers (~344 sites across 40+ files) can migrate gradually in follow-up PRs.

### References

Suggested by @dankenigsberg in [#18263 review](https://github.com/kubevirt/kubevirt/pull/18263#discussion_r3487489845). Builds on the cleanup direction started in #17821.

### Why we need it and why it was done in this way

The nested decorator pattern (`InterfaceWithPorts(InterfaceWithMac(InterfaceDeviceWithPasstBinding(...), ...), ...)`) becomes unwieldy when composing multiple options. The builder pattern is already established for VMI construction (`libvmi.New(opts...)`) — this extends the same idiom to Interface construction.

Existing functions are kept rather than removed to keep the PR reviewable and avoid a 40+ file change.

### Special notes for your reviewer

- Option functions (`WithMasqueradeBinding`, `WithBridgeBinding`, `WithPasstBinding`, `WithSRIOVBinding`, `WithMac`, `WithPorts`, `WithPciAddress`, `WithTag`, `WithModel`, `WithState`, `WithBindingPlugin`) are all added in commit 1 even though not all are used in this PR — they complete the API surface for follow-up migrations.
- `InterfaceOption` is a distinct type from `Option`, so the compiler prevents accidentally mixing VMI-level and Interface-level options.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

/kind cleanup

```release-note
NONE
```