### PR TITLE
docs/sriov: describe the emulated igb development flow

### DIFF
--- a/docs/network/sriov.md
+++ b/docs/network/sriov.md
@@ -42,6 +42,10 @@ environment.
 
 # Configuration
 
+This section first explains how to configure SR-IOV-capable hardware on a
+host. Later in this document, the recommended practical workflow for
+development and CI uses the emulated `igb` SR-IOV setup.
+
 > NOTE: steps to configure SR-IOV on a host are only applicable if you don't
 > use the SR-IOV Network Operator to deploy SR-IOV components. The operator
 > handles most of the steps discussed below, including configuring kernel
@@ -54,19 +58,10 @@ environment.
 > Just remember to set `SriovNetworkNodePolicy` to use `deviceType: vfio-pci`
 > when configuring the operator.
 >
-> For local development purposes, one should be able to (re)use the same
-> [kind](https://kind.sigs.k8s.io/) based provider that the official upstream
-> SR-IOV CI relies on:
->
-> ``` 
-> $ export KUBEVIRT_PROVIDER=kind-sriov
->
-> $ make cluster-up
-> ```
->
-> Assuming you run these commands on an SR-IOV-enabled host, they should bring
-> up a dockerized cluster with all SR-IOV components and resources set up and
-> ready to use.
+> For local development and CI, KubeVirt can exercise the SR-IOV flow in
+> emulated mode with an emulated `igb` NIC. The automation target for this
+> setup ends with `-emulated-igb` and runs the SR-IOV suite with
+> `-emulated-sriov=true`.
 >
 > If you know what you are doing and still would like to follow the manual
 > configuration path, keep reading.
@@ -125,26 +120,26 @@ you may need to configure the host as follows:
 $ echo "options vfio_iommu_type1 allow_unsafe_interrupts=1" > /etc/modprobe.d/iommu_unsafe_interrupts.conf
 ```
 
-Now you are ready to set up your cluster.
-
 # Set up a Kubernetes cluster
 
-You can use your preferred mechanism to deploy your Kubernetes cluster as long
-as you deploy on bare metal. Note that using virtualized environment is
-problematic with SR-IOV because to use SR-IOV PFs in such environment, one
-would first need to pass through PF devices from hypervisor level into the
-virtual machines.
+The recommended approach for development and CI is to use the emulated `igb`
+SR-IOV setup used by automation. It runs the SR-IOV suite in emulated mode,
+which is useful when no SR-IOV-capable NIC is available on the host.
 
-The recommended approach for development is to use the `kind-sriov` provider,
-which sets up a Kind-based cluster with all SR-IOV components pre-configured:
+The emulated `igb` flow is not a separate `KUBEVIRT_PROVIDER` value. In
+automation, it is expressed as a `*-emulated-igb` target suffix layered on top
+of a base provider such as `k8s-1.36`, and it enables SR-IOV emulation in tests with
+`-emulated-sriov=true`.
 
-``` 
-$ export KUBEVIRT_PROVIDER=kind-sriov
-$ make cluster-up
 ```
+export KUBEVIRT_PROVIDER=k8s-1.36
+export KUBEVIRT_NUM_NODES=3
+export KUBEVIRT_WITH_SRIOV=true
+export KUBEVIRT_DEPLOY_NETWORK_RESOURCES_INJECTOR=true
+export KUBEVIRT_FUNC_TEST_SUITE_ARGS="${KUBEVIRT_FUNC_TEST_SUITE_ARGS} -emulated-sriov=true"
 
-See `kubevirtci/cluster-up/cluster/kind-sriov/README.md` for more details,
-including multi-cluster and custom-image configurations.
+make cluster-up
+```
 
 Once the cluster is deployed, we can move to SR-IOV specific components.
 
@@ -153,8 +148,8 @@ Once the cluster is deployed, we can move to SR-IOV specific components.
 > NOTE: manual deployment of SR-IOV components is not recommended. Please
 > consider using the
 > [SR-IOV Network Operator](https://github.com/k8snetworkplumbingwg/sriov-network-operator)
-> instead. The `kind-sriov` provider handles this automatically for development
-> clusters.
+> instead. The emulated `igb` SR-IOV setup used by automation handles this
+> automatically for development and CI environments.
 
 The following components must be deployed to support SR-IOV:
 

--- a/docs/network/sriov.md
+++ b/docs/network/sriov.md
@@ -42,6 +42,12 @@ environment.
 
 # Configuration
 
+This section first explains how to configure SR-IOV-capable hardware on a
+host. Later in this document, the recommended practical workflow for
+development and CI uses the emulated `igb` [1] SR-IOV setup.
+
+[1] https://www.qemu.org/docs/master/system/devices/igb.html
+
 > NOTE: steps to configure SR-IOV on a host are only applicable if you don't
 > use the SR-IOV Network Operator to deploy SR-IOV components. The operator
 > handles most of the steps discussed below, including configuring kernel
@@ -54,19 +60,9 @@ environment.
 > Just remember to set `SriovNetworkNodePolicy` to use `deviceType: vfio-pci`
 > when configuring the operator.
 >
-> For local development purposes, one should be able to (re)use the same
-> [kind](https://kind.sigs.k8s.io/) based provider that the official upstream
-> SR-IOV CI relies on:
->
-> ``` 
-> $ export KUBEVIRT_PROVIDER=kind-sriov
->
-> $ make cluster-up
-> ```
->
-> Assuming you run these commands on an SR-IOV-enabled host, they should bring
-> up a dockerized cluster with all SR-IOV components and resources set up and
-> ready to use.
+> For local development and CI, KubeVirt can exercise the SR-IOV flow in
+> emulated mode with an emulated `igb` NIC.
+> `igb` NIC allows to test SR-IOV networking without requiring physical hardware.
 >
 > If you know what you are doing and still would like to follow the manual
 > configuration path, keep reading.
@@ -125,26 +121,20 @@ you may need to configure the host as follows:
 $ echo "options vfio_iommu_type1 allow_unsafe_interrupts=1" > /etc/modprobe.d/iommu_unsafe_interrupts.conf
 ```
 
-Now you are ready to set up your cluster.
-
 # Set up a Kubernetes cluster
 
-You can use your preferred mechanism to deploy your Kubernetes cluster as long
-as you deploy on bare metal. Note that using virtualized environment is
-problematic with SR-IOV because to use SR-IOV PFs in such environment, one
-would first need to pass through PF devices from hypervisor level into the
-virtual machines.
+The recommended approach for development and CI is to use the emulated `igb`
+SR-IOV setup used by automation. It runs the SR-IOV suite in emulated mode,
+which is useful when no SR-IOV-capable NIC is available on the host.
 
-The recommended approach for development is to use the `kind-sriov` provider,
-which sets up a Kind-based cluster with all SR-IOV components pre-configured:
-
-``` 
-$ export KUBEVIRT_PROVIDER=kind-sriov
-$ make cluster-up
 ```
+export KUBEVIRT_PROVIDER=k8s-1.36
+export KUBEVIRT_NUM_NODES=3
+export KUBEVIRT_WITH_SRIOV=true
+export KUBEVIRT_DEPLOY_NETWORK_RESOURCES_INJECTOR=true
 
-See `kubevirtci/cluster-up/cluster/kind-sriov/README.md` for more details,
-including multi-cluster and custom-image configurations.
+make cluster-up
+```
 
 Once the cluster is deployed, we can move to SR-IOV specific components.
 
@@ -153,8 +143,8 @@ Once the cluster is deployed, we can move to SR-IOV specific components.
 > NOTE: manual deployment of SR-IOV components is not recommended. Please
 > consider using the
 > [SR-IOV Network Operator](https://github.com/k8snetworkplumbingwg/sriov-network-operator)
-> instead. The `kind-sriov` provider handles this automatically for development
-> clusters.
+> instead. The emulated `igb` SR-IOV setup used by automation handles this
+> automatically for development and CI environments.
 
 The following components must be deployed to support SR-IOV:
 
@@ -173,6 +163,14 @@ This particular step is not specific to SR-IOV.
 
 ``` 
 make cluster-sync
+```
+
+# Run the tests (`igb` mode)
+
+```
+export KUBEVIRT_FUNC_TEST_SUITE_ARGS="-emulated-sriov=true"
+export FUNC_TEST_ARGS='--label-filter=SRIOV'
+make functest
 ```
 
 # Usage


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Replace the outdated kind-sriov guidance with the current emulated igb SR-IOV 
workflow used by automation.
Clarify that the document first covers real hardware configuration and later presents the practical development and CI path.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

