### PR TITLE
Expose VFIO cdev devices to virt-launcher for IOMMUFD passthrough

### DIFF
--- a/pkg/virt-handler/device-manager/BUILD.bazel
+++ b/pkg/virt-handler/device-manager/BUILD.bazel
@@ -46,8 +46,10 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
+        "common_test.go",
         "device_controller_test.go",
         "device_manager_suite_test.go",
+        "export_test.go",
         "generic_device_test.go",
         "iommufd_device_test.go",
         "mediated_device_test.go",

--- a/pkg/virt-handler/device-manager/common.go
+++ b/pkg/virt-handler/device-manager/common.go
@@ -290,6 +290,30 @@ func formatVFIODeviceSpecs(devID string) []*v1beta1.DeviceSpec {
 	return devSpecs
 }
 
+func formatVFIOCdevDeviceSpecs(pciAddress string) []*v1beta1.DeviceSpec {
+	vfioDevDir := filepath.Join(pciBasePath, pciAddress, "vfio-dev")
+	entries, err := os.ReadDir(vfioDevDir)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			log.DefaultLogger().V(4).Infof("No VFIO cdev found for %s", pciAddress)
+		} else {
+			log.DefaultLogger().Reason(err).Errorf("Failed to read VFIO cdev directory for %s", pciAddress)
+		}
+		return nil
+	}
+
+	devSpecs := make([]*v1beta1.DeviceSpec, 0, len(entries))
+	for _, entry := range entries {
+		cdevPath := filepath.Join("/dev/vfio/devices", entry.Name())
+		devSpecs = append(devSpecs, &v1beta1.DeviceSpec{
+			HostPath:      cdevPath,
+			ContainerPath: cdevPath,
+			Permissions:   "mrw",
+		})
+	}
+	return devSpecs
+}
+
 type deviceHealth struct {
 	DevId  string
 	Health string

--- a/pkg/virt-handler/device-manager/common_test.go
+++ b/pkg/virt-handler/device-manager/common_test.go
@@ -1,0 +1,88 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package device_manager_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	devicemanager "kubevirt.io/kubevirt/pkg/virt-handler/device-manager"
+	pluginapi "kubevirt.io/kubevirt/pkg/virt-handler/device-manager/deviceplugin/v1beta1"
+)
+
+var _ = Describe("PCI device plugin VFIO cdev allocation", func() {
+	var tmpDir string
+
+	BeforeEach(func() {
+		tmpDir = GinkgoT().TempDir()
+		DeferCleanup(devicemanager.SetPCIBasePath(tmpDir))
+	})
+
+	It("should include VFIO cdev device specs in Allocate response", func() {
+		pciAddr := "0000:08:00.0"
+		iommuGroup := "42"
+		vfioDevDir := filepath.Join(tmpDir, pciAddr, "vfio-dev")
+		Expect(os.MkdirAll(vfioDevDir, 0755)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(vfioDevDir, "vfio0"), []byte{}, 0644)).To(Succeed())
+
+		dpi := devicemanager.NewPCIDevicePluginForTest(map[string]string{iommuGroup: pciAddr})
+
+		resp, err := dpi.Allocate(context.Background(), &pluginapi.AllocateRequest{
+			ContainerRequests: []*pluginapi.ContainerAllocateRequest{
+				{DevicesIDs: []string{iommuGroup}},
+			},
+		})
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(resp.ContainerResponses).To(HaveLen(1))
+
+		Expect(resp.ContainerResponses[0].Devices).To(ContainElement(
+			BeEquivalentTo(&pluginapi.DeviceSpec{
+				HostPath:      "/dev/vfio/devices/vfio0",
+				ContainerPath: "/dev/vfio/devices/vfio0",
+				Permissions:   "mrw",
+			})))
+	})
+
+	It("should not fail when no VFIO cdev devices exist", func() {
+		iommuGroup := "42"
+		pciAddr := "0000:08:00.0"
+		dpi := devicemanager.NewPCIDevicePluginForTest(map[string]string{iommuGroup: pciAddr})
+
+		resp, err := dpi.Allocate(context.Background(), &pluginapi.AllocateRequest{
+			ContainerRequests: []*pluginapi.ContainerAllocateRequest{
+				{DevicesIDs: []string{iommuGroup}},
+			},
+		})
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(resp.ContainerResponses).To(HaveLen(1))
+
+		devicePaths := make([]string, 0)
+		for _, spec := range resp.ContainerResponses[0].Devices {
+			devicePaths = append(devicePaths, spec.ContainerPath)
+		}
+		Expect(devicePaths).ToNot(ContainElement(ContainSubstring("/dev/vfio/devices/")))
+	})
+})

