### PR TITLE
automation: enable fail fast mode when triggered by a Prow batch

### DIFF
--- a/automation/repeated_test.sh
+++ b/automation/repeated_test.sh
@@ -197,6 +197,11 @@ elif should_skip_test_run_due_to_too_many_tests "${NEW_TESTS}"; then
     exit 0
 fi
 
+# Tests triggered by a Prow batch should stop after the first failure to save CI resources
+if [[ -n ${PROW_JOB_ID:-} && ${JOB_TYPE} == "batch" ]]; then
+  ginkgo_params="$ginkgo_params --fail-fast"
+fi
+
 # for some tests we need three nodes aka two nodes with cpu manager installed
 # TODO: check whether no test with label `RequiresTwoWorkerNodesWithCPUManager` is present, in that case use two nodes
 KUBEVIRT_NUM_NODES=3

--- a/automation/test.sh
+++ b/automation/test.sh
@@ -463,7 +463,12 @@ else
   fi
 fi
 
-ginko_params="--no-color"
+ginkgo_params="--no-color"
+
+# Tests triggered by a Prow batch should stop after the first failure to save CI resources
+if [[ -n ${PROW_JOB_ID:-} && ${JOB_TYPE} == "batch" ]]; then
+  ginkgo_params="$ginkgo_params --fail-fast"
+fi
 
 # Prepare PV for Windows testing
 if [[ $TARGET =~ windows.* ]]; then
@@ -662,7 +667,7 @@ fi
 
 # Prepare RHEL PV for Template testing
 if [[ $TARGET =~ os-.* ]]; then
-  ginko_params="$ginko_params|Networkpolicy"
+  ginkgo_params="$ginkgo_params|Networkpolicy"
 
   kubectl create -f - <<EOF
 ---
@@ -704,7 +709,7 @@ fi
 
 
 # Run functional tests
-FUNC_TEST_ARGS=$ginko_params FUNC_TEST_LABEL_FILTER="--label-filter=(!flake-check)&&(${label_filter})" make functest
+FUNC_TEST_ARGS=$ginkgo_params FUNC_TEST_LABEL_FILTER="--label-filter=(!flake-check)&&(${label_filter})" make functest
 
 # Run REST API coverage based on k8s audit log and openapi spec
 if [ -n "$RUN_REST_COVERAGE" ]; then


### PR DESCRIPTION
### What this PR does

Unlike regular presubmits jobs created by Prow's Hook trigger plugin when a developper updates its PR or issue a `/test` command, in the case of Prow's Tide batch jobs there is no value in spending hours continuing to run the entire test suite once a test case has failed.

#### Before this PR:

kubevirt e2e jobs triggered for a batch were always running the test suite entirely.

#### After this PR:

kubevirt e2e jobs triggered for a batch stop running the test suite after a test case fails.

### Why we need it and why it was done in this way

This PR should help us to save CI resources and possibly get batches merged faster.

The following tradeoffs were made: only batch jobs are impacted, regular presubmit jobs are not modified.

The following alternatives were considered:

Links to places where the discussion took place: SIG-CI meeting: https://groups.google.com/g/kubevirt-dev/c/cV94dU53zdQ

### Special notes for your reviewer

/cc @fossedihelm 
/cc @dhiller 

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```