### PR TITLE
backup, backuptracker: add VirtualMachineBackupTracker finalizer

### DIFF
--- a/pkg/storage/cbt/backup.go
+++ b/pkg/storage/cbt/backup.go
@@ -53,8 +53,6 @@ import (
 )
 
 const (
-	vmBackupFinalizer = "backup.kubevirt.io/vmbackup-protection"
-
 	backupAbortingEvent             = "VirtualMachineBackupAborting"
 	backupCompletedEvent            = "VirtualMachineBackupCompletedSuccessfully"
 	backupCompletedWithWarningEvent = "VirtualMachineBackupCompletedWithWarning"
@@ -72,6 +70,7 @@ const (
 	vmNoVolumesToBackupMsg               = "vm %s has no volumes to backup"
 	vmNoChangedBlockTrackingMsg          = "vm %s has no ChangedBlockTracking, cannot start backup"
 	backupTrackerNotFoundMsg             = "BackupTracker %s does not exist"
+	trackerDeletingMsg                   = "tracker %s is being deleted"
 	trackerCheckpointRedefinitionPending = "Waiting for checkpoint redefinition on tracker %s"
 	invalidBackupModeMsg                 = "invalid backup mode: %s"
 	vmMigrationInProgressMsg             = "vm %s is currently migrating, waiting for migration to complete before starting backup"
@@ -84,6 +83,7 @@ const (
 var (
 	errSourceNameEmpty = errors.New("source name is empty")
 	errCleanupPending  = errors.New("cleanup pending")
+	errActiveBackups   = errors.New("active backups pending")
 )
 
 type VMBackupController struct {
@@ -162,6 +162,7 @@ func NewVMBackupController(client kubecli.KubevirtClient,
 		cache.ResourceEventHandlerFuncs{
 			AddFunc:    c.handleBackupTracker,
 			UpdateFunc: func(oldObj, newObj interface{}) { c.handleBackupTracker(newObj) },
+			DeleteFunc: c.handleBackupTracker,
 		},
 	)
 	if err != nil {
@@ -192,15 +193,23 @@ func (ctrl *VMBackupController) handleBackup(obj interface{}) {
 		obj = unknown.Obj
 	}
 
-	if backup, ok := obj.(*backupv1.VirtualMachineBackup); ok {
-		objName, err := cache.DeletionHandlingMetaNamespaceKeyFunc(backup)
-		if err != nil {
-			log.Log.Errorf("failed to get key from object: %v, %v", err, backup)
-			return
-		}
+	backup, ok := obj.(*backupv1.VirtualMachineBackup)
+	if !ok {
+		return
+	}
 
-		log.Log.V(3).Infof("enqueued %q for sync", objName)
-		ctrl.backupQueue.Add(objName)
+	objName, err := cache.DeletionHandlingMetaNamespaceKeyFunc(backup)
+	if err != nil {
+		log.Log.Errorf("failed to get key from object: %v, %v", err, backup)
+		return
+	}
+
+	log.Log.V(3).Infof("enqueued %q for sync", objName)
+	ctrl.backupQueue.Add(objName)
+
+	if backup.Spec.Source.Kind == backupv1.VirtualMachineBackupTrackerGroupVersionKind.Kind {
+		trackerKey := types.NamespacedName{Namespace: backup.Namespace, Name: backup.Spec.Source.Name}.String()
+		ctrl.trackerQueue.Add(trackerKey)
 	}
 }
 
@@ -261,8 +270,10 @@ func (ctrl *VMBackupController) handleBackupTracker(obj interface{}) {
 
 	key := types.NamespacedName{Namespace: tracker.Namespace, Name: tracker.Name}.String()
 
-	// Enqueue tracker for checkpoint redefinition if needed
-	if trackerNeedsCheckpointRedefinition(tracker) {
+	if isTrackerDeleting(tracker) && controller.HasFinalizer(tracker, backupv1.VirtualMachineBackupTrackerFinalizer) {
+		log.Log.V(3).Infof("enqueued tracker %q for deletion cleanup", key)
+		ctrl.trackerQueue.Add(key)
+	} else if trackerNeedsCheckpointRedefinition(tracker) {
 		log.Log.V(3).Infof("enqueued tracker %q for checkpoint redefinition", key)
 		ctrl.trackerQueue.Add(key)
 	}
@@ -537,6 +548,9 @@ func (ctrl *VMBackupController) checkPrerequisites(backup *backupv1.VirtualMachi
 	if reason := ctrl.verifyVMIEligibleForBackup(vmi); reason != "" {
 		return reason, nil
 	}
+	if isTrackerDeleting(backupTracker) {
+		return fmt.Sprintf(trackerDeletingMsg, backupTracker.Name), nil
+	}
 	if trackerNeedsCheckpointRedefinition(backupTracker) {
 		return fmt.Sprintf(trackerCheckpointRedefinitionPending, backupTracker.Name), nil
 	}
@@ -618,6 +632,12 @@ func (ctrl *VMBackupController) startBackup(backup *backupv1.VirtualMachineBacku
 		return err
 	}
 
+	if backupTracker != nil {
+		if err := ctrl.addTrackerFinalizer(backupTracker); err != nil {
+			return err
+		}
+	}
+
 	backupOptions := backupv1.BackupOptions{
 		BackupName:      backup.Name,
 		Cmd:             backupv1.Start,
@@ -693,12 +713,12 @@ func generateFinalizerPatch(test, replace []string) ([]byte, error) {
 }
 
 func (ctrl *VMBackupController) addBackupFinalizer(backup *backupv1.VirtualMachineBackup) error {
-	if controller.HasFinalizer(backup, vmBackupFinalizer) {
+	if controller.HasFinalizer(backup, backupv1.VirtualMachineBackupFinalizer) {
 		return nil
 	}
 
 	cpy := backup.DeepCopy()
-	controller.AddFinalizer(cpy, vmBackupFinalizer)
+	controller.AddFinalizer(cpy, backupv1.VirtualMachineBackupFinalizer)
 
 	patchBytes, err := generateFinalizerPatch(backup.Finalizers, cpy.Finalizers)
 	if err != nil {
@@ -714,12 +734,12 @@ func (ctrl *VMBackupController) addBackupFinalizer(backup *backupv1.VirtualMachi
 }
 
 func (ctrl *VMBackupController) removeBackupFinalizer(backup *backupv1.VirtualMachineBackup) error {
-	if !controller.HasFinalizer(backup, vmBackupFinalizer) {
+	if !controller.HasFinalizer(backup, backupv1.VirtualMachineBackupFinalizer) {
 		return nil
 	}
 
 	cpy := backup.DeepCopy()
-	controller.RemoveFinalizer(cpy, vmBackupFinalizer)
+	controller.RemoveFinalizer(cpy, backupv1.VirtualMachineBackupFinalizer)
 
 	patchBytes, err := generateFinalizerPatch(backup.Finalizers, cpy.Finalizers)
 	if err != nil {
@@ -729,6 +749,49 @@ func (ctrl *VMBackupController) removeBackupFinalizer(backup *backupv1.VirtualMa
 	_, err = ctrl.client.VirtualMachineBackup(cpy.Namespace).Patch(context.Background(), cpy.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to patch backup to remove finalizer: %w", err)
+	}
+	return nil
+}
+
+func (ctrl *VMBackupController) addTrackerFinalizer(tracker *backupv1.VirtualMachineBackupTracker) error {
+	if controller.HasFinalizer(tracker, backupv1.VirtualMachineBackupTrackerFinalizer) {
+		return nil
+	}
+
+	cpy := tracker.DeepCopy()
+	controller.AddFinalizer(cpy, backupv1.VirtualMachineBackupTrackerFinalizer)
+
+	patchBytes, err := generateFinalizerPatch(tracker.Finalizers, cpy.Finalizers)
+	if err != nil {
+		return fmt.Errorf("failed to generate tracker finalizer patch: %w", err)
+	}
+
+	patched, err := ctrl.client.VirtualMachineBackupTracker(cpy.Namespace).Patch(context.Background(), cpy.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to add tracker finalizer: %w", err)
+	}
+	if patched.DeletionTimestamp != nil {
+		return fmt.Errorf("tracker %s/%s is being deleted", tracker.Namespace, tracker.Name)
+	}
+	return nil
+}
+
+func (ctrl *VMBackupController) removeTrackerFinalizer(tracker *backupv1.VirtualMachineBackupTracker) error {
+	if !controller.HasFinalizer(tracker, backupv1.VirtualMachineBackupTrackerFinalizer) {
+		return nil
+	}
+
+	cpy := tracker.DeepCopy()
+	controller.RemoveFinalizer(cpy, backupv1.VirtualMachineBackupTrackerFinalizer)
+
+	patchBytes, err := generateFinalizerPatch(tracker.Finalizers, cpy.Finalizers)
+	if err != nil {
+		return fmt.Errorf("failed to generate tracker finalizer patch: %w", err)
+	}
+
+	_, err = ctrl.client.VirtualMachineBackupTracker(cpy.Namespace).Patch(context.Background(), cpy.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to remove tracker finalizer: %w", err)
 	}
 	return nil
 }

--- a/pkg/storage/cbt/backup.go
+++ b/pkg/storage/cbt/backup.go
@@ -53,8 +53,6 @@ import (
 )
 
 const (
-	vmBackupFinalizer = "backup.kubevirt.io/vmbackup-protection"
-
 	backupAbortingEvent             = "VirtualMachineBackupAborting"
 	backupCompletedEvent            = "VirtualMachineBackupCompletedSuccessfully"
 	backupCompletedWithWarningEvent = "VirtualMachineBackupCompletedWithWarning"
@@ -72,6 +70,7 @@ const (
 	vmNoVolumesToBackupMsg               = "vm %s has no volumes to backup"
 	vmNoChangedBlockTrackingMsg          = "vm %s has no ChangedBlockTracking, cannot start backup"
 	backupTrackerNotFoundMsg             = "BackupTracker %s does not exist"
+	trackerDeletingMsg                   = "tracker %s is being deleted"
 	trackerCheckpointRedefinitionPending = "Waiting for checkpoint redefinition on tracker %s"
 	invalidBackupModeMsg                 = "invalid backup mode: %s"
 	vmMigrationInProgressMsg             = "vm %s is currently migrating, waiting for migration to complete before starting backup"
@@ -84,6 +83,7 @@ const (
 var (
 	errSourceNameEmpty = errors.New("source name is empty")
 	errCleanupPending  = errors.New("cleanup pending")
+	errActiveBackups   = errors.New("active backups pending")
 )
 
 type VMBackupController struct {
@@ -162,6 +162,7 @@ func NewVMBackupController(client kubecli.KubevirtClient,
 		cache.ResourceEventHandlerFuncs{
 			AddFunc:    c.handleBackupTracker,
 			UpdateFunc: func(oldObj, newObj interface{}) { c.handleBackupTracker(newObj) },
+			DeleteFunc: c.handleBackupTracker,
 		},
 	)
 	if err != nil {
@@ -192,15 +193,23 @@ func (ctrl *VMBackupController) handleBackup(obj interface{}) {
 		obj = unknown.Obj
 	}
 
-	if backup, ok := obj.(*backupv1.VirtualMachineBackup); ok {
-		objName, err := cache.DeletionHandlingMetaNamespaceKeyFunc(backup)
-		if err != nil {
-			log.Log.Errorf("failed to get key from object: %v, %v", err, backup)
-			return
-		}
+	backup, ok := obj.(*backupv1.VirtualMachineBackup)
+	if !ok {
+		return
+	}
 
-		log.Log.V(3).Infof("enqueued %q for sync", objName)
-		ctrl.backupQueue.Add(objName)
+	objName, err := cache.DeletionHandlingMetaNamespaceKeyFunc(backup)
+	if err != nil {
+		log.Log.Errorf("failed to get key from object: %v, %v", err, backup)
+		return
+	}
+
+	log.Log.V(3).Infof("enqueued %q for sync", objName)
+	ctrl.backupQueue.Add(objName)
+
+	if backup.Spec.Source.Kind == backupv1.VirtualMachineBackupTrackerGroupVersionKind.Kind {
+		trackerKey := types.NamespacedName{Namespace: backup.Namespace, Name: backup.Spec.Source.Name}.String()
+		ctrl.trackerQueue.Add(trackerKey)
 	}
 }
 
@@ -261,8 +270,10 @@ func (ctrl *VMBackupController) handleBackupTracker(obj interface{}) {
 
 	key := types.NamespacedName{Namespace: tracker.Namespace, Name: tracker.Name}.String()
 
-	// Enqueue tracker for checkpoint redefinition if needed
-	if trackerNeedsCheckpointRedefinition(tracker) {
+	if isTrackerDeleting(tracker) && controller.HasFinalizer(tracker, backupv1.VirtualMachineBackupTrackerFinalizer) {
+		log.Log.V(3).Infof("enqueued tracker %q for deletion cleanup", key)
+		ctrl.trackerQueue.Add(key)
+	} else if trackerNeedsCheckpointRedefinition(tracker) {
 		log.Log.V(3).Infof("enqueued tracker %q for checkpoint redefinition", key)
 		ctrl.trackerQueue.Add(key)
 	}
@@ -537,6 +548,9 @@ func (ctrl *VMBackupController) checkPrerequisites(backup *backupv1.VirtualMachi
 	if reason := ctrl.verifyVMIEligibleForBackup(vmi); reason != "" {
 		return reason, nil
 	}
+	if isTrackerDeleting(backupTracker) {
+		return fmt.Sprintf(trackerDeletingMsg, backupTracker.Name), nil
+	}
 	if trackerNeedsCheckpointRedefinition(backupTracker) {
 		return fmt.Sprintf(trackerCheckpointRedefinitionPending, backupTracker.Name), nil
 	}
@@ -618,6 +632,12 @@ func (ctrl *VMBackupController) startBackup(backup *backupv1.VirtualMachineBacku
 		return err
 	}
 
+	if backupTracker != nil {
+		if err := ctrl.addTrackerFinalizer(backupTracker); err != nil {
+			return err
+		}
+	}
+
 	backupOptions := backupv1.BackupOptions{
 		BackupName:      backup.Name,
 		Cmd:             backupv1.Start,
@@ -693,12 +713,12 @@ func generateFinalizerPatch(test, replace []string) ([]byte, error) {
 }
 
 func (ctrl *VMBackupController) addBackupFinalizer(backup *backupv1.VirtualMachineBackup) error {
-	if controller.HasFinalizer(backup, vmBackupFinalizer) {
+	if controller.HasFinalizer(backup, backupv1.VirtualMachineBackupFinalizer) {
 		return nil
 	}
 
 	cpy := backup.DeepCopy()
-	controller.AddFinalizer(cpy, vmBackupFinalizer)
+	controller.AddFinalizer(cpy, backupv1.VirtualMachineBackupFinalizer)
 
 	patchBytes, err := generateFinalizerPatch(backup.Finalizers, cpy.Finalizers)
 	if err != nil {
@@ -714,12 +734,12 @@ func (ctrl *VMBackupController) addBackupFinalizer(backup *backupv1.VirtualMachi
 }
 
 func (ctrl *VMBackupController) removeBackupFinalizer(backup *backupv1.VirtualMachineBackup) error {
-	if !controller.HasFinalizer(backup, vmBackupFinalizer) {
+	if !controller.HasFinalizer(backup, backupv1.VirtualMachineBackupFinalizer) {
 		return nil
 	}
 
 	cpy := backup.DeepCopy()
-	controller.RemoveFinalizer(cpy, vmBackupFinalizer)
+	controller.RemoveFinalizer(cpy, backupv1.VirtualMachineBackupFinalizer)
 
 	patchBytes, err := generateFinalizerPatch(backup.Finalizers, cpy.Finalizers)
 	if err != nil {
@@ -729,6 +749,49 @@ func (ctrl *VMBackupController) removeBackupFinalizer(backup *backupv1.VirtualMa
 	_, err = ctrl.client.VirtualMachineBackup(cpy.Namespace).Patch(context.Background(), cpy.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{})
 	if err != nil {
 		return fmt.Errorf("failed to patch backup to remove finalizer: %w", err)
+	}
+	return nil
+}
+
+func (ctrl *VMBackupController) addTrackerFinalizer(tracker *backupv1.VirtualMachineBackupTracker) error {
+	if !tracker.DeletionTimestamp.IsZero() {
+		return nil
+	}
+	if controller.HasFinalizer(tracker, backupv1.VirtualMachineBackupTrackerFinalizer) {
+		return nil
+	}
+
+	cpy := tracker.DeepCopy()
+	controller.AddFinalizer(cpy, backupv1.VirtualMachineBackupTrackerFinalizer)
+
+	patchBytes, err := generateFinalizerPatch(tracker.Finalizers, cpy.Finalizers)
+	if err != nil {
+		return fmt.Errorf("failed to generate tracker finalizer patch: %w", err)
+	}
+
+	_, err = ctrl.client.VirtualMachineBackupTracker(cpy.Namespace).Patch(context.Background(), cpy.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to add tracker finalizer: %w", err)
+	}
+	return nil
+}
+
+func (ctrl *VMBackupController) removeTrackerFinalizer(tracker *backupv1.VirtualMachineBackupTracker) error {
+	if !controller.HasFinalizer(tracker, backupv1.VirtualMachineBackupTrackerFinalizer) {
+		return nil
+	}
+
+	cpy := tracker.DeepCopy()
+	controller.RemoveFinalizer(cpy, backupv1.VirtualMachineBackupTrackerFinalizer)
+
+	patchBytes, err := generateFinalizerPatch(tracker.Finalizers, cpy.Finalizers)
+	if err != nil {
+		return fmt.Errorf("failed to generate tracker finalizer patch: %w", err)
+	}
+
+	_, err = ctrl.client.VirtualMachineBackupTracker(cpy.Namespace).Patch(context.Background(), cpy.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{})
+	if err != nil {
+		return fmt.Errorf("failed to remove tracker finalizer: %w", err)
 	}
 	return nil
 }

--- a/pkg/storage/cbt/backup_test.go
+++ b/pkg/storage/cbt/backup_test.go
@@ -371,10 +371,11 @@ var _ = Describe("Backup Controller", func() {
 
 		It("should get source name from backupTracker when source kind is VirtualMachineBackupTracker", func() {
 			backupTracker := createBackupTracker(backupTrackerName, vmName, "")
+			backupTracker.Finalizers = []string{backupv1.VirtualMachineBackupTrackerFinalizer}
 			controller.backupTrackerInformer.GetStore().Add(backupTracker)
 
 			backup := createBackupWithTracker(backupName, vmName, pvcName)
-			backup.Finalizers = []string{vmBackupFinalizer}
+			backup.Finalizers = []string{backupv1.VirtualMachineBackupFinalizer}
 
 			vm := createVM(vmName)
 			controller.vmStore.Add(vm)
@@ -457,6 +458,44 @@ var _ = Describe("Backup Controller", func() {
 			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
 			Expect(cond.Reason).To(Equal(backupv1.ReasonInitializing))
 			Expect(cond.Message).To(ContainSubstring(fmt.Sprintf(trackerCheckpointRedefinitionPending, backupTrackerName)))
+			return true, updateObj, nil
+		})
+
+		err := controller.execute(types.NamespacedName{Namespace: testNamespace, Name: backupName}.String())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(statusUpdated).To(BeTrue())
+	})
+
+	It("should wait when backupTracker is being deleted", func() {
+		backupTracker := createBackupTracker(backupTrackerName, vmName, "existing-checkpoint")
+		now := metav1.Now()
+		backupTracker.DeletionTimestamp = &now
+		backupTracker.Finalizers = []string{backupv1.VirtualMachineBackupTrackerFinalizer}
+		controller.backupTrackerInformer.GetStore().Add(backupTracker)
+
+		backup := createBackupWithTracker(backupName, vmName, pvcName)
+		addBackup(backup)
+
+		vm := createVM(vmName)
+		controller.vmStore.Add(vm)
+
+		vmi := createVMIWithPVCAttached()
+		controller.vmiStore.Add(vmi)
+
+		statusUpdated := false
+		kubevirtClient.Fake.PrependReactor("update", "virtualmachinebackups", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+			update := action.(testing.UpdateAction)
+			if update.GetSubresource() != "status" {
+				return false, nil, nil
+			}
+			statusUpdated = true
+			updateObj := update.GetObject().(*backupv1.VirtualMachineBackup)
+
+			cond := meta.FindStatusCondition(updateObj.Status.Conditions, string(backupv1.ConditionProgressing))
+			Expect(cond).NotTo(BeNil())
+			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+			Expect(cond.Reason).To(Equal(backupv1.ReasonInitializing))
+			Expect(cond.Message).To(ContainSubstring(fmt.Sprintf(trackerDeletingMsg, backupTrackerName)))
 			return true, updateObj, nil
 		})
 
@@ -638,7 +677,7 @@ var _ = Describe("Backup Controller", func() {
 
 			It("should proceed when VMI migration has completed", func() {
 				backup := createBackup(backupName, vmName, pvcName, backupv1.PushMode)
-				backup.Finalizers = []string{vmBackupFinalizer}
+				backup.Finalizers = []string{backupv1.VirtualMachineBackupFinalizer}
 				vm := createVM(vmName)
 				controller.vmStore.Add(vm)
 				vmi := createVMIWithPVCAttached()
@@ -680,18 +719,18 @@ var _ = Describe("Backup Controller", func() {
 				patched = true
 
 				updatedBackup := backup.DeepCopy()
-				updatedBackup.Finalizers = []string{vmBackupFinalizer}
+				updatedBackup.Finalizers = []string{backupv1.VirtualMachineBackupFinalizer}
 				return true, updatedBackup, nil
 			})
 
 			Expect(controller.addBackupFinalizer(backup)).To(Succeed())
 			Expect(patched).To(BeTrue())
-			Expect(backup.Finalizers).To(ContainElement(vmBackupFinalizer))
+			Expect(backup.Finalizers).To(ContainElement(backupv1.VirtualMachineBackupFinalizer))
 		})
 
 		It("should not re-add finalizer if already present", func() {
 			backup := createBackup(backupName, vmName, pvcName, backupv1.PushMode)
-			backup.Finalizers = []string{vmBackupFinalizer}
+			backup.Finalizers = []string{backupv1.VirtualMachineBackupFinalizer}
 
 			kubevirtClient.Fake.PrependReactor("patch", "virtualmachinebackups", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
 				Fail("Should not patch when finalizer already exists")
@@ -699,13 +738,13 @@ var _ = Describe("Backup Controller", func() {
 			})
 
 			Expect(controller.addBackupFinalizer(backup)).To(Succeed())
-			Expect(backup.Finalizers).To(ContainElement(vmBackupFinalizer))
+			Expect(backup.Finalizers).To(ContainElement(backupv1.VirtualMachineBackupFinalizer))
 		})
 	})
 
 	It("should do nothing when backup already done", func() {
 		backup := createBackup(backupName, vmName, pvcName, backupv1.PushMode)
-		backup.Finalizers = []string{vmBackupFinalizer}
+		backup.Finalizers = []string{backupv1.VirtualMachineBackupFinalizer}
 		backup.Status = &backupv1.VirtualMachineBackupStatus{
 			Conditions: []metav1.Condition{
 				newCondition(string(backupv1.ConditionProgressing), metav1.ConditionFalse, "Progressing", ""),
@@ -736,7 +775,7 @@ var _ = Describe("Backup Controller", func() {
 				newCondition(string(backupv1.ConditionProgressing), metav1.ConditionTrue, "Progressing", ""),
 			},
 		}
-		backup.Finalizers = []string{vmBackupFinalizer}
+		backup.Finalizers = []string{backupv1.VirtualMachineBackupFinalizer}
 
 		vm := createVM(vmName)
 		controller.vmStore.Add(vm)
@@ -764,7 +803,7 @@ var _ = Describe("Backup Controller", func() {
 	Context("Backup deletion cleanup", func() {
 		It("should populate includedVolumes early when backup in progress and volumes available", func() {
 			backup := createBackup(backupName, vmName, pvcName, backupv1.PushMode)
-			backup.Finalizers = []string{vmBackupFinalizer}
+			backup.Finalizers = []string{backupv1.VirtualMachineBackupFinalizer}
 			backup.Status = &backupv1.VirtualMachineBackupStatus{
 				Conditions: []metav1.Condition{
 					newCondition(string(backupv1.ConditionProgressing), metav1.ConditionTrue, "Progressing", ""),
@@ -800,7 +839,7 @@ var _ = Describe("Backup Controller", func() {
 				{VolumeName: "rootdisk", DiskTarget: "vda"},
 			}
 			backup := createBackup(backupName, vmName, pvcName, backupv1.PushMode)
-			backup.Finalizers = []string{vmBackupFinalizer}
+			backup.Finalizers = []string{backupv1.VirtualMachineBackupFinalizer}
 			backup.Status = &backupv1.VirtualMachineBackupStatus{
 				Conditions: []metav1.Condition{
 					newCondition(string(backupv1.ConditionProgressing), metav1.ConditionTrue, "Progressing", ""),
@@ -828,7 +867,7 @@ var _ = Describe("Backup Controller", func() {
 		DescribeTable("should set Quiesced condition correctly",
 			func(quiesceStatus string, expectedConditionStatus metav1.ConditionStatus, expectedReason string) {
 				backup := createBackup(backupName, vmName, pvcName, backupv1.PushMode)
-				backup.Finalizers = []string{vmBackupFinalizer}
+				backup.Finalizers = []string{backupv1.VirtualMachineBackupFinalizer}
 				backup.Status = &backupv1.VirtualMachineBackupStatus{
 					Conditions: []metav1.Condition{
 						newCondition(string(backupv1.ConditionProgressing), metav1.ConditionTrue, "Progressing", ""),
@@ -865,7 +904,7 @@ var _ = Describe("Backup Controller", func() {
 
 		It("should set Quiesced condition when backup completes before reconcileActive runs", func() {
 			backup := createBackup(backupName, vmName, pvcName, backupv1.PushMode)
-			backup.Finalizers = []string{vmBackupFinalizer}
+			backup.Finalizers = []string{backupv1.VirtualMachineBackupFinalizer}
 			backup.Status = &backupv1.VirtualMachineBackupStatus{
 				Conditions: []metav1.Condition{
 					newCondition(string(backupv1.ConditionProgressing), metav1.ConditionTrue, "Progressing", ""),
@@ -906,7 +945,7 @@ var _ = Describe("Backup Controller", func() {
 
 		It("should patch VMI to remove backup status when backup is completed", func() {
 			backup := createBackup(backupName, vmName, pvcName, backupv1.PushMode)
-			backup.Finalizers = []string{vmBackupFinalizer}
+			backup.Finalizers = []string{backupv1.VirtualMachineBackupFinalizer}
 			backup.Status = &backupv1.VirtualMachineBackupStatus{
 				Conditions: []metav1.Condition{
 					newCondition(string(backupv1.ConditionProgressing), metav1.ConditionTrue, "Progressing", ""),
@@ -935,7 +974,7 @@ var _ = Describe("Backup Controller", func() {
 
 		It("should remove finalizer when a completed backup is being deleted", func() {
 			backup := createBackup(backupName, vmName, pvcName, backupv1.PushMode)
-			backup.Finalizers = []string{vmBackupFinalizer}
+			backup.Finalizers = []string{backupv1.VirtualMachineBackupFinalizer}
 			backup.Status = &backupv1.VirtualMachineBackupStatus{
 				Conditions: []metav1.Condition{
 					newCondition(string(backupv1.ConditionProgressing), metav1.ConditionFalse, "Progressing", ""),
@@ -962,7 +1001,7 @@ var _ = Describe("Backup Controller", func() {
 		It("should handle backup deletion during initialization when VMI is already gone", func() {
 			backup := createBackup(backupName, vmName, pvcName, backupv1.PushMode)
 			backup.DeletionTimestamp = &metav1.Time{Time: metav1.Now().Time}
-			backup.Finalizers = []string{vmBackupFinalizer}
+			backup.Finalizers = []string{backupv1.VirtualMachineBackupFinalizer}
 
 			patched := false
 			kubevirtClient.Fake.PrependReactor("patch", "virtualmachinebackups", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
@@ -981,7 +1020,7 @@ var _ = Describe("Backup Controller", func() {
 		It("should handle backup deletion during initialization when the VMI exists", func() {
 			backup := createBackup(backupName, vmName, pvcName, backupv1.PushMode)
 			backup.DeletionTimestamp = &metav1.Time{Time: metav1.Now().Time}
-			backup.Finalizers = []string{vmBackupFinalizer}
+			backup.Finalizers = []string{backupv1.VirtualMachineBackupFinalizer}
 
 			vm := createVM(vmName)
 			controller.vmStore.Add(vm)
@@ -1000,7 +1039,7 @@ var _ = Describe("Backup Controller", func() {
 		It("should retry cleanup if it fails when backup is deleted during initialization", func() {
 			backup := createBackup(backupName, vmName, pvcName, backupv1.PushMode)
 			backup.DeletionTimestamp = &metav1.Time{Time: metav1.Now().Time}
-			backup.Finalizers = []string{vmBackupFinalizer}
+			backup.Finalizers = []string{backupv1.VirtualMachineBackupFinalizer}
 
 			vm := createVM(vmName)
 			controller.vmStore.Add(vm)
@@ -1242,7 +1281,7 @@ var _ = Describe("Backup Controller", func() {
 	Context("startBackup", func() {
 		It("should return error if updateSourceBackupInProgress fails", func() {
 			backup := createBackup(backupName, vmName, pvcName, backupv1.PushMode)
-			backup.Finalizers = []string{vmBackupFinalizer}
+			backup.Finalizers = []string{backupv1.VirtualMachineBackupFinalizer}
 			backup.Status = &backupv1.VirtualMachineBackupStatus{}
 
 			vm := createVM(vmName)
@@ -1266,7 +1305,7 @@ var _ = Describe("Backup Controller", func() {
 
 		It("should return error if Start backup command fails", func() {
 			backup := createBackup(backupName, vmName, pvcName, backupv1.PushMode)
-			backup.Finalizers = []string{vmBackupFinalizer}
+			backup.Finalizers = []string{backupv1.VirtualMachineBackupFinalizer}
 			backup.Status = &backupv1.VirtualMachineBackupStatus{}
 
 			vm := createVM(vmName)
@@ -1284,6 +1323,52 @@ var _ = Describe("Backup Controller", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("failed to send Start backup command"))
 		})
+
+		It("should add tracker finalizer when starting backup with tracker", func() {
+			backupTracker := createBackupTracker(backupTrackerName, vmName, "")
+			controller.backupTrackerInformer.GetStore().Add(backupTracker)
+
+			backup := createBackupWithTracker(backupName, vmName, pvcName)
+			backup.Finalizers = []string{backupv1.VirtualMachineBackupFinalizer}
+
+			vm := createVM(vmName)
+			controller.vmStore.Add(vm)
+
+			vmi := createVMIWithPVCAttached()
+			controller.vmiStore.Add(vmi)
+
+			pvc := createPVC(pvcName)
+			controller.pvcStore.Add(pvc)
+
+			trackerPatched := false
+			kubevirtClient.Fake.PrependReactor("patch", "virtualmachinebackuptrackers", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+				patchAction := action.(testing.PatchAction)
+				if patchAction.GetSubresource() == "" {
+					trackerPatched = true
+					Expect(string(patchAction.GetPatch())).To(ContainSubstring(backupv1.VirtualMachineBackupTrackerFinalizer))
+					updatedTracker := backupTracker.DeepCopy()
+					updatedTracker.Finalizers = []string{backupv1.VirtualMachineBackupTrackerFinalizer}
+					return true, updatedTracker, nil
+				}
+				return false, nil, nil
+			})
+
+			virtClient.EXPECT().VirtualMachineBackupTracker(testNamespace).
+				Return(kubevirtClient.BackupV1alpha1().VirtualMachineBackupTrackers(testNamespace)).AnyTimes()
+
+			vmiInterface.EXPECT().
+				Patch(gomock.Any(), vmName, types.JSONPatchType, gomock.Any(), gomock.Any()).
+				Return(vmi, nil)
+			vmiInterface.EXPECT().
+				Backup(gomock.Any(), vmName, gomock.Any()).
+				Return(nil)
+
+			backupCopy, err := syncBackup(backup)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(trackerPatched).To(BeTrue())
+			Expect(meta.IsStatusConditionTrue(backupCopy.Status.Conditions, string(backupv1.ConditionProgressing))).To(BeTrue())
+		})
+
 	})
 
 	Context("updateSourceBackupInProgress", func() {
@@ -1378,7 +1463,7 @@ var _ = Describe("Backup Controller", func() {
 
 	It("should attach PVC and return when PVC not yet attached", func() {
 		backup := createBackup(backupName, vmName, pvcName, backupv1.PushMode)
-		backup.Finalizers = []string{vmBackupFinalizer}
+		backup.Finalizers = []string{backupv1.VirtualMachineBackupFinalizer}
 
 		vm := createVM(vmName)
 		controller.vmStore.Add(vm)
@@ -1403,7 +1488,7 @@ var _ = Describe("Backup Controller", func() {
 
 	It("should successfully initiate backup with Full type", func() {
 		backup := createBackup(backupName, vmName, pvcName, backupv1.PushMode)
-		backup.Finalizers = []string{vmBackupFinalizer}
+		backup.Finalizers = []string{backupv1.VirtualMachineBackupFinalizer}
 
 		vm := createVM(vmName)
 		controller.vmStore.Add(vm)
@@ -1435,10 +1520,11 @@ var _ = Describe("Backup Controller", func() {
 
 	It("should initiate full backup when backupTracker exists but has no LatestCheckpoint", func() {
 		backupTracker := createBackupTracker(backupTrackerName, vmName, "")
+		backupTracker.Finalizers = []string{backupv1.VirtualMachineBackupTrackerFinalizer}
 		controller.backupTrackerInformer.GetStore().Add(backupTracker)
 
 		backup := createBackupWithTracker(backupName, vmName, pvcName)
-		backup.Finalizers = []string{vmBackupFinalizer}
+		backup.Finalizers = []string{backupv1.VirtualMachineBackupFinalizer}
 
 		vm := createVM(vmName)
 		controller.vmStore.Add(vm)
@@ -1471,10 +1557,11 @@ var _ = Describe("Backup Controller", func() {
 
 	It("should initiate incremental backup when backupTracker has LatestCheckpoint", func() {
 		backupTracker := createBackupTracker(backupTrackerName, vmName, checkpointName)
+		backupTracker.Finalizers = []string{backupv1.VirtualMachineBackupTrackerFinalizer}
 		controller.backupTrackerInformer.GetStore().Add(backupTracker)
 
 		backup := createBackupWithTracker(backupName, vmName, pvcName)
-		backup.Finalizers = []string{vmBackupFinalizer}
+		backup.Finalizers = []string{backupv1.VirtualMachineBackupFinalizer}
 
 		vm := createVM(vmName)
 		controller.vmStore.Add(vm)
@@ -1508,10 +1595,11 @@ var _ = Describe("Backup Controller", func() {
 
 	It("should initiate full backup with ForceFullBackup even with LatestCheckpoint", func() {
 		backupTracker := createBackupTracker(backupTrackerName, vmName, checkpointName)
+		backupTracker.Finalizers = []string{backupv1.VirtualMachineBackupTrackerFinalizer}
 		controller.backupTrackerInformer.GetStore().Add(backupTracker)
 
 		backup := createBackupWithTracker(backupName, vmName, pvcName)
-		backup.Finalizers = []string{vmBackupFinalizer}
+		backup.Finalizers = []string{backupv1.VirtualMachineBackupFinalizer}
 		backup.Spec.ForceFullBackup = true
 
 		vm := createVM(vmName)
@@ -1545,7 +1633,7 @@ var _ = Describe("Backup Controller", func() {
 
 	It("should return error when cleanup not complete for finished backup", func() {
 		backup := createBackup(backupName, vmName, pvcName, backupv1.PushMode)
-		backup.Finalizers = []string{vmBackupFinalizer}
+		backup.Finalizers = []string{backupv1.VirtualMachineBackupFinalizer}
 		backup.Status = &backupv1.VirtualMachineBackupStatus{
 			Conditions: []metav1.Condition{
 				newCondition(string(backupv1.ConditionProgressing), metav1.ConditionTrue, "Progressing", ""),
@@ -1575,7 +1663,7 @@ var _ = Describe("Backup Controller", func() {
 
 	It("should remove backup status from VMI and return completed event when already detached", func() {
 		backup := createBackup(backupName, vmName, pvcName, backupv1.PushMode)
-		backup.Finalizers = []string{vmBackupFinalizer}
+		backup.Finalizers = []string{backupv1.VirtualMachineBackupFinalizer}
 		backup.Status = &backupv1.VirtualMachineBackupStatus{
 			Conditions: []metav1.Condition{
 				newCondition(string(backupv1.ConditionProgressing), metav1.ConditionTrue, "Progressing", ""),
@@ -1626,7 +1714,7 @@ var _ = Describe("Backup Controller", func() {
 			controller.backupTrackerInformer.GetStore().Add(backupTracker)
 
 			backup := createBackupWithTracker(backupName, vmName, pvcName)
-			backup.Finalizers = []string{vmBackupFinalizer}
+			backup.Finalizers = []string{backupv1.VirtualMachineBackupFinalizer}
 			backup.Status = &backupv1.VirtualMachineBackupStatus{
 				Conditions: []metav1.Condition{
 					newCondition(string(backupv1.ConditionProgressing), metav1.ConditionTrue, "Progressing", ""),
@@ -1711,7 +1799,7 @@ var _ = Describe("Backup Controller", func() {
 		controller.backupTrackerInformer.GetStore().Add(backupTracker)
 
 		backup := createBackupWithTracker(backupName, vmName, pvcName)
-		backup.Finalizers = []string{vmBackupFinalizer}
+		backup.Finalizers = []string{backupv1.VirtualMachineBackupFinalizer}
 		backup.Status = &backupv1.VirtualMachineBackupStatus{
 			Conditions: []metav1.Condition{
 				newCondition(string(backupv1.ConditionProgressing), metav1.ConditionTrue, "Progressing", ""),
@@ -1762,7 +1850,7 @@ var _ = Describe("Backup Controller", func() {
 		BeforeEach(func() {
 			backup = createBackup(backupName, vmName, pvcName, backupv1.PullMode)
 			backup.CreationTimestamp = metav1.Now()
-			backup.Finalizers = []string{vmBackupFinalizer}
+			backup.Finalizers = []string{backupv1.VirtualMachineBackupFinalizer}
 			backup.Status = &backupv1.VirtualMachineBackupStatus{
 				Conditions: []metav1.Condition{
 					newCondition(string(backupv1.ConditionProgressing), metav1.ConditionTrue, "Progressing", ""),

--- a/pkg/storage/cbt/backuptracker.go
+++ b/pkg/storage/cbt/backuptracker.go
@@ -21,6 +21,7 @@ package cbt
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -32,7 +33,12 @@ import (
 	"kubevirt.io/client-go/log"
 
 	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
+	"kubevirt.io/kubevirt/pkg/controller"
 )
+
+func isTrackerDeleting(tracker *backupv1.VirtualMachineBackupTracker) bool {
+	return tracker != nil && tracker.DeletionTimestamp != nil
+}
 
 func trackerNeedsCheckpointRedefinition(tracker *backupv1.VirtualMachineBackupTracker) bool {
 	return tracker != nil &&
@@ -57,10 +63,14 @@ func (ctrl *VMBackupController) ExecuteTracker() bool {
 
 	err := ctrl.executeTracker(key)
 	if err != nil {
-		log.Log.Reason(err).Infof("reenqueuing VirtualMachineBackupTracker %v for redefinition", key)
+		if errors.Is(err, errActiveBackups) {
+			log.Log.V(4).Infof("reenqueuing VirtualMachineBackupTracker %v: %v", key, err)
+		} else {
+			log.Log.Reason(err).Infof("reenqueuing VirtualMachineBackupTracker %v", key)
+		}
 		ctrl.trackerQueue.AddRateLimited(key)
 	} else {
-		log.Log.V(4).Infof("processed VirtualMachineBackupTracker redefinition %v", key)
+		log.Log.V(4).Infof("processed VirtualMachineBackupTracker %v", key)
 		ctrl.trackerQueue.Forget(key)
 	}
 	return true
@@ -68,7 +78,7 @@ func (ctrl *VMBackupController) ExecuteTracker() bool {
 
 func (ctrl *VMBackupController) executeTracker(key string) error {
 	logger := log.Log.With("VirtualMachineBackupTracker", key)
-	logger.V(3).Infof("Processing tracker checkpoint redefinition %s", key)
+	logger.V(3).Infof("Processing tracker %s", key)
 
 	storeObj, exists, err := ctrl.backupTrackerInformer.GetStore().GetByKey(key)
 	if err != nil {
@@ -84,6 +94,10 @@ func (ctrl *VMBackupController) executeTracker(key string) error {
 	if !ok {
 		logger.Errorf("Unexpected resource type: %T", storeObj)
 		return fmt.Errorf("unexpected resource %+v", storeObj)
+	}
+
+	if isTrackerDeleting(tracker) && controller.HasFinalizer(tracker, backupv1.VirtualMachineBackupTrackerFinalizer) {
+		return ctrl.handleTrackerDeletion(tracker)
 	}
 
 	if !trackerNeedsCheckpointRedefinition(tracker) {
@@ -116,6 +130,48 @@ func (ctrl *VMBackupController) handleCheckpointRedefinition(tracker *backupv1.V
 
 	logger.Infof("Checkpoint redefinition successful for tracker %s/%s", tracker.Namespace, tracker.Name)
 	return ctrl.clearRedefinitionFlag(tracker)
+}
+
+func (ctrl *VMBackupController) handleTrackerDeletion(tracker *backupv1.VirtualMachineBackupTracker) error {
+	logger := log.Log.With("VirtualMachineBackupTracker", tracker.Name)
+	logger.Infof("Handling deletion for tracker %s/%s", tracker.Namespace, tracker.Name)
+
+	hasActiveBackups, err := ctrl.trackerHasActiveBackups(tracker)
+	if err != nil {
+		return fmt.Errorf("failed to check active backups for tracker %s/%s: %w", tracker.Namespace, tracker.Name, err)
+	}
+	if hasActiveBackups {
+		return fmt.Errorf("tracker %s/%s has active backups, cannot remove finalizer: %w", tracker.Namespace, tracker.Name, errActiveBackups)
+	}
+
+	return ctrl.removeTrackerFinalizer(tracker)
+}
+
+func (ctrl *VMBackupController) trackerHasActiveBackups(tracker *backupv1.VirtualMachineBackupTracker) (bool, error) {
+	trackerKey := fmt.Sprintf("%s/%s", tracker.Namespace, tracker.Name)
+	backupKeys, err := ctrl.backupInformer.GetIndexer().IndexKeys("backupTracker", trackerKey)
+	if err != nil {
+		return false, err
+	}
+
+	for _, key := range backupKeys {
+		obj, exists, err := ctrl.backupInformer.GetStore().GetByKey(key)
+		if err != nil {
+			return false, fmt.Errorf("failed to get backup %s from store: %w", key, err)
+		}
+		if !exists {
+			continue
+		}
+		backup, ok := obj.(*backupv1.VirtualMachineBackup)
+		if !ok {
+			continue
+		}
+		if !IsBackupTerminal(backup) {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }
 
 func (ctrl *VMBackupController) handleRedefinitionError(tracker *backupv1.VirtualMachineBackupTracker, err error) error {

--- a/pkg/storage/cbt/backuptracker_test.go
+++ b/pkg/storage/cbt/backuptracker_test.go
@@ -194,10 +194,121 @@ var _ = Describe("VMBackupController", func() {
 		})
 	})
 
+	Context("handleTrackerDeletion", func() {
+		var (
+			ctrl           *VMBackupController
+			backupInformer cache.SharedIndexInformer
+		)
+
+		BeforeEach(func() {
+			backupInformer, _ = testutils.NewFakeInformerWithIndexersFor(
+				&backupv1.VirtualMachineBackup{},
+				controller.GetVirtualMachineBackupInformerIndexers(),
+			)
+
+			ctrl = &VMBackupController{
+				client:         virtClient,
+				backupInformer: backupInformer,
+			}
+		})
+
+		It("should remove finalizer when no backups exist", func() {
+			tracker := createTracker("tracker1", "test-vmi", true, false)
+			tracker.DeletionTimestamp = new(metav1.Now())
+			tracker.Finalizers = []string{backupv1.VirtualMachineBackupTrackerFinalizer}
+			_, err := kubevirtCli.BackupV1alpha1().VirtualMachineBackupTrackers(testNamespace).Create(
+				context.Background(), tracker, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			virtClient.EXPECT().VirtualMachineBackupTracker(testNamespace).
+				Return(kubevirtCli.BackupV1alpha1().VirtualMachineBackupTrackers(testNamespace))
+
+			err = ctrl.handleTrackerDeletion(tracker)
+			Expect(err).ToNot(HaveOccurred())
+
+			updated, err := kubevirtCli.BackupV1alpha1().VirtualMachineBackupTrackers(testNamespace).Get(
+				context.Background(), "tracker1", metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updated.Finalizers).To(BeEmpty())
+		})
+
+		DescribeTable("should remove finalizer only when all backups are terminal",
+			func(backup *backupv1.VirtualMachineBackup, shouldRemove bool) {
+				tracker := createTracker("tracker1", "test-vmi", true, false)
+				tracker.DeletionTimestamp = new(metav1.Now())
+				tracker.Finalizers = []string{backupv1.VirtualMachineBackupTrackerFinalizer}
+				_, err := kubevirtCli.BackupV1alpha1().VirtualMachineBackupTrackers(testNamespace).Create(
+					context.Background(), tracker, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(backupInformer.GetStore().Add(backup)).To(Succeed())
+
+				if shouldRemove {
+					virtClient.EXPECT().VirtualMachineBackupTracker(testNamespace).
+						Return(kubevirtCli.BackupV1alpha1().VirtualMachineBackupTrackers(testNamespace))
+				}
+
+				err = ctrl.handleTrackerDeletion(tracker)
+				if shouldRemove {
+					Expect(err).ToNot(HaveOccurred())
+				} else {
+					Expect(err).To(HaveOccurred())
+				}
+
+				updated, err := kubevirtCli.BackupV1alpha1().VirtualMachineBackupTrackers(testNamespace).Get(
+					context.Background(), "tracker1", metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				if shouldRemove {
+					Expect(updated.Finalizers).To(BeEmpty())
+				} else {
+					Expect(updated.Finalizers).To(ContainElement(backupv1.VirtualMachineBackupTrackerFinalizer))
+				}
+			},
+			Entry("active backup blocks removal",
+				&backupv1.VirtualMachineBackup{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "active-backup",
+						Namespace: testNamespace,
+					},
+					Spec: backupv1.VirtualMachineBackupSpec{
+						Source: corev1.TypedLocalObjectReference{
+							APIGroup: new(backupv1.SchemeGroupVersion.Group),
+							Kind:     backupv1.VirtualMachineBackupTrackerGroupVersionKind.Kind,
+							Name:     "tracker1",
+						},
+					},
+				}, false),
+			Entry("completed backup allows removal",
+				&backupv1.VirtualMachineBackup{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "completed-backup",
+						Namespace: testNamespace,
+					},
+					Spec: backupv1.VirtualMachineBackupSpec{
+						Source: corev1.TypedLocalObjectReference{
+							APIGroup: new(backupv1.SchemeGroupVersion.Group),
+							Kind:     backupv1.VirtualMachineBackupTrackerGroupVersionKind.Kind,
+							Name:     "tracker1",
+						},
+					},
+					Status: &backupv1.VirtualMachineBackupStatus{
+						Conditions: []metav1.Condition{
+							{
+								Type:   string(backupv1.ConditionComplete),
+								Status: metav1.ConditionTrue,
+							},
+						},
+					},
+				}, true),
+		)
+	})
+
 	Context("executeTracker", func() {
 		var (
 			ctrl            *VMBackupController
 			trackerInformer cache.SharedIndexInformer
+			backupInformer  cache.SharedIndexInformer
 			vmiInformer     cache.SharedIndexInformer
 			recorder        *record.FakeRecorder
 			vmiInterface    *kubecli.MockVirtualMachineInstanceInterface
@@ -208,6 +319,10 @@ var _ = Describe("VMBackupController", func() {
 				&backupv1.VirtualMachineBackupTracker{},
 				controller.GetVirtualMachineBackupTrackerInformerIndexers(),
 			)
+			backupInformer, _ = testutils.NewFakeInformerWithIndexersFor(
+				&backupv1.VirtualMachineBackup{},
+				controller.GetVirtualMachineBackupInformerIndexers(),
+			)
 			vmiInformer, _ = testutils.NewFakeInformerFor(&v1.VirtualMachineInstance{})
 			recorder = record.NewFakeRecorder(100)
 			recorder.IncludeObject = true
@@ -216,6 +331,7 @@ var _ = Describe("VMBackupController", func() {
 			ctrl = &VMBackupController{
 				client:                virtClient,
 				backupTrackerInformer: trackerInformer,
+				backupInformer:        backupInformer,
 				vmiStore:              vmiInformer.GetStore(),
 				recorder:              recorder,
 			}
@@ -227,7 +343,6 @@ var _ = Describe("VMBackupController", func() {
 		})
 
 		It("should return nil when tracker no longer needs redefinition", func() {
-			// Tracker without redefinition flag set
 			tracker := createTracker("tracker1", "test-vmi", false, false)
 			Expect(trackerInformer.GetStore().Add(tracker)).To(Succeed())
 

--- a/staging/src/kubevirt.io/api/backup/v1alpha1/types.go
+++ b/staging/src/kubevirt.io/api/backup/v1alpha1/types.go
@@ -25,6 +25,11 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
+const (
+	VirtualMachineBackupFinalizer        = "backup.kubevirt.io/vmbackup-protection"
+	VirtualMachineBackupTrackerFinalizer = "backup.kubevirt.io/vmbt-protection"
+)
+
 // BackupMode is the const type for the backup possible modes
 type BackupMode string
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
VirtualMachineBackupTracker lacked a finalizer which made it possible to delete one while a VirtualMachineBackup referencing it is still running. 

#### After this PR:
Add a finalizer to VirtualMachineBackupTrackers during an active backup that references them to prevent accidental deletion. This will also enable other planned cleanup coordination capabilities such as checkpoint housekeeping.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

