### PR TITLE
fix: make hugetblfs-dir EmptyDir hugepage-backed and skip memfd on s390x

### DIFF
--- a/pkg/virt-controller/services/rendervolumes.go
+++ b/pkg/virt-controller/services/rendervolumes.go
@@ -516,7 +516,9 @@ func withHugepages() VolumeRendererOption {
 		renderer.podVolumes = append(renderer.podVolumes, k8sv1.Volume{
 			Name: "hugetblfs-dir",
 			VolumeSource: k8sv1.VolumeSource{
-				EmptyDir: &k8sv1.EmptyDirVolumeSource{},
+				EmptyDir: &k8sv1.EmptyDirVolumeSource{
+					Medium: k8sv1.StorageMediumHugePages,
+				},
 			},
 		})
 		renderer.podVolumeMounts = append(renderer.podVolumeMounts, k8sv1.VolumeMount{

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -2638,7 +2638,7 @@ var _ = Describe("Template", func() {
 						k8sv1.Volume{
 							Name: "hugetblfs-dir",
 							VolumeSource: k8sv1.VolumeSource{
-								EmptyDir: &k8sv1.EmptyDirVolumeSource{},
+								EmptyDir: &k8sv1.EmptyDirVolumeSource{Medium: k8sv1.StorageMediumHugePages},
 							}}))
 
 				Expect(pod.Spec.Containers[0].VolumeMounts).To(HaveLen(8))
@@ -2718,7 +2718,7 @@ var _ = Describe("Template", func() {
 						k8sv1.Volume{
 							Name: "hugetblfs-dir",
 							VolumeSource: k8sv1.VolumeSource{
-								EmptyDir: &k8sv1.EmptyDirVolumeSource{},
+								EmptyDir: &k8sv1.EmptyDirVolumeSource{Medium: k8sv1.StorageMediumHugePages},
 							}}))
 
 				Expect(pod.Spec.Containers[0].VolumeMounts).To(HaveLen(8))

--- a/pkg/virt-launcher/virtwrap/converter/arch/amd64.go
+++ b/pkg/virt-launcher/virtwrap/converter/arch/amd64.go
@@ -96,3 +96,7 @@ func (converterAMD64) SupportPCIHole64Disabling() bool {
 func (converterAMD64) SupportPCIePlacement() bool {
 	return true
 }
+
+func (converterAMD64) IsMemfdSupported() bool {
+	return true
+}

--- a/pkg/virt-launcher/virtwrap/converter/arch/arm64.go
+++ b/pkg/virt-launcher/virtwrap/converter/arch/arm64.go
@@ -73,3 +73,7 @@ func (converterARM64) SupportPCIHole64Disabling() bool {
 func (converterARM64) SupportPCIePlacement() bool {
 	return true
 }
+
+func (converterARM64) IsMemfdSupported() bool {
+	return true
+}

--- a/pkg/virt-launcher/virtwrap/converter/arch/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/arch/converter.go
@@ -41,6 +41,7 @@ type Converter interface {
 	ShouldVerboseLogsBeEnabled() bool
 	SupportPCIHole64Disabling() bool
 	SupportPCIePlacement() bool
+	IsMemfdSupported() bool
 }
 
 func NewConverter(arch string) Converter {

--- a/pkg/virt-launcher/virtwrap/converter/arch/s390x.go
+++ b/pkg/virt-launcher/virtwrap/converter/arch/s390x.go
@@ -82,3 +82,8 @@ func (converterS390X) SupportPCIePlacement() bool {
 	// All devices are attached via zPCI in a flat topology.
 	return false
 }
+
+func (converterS390X) IsMemfdSupported() bool {
+	// s390x does not support NUMA, and memfd requires a NUMA topology definition.
+	return false
+}

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -1069,8 +1069,10 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 		domain.Spec.MemoryBacking = &api.MemoryBacking{
 			HugePages: &api.HugePages{},
 		}
-		if val := vmi.Annotations[v1.MemfdMemoryBackend]; val != "false" {
-			isMemfdRequired = true
+		if c.Architecture.IsMemfdSupported() {
+			if val := vmi.Annotations[v1.MemfdMemoryBackend]; val != "false" {
+				isMemfdRequired = true
+			}
 		}
 	}
 	// virtiofs require shared access

--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -1628,19 +1628,29 @@ var _ = Describe("Converter", func() {
 			Expect(err).To(HaveOccurred())
 		})
 
-		It("should convert hugepages", func() {
+		DescribeTable("should convert hugepages", func(arch string, expectMemfd bool) {
 			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
 			vmi.Spec.Domain.Memory = &v1.Memory{
 				Hugepages: &v1.Hugepages{},
 			}
+			c.Architecture = archconverter.NewConverter(arch)
 			domainSpec := vmiToDomainXMLToDomainSpec(vmi, c)
-			Expect(domainSpec.MemoryBacking.HugePages).ToNot(BeNil())
-			Expect(domainSpec.MemoryBacking.Source).ToNot(BeNil())
-			Expect(domainSpec.MemoryBacking.Source.Type).To(Equal("memfd"))
 
+			Expect(domainSpec.MemoryBacking.HugePages).ToNot(BeNil())
 			Expect(domainSpec.Memory.Value).To(Equal(uint64(8388608)))
 			Expect(domainSpec.Memory.Unit).To(Equal("b"))
-		})
+
+			if expectMemfd {
+				Expect(domainSpec.MemoryBacking.Source).ToNot(BeNil())
+				Expect(domainSpec.MemoryBacking.Source.Type).To(Equal("memfd"))
+			} else {
+				Expect(domainSpec.MemoryBacking.Source).To(BeNil())
+			}
+		},
+			Entry("with memfd on amd64", amd64, true),
+			Entry("with memfd on arm64", arm64, true),
+			Entry("without memfd on s390x", s390x, false),
+		)
 
 		It("should not add RNG when not present", func() {
 			domainSpec := vmiToDomainXMLToDomainSpec(vmi, c)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
1. **Skip memfd memory backend on s390x** (`converter.go`): memfd requires a NUMA topology definition in the domain XML. s390x does not support NUMA, so enabling memfd causes an unsupported `-numa` argument to be passed to qemu-kvm, crashing the VM. This change skips memfd on s390x so QEMU falls back to allocating hugepages directly from the hugetlbfs mount.
2. **Fix hugetlbfs masked by plain EmptyDir** (`rendervolumes.go`): The`hugetblfs-dir` EmptyDir volume mounted at `/dev/hugepages/libvirt/qemu` was not backed by hugepages, masking the parent hugetlbfs mount at `/dev/hugepages`. On x86 this is hidden because memfd bypasses the filesystem entirely. On s390x (where memfd is now skipped), QEMU allocates hugepages directly from this path using `-mem-path`, so it must be a hugetlbfs mount.

#### Before this PR:

- s390x VMs with hugepages crash with:
`LibvirtError(Code=1, Domain=10, Message='internal error: QEMU unexpectedly closed the monitor: qemu-kvm: -numa node,nodeid=0,cpus=0-3,memdev=ram-node0: NUMA is not supported by this machine-type')`

- After skipping memfd to fix the above, the VM boots but its memory is not actually backed by hugepages. The hugepage consumption does not match the requested guest memory because the `hugetblfs-dir` is plain EmptyDir masks the hugetlbfs mount at `/dev/hugepages/libvirt/qemu`.

#### After this PR:

- s390x VMs with hugepages boot successfully
- Hugepage consumption matches the guest memory as expected
- The `hugetblfs-dir` EmptyDir is hugepage-backed, so the hugetlbfs mount is no longer masked

### References

- Fixes #16393 

<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes # 
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bug fix: Fixed hugetblfs-dir EmptyDir volume masking the parent hugetlbfs mount at /dev/hugepages, which prevented QEMU from allocating hugepages via -mem-path. The EmptyDir is now explicitly hugepage-backed.
```

