### PR TITLE
fix: skip CDI deployment for minikube provider

### DIFF
--- a/hack/cluster-deploy.sh
+++ b/hack/cluster-deploy.sh
@@ -75,8 +75,8 @@ metadata:
     pod-security.kubernetes.io/enforce: "privileged"
 EOF
 
-if [[ "$KUBEVIRT_PROVIDER" =~ kind.* || "$KUBEVIRT_PROVIDER" = "external" ]]; then
-    # Don't install CDI and loopback devices it's crashing with dind because loopback devices are shared with the host
+if [[ "$KUBEVIRT_PROVIDER" =~ ^(kind.*|external|minikube)$ ]]; then
+    # Don't install CDI: kind shares loopback devices with the host (kind/external), and minikube has no CDI deployment
     export KUBEVIRT_DEPLOY_CDI=false
 fi
 


### PR DESCRIPTION
Extend the provider check in cluster-deploy.sh to include `minikube`, preventing CDI from being deployed in that environment.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

