### PR TITLE
Default LUN bus to SCSI when persistent reservation is enabled

### DIFF
--- a/pkg/defaults/amd64.go
+++ b/pkg/defaults/amd64.go
@@ -35,7 +35,11 @@ func setDefaultAmd64DisksBus(spec *v1.VirtualMachineInstanceSpec) {
 			disk.CDRom.Bus = bus
 		}
 		if disk.LUN != nil && disk.LUN.Bus == "" {
-			disk.LUN.Bus = bus
+			if disk.LUN.Reservation {
+				disk.LUN.Bus = v1.DiskBusSCSI
+			} else {
+				disk.LUN.Bus = bus
+			}
 		}
 	}
 }

--- a/pkg/defaults/arm64.go
+++ b/pkg/defaults/arm64.go
@@ -66,7 +66,11 @@ func setDefaultArm64DisksBus(spec *v1.VirtualMachineInstanceSpec) {
 			disk.CDRom.Bus = bus
 		}
 		if disk.LUN != nil && disk.LUN.Bus == "" {
-			disk.LUN.Bus = bus
+			if disk.LUN.Reservation {
+				disk.LUN.Bus = v1.DiskBusSCSI
+			} else {
+				disk.LUN.Bus = bus
+			}
 		}
 	}
 

--- a/pkg/defaults/s390x.go
+++ b/pkg/defaults/s390x.go
@@ -34,7 +34,11 @@ func setDefaultS390xDisksBus(spec *v1.VirtualMachineInstanceSpec) {
 			disk.CDRom.Bus = bus
 		}
 		if disk.LUN != nil && disk.LUN.Bus == "" {
-			disk.LUN.Bus = bus
+			if disk.LUN.Reservation {
+				disk.LUN.Bus = v1.DiskBusSCSI
+			} else {
+				disk.LUN.Bus = bus
+			}
 		}
 	}
 }

--- a/pkg/storage/admitters/disks.go
+++ b/pkg/storage/admitters/disks.go
@@ -52,6 +52,7 @@ func ValidateDisks(field *k8sfield.Path, disks []v1.Disk) []metav1.StatusCause {
 		causes = append(causes, validatePciAddress(field, idx, disk)...)
 		causes = append(causes, validateBootOrderValue(field, idx, disk)...)
 		causes = append(causes, validateBusSupport(field, idx, disk)...)
+		causes = append(causes, validateReservationBus(field, idx, disk)...)
 		causes = append(causes, validateSerialNumValue(field, idx, disk)...)
 		causes = append(causes, validateSerialNumLength(field, idx, disk)...)
 		causes = append(causes, validateCacheMode(field, idx, disk)...)
@@ -225,6 +226,18 @@ func validateBusSupport(field *k8sfield.Path, idx int, disk v1.Disk) []metav1.St
 			Type:    metav1.CauseTypeFieldValueNotSupported,
 			Message: fmt.Sprintf("IOThreads are not supported for disks on a %s bus", bus),
 			Field:   field.Child("domain", "devices", "disks").Index(idx).String(),
+		})
+	}
+	return causes
+}
+
+func validateReservationBus(field *k8sfield.Path, idx int, disk v1.Disk) []metav1.StatusCause {
+	var causes []metav1.StatusCause
+	if disk.LUN != nil && disk.LUN.Reservation && disk.LUN.Bus != v1.DiskBusSCSI {
+		causes = append(causes, metav1.StatusCause{
+			Type:    metav1.CauseTypeFieldValueInvalid,
+			Message: fmt.Sprintf("Persistent reservation requires a SCSI bus, but %s was specified", disk.LUN.Bus),
+			Field:   field.Index(idx).Child("lun", "bus").String(),
 		})
 	}
 	return causes

--- a/pkg/storage/admitters/disks_test.go
+++ b/pkg/storage/admitters/disks_test.go
@@ -260,6 +260,35 @@ var _ = Describe("Disk Validation", func() {
 			Expect(causes[1].Field).To(Equal("fake[1].lun.bus"))
 		})
 
+		It("should reject LUN with reservation and non-SCSI bus", func() {
+			vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
+				Name: "testdisk",
+				DiskDevice: v1.DiskDevice{
+					LUN: &v1.LunTarget{
+						Bus:         v1.DiskBusSATA,
+						Reservation: true,
+					},
+				},
+			})
+			causes := ValidateDisks(k8sfield.NewPath("fake"), vmi.Spec.Domain.Devices.Disks)
+			Expect(causes).To(HaveLen(1))
+			Expect(causes[0].Field).To(Equal("fake[0].lun.bus"))
+		})
+
+		It("should accept LUN with reservation and SCSI bus", func() {
+			vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
+				Name: "testdisk",
+				DiskDevice: v1.DiskDevice{
+					LUN: &v1.LunTarget{
+						Bus:         v1.DiskBusSCSI,
+						Reservation: true,
+					},
+				},
+			})
+			causes := ValidateDisks(k8sfield.NewPath("fake"), vmi.Spec.Domain.Devices.Disks)
+			Expect(causes).To(BeEmpty())
+		})
+
 		It("should reject disks with unsupported I/O modes", func() {
 			vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
 				Name: "testdisk1",

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vmi-mutator_test.go
@@ -992,6 +992,33 @@ var _ = Describe("VirtualMachineInstance Mutator", func() {
 			}, "LUN", v1.DiskBusVirtio),
 	)
 
+	DescribeTable("should default LUN bus to SCSI when reservation is enabled", func(arch string) {
+		vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
+			Name: "a",
+			VolumeSource: v1.VolumeSource{
+				PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+					PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
+						ClaimName: "testclaim",
+					},
+				},
+			},
+		})
+		vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
+			Name: "a",
+			DiskDevice: v1.DiskDevice{
+				LUN: &v1.LunTarget{
+					Reservation: true,
+				},
+			},
+		})
+		_, vmiSpec, _ := getMetaSpecStatusFromAdmitWithArch(arch)
+		Expect(vmiSpec.Domain.Devices.Disks[0].DiskDevice.LUN.Bus).To(Equal(v1.DiskBusSCSI))
+	},
+		Entry("on amd64", "amd64"),
+		Entry("on arm64", "arm64"),
+		Entry("on s390x", "s390x"),
+	)
+
 	var (
 		vmxFeature = v1.CPUFeature{
 			Name:   nodelabellerutil.VmxFeature,

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -3645,6 +3645,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 					Name: "testdisk",
 					DiskDevice: v1.DiskDevice{
 						LUN: &v1.LunTarget{
+							Bus:         v1.DiskBusSCSI,
 							Reservation: true,
 						},
 					},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
SCSI persistent reservations (PR) are a SCSI-specific feature defined
in SPC spec that allows multiple initiators to coordinate access to
shared storage. Since PR commands are only valid on SCSI transport,
a LUN with reservation:true must use a SCSI bus — other bus types
(virtio, SATA) do not expose the command set needed for PR operations.

Default bus to SCSI when reservation is true and bus is unset, and
reject with a validation error when reservation is true with an
explicitly non-SCSI bus.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Default LUN bus to SCSI when persistent reservation is enabled
```

