### PR TITLE
fix(vmi): exclude terminated pods from status.activePods after migration

### DIFF
--- a/pkg/virt-controller/watch/vmi/lifecycle.go
+++ b/pkg/virt-controller/watch/vmi/lifecycle.go
@@ -1038,6 +1038,9 @@ func (c *Controller) setActivePods(vmi *virtv1.VirtualMachineInstance) (*virtv1.
 		if !v1.IsControlledBy(pod, vmi) {
 			continue
 		}
+		if controller.PodIsDown(pod) {
+			continue
+		}
 		count++
 		activePods[pod.UID] = pod.Spec.NodeName
 	}

--- a/pkg/virt-controller/watch/vmi/lifecycle.go
+++ b/pkg/virt-controller/watch/vmi/lifecycle.go
@@ -1051,6 +1051,9 @@ func (c *Controller) setActivePods(vmi *virtv1.VirtualMachineInstance) (*virtv1.
 	}
 	activePods := make(map[types.UID]string)
 	for _, pod := range pods {
+		if controller.PodIsDown(pod) {
+			continue
+		}
 		activePods[pod.UID] = pod.Spec.NodeName
 	}
 	vmi.Status.ActivePods = activePods

--- a/pkg/virt-controller/watch/vmi/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi/vmi_test.go
@@ -1834,7 +1834,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			Entry("should be left if VM owner is present", true, true, true),
 		)
 
