### PR TITLE
Increase IOMMUFD socket accept timeout to 15 minutes

### DIFF
--- a/pkg/virt-handler/device-manager/iommufd_device.go
+++ b/pkg/virt-handler/device-manager/iommufd_device.go
@@ -57,7 +57,7 @@ const (
 	//nolint:revive,stylecheck
 	IOMMU_OPTION = 0x3B87
 
-	iommufdSocketAcceptTimeout = 60 * time.Second
+	iommufdSocketAcceptTimeout = 15 * time.Minute
 )
 
 var iommufdSocketDir = "/var/run/kubevirt"


### PR DESCRIPTION
### What this PR does
#### Before this PR:

The IOMMUFD device plugin creates a Unix domain socket during the Allocate call (pod scheduling) and waits for the virt-launcher to connect. The accept timeout was 60 seconds. On environments with slow container image pulls or many init containers, the virt-launcher may not connect for several minutes after allocation. The goroutine expires, deletes the socket, and the bind mount points to a deleted inode (Links: 0). IOMMUFD initialization fails silently and falls back to legacy VFIO without SMMUv3 support.

#### After this PR:

The timeout is increased to 15 minutes, accommodating slow networks and large images while still providing a finite cleanup bound.

### References

- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/199

### Why we need it and why it was done in this way

Discovered during GB200 bare metal hardware validation in an NVIDIA partner lab. The lab has slow network connectivity (~4-11MB/s) and container image pulls take several minutes. The 60-second timeout consistently expired before virt-launcher started, causing IOMMUFD to silently fall back to legacy VFIO. This made GPU passthrough appear to work but without SMMUv3 translation, leading to subtle failures.

The following tradeoffs were made:

A long timeout (15 minutes) was chosen over a shorter one to avoid false negatives on very slow networks. The goroutine is lightweight and the socket is cleaned up on expiry regardless.

The following alternatives were considered:

- Making the timeout configurable via env var or KubeVirt CR — not pursued as this is a simple fix and the timeout is generous enough for all practical scenarios.
- Retrying the socket creation — unnecessary complexity since the issue is purely timing.

### Special notes for your reviewer

Single constant change: `60 * time.Second` → `15 * time.Minute` in `pkg/virt-handler/device-manager/iommufd_device.go`.

### Checklist

- [x] Design: Not required (bug fix)
- [x] PR: The PR description is expressive enough
- [x] Code: Single constant change
- [x] Upgrade: No upgrade impact
- [ ] Testing: Existing e2e coverage for IOMMUFD passthrough covers the happy path; the timeout is not easily testable in CI
- [ ] Documentation: Not required
- [x] AI Contributions: The PR abides by the KubeVirt AI Contribution Policy.

### Release note
```release-note
Bug fix: Increase IOMMUFD socket accept timeout from 60 seconds to 15 minutes to prevent silent fallback to legacy VFIO on environments with slow container image pulls.
```