### PR TITLE
tests: decorate kvm-pit emulator thread test with RequiresAMD64

### DIFF
--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -1229,7 +1229,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 				By("Checking if pod memory usage is > 80Mi")
 				Expect(m).To(BeNumerically(">", 83886080), "83886080 B = 80 Mi")
 			})
-			DescribeTable("[test_id:4023]should start a vmi with dedicated cpus and isolated emulator thread", func(resources *v1.ResourceRequirements) {
+			DescribeTable("[test_id:4023]should start a vmi with dedicated cpus and isolated emulator thread", decorators.RequiresAMD64, func(resources *v1.ResourceRequirements) {
 				cpuVmi := libvmifact.NewAlpine()
 				cpuVmi.Spec.Domain.CPU = &v1.CPU{
 					Cores:                 2,


### PR DESCRIPTION
### What this PR does
Adds `decorators.RequiresAMD64` to the `test_id:4023` DescribeTable so it is skipped on multi arch and ARM64 environments.

#### Before this PR:
- `test_id:4023` (both entries) runs `pgrep -f kvm-pit/<pid>` to verify the kvm-pit kernel thread is affined to the same CPU mask as vcpu0
- KVM PIT (i8254) is x86-only hardware — ARM64 uses the Generic Timer and has no `kvm-pit` kernel thread
- The `pgrep` always fails with exit code 1 on ARM64 nodes

#### After this PR:
- The DescribeTable is decorated with `RequiresAMD64` and skipped on multi-arch and ARM64 environments.

### References
- Relates-To: https://github.com/kubevirt/kubevirt/issues/18030

### Release note
```release-note
NONE
```