--- a/pkg/virt-handler/device-manager/export_test.go
+++ b/pkg/virt-handler/device-manager/export_test.go
@@ -1,0 +1,35 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package device_manager
+
+func NewPCIDevicePluginForTest(iommuToPCIMap map[string]string) *PCIDevicePlugin {
+	return &PCIDevicePlugin{
+		DevicePluginBase: &DevicePluginBase{
+			resourceName: "test-resource",
+		},
+		iommuToPCIMap: iommuToPCIMap,
+	}
+}
+
+func SetPCIBasePath(p string) func() {
+	old := pciBasePath
+	pciBasePath = p
+	return func() { pciBasePath = old }
+}

--- a/pkg/virt-handler/device-manager/pci_device.go
+++ b/pkg/virt-handler/device-manager/pci_device.go
@@ -42,8 +42,9 @@ import (
 const (
 	vfioDevicePath = "/dev/vfio/"
 	vfioMount      = "/dev/vfio/vfio"
-	pciBasePath    = "/sys/bus/pci/devices"
 )
+
+var pciBasePath = "/sys/bus/pci/devices"
 
 type PCIDevice struct {
 	pciID      string
@@ -164,6 +165,7 @@ func (dpi *PCIDevicePlugin) Allocate(_ context.Context, r *pluginapi.AllocateReq
 			}
 			allocatedDevices = append(allocatedDevices, devPCIAddress)
 			deviceSpecs = append(deviceSpecs, formatVFIODeviceSpecs(devID)...)
+			deviceSpecs = append(deviceSpecs, formatVFIOCdevDeviceSpecs(devPCIAddress)...)
 		}
 		containerResponse.Devices = deviceSpecs
 		envVar := make(map[string]string)


### PR DESCRIPTION
### What this PR does
#### Before this PR:

The PCI device plugin's `Allocate` response only provides legacy VFIO group devices (`/dev/vfio/N`) to the virt-launcher container. When IOMMUFD is enabled, libvirt uses the VFIO cdev path (`/dev/vfio/devices/vfioN`) instead. Since these are not included in the device specs, libvirt fails with:

```
cannot open VFIO device /dev/vfio/devices/vfio0: No such file or directory
```

#### After this PR:

`formatVFIOCdevDeviceSpecs()` discovers VFIO cdev device names via sysfs at `/sys/bus/pci/devices/<BDF>/vfio-dev/` and includes them in the Allocate response alongside the legacy VFIO group devices.

### References

- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/199
- Related: CNV-91802

### Why we need it and why it was done in this way

VFIO cdev devices (`/dev/vfio/devices/vfioN`) are the modern VFIO interface used by IOMMUFD. On ARM64 systems with SMMUv3 (e.g. NVIDIA Grace Hopper/Blackwell), libvirt opens the cdev path when IOMMUFD is enabled. Without exposing these devices to the virt-launcher container, GPU passthrough fails silently — IOMMUFD cannot attach the device and the VM either fails to start or falls back to legacy VFIO without SMMUv3 support.

The following tradeoffs were made:

The cdev device name is discovered dynamically from sysfs rather than constructed from a naming convention. This is more robust since the kernel assigns cdev names (vfio0, vfio1, ...) based on device probe order, not PCI topology.

The following alternatives were considered:

- Mounting the entire `/dev/vfio/devices/` directory — rejected as it would expose all cdev devices to all containers rather than only the allocated device.

### Special notes for your reviewer

The cdev path discovery uses `/sys/bus/pci/devices/<BDF>/vfio-dev/` which contains symlinks to the cdev device. This sysfs path is only present when the device is bound to `vfio-pci`. The function gracefully returns nil if the path doesn't exist (e.g. on systems without VFIO cdev support).

### Checklist

- [x] Design: Part of VEP 199 (GH/GB passthrough)
- [x] PR: The PR description is expressive enough
- [x] Code: Simple addition, follows existing patterns
- [x] Upgrade: No upgrade impact
- [ ] Testing: Needs unit test for formatVFIOCdevDeviceSpecs
- [ ] Documentation: Not required
- [x] AI Contributions: The PR abides by the KubeVirt AI Contribution Policy.

### Release note
```release-note
Bug fix: Expose VFIO cdev devices (/dev/vfio/devices/vfioN) to virt-launcher containers, fixing IOMMUFD-based GPU passthrough on ARM64 systems with SMMUv3.
```