### PR TITLE
fix: only let VM adopt DVs if created from DVTemplate

### DIFF
--- a/pkg/controller/controller_ref_manager.go
+++ b/pkg/controller/controller_ref_manager.go
@@ -39,6 +39,8 @@ import (
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 )
 
+const AllowClaimAdoptionAnnotation = "cdi.kubevirt.io/allowClaimAdoption"
+
 type BaseControllerRefManager struct {
 	Controller metav1.Object
 	Selector   labels.Selector
@@ -340,8 +342,15 @@ func (m *VirtualMachineControllerRefManager) ClaimMatchedDataVolumes(dataVolumes
 	var errlist []error
 
 	match := func(obj metav1.Object) bool {
+		dv := obj.(*cdiv1.DataVolume)
+		// for non-owned DVs, only match if the DV was explicitly created from VM's DVTemplate
+		// this prevents a VM from adopting an existing DV that shares same name as a DVTemplate entry
+		if len(dv.OwnerReferences) == 0 {
+			if _, exists := dv.GetAnnotations()[AllowClaimAdoptionAnnotation]; !exists {
+				return false
+			}
+		}
 		return true
-
 	}
 	adopt := func(obj metav1.Object) error {
 		return m.AdoptDataVolume(obj.(*cdiv1.DataVolume))

--- a/pkg/controller/controller_ref_manager_test.go
+++ b/pkg/controller/controller_ref_manager_test.go
@@ -188,6 +188,9 @@ func newDataVolume(name string, owner metav1.Object) *cdiv1.DataVolume {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: metav1.NamespaceDefault,
+			Annotations: map[string]string{
+				AllowClaimAdoptionAnnotation: "true",
+			},
 		},
 	}
 	if owner != nil {
@@ -273,6 +276,26 @@ func TestClaimDataVolume(t *testing.T) {
 					func() error { return nil }),
 				datavolumes: []*cdiv1.DataVolume{datavolumeToDelete1, datavolumeToDelete2},
 				claimed:     []*cdiv1.DataVolume{datavolumeToDelete1},
+			}
+		}(),
+		func() test {
+			controller := v1.ReplicationController{}
+			controller.UID = types.UID(controllerUID)
+			standaloneDV := &cdiv1.DataVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "datavolume1",
+					Namespace: metav1.NamespaceDefault,
+				},
+			}
+			return test{
+				name: "Controller does not claim orphaned datavolumes without claim adoption annotation",
+				manager: NewVirtualMachineControllerRefManager(&FakeVirtualMachineControl{},
+					&controller,
+					productionLabelSelector,
+					controllerKind,
+					func() error { return nil }),
+				datavolumes: []*cdiv1.DataVolume{standaloneDV},
+				claimed:     nil,
 			}
 		}(),
 	}

--- a/pkg/virt-controller/watch/vm/vm.go
+++ b/pkg/virt-controller/watch/vm/vm.go
@@ -114,6 +114,10 @@ const (
 	// SourcePVCNotAvailabe is added in an event when the source PVC of a valid
 	// clone Datavolume doesn't exist
 	SourcePVCNotAvailabe = "SourcePVCNotAvailabe"
+
+	// DataVolumeNotOwnedByVM is added in an event when a VM's DVTemplate attempts to create
+	// a DataVolume that already exists and is not already owned by the VM.
+	DataVolumeNotOwnedByVM = "DataVolumeNotOwnedByVM"
 )
 
 const (
@@ -554,6 +558,12 @@ func (c *Controller) handleDataVolumes(vm *virtv1.VirtualMachine) (bool, error) 
 			}
 			c.recorder.Eventf(vm, k8score.EventTypeNormal, SuccessfulDataVolumeCreateReason, "Created DataVolume %s", curDataVolume.Name)
 		} else {
+			// check that if the DV exists, it is owned by this VM
+			if len(curDataVolume.OwnerReferences) == 0 || metav1.GetControllerOf(curDataVolume).UID != vm.UID {
+				c.recorder.Eventf(vm, k8score.EventTypeWarning, DataVolumeNotOwnedByVM, "DataVolume %s already exists and is not owned by this VM", curDataVolume.Name)
+				return ready, fmt.Errorf("DataVolume %s already exists and is not owned by this VM", curDataVolume.Name)
+			}
+
 			switch curDataVolume.Status.Phase {
 			case cdiv1.Succeeded, cdiv1.WaitForFirstConsumer, cdiv1.PendingPopulation:
 				continue

--- a/pkg/virt-controller/watch/vm/vm_test.go
+++ b/pkg/virt-controller/watch/vm/vm_test.go
@@ -2820,6 +2820,56 @@ var _ = Describe("VirtualMachine", func() {
 			sanityExecute(vm)
 		})
 
+		It("should not adopt a DataVolume that was not created from the VM's template", func() {
+			vm, _ := watchtesting.DefaultVirtualMachine(false)
+			vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, v1.Volume{
+				Name: "test1",
+				VolumeSource: v1.VolumeSource{
+					DataVolume: &v1.DataVolumeSource{
+						Name: "dv1",
+					},
+				},
+			})
+
+			vm.Spec.DataVolumeTemplates = append(vm.Spec.DataVolumeTemplates, v1.DataVolumeTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "dv1",
+					Namespace: vm.Namespace,
+				},
+			})
+
+			vm, err := virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Create(context.TODO(), vm, metav1.CreateOptions{})
+			Expect(err).To(Succeed())
+			addVirtualMachine(vm)
+
+			standaloneDV := &cdiv1.DataVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "dv1",
+					Namespace: vm.Namespace,
+				},
+				Status: cdiv1.DataVolumeStatus{
+					Phase: cdiv1.Succeeded,
+				},
+			}
+			Expect(controller.dataVolumeStore.Add(standaloneDV)).To(Succeed())
+
+			sanityExecute(vm)
+
+			vm, err = virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
+			Expect(err).To(Succeed())
+
+			cond := virtcontroller.NewVirtualMachineConditionManager().GetCondition(vm, v1.VirtualMachineFailure)
+			Expect(cond).To(Not(BeNil()))
+			Expect(*cond).To(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+				"Type":    Equal(v1.VirtualMachineFailure),
+				"Reason":  Equal("FailedCreate"),
+				"Message": ContainSubstring("already exists and is not owned by this VM"),
+				"Status":  Equal(k8sv1.ConditionTrue),
+			}))
+
+			testutils.ExpectEvent(recorder, DataVolumeNotOwnedByVM)
+		})
+
 		It("should detect that it has nothing to do beside updating the status", func() {
 			vm, vmi := watchtesting.DefaultVirtualMachine(true)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
If you have a preexisting DataVolume that shares the same name as an entry in a VM's DVTemplate, the controller will see that this DV exists, and will perform a claim adoption on this resource. However, now that this previous independent DV is owned by the VM, it will be destroyed once the owner VM is cleaned up.

DataVolume's explicitly created from DVTemplates receive a `cdi.kubevirt.io/allowClaimAdoption` annotation which we can use to filter by during the claim adoption logic.

Now if the VM controller encounters a DV from it's template that already exists _and_ was not claim adopted by the VM, we know there is a name clash and the VM will fail to start with new error condition `DataVolumeNotOwnedByVM`.

This condition is automatically resolved once the standalone DV is deleted and the VM can recreate it's own DV from the template.

Fixes: https://redhat.atlassian.net/browse/CNV-75958


### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix: only let VM adopt DVs if created from DVTemplate
```