-		DescribeTable("should do nothing if pod is handed to virt-handler", func(phase k8sv1.PodPhase) {
+		DescribeTable("should do nothing if pod is handed to virt-handler", func(phase k8sv1.PodPhase, expectedVirtActions int) {
 			vmi := newPendingVirtualMachine("testvmi")
 			vmi.Status.Phase = virtv1.Scheduled
 			pod := newPodForVirtualMachine(vmi, phase)
@@ -1845,23 +1845,23 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			}
 			setReadyCondition(vmi, k8sv1.ConditionFalse, unreadyReason)
 
+			addActivePods(vmi, pod.UID, "")
 			addVirtualMachine(vmi)
 			addPod(pod)
-			addActivePods(vmi, pod.UID, "")
 
 			sanityExecute()
-			Expect(virtClientset.Actions()).To(HaveLen(1))
+			Expect(virtClientset.Actions()).To(HaveLen(expectedVirtActions))
 			Expect(virtClientset.Actions()[0].GetVerb()).To(Equal("create"))
 			Expect(virtClientset.Actions()[0].GetResource().Resource).To(Equal("virtualmachineinstances"))
 			Expect(kubeClient.Actions()).To(HaveLen(1))
 			Expect(kubeClient.Actions()[0].GetVerb()).To(Equal("create"))
 			Expect(kubeClient.Actions()[0].GetResource().Resource).To(Equal("pods"))
 		},
-			Entry("and in running state", k8sv1.PodRunning),
-			Entry("and in unknown state", k8sv1.PodUnknown),
-			Entry("and in succeeded state", k8sv1.PodSucceeded),
-			Entry("and in failed state", k8sv1.PodFailed),
-			Entry("and in pending state", k8sv1.PodPending),
+			Entry("and in running state", k8sv1.PodRunning, 1),
+			Entry("and in unknown state", k8sv1.PodUnknown, 1),
+			Entry("and in succeeded state", k8sv1.PodSucceeded, 2),
+			Entry("and in failed state", k8sv1.PodFailed, 2),
+			Entry("and in pending state", k8sv1.PodPending, 1),
 		)
 
 		It("should add outdated label if pod's image is outdated and VMI is in running state", func() {
@@ -4529,8 +4529,8 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				pod := newPodForVirtualMachine(vmi, podPhase)
 				pod.Spec.NodeName = "targetnode"
 
-				addVirtualMachine(vmi)
 				addActivePods(vmi, pod.UID, "targetnode")
+				addVirtualMachine(vmi)
 				addPod(pod)
 
 				sanityExecute()
@@ -5105,6 +5105,75 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				},
 				stubMigrationEvaluator{result: k8sv1.ConditionUnknown},
 				noConditionMatcher,
+			),
+		)
+	})
+
+	Context("setActivePods", func() {
+		type podSpec struct {
+			phase    k8sv1.PodPhase
+			uid      string
+			name     string
+			nodeName string
+		}
+
+		DescribeTable("should only include non-terminated pods", func(pods []podSpec, expectedLen int, expectedEntries map[types.UID]string) {
+			vmi := newPendingVirtualMachine("testvmi")
+			vmi.Status.Phase = virtv1.Running
+
+			for _, ps := range pods {
+				pod := newPodForVirtualMachine(vmi, ps.phase)
+				pod.UID = types.UID(ps.uid)
+				pod.Name = ps.name
+				pod.Spec.NodeName = ps.nodeName
+				Expect(controller.podIndexer.Add(pod)).To(Succeed())
+			}
+
+			updatedVMI, err := controller.setActivePods(vmi)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updatedVMI.Status.ActivePods).To(HaveLen(expectedLen))
+			for uid, node := range expectedEntries {
+				Expect(updatedVMI.Status.ActivePods).To(HaveKeyWithValue(uid, node))
+			}
+		},
+			Entry("excludes succeeded pods",
+				[]podSpec{
+					{k8sv1.PodRunning, "running-uid", "running-pod", "node1"},
+					{k8sv1.PodSucceeded, "succeeded-uid", "succeeded-pod", "node2"},
+				},
+				1, map[types.UID]string{"running-uid": "node1"},
+			),
+			Entry("excludes failed pods",
+				[]podSpec{
+					{k8sv1.PodRunning, "running-uid", "running-pod", "node1"},
+					{k8sv1.PodFailed, "failed-uid", "failed-pod", "node2"},
+				},
+				1, map[types.UID]string{"running-uid": "node1"},
+			),
+			Entry("keeps only target pod after migration",
+				[]podSpec{
+					{k8sv1.PodSucceeded, "source-uid", "source-pod", "source-node"},
+					{k8sv1.PodRunning, "target-uid", "target-pod", "target-node"},
+				},
+				1, map[types.UID]string{"target-uid": "target-node"},
+			),
+			Entry("includes pending pods",
+				[]podSpec{
+					{k8sv1.PodPending, "pending-uid", "pending-pod", "node1"},
+				},
+				1, map[types.UID]string{"pending-uid": "node1"},
+			),
+			Entry("includes unknown pods",
+				[]podSpec{
+					{k8sv1.PodUnknown, "unknown-uid", "unknown-pod", "node1"},
+				},
+				1, map[types.UID]string{"unknown-uid": "node1"},
+			),
+			Entry("produces empty map when all pods are terminated",
+				[]podSpec{
+					{k8sv1.PodSucceeded, "succeeded-uid", "succeeded-pod", "node1"},
+				},
+				0, map[types.UID]string{},
 			),
 		)
 	})

--- a/pkg/virt-controller/watch/vmi/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi/vmi_test.go
@@ -1912,7 +1912,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			Entry("should be left if VM owner is present", true, true, true),
 		)
 
