### PR TITLE
client-go/log: Use private FlagSet to avoid flag conflicts

### DIFF
--- a/cmd/fake-cmd-server/fake-cmd-server.go
+++ b/cmd/fake-cmd-server/fake-cmd-server.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"errors"
-	goflag "flag"
 
 	"github.com/spf13/pflag"
 	"go.uber.org/mock/gomock"
@@ -18,7 +17,7 @@ import (
 func main() {
 	socket := pflag.String("socket", cmdclient.SocketOnGuest(), "Socket for the cmd server")
 
-	pflag.CommandLine.AddGoFlag(goflag.CommandLine.Lookup("v"))
+	pflag.CommandLine.AddGoFlag(log.VerbosityFlag())
 	pflag.Parse()
 
 	log.InitializeLogging("fake-cmd-server")

--- a/cmd/virt-launcher-monitor/virt-launcher-monitor.go
+++ b/cmd/virt-launcher-monitor/virt-launcher-monitor.go
@@ -22,7 +22,6 @@ package main
 import (
 	"bufio"
 	"errors"
-	goflag "flag"
 	"fmt"
 	"net/http"
 	"os"
@@ -62,7 +61,7 @@ func main() {
 	keepAfterFailure := pflag.Bool("keep-after-failure", false, "virt-launcher will be kept alive after failure for debugging if set to true")
 	uid := pflag.String("uid", "", "UID of the VirtualMachineInstance")
 
-	pflag.CommandLine.AddGoFlag(goflag.CommandLine.Lookup("v"))
+	pflag.CommandLine.AddGoFlag(log.VerbosityFlag())
 	pflag.CommandLine.ParseErrorsWhitelist = pflag.ParseErrorsWhitelist{UnknownFlags: true}
 	pflag.Parse()
 

--- a/cmd/virt-launcher/virt-launcher.go
+++ b/cmd/virt-launcher/virt-launcher.go
@@ -22,7 +22,6 @@ package main
 import (
 	"context"
 	"errors"
-	goflag "flag"
 	"fmt"
 	"os"
 	"os/signal"
@@ -375,7 +374,7 @@ func main() {
 	libvirtLogFilters := pflag.String("libvirt-log-filters", "", "Set custom log filters for libvirt")
 	hypervisor := pflag.String("hypervisor", v1.KvmHypervisorName, "Hypervisor to be used by the VMI")
 
-	pflag.CommandLine.AddGoFlag(goflag.CommandLine.Lookup("v"))
+	pflag.CommandLine.AddGoFlag(log.VerbosityFlag())
 	pflag.Parse()
 
 	log.InitializeLogging("virt-launcher")

--- a/cmd/virt-probe/virt-probe.go
+++ b/cmd/virt-probe/virt-probe.go
@@ -20,7 +20,6 @@
 package main
 
 import (
-	goflag "flag"
 	"fmt"
 	"os"
 	"runtime/pprof"
@@ -40,7 +39,7 @@ func main() {
 	timeoutSeconds := pflag.Int32("timeoutSeconds", 1, "Duration in seconds the probe will wait for the guest command to return.")
 	guestAgentPing := pflag.Bool("guestAgentPing", false, "Flag to specify readiness probe based of guest-agent ping")
 
-	pflag.CommandLine.AddGoFlag(goflag.CommandLine.Lookup("v"))
+	pflag.CommandLine.AddGoFlag(log.VerbosityFlag())
 	pflag.Parse()
 
 	log.InitializeLogging("virt-probe")

--- a/cmd/virt-tail/main.go
+++ b/cmd/virt-tail/main.go
@@ -22,7 +22,6 @@ package main
 import (
 	"context"
 	"errors"
-	goflag "flag"
 	"fmt"
 	"os"
 	"os/signal"
@@ -102,7 +101,7 @@ func (v *VirtTail) tailLogs(location tail.SeekInfo) (*tail.SeekInfo, error) {
 }
 
 func main() {
-	pflag.CommandLine.AddGoFlag(goflag.CommandLine.Lookup("v"))
+	pflag.CommandLine.AddGoFlag(log.VerbosityFlag())
 	pflag.CommandLine.ParseErrorsWhitelist = pflag.ParseErrorsWhitelist{UnknownFlags: true}
 	logFile := pflag.String("logfile", "", "path of the logfile to be streamed")
 	pflag.Parse()

--- a/pkg/service/BUILD.bazel
+++ b/pkg/service/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/github.com/spf13/pflag:go_default_library",
     ],
 )

--- a/pkg/service/service.go
+++ b/pkg/service/service.go
@@ -27,6 +27,7 @@ import (
 	flag "github.com/spf13/pflag"
 
 	"kubevirt.io/client-go/kubecli"
+	kvlog "kubevirt.io/client-go/log"
 )
 
 func init() {
@@ -53,7 +54,7 @@ func (service *ServiceListen) Address() string {
 }
 
 func (service *ServiceListen) InitFlags() {
-	flag.CommandLine.AddGoFlag(goflag.CommandLine.Lookup("v"))
+	flag.CommandLine.AddGoFlag(kvlog.VerbosityFlag())
 	flag.CommandLine.AddGoFlag(goflag.CommandLine.Lookup("kubeconfig"))
 	flag.CommandLine.AddGoFlag(goflag.CommandLine.Lookup("master"))
 }

--- a/pkg/storage/export/virt-exportserver/exportserver.go
+++ b/pkg/storage/export/virt-exportserver/exportserver.go
@@ -26,7 +26,6 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"errors"
-	goflag "flag"
 	"fmt"
 	"io"
 	golog "log"
@@ -312,7 +311,7 @@ func (s *exportServer) buildServer(ctx context.Context) *http.Server {
 }
 
 func (s *exportServer) AddFlags() {
-	flag.CommandLine.AddGoFlag(goflag.CommandLine.Lookup("v"))
+	flag.CommandLine.AddGoFlag(log.VerbosityFlag())
 }
 
 func NewExportServer(config ExportServerConfig) (service.Service, error) {

--- a/pkg/virtctl/root.go
+++ b/pkg/virtctl/root.go
@@ -2,7 +2,6 @@ package virtctl
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -144,14 +143,7 @@ func NewVirtctlCommandFn() *cobra.Command {
 }
 
 func addVerbosityFlag(fs *pflag.FlagSet) {
-	// The verbosity flag is added to the default flag set
-	// by init() in staging/src/kubevirt.io/client-go/log/log.go.
-	// We re-add it here to make it available in virtctl commands.
-	if f := flag.CommandLine.Lookup("v"); f != nil {
-		fs.AddFlag(pflag.PFlagFromGoFlag(f))
-	} else {
-		panic("failed to find verbosity flag \"v\" in default flag set")
-	}
+	fs.AddFlag(pflag.PFlagFromGoFlag(log.VerbosityFlag()))
 }
 
 func Execute() int {

--- a/staging/src/kubevirt.io/client-go/log/log.go
+++ b/staging/src/kubevirt.io/client-go/log/log.go
@@ -82,10 +82,29 @@ type FilteredLogger struct {
 
 var Log = DefaultLogger()
 
+var logFlags = goflag.NewFlagSet("kubevirt-log", goflag.ContinueOnError)
+
 func init() {
 	// "the practical default level is V(2)"
 	// see https://github.com/kubernetes/community/blob/master/contributors/devel/logging.md
-	goflag.IntVar(&defaultVerbosity, "v", 2, "log level for V logs")
+	logFlags.IntVar(&defaultVerbosity, "v", 2, "log level for V logs")
+}
+
+// VerbosityFlag returns the "-v" verbosity flag for bridging into
+// other flag sets (e.g. pflag). The flag is owned by a package-
+// internal FlagSet so that importing this package never registers
+// flags on flag.CommandLine and therefore cannot conflict with
+// other packages that register a "-v" flag there.
+//
+// Example:
+//
+//	pflag.CommandLine.AddGoFlag(log.VerbosityFlag())
+func VerbosityFlag() *goflag.Flag {
+	f := logFlags.Lookup("v")
+	if f == nil {
+		panic("kubevirt.io/client-go/log: verbosity flag \"v\" not registered on internal FlagSet")
+	}
+	return f
 }
 
 func InitializeLogging(comp string) {

--- a/staging/src/kubevirt.io/client-go/log/log_test.go
+++ b/staging/src/kubevirt.io/client-go/log/log_test.go
@@ -21,6 +21,7 @@ package log
 
 import (
 	"errors"
+	goflag "flag"
 	"fmt"
 	"path/filepath"
 	"runtime"
@@ -449,6 +450,40 @@ func TestObjectContextLeakage(t *testing.T) {
 		}
 	}
 
+	tearDown()
+}
+
+func TestVerbosityFlagDoesNotRegisterOnCommandLine(t *testing.T) {
+	goflag.CommandLine.VisitAll(func(f *goflag.Flag) {
+		if f.Name == "v" {
+			t.Fatal("\"v\" flag must not be registered on flag.CommandLine")
+		}
+	})
+}
+
+func TestVerbosityFlagReturnsNonNil(t *testing.T) {
+	f := VerbosityFlag()
+	if f == nil {
+		t.Fatal("VerbosityFlag() returned nil")
+	}
+	if f.Name != "v" {
+		t.Fatalf("VerbosityFlag() returned flag with name %q, want \"v\"", f.Name)
+	}
+}
+
+func TestVerbosityFlagSharesDefaultVerbosity(t *testing.T) {
+	setUp()
+	original := defaultVerbosity
+	defer func() { defaultVerbosity = original }()
+
+	f := VerbosityFlag()
+	if err := f.Value.Set("5"); err != nil {
+		t.Fatalf("Setting verbosity flag value: %v", err)
+	}
+	assert(t, defaultVerbosity == 5, "VerbosityFlag value must be shared with defaultVerbosity")
+
+	log := MakeLogger(MockLogger{})
+	assert(t, log.verbosityLevel == 5, "MakeLogger must pick up updated defaultVerbosity")
 	tearDown()
 }
 


### PR DESCRIPTION
### What this PR does
#### Before this PR:

`kubevirt.io/client-go/log`'s `init()` unconditionally calls `flag.IntVar` to register a `v` flag in `flag.CommandLine`. This panics in any binary where `v` is already registered — which happens in practice when a project that already has a `-v` flag registered (e.g. via glog, which unconditionally registers `-v` in its own `init()`) imports `kubevirt.io/client-go`.

**Real-world impact:** Red Hat's StackRox/ACS project needed to use `kubevirt.io/client-go` for KubeVirt VSOCK subresource access (VM vulnerability scanning). Importing the client library panicked because glog (an indirect dependency via grpc-http1) had already registered `-v` on `flag.CommandLine`. The team was forced to reimplement the VSOCK WebSocket dialer from scratch instead of using kubevirt's supported client — adding ~500 lines of custom infrastructure code to work around this bug.

#### After this PR:

The `-v` flag is registered on a package-private `FlagSet` instead of the global `flag.CommandLine`. A new `VerbosityFlag()` function is exported so that consumers can bridge it into pflag without going through `flag.CommandLine`. All 8 internal call sites are updated. Importing `kubevirt.io/client-go/log` no longer registers any flags on the global `flag.CommandLine`, eliminating the conflict entirely regardless of `init()` ordering.

### References

- Fixes #16951
- Fixes https://github.com/kubevirt/client-go/issues/42

### Why we need it and why it was done in this way
The following tradeoffs were made:

- This changes the public API surface: `VerbosityFlag()` is a new exported function. External consumers who relied on `flag.CommandLine.Lookup("v")` returning non-nil after importing this package need to switch to `log.VerbosityFlag()`. This is an intentional change — the old behavior (registering on `flag.CommandLine` in `init()`) is the root cause of the bug and cannot be preserved without keeping the panic.

The following alternatives were considered:

- **Guard with `flag.CommandLine.Lookup("v") == nil`**: Only fixes one direction — if kubevirt's `init()` runs first and another package registers `v` second, the panic still occurs.
- **Build tag approach**: Lets consumers opt out, but by default the `init()` still registers unconditionally, so the panic persists for consumers who don't discover the tag. See companion PR #18295 for this approach.
- **Replace `init()` with explicit `RegisterFlags()`**: Clean API but still registers on `flag.CommandLine`, keeping the conflict potential. Also a larger breaking change.

This approach follows klog's own architecture (private FlagSet, explicit bridging) and is the only option that fully eliminates the panic in both `init()` orderings.

See the discussion in https://github.com/kubevirt/kubevirt/issues/16951 for details

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Testing: New unit tests verify the fix (3 new tests for the VerbosityFlag behavior)
- [x] AI Contributions: The PR abides by the KubeVirt AI Contribution Policy

### Release note

```release-note
client-go/log: The `-v` verbosity flag is no longer registered on `flag.CommandLine` during `init()`. External consumers that used `flag.CommandLine.Lookup("v")` to obtain the verbosity flag must switch to `log.VerbosityFlag()`. This eliminates panics when importing `kubevirt.io/client-go` alongside packages that also register a `-v` flag (e.g. glog, klog).
```