### PR TITLE
client-go/log: Guard flag registration with build tag

### DIFF
--- a/staging/src/kubevirt.io/client-go/log/BUILD.bazel
+++ b/staging/src/kubevirt.io/client-go/log/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
-    srcs = ["log.go"],
+    srcs = [
+        "log.go",
+        "verbosity_flag.go",
+    ],
     importpath = "kubevirt.io/client-go/log",
     visibility = ["//visibility:public"],
     deps = [
@@ -17,8 +20,29 @@ go_test(
     srcs = [
         "log_suite_test.go",
         "log_test.go",
+        "verbosity_flag_test.go",
     ],
     embed = [":go_default_library"],
+    race = "on",
+    deps = [
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/reporter:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/v2/reporters:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_noflag_test",
+    srcs = [
+        "log_suite_test.go",
+        "log_test.go",
+        "verbosity_flag_disabled_test.go",
+    ],
+    embed = [":go_default_library"],
+    gotags = ["nokubevirtlogflag"],
     race = "on",
     deps = [
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",

--- a/staging/src/kubevirt.io/client-go/log/log.go
+++ b/staging/src/kubevirt.io/client-go/log/log.go
@@ -82,12 +82,6 @@ type FilteredLogger struct {
 
 var Log = DefaultLogger()
 
-func init() {
-	// "the practical default level is V(2)"
-	// see https://github.com/kubernetes/community/blob/master/contributors/devel/logging.md
-	goflag.IntVar(&defaultVerbosity, "v", 2, "log level for V logs")
-}
-
 func InitializeLogging(comp string) {
 	defaultComponent = comp
 	Log = DefaultLogger()
@@ -119,7 +113,9 @@ func (n NullLogger) Log(params ...interface{}) error { return nil }
 
 var loggers = make(map[string]*FilteredLogger)
 var defaultComponent = ""
-var defaultVerbosity = 0
+const defaultVerbosityLevel = 2
+
+var defaultVerbosity = defaultVerbosityLevel
 
 func createLogger(component string) {
 	lock.Lock()

--- a/staging/src/kubevirt.io/client-go/log/verbosity_flag.go
+++ b/staging/src/kubevirt.io/client-go/log/verbosity_flag.go
@@ -1,0 +1,34 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+// This file registers the "-v" verbosity flag on flag.CommandLine.
+// Build with -tags nokubevirtlogflag to disable this registration,
+// e.g. when another package in the binary already registers "-v".
+
+//go:build !nokubevirtlogflag
+
+package log
+
+import goflag "flag"
+
+func init() {
+	// "the practical default level is V(2)"
+	// see https://github.com/kubernetes/community/blob/master/contributors/devel/logging.md
+	goflag.IntVar(&defaultVerbosity, "v", defaultVerbosityLevel, "log level for V logs")
+}

--- a/staging/src/kubevirt.io/client-go/log/verbosity_flag_disabled_test.go
+++ b/staging/src/kubevirt.io/client-go/log/verbosity_flag_disabled_test.go
@@ -1,0 +1,40 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+//go:build nokubevirtlogflag
+
+package log
+
+import (
+	goflag "flag"
+	"testing"
+)
+
+func TestVerbosityFlagNotRegisteredWithBuildTag(t *testing.T) {
+	if goflag.CommandLine.Lookup("v") != nil {
+		t.Fatal("\"v\" flag must not be registered on flag.CommandLine when nokubevirtlogflag tag is set")
+	}
+}
+
+func TestDefaultVerbosityCorrectWhenFlagRegistrationDisabled(t *testing.T) {
+	log := MakeLogger(MockLogger{})
+	if log.verbosityLevel != 2 {
+		t.Fatalf("Default verbosity should be 2 when flag registration is disabled via nokubevirtlogflag, got %d", log.verbosityLevel)
+	}
+}

--- a/staging/src/kubevirt.io/client-go/log/verbosity_flag_test.go
+++ b/staging/src/kubevirt.io/client-go/log/verbosity_flag_test.go
@@ -1,0 +1,34 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+//go:build !nokubevirtlogflag
+
+package log
+
+import (
+	goflag "flag"
+	"testing"
+)
+
+func TestVerbosityFlagRegisteredOnCommandLine(t *testing.T) {
+	f := goflag.CommandLine.Lookup("v")
+	if f == nil {
+		t.Fatal("\"v\" flag must be registered on flag.CommandLine in default build")
+	}
+}


### PR DESCRIPTION
### What this PR does
#### Before this PR:

`kubevirt.io/client-go/log`'s `init()` unconditionally calls `flag.IntVar` to register a `v` flag in `flag.CommandLine`. This panics in any binary where `v` is already registered — which happens in practice when a project that already has a `-v` flag registered (e.g. via glog, which unconditionally registers `-v` in its own `init()`) imports `kubevirt.io/client-go`.

**Real-world impact:** Red Hat's StackRox/ACS project needed to use `kubevirt.io/client-go` for KubeVirt VSOCK subresource access (VM vulnerability scanning). Importing the client library panicked because glog (an indirect dependency via grpc-http1) had already registered `-v` on `flag.CommandLine`. The team was forced to reimplement the VSOCK WebSocket dialer from scratch instead of using kubevirt's supported client — adding ~500 lines of custom infrastructure code to work around this bug.

#### After this PR:

The `init()` that registers the `-v` flag is moved into a separate file (`verbosity_flag.go`) guarded by a `//go:build !nokubevirtlogflag` build constraint. Consumers who experience the panic can now opt out by building with:

```
go build -tags nokubevirtlogflag
```

The default behavior is unchanged — without the tag, `-v` is registered on `flag.CommandLine` as before.

### References

- Partially addresses #16951
- Related: https://github.com/kubevirt/client-go/issues/42

### Why it was done in this way

This is a minimal, backwards-compatible change. Default behavior is identical to before. Only consumers who explicitly set the build tag see different behavior.

The following alternatives were considered:

- **Private FlagSet + `VerbosityFlag()` helper**: Fully eliminates the conflict by never registering on `flag.CommandLine`, but requires updating all internal call sites and changes the public API surface. See companion PR #18294 for this approach.
- **Guard with `flag.CommandLine.Lookup("v") == nil`**: Only fixes one direction of the `init()` ordering conflict.

This approach was suggested in https://github.com/kubevirt/kubevirt/issues/16951#issuecomment-4799446643 and provides a pragmatic escape hatch for affected consumers without changing any internal call sites.

Links to places where the discussion took place:

- https://github.com/kubevirt/kubevirt/issues/16951
- https://github.com/kubevirt/kubevirt/issues/16951#issuecomment-4799446643

### Special notes for your reviewer

This is one of two alternative PRs. The other (#18294) uses a private FlagSet approach that fully eliminates the conflict. Both are submitted as drafts for discussion — the maintainers should decide which approach is preferred.

The `defaultVerbosity` variable declaration is also changed from `0` to `2`. In the old code, `init()` immediately overwrote it to `2` via `IntVar`, so the observable default was always `2`. The new declaration ensures the correct default applies even when the build tag disables the `init()`.

A second Bazel test target (`go_noflag_test`) with `gotags = ["nokubevirtlogflag"]` ensures the disabled-mode tests have CI coverage in Bazel builds.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Testing: New unit tests verify both build modes (with and without the tag), including Bazel coverage for both
- [x] AI Contributions: The PR abides by the KubeVirt AI Contribution Policy