-		DescribeTable("should do nothing if pod is handed to virt-handler", func(phase k8sv1.PodPhase, expectedVirtActions int) {
+		DescribeTable("should do nothing if pod is handed to virt-handler", func(phase k8sv1.PodPhase, expectedVirtActions []expectedAction) {
 			vmi := newPendingVirtualMachine("testvmi")
 			vmi.Status.Phase = virtv1.Scheduled
 			pod := newPodForVirtualMachine(vmi, phase)
@@ -1928,18 +1928,28 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			addPod(pod)
 
 			sanityExecute()
-			Expect(virtClientset.Actions()).To(HaveLen(expectedVirtActions))
-			Expect(virtClientset.Actions()[0].GetVerb()).To(Equal("create"))
-			Expect(virtClientset.Actions()[0].GetResource().Resource).To(Equal("virtualmachineinstances"))
+			Expect(virtClientset.Actions()).To(WithTransform(actionsSummary, ConsistOf(expectedVirtActions)))
 			Expect(kubeClient.Actions()).To(HaveLen(1))
 			Expect(kubeClient.Actions()[0].GetVerb()).To(Equal("create"))
 			Expect(kubeClient.Actions()[0].GetResource().Resource).To(Equal("pods"))
 		},
-			Entry("and in running state", k8sv1.PodRunning, 1),
-			Entry("and in unknown state", k8sv1.PodUnknown, 1),
-			Entry("and in succeeded state", k8sv1.PodSucceeded, 2),
-			Entry("and in failed state", k8sv1.PodFailed, 2),
-			Entry("and in pending state", k8sv1.PodPending, 1),
+			Entry("and in running state", k8sv1.PodRunning, []expectedAction{
+				{Verb: "create", Resource: "virtualmachineinstances"},
+			}),
+			Entry("and in unknown state", k8sv1.PodUnknown, []expectedAction{
+				{Verb: "create", Resource: "virtualmachineinstances"},
+			}),
+			Entry("and in succeeded state", k8sv1.PodSucceeded, []expectedAction{
+				{Verb: "create", Resource: "virtualmachineinstances"},
+				{Verb: "patch", Resource: "virtualmachineinstances"},
+			}),
+			Entry("and in failed state", k8sv1.PodFailed, []expectedAction{
+				{Verb: "create", Resource: "virtualmachineinstances"},
+				{Verb: "patch", Resource: "virtualmachineinstances"},
+			}),
+			Entry("and in pending state", k8sv1.PodPending, []expectedAction{
+				{Verb: "create", Resource: "virtualmachineinstances"},
+			}),
 		)
 
 		It("should add outdated label if pod's image is outdated and VMI is in running state", func() {
@@ -5737,4 +5747,17 @@ type stubMigrationEvaluator struct {
 
 func (e stubMigrationEvaluator) Evaluate(_ *virtv1.VirtualMachineInstance, _ *k8sv1.Pod) k8sv1.ConditionStatus {
 	return e.result
+}
+
+type expectedAction struct {
+	Verb     string
+	Resource string
+}
+
+func actionsSummary(actions []testing.Action) []expectedAction {
+	result := make([]expectedAction, 0, len(actions))
+	for _, a := range actions {
+		result = append(result, expectedAction{Verb: a.GetVerb(), Resource: a.GetResource().Resource})
+	}
+	return result
 }

--- a/pkg/virt-controller/watch/vmi/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi/vmi_test.go
@@ -1912,7 +1912,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			Entry("should be left if VM owner is present", true, true, true),
 		)
 
-		DescribeTable("should do nothing if pod is handed to virt-handler", func(phase k8sv1.PodPhase) {
+		DescribeTable("should do nothing if pod is handed to virt-handler", func(phase k8sv1.PodPhase, expectedVirtActions int) {
 			vmi := newPendingVirtualMachine("testvmi")
 			vmi.Status.Phase = virtv1.Scheduled
 			pod := newPodForVirtualMachine(vmi, phase)
@@ -1923,23 +1923,23 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			}
 			setReadyCondition(vmi, k8sv1.ConditionFalse, unreadyReason)
 
+			addActivePods(vmi, pod.UID, "")
 			addVirtualMachine(vmi)
 			addPod(pod)
-			addActivePods(vmi, pod.UID, "")
 
 			sanityExecute()
-			Expect(virtClientset.Actions()).To(HaveLen(1))
+			Expect(virtClientset.Actions()).To(HaveLen(expectedVirtActions))
 			Expect(virtClientset.Actions()[0].GetVerb()).To(Equal("create"))
 			Expect(virtClientset.Actions()[0].GetResource().Resource).To(Equal("virtualmachineinstances"))
 			Expect(kubeClient.Actions()).To(HaveLen(1))
 			Expect(kubeClient.Actions()[0].GetVerb()).To(Equal("create"))
 			Expect(kubeClient.Actions()[0].GetResource().Resource).To(Equal("pods"))
 		},
-			Entry("and in running state", k8sv1.PodRunning),
-			Entry("and in unknown state", k8sv1.PodUnknown),
-			Entry("and in succeeded state", k8sv1.PodSucceeded),
-			Entry("and in failed state", k8sv1.PodFailed),
-			Entry("and in pending state", k8sv1.PodPending),
+			Entry("and in running state", k8sv1.PodRunning, 1),
+			Entry("and in unknown state", k8sv1.PodUnknown, 1),
+			Entry("and in succeeded state", k8sv1.PodSucceeded, 2),
+			Entry("and in failed state", k8sv1.PodFailed, 2),
+			Entry("and in pending state", k8sv1.PodPending, 1),
 		)
 
 		It("should add outdated label if pod's image is outdated and VMI is in running state", func() {
@@ -4736,8 +4736,8 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				pod := newPodForVirtualMachine(vmi, podPhase)
 				pod.Spec.NodeName = "targetnode"
 
-				addVirtualMachine(vmi)
 				addActivePods(vmi, pod.UID, "targetnode")
+				addVirtualMachine(vmi)
 				addPod(pod)
 
 				sanityExecute()
@@ -5312,6 +5312,75 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 				},
 				stubMigrationEvaluator{result: k8sv1.ConditionUnknown},
 				noConditionMatcher,
+			),
+		)
+	})
+
+	Context("setActivePods", func() {
+		type podSpec struct {
+			phase    k8sv1.PodPhase
+			uid      string
+			name     string
+			nodeName string
+		}
+
+		DescribeTable("should only include non-terminated pods", func(pods []podSpec, expectedLen int, expectedEntries map[types.UID]string) {
+			vmi := newPendingVirtualMachine("testvmi")
+			vmi.Status.Phase = virtv1.Running
+
+			for _, ps := range pods {
+				pod := newPodForVirtualMachine(vmi, ps.phase)
+				pod.UID = types.UID(ps.uid)
+				pod.Name = ps.name
+				pod.Spec.NodeName = ps.nodeName
+				Expect(controller.podIndexer.Add(pod)).To(Succeed())
+			}
+
+			updatedVMI, err := controller.setActivePods(vmi)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updatedVMI.Status.ActivePods).To(HaveLen(expectedLen))
+			for uid, node := range expectedEntries {
+				Expect(updatedVMI.Status.ActivePods).To(HaveKeyWithValue(uid, node))
+			}
+		},
+			Entry("excludes succeeded pods",
+				[]podSpec{
+					{k8sv1.PodRunning, "running-uid", "running-pod", "node1"},
+					{k8sv1.PodSucceeded, "succeeded-uid", "succeeded-pod", "node2"},
+				},
+				1, map[types.UID]string{"running-uid": "node1"},
+			),
+			Entry("excludes failed pods",
+				[]podSpec{
+					{k8sv1.PodRunning, "running-uid", "running-pod", "node1"},
+					{k8sv1.PodFailed, "failed-uid", "failed-pod", "node2"},
+				},
+				1, map[types.UID]string{"running-uid": "node1"},
+			),
+			Entry("keeps only target pod after migration",
+				[]podSpec{
+					{k8sv1.PodSucceeded, "source-uid", "source-pod", "source-node"},
+					{k8sv1.PodRunning, "target-uid", "target-pod", "target-node"},
+				},
+				1, map[types.UID]string{"target-uid": "target-node"},
+			),
+			Entry("includes pending pods",
+				[]podSpec{
+					{k8sv1.PodPending, "pending-uid", "pending-pod", "node1"},
+				},
+				1, map[types.UID]string{"pending-uid": "node1"},
+			),
+			Entry("includes unknown pods",
+				[]podSpec{
+					{k8sv1.PodUnknown, "unknown-uid", "unknown-pod", "node1"},
+				},
+				1, map[types.UID]string{"unknown-uid": "node1"},
+			),
+			Entry("produces empty map when all pods are terminated",
+				[]podSpec{
+					{k8sv1.PodSucceeded, "succeeded-uid", "succeeded-pod", "node1"},
+				},
+				0, map[types.UID]string{},
 			),
 		)
 	})

--- a/pkg/virt-controller/watch/vmi/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi/vmi_test.go
@@ -1834,7 +1834,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			Entry("should be left if VM owner is present", true, true, true),
 		)
 
-		DescribeTable("should do nothing if pod is handed to virt-handler", func(phase k8sv1.PodPhase, expectedVirtActions int) {
+		DescribeTable("should do nothing if pod is handed to virt-handler", func(phase k8sv1.PodPhase, expectedVirtActions []expectedAction) {
 			vmi := newPendingVirtualMachine("testvmi")
 			vmi.Status.Phase = virtv1.Scheduled
 			pod := newPodForVirtualMachine(vmi, phase)
@@ -1850,18 +1850,28 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			addPod(pod)
 
 			sanityExecute()
-			Expect(virtClientset.Actions()).To(HaveLen(expectedVirtActions))
-			Expect(virtClientset.Actions()[0].GetVerb()).To(Equal("create"))
-			Expect(virtClientset.Actions()[0].GetResource().Resource).To(Equal("virtualmachineinstances"))
+			Expect(virtClientset.Actions()).To(WithTransform(actionsSummary, ConsistOf(expectedVirtActions)))
 			Expect(kubeClient.Actions()).To(HaveLen(1))
 			Expect(kubeClient.Actions()[0].GetVerb()).To(Equal("create"))
 			Expect(kubeClient.Actions()[0].GetResource().Resource).To(Equal("pods"))
 		},
-			Entry("and in running state", k8sv1.PodRunning, 1),
-			Entry("and in unknown state", k8sv1.PodUnknown, 1),
-			Entry("and in succeeded state", k8sv1.PodSucceeded, 2),
-			Entry("and in failed state", k8sv1.PodFailed, 2),
-			Entry("and in pending state", k8sv1.PodPending, 1),
+			Entry("and in running state", k8sv1.PodRunning, []expectedAction{
+				{Verb: "create", Resource: "virtualmachineinstances"},
+			}),
+			Entry("and in unknown state", k8sv1.PodUnknown, []expectedAction{
+				{Verb: "create", Resource: "virtualmachineinstances"},
+			}),
+			Entry("and in succeeded state", k8sv1.PodSucceeded, []expectedAction{
+				{Verb: "create", Resource: "virtualmachineinstances"},
+				{Verb: "patch", Resource: "virtualmachineinstances"},
+			}),
+			Entry("and in failed state", k8sv1.PodFailed, []expectedAction{
+				{Verb: "create", Resource: "virtualmachineinstances"},
+				{Verb: "patch", Resource: "virtualmachineinstances"},
+			}),
+			Entry("and in pending state", k8sv1.PodPending, []expectedAction{
+				{Verb: "create", Resource: "virtualmachineinstances"},
+			}),
 		)
 
 		It("should add outdated label if pod's image is outdated and VMI is in running state", func() {
@@ -5528,4 +5538,17 @@ type stubMigrationEvaluator struct {
 
 func (e stubMigrationEvaluator) Evaluate(_ *virtv1.VirtualMachineInstance, _ *k8sv1.Pod) k8sv1.ConditionStatus {
 	return e.result
+}
+
+type expectedAction struct {
+	Verb     string
+	Resource string
+}
+
+func actionsSummary(actions []testing.Action) []expectedAction {
+	result := make([]expectedAction, 0, len(actions))
+	for _, a := range actions {
+		result = append(result, expectedAction{Verb: a.GetVerb(), Resource: a.GetResource().Resource})
+	}
+	return result
 }


### PR DESCRIPTION
### What this PR does

After a successful live migration, `setActivePods()` in virt-controller was including terminated source launcher pods (phase `Succeeded`/`Failed`) in `VMI.status.activePods`. This left stale UIDs alongside the new target pod, which caused virt-handler's `findVirtlauncherUID()` to return an empty UID (it expects exactly one entry), triggering a `SyncFailed` hotplug volume reconciliation loop.

The fix adds a `controller.PodIsDown()` check to filter out terminated pods, aligning `setActivePods()` with the same filtering already applied by `VMIActivePodsCount()`.

#### Before this PR:
- After live migration, `status.activePods` contains both the terminated source pod UID and the running target pod UID
- `findVirtlauncherUID()` in virt-handler sees multiple entries and returns empty, causing hotplug volume mounts to fail in a loop

#### After this PR:
- `setActivePods()` skips pods in `Succeeded`/`Failed` phase
- Only the running target pod UID remains in `status.activePods` after migration
- Hotplug volume reconciliation proceeds normally


### Release note
```release-note
Ensure terminated launcher pods are pruned from VMI status.activePods after live migration
```