### PR TITLE
dockerized: Bound podman rsync stalls during _out sync

### DIFF
--- a/hack/dockerized
+++ b/hack/dockerized
@@ -59,6 +59,8 @@ if [ "${KUBEVIRT_BUILDER_IMAGE}" == "${default_builder_image}" ] && [ -n "${BUIL
 fi
 
 SYNC_OUT=${SYNC_OUT:-true}
+DOCKERIZED_RSYNC_CONNECT_TIMEOUT=${DOCKERIZED_RSYNC_CONNECT_TIMEOUT:-15}
+DOCKERIZED_RSYNC_IO_TIMEOUT=${DOCKERIZED_RSYNC_IO_TIMEOUT:-60}
 
 BUILDER=${job_prefix}
 
@@ -121,7 +123,7 @@ printf "\n"
 rsynch_fail_count=0
 
 _rsync() {
-    rsync -al "$@"
+    rsync -al --contimeout="${DOCKERIZED_RSYNC_CONNECT_TIMEOUT}" --timeout="${DOCKERIZED_RSYNC_IO_TIMEOUT}" "$@"
 }
 
 # Copy kubevirt into the persistent container volume


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
On podman, dockerized can hang after the inner build already completed while rsyncing _out back to the host. We narrowed the stall to the final _out sync path, where rsync on
_out/tests/tools/manifest-templator could stop making progress and wait indefinitely on the socket.

Keep the fix minimal and local to the shared rsync helper: add connect and I/O timeouts to _rsync() so podman-backed stalls no longer block forever and instead complete or fail in bounded time.
This basically solved the hang and allowed to complete successfully, instead blocking forever.
Due to internal mechanism that `--timeout` enables.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

