### PR TITLE
[VEP-10] nit: use MatchError matcher in validatePermittedHostDevices test

### DIFF
--- a/pkg/virt-controller/services/renderresources_test.go
+++ b/pkg/virt-controller/services/renderresources_test.go
@@ -887,8 +887,7 @@ var _ = Describe("validatePermittedHostDevices", func() {
 			func(setupDevices func(), expectedError string) {
 				setupDevices()
 				err := validatePermittedHostDevices(vmiSpec, config)
-				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring(expectedError))
+				Expect(err).To(MatchError(ContainSubstring(expectedError)))
 			},
 			Entry("unpermitted legacy HostDevice", func() {
 				vmiSpec.Domain.Devices.HostDevices = []v1.HostDevice{


### PR DESCRIPTION
The MatchError matcher already implies HaveOccurred() (it fails if err is nil), and it accepts a nested matcher, so both checks can be expressed in a single line.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

