### PR TITLE
network: move DHCP server launching into the dhcp package

### DIFF
--- a/pkg/network/dhcp/BUILD.bazel
+++ b/pkg/network/dhcp/BUILD.bazel
@@ -12,6 +12,9 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/network/cache:go_default_library",
+        "//pkg/network/dhcp/server:go_default_library",
+        "//pkg/network/dhcp/serverv6:go_default_library",
+        "//pkg/network/dns:go_default_library",
         "//pkg/network/driver:go_default_library",
         "//pkg/network/link:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",

--- a/pkg/network/dhcp/configurator.go
+++ b/pkg/network/dhcp/configurator.go
@@ -31,6 +31,9 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 
 	"kubevirt.io/kubevirt/pkg/network/cache"
+	dhcpserver "kubevirt.io/kubevirt/pkg/network/dhcp/server"
+	dhcpserverv6 "kubevirt.io/kubevirt/pkg/network/dhcp/serverv6"
+	"kubevirt.io/kubevirt/pkg/network/dns"
 	netdriver "kubevirt.io/kubevirt/pkg/network/driver"
 )
 
@@ -41,12 +44,14 @@ type Configurator interface {
 	Generate() (*cache.DHCPConfig, error)
 }
 
+type dhcpStartFunc func(nic *cache.DHCPConfig, bridgeInterfaceName string, dhcpOptions *v1.DHCPOptions) error
+
 type configurator struct {
 	advertisingIfaceName string
 	configGenerator      ConfigGenerator
-	handler              netdriver.NetworkHandler
 	dhcpStartedDirectory string
 	podInterfaceName     string
+	startDHCPFunc        dhcpStartFunc
 }
 
 type ConfigGenerator interface {
@@ -58,8 +63,8 @@ func NewBridgeConfigurator(cacheCreator cacheCreator, advertisingIfaceName strin
 	return &configurator{
 		podInterfaceName:     podInterfaceName,
 		advertisingIfaceName: advertisingIfaceName,
-		handler:              handler,
 		dhcpStartedDirectory: defaultDHCPStartedDirectory,
+		startDHCPFunc:        startDHCP,
 		configGenerator: &BridgeConfigGenerator{
 			handler:          handler,
 			podInterfaceName: podInterfaceName,
@@ -78,8 +83,8 @@ func NewMasqueradeConfigurator(advertisingIfaceName string, handler netdriver.Ne
 		advertisingIfaceName: advertisingIfaceName,
 		configGenerator: &MasqueradeConfigGenerator{handler: handler, vmiSpecIface: vmiSpecIface, vmiSpecNetwork: vmiSpecNetwork,
 			subdomain: subdomain, podInterfaceName: podInterfaceName},
-		handler:              handler,
 		dhcpStartedDirectory: defaultDHCPStartedDirectory,
+		startDHCPFunc:        startDHCP,
 	}
 }
 
@@ -90,7 +95,7 @@ func (d *configurator) EnsureDHCPServerStarted(podInterfaceName string, dhcpConf
 	dhcpStartedFile := d.getDHCPStartedFilePath(podInterfaceName)
 	_, err := os.Stat(dhcpStartedFile)
 	if errors.Is(err, os.ErrNotExist) {
-		if err := d.handler.StartDHCP(&dhcpConfig, d.advertisingIfaceName, dhcpOptions); err != nil {
+		if err := d.startDHCPFunc(&dhcpConfig, d.advertisingIfaceName, dhcpOptions); err != nil {
 			return fmt.Errorf("failed to start DHCP server for interface %s", podInterfaceName)
 		}
 		newFile, err := os.Create(dhcpStartedFile)
@@ -112,4 +117,53 @@ func (d *configurator) getDHCPStartedFilePath(podInterfaceName string) string {
 
 func (d *configurator) Generate() (*cache.DHCPConfig, error) {
 	return d.configGenerator.Generate()
+}
+
+func startDHCP(nic *cache.DHCPConfig, bridgeInterfaceName string, dhcpOptions *v1.DHCPOptions) error {
+	log.Log.V(4).Infof("StartDHCP network Nic: %+v", nic)
+	nameservers, searchDomains, err := dns.GetResolvConfDetailsFromPod()
+	if err != nil {
+		return fmt.Errorf("Failed to get DNS servers from resolv.conf: %v", err)
+	}
+
+	domain := dns.DomainNameWithSubdomain(searchDomains, nic.Subdomain)
+	if domain != "" {
+		searchDomains = append([]string{domain}, searchDomains...)
+	}
+
+	if nic.IP.IPNet != nil {
+		go func() {
+			if err = dhcpserver.SingleClientDHCPServer(
+				nic.MAC,
+				nic.IP.IP,
+				nic.IP.Mask,
+				bridgeInterfaceName,
+				nic.AdvertisingIPAddr,
+				nic.Gateway,
+				nameservers.IPv4,
+				nic.Routes,
+				searchDomains,
+				nic.Mtu,
+				dhcpOptions,
+			); err != nil {
+				log.Log.Errorf("failed to run DHCP Server: %v", err)
+				panic(err)
+			}
+		}()
+	}
+
+	if nic.IPv6.IPNet != nil {
+		go func() {
+			if err = dhcpserverv6.SingleClientDHCPv6Server(
+				nic.IPv6.IP,
+				bridgeInterfaceName,
+				nameservers.IPv6,
+			); err != nil {
+				log.Log.Reason(err).Error("failed to run DHCPv6 Server")
+				panic(err)
+			}
+		}()
+	}
+
+	return nil
 }

--- a/pkg/network/dhcp/configurator_test.go
+++ b/pkg/network/dhcp/configurator_test.go
@@ -24,121 +24,91 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"go.uber.org/mock/gomock"
-
-	"github.com/vishvananda/netlink"
 
 	v1 "kubevirt.io/api/core/v1"
 
 	"kubevirt.io/kubevirt/pkg/network/cache"
-	netdriver "kubevirt.io/kubevirt/pkg/network/driver"
 )
 
 var _ = Describe("DHCP configurator", func() {
 
 	const (
-		advertisingCIDR    = "10.10.10.0/24"
-		bridgeName         = "br0"
-		ifaceName          = "eth0"
-		fakeDhcpStartedDir = "/tmp/dhcpStartedPath"
+		bridgeName = "br0"
+		ifaceName  = "eth0"
 	)
 
-	var cacheCreator tempCacheCreator
+	var (
+		dhcpStartedDir string
+		cfg            *configurator
+		dhcpConfig     cache.DHCPConfig
+		dhcpOptions    *v1.DHCPOptions
+	)
 
 	BeforeEach(func() {
-		// make sure the test can write a file in the whatever dir ensure uses.
-		Expect(os.MkdirAll(fakeDhcpStartedDir, 0755)).To(Succeed())
+		var err error
+		dhcpStartedDir, err = os.MkdirTemp("", "dhcp-started-")
+		Expect(err).NotTo(HaveOccurred())
+
+		dhcpConfig = cache.DHCPConfig{
+			Name: ifaceName,
+			Mtu:  1400,
+		}
 	})
 
 	AfterEach(func() {
-		Expect(cacheCreator.New("").Delete()).To(Succeed())
-		Expect(os.RemoveAll(fakeDhcpStartedDir)).To(Succeed())
+		Expect(os.RemoveAll(dhcpStartedDir)).To(Succeed())
 	})
 
-	newBridgeConfigurator := func(advertisingIfaceName string) *configurator {
-		configurator := NewBridgeConfigurator(&cacheCreator, advertisingIfaceName, netdriver.NewMockNetworkHandler(gomock.NewController(GinkgoT())), "", nil, nil, "")
-		configurator.dhcpStartedDirectory = fakeDhcpStartedDir
-		return configurator
+	newConfigurator := func(startFunc dhcpStartFunc) *configurator {
+		return &configurator{
+			advertisingIfaceName: bridgeName,
+			dhcpStartedDirectory: dhcpStartedDir,
+			startDHCPFunc:        startFunc,
+		}
 	}
 
-	newMasqueradeConfigurator := func(advertisingIfaceName string) *configurator {
-		configurator := NewMasqueradeConfigurator(advertisingIfaceName, netdriver.NewMockNetworkHandler(gomock.NewController(GinkgoT())), nil, nil, "", "")
-		configurator.dhcpStartedDirectory = fakeDhcpStartedDir
-		return configurator
-	}
-
-	Context("start DHCP function", func() {
-		var advertisingAddr netlink.Addr
-		var dhcpConfig cache.DHCPConfig
-		var dhcpOptions *v1.DHCPOptions
-
-		BeforeEach(func() {
-			addr, err := netlink.ParseAddr(advertisingCIDR)
-			Expect(err).NotTo(HaveOccurred())
-			advertisingAddr = *addr
-		})
-
-		BeforeEach(func() {
-			dhcpConfig = cache.DHCPConfig{
-				Name:              ifaceName,
-				IP:                netlink.Addr{},
-				AdvertisingIPAddr: advertisingAddr.IP,
-				Mtu:               1400,
-				IPAMDisabled:      false,
-			}
-		})
-
-		DescribeTable("should succeed when DHCP server started", func(f func(advertisingIfaceName string) *configurator) {
-			cfg := f(bridgeName)
-			cfg.handler.(*netdriver.MockNetworkHandler).EXPECT().StartDHCP(&dhcpConfig, bridgeName, nil).Return(nil)
-
-			Expect(cfg.EnsureDHCPServerStarted(ifaceName, dhcpConfig, dhcpOptions)).To(Succeed())
-		},
-			Entry("with bridge configurator", newBridgeConfigurator),
-			Entry("with masquerade configurator", newMasqueradeConfigurator),
-		)
-
-		DescribeTable("should succeed when DHCP server is started multiple times", func(f func(advertisingIfaceName string) *configurator) {
-			cfg := f(bridgeName)
-			cfg.handler.(*netdriver.MockNetworkHandler).EXPECT().StartDHCP(&dhcpConfig, bridgeName, nil).Return(nil)
-
-			Expect(cfg.EnsureDHCPServerStarted(ifaceName, dhcpConfig, dhcpOptions)).To(Succeed())
-			Expect(cfg.EnsureDHCPServerStarted(ifaceName, dhcpConfig, dhcpOptions)).To(Succeed())
-		},
-			Entry("with bridge configurator", newBridgeConfigurator),
-			Entry("with masquerade configurator", newMasqueradeConfigurator),
-		)
-
-		DescribeTable("should fail when DHCP server failed", func(f func(advertisingIfaceName string) *configurator) {
-			cfg := f(bridgeName)
-			cfg.handler.(*netdriver.MockNetworkHandler).EXPECT().StartDHCP(&dhcpConfig, bridgeName, nil).Return(fmt.Errorf("failed to start DHCP server"))
-
-			Expect(cfg.EnsureDHCPServerStarted(ifaceName, dhcpConfig, dhcpOptions)).To(HaveOccurred())
-		},
-			Entry("with bridge configurator", newBridgeConfigurator),
-			Entry("with masquerade configurator", newMasqueradeConfigurator),
-		)
-
-		When("IPAM is disabled on the DHCPConfig", func() {
-			BeforeEach(func() {
-				dhcpConfig = cache.DHCPConfig{
-					Name:              ifaceName,
-					IP:                netlink.Addr{},
-					AdvertisingIPAddr: advertisingAddr.IP,
-					Mtu:               1400,
-					IPAMDisabled:      true,
-				}
+	Context("EnsureDHCPServerStarted", func() {
+		It("should succeed when DHCP server starts", func() {
+			cfg = newConfigurator(func(_ *cache.DHCPConfig, _ string, _ *v1.DHCPOptions) error {
+				return nil
 			})
 
-			DescribeTable("shouldn't fail when DHCP server failed", func(f func(advertisingIfaceName string) *configurator) {
-				cfg := f(bridgeName)
-				cfg.handler.(*netdriver.MockNetworkHandler).EXPECT().StartDHCP(&dhcpConfig, bridgeName, nil).Return(nil).Times(0)
+			Expect(cfg.EnsureDHCPServerStarted(ifaceName, dhcpConfig, dhcpOptions)).To(Succeed())
+		})
+
+		It("should only start the DHCP server once for the same interface", func() {
+			callCount := 0
+			cfg = newConfigurator(func(_ *cache.DHCPConfig, _ string, _ *v1.DHCPOptions) error {
+				callCount++
+				return nil
+			})
+
+			Expect(cfg.EnsureDHCPServerStarted(ifaceName, dhcpConfig, dhcpOptions)).To(Succeed())
+			Expect(cfg.EnsureDHCPServerStarted(ifaceName, dhcpConfig, dhcpOptions)).To(Succeed())
+			Expect(callCount).To(Equal(1))
+		})
+
+		It("should fail when DHCP server fails to start", func() {
+			cfg = newConfigurator(func(_ *cache.DHCPConfig, _ string, _ *v1.DHCPOptions) error {
+				return fmt.Errorf("failed to start DHCP server")
+			})
+
+			Expect(cfg.EnsureDHCPServerStarted(ifaceName, dhcpConfig, dhcpOptions)).To(HaveOccurred())
+		})
+
+		When("IPAM is disabled", func() {
+			BeforeEach(func() {
+				dhcpConfig.IPAMDisabled = true
+			})
+
+			It("should skip starting the DHCP server", func() {
+				cfg = newConfigurator(func(_ *cache.DHCPConfig, _ string, _ *v1.DHCPOptions) error {
+					Fail("startDHCP should not be called when IPAM is disabled")
+					return nil
+				})
 
 				Expect(cfg.EnsureDHCPServerStarted(ifaceName, dhcpConfig, dhcpOptions)).To(Succeed())
-			},
-				Entry("with bridge configurator", newBridgeConfigurator),
-				Entry("with masquerade", newMasqueradeConfigurator),
-			)
+			})
 		})
 	})
 })

--- a/pkg/network/driver/BUILD.bazel
+++ b/pkg/network/driver/BUILD.bazel
@@ -9,12 +9,6 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/network/driver",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/network/cache:go_default_library",
-        "//pkg/network/dhcp/server:go_default_library",
-        "//pkg/network/dhcp/serverv6:go_default_library",
-        "//pkg/network/dns:go_default_library",
-        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
-        "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/github.com/vishvananda/netlink:go_default_library",
         "//vendor/go.uber.org/mock/gomock:go_default_library",
     ],

--- a/pkg/network/driver/common.go
+++ b/pkg/network/driver/common.go
@@ -22,17 +22,7 @@
 package driver
 
 import (
-	"fmt"
-
 	"github.com/vishvananda/netlink"
-
-	v1 "kubevirt.io/api/core/v1"
-	"kubevirt.io/client-go/log"
-
-	"kubevirt.io/kubevirt/pkg/network/cache"
-	dhcpserver "kubevirt.io/kubevirt/pkg/network/dhcp/server"
-	dhcpserverv6 "kubevirt.io/kubevirt/pkg/network/dhcp/serverv6"
-	"kubevirt.io/kubevirt/pkg/network/dns"
 )
 
 const (
@@ -48,7 +38,6 @@ const (
 
 type NetworkHandler interface {
 	LinkByName(name string) (netlink.Link, error)
-	StartDHCP(nic *cache.DHCPConfig, bridgeInterfaceName string, dhcpOptions *v1.DHCPOptions) error
 	HasIPv4GlobalUnicastAddress(interfaceName string) (bool, error)
 	HasIPv6GlobalUnicastAddress(interfaceName string) (bool, error)
 }
@@ -93,58 +82,3 @@ func (h *NetworkUtilsHandler) HasIPv6GlobalUnicastAddress(interfaceName string) 
 	}
 	return false, nil
 }
-
-func (h *NetworkUtilsHandler) StartDHCP(nic *cache.DHCPConfig, bridgeInterfaceName string, dhcpOptions *v1.DHCPOptions) error {
-	log.Log.V(4).Infof("StartDHCP network Nic: %+v", nic)
-	nameservers, searchDomains, err := dns.GetResolvConfDetailsFromPod()
-	if err != nil {
-		return fmt.Errorf("Failed to get DNS servers from resolv.conf: %v", err)
-	}
-
-	domain := dns.DomainNameWithSubdomain(searchDomains, nic.Subdomain)
-	if domain != "" {
-		searchDomains = append([]string{domain}, searchDomains...)
-	}
-
-	if nic.IP.IPNet != nil {
-		// panic in case the DHCP server failed during the vm creation
-		// but ignore dhcp errors when the vm is destroyed or shutting down
-		go func() {
-			if err = DHCPServer(
-				nic.MAC,
-				nic.IP.IP,
-				nic.IP.Mask,
-				bridgeInterfaceName,
-				nic.AdvertisingIPAddr,
-				nic.Gateway,
-				nameservers.IPv4,
-				nic.Routes,
-				searchDomains,
-				nic.Mtu,
-				dhcpOptions,
-			); err != nil {
-				log.Log.Errorf("failed to run DHCP Server: %v", err)
-				panic(err)
-			}
-		}()
-	}
-
-	if nic.IPv6.IPNet != nil {
-		go func() {
-			if err = DHCPv6Server(
-				nic.IPv6.IP,
-				bridgeInterfaceName,
-				nameservers.IPv6,
-			); err != nil {
-				log.Log.Reason(err).Error("failed to run DHCPv6 Server")
-				panic(err)
-			}
-		}()
-	}
-
-	return nil
-}
-
-// Allow mocking for tests
-var DHCPServer = dhcpserver.SingleClientDHCPServer
-var DHCPv6Server = dhcpserverv6.SingleClientDHCPv6Server

--- a/pkg/network/driver/generated_mock_common.go
+++ b/pkg/network/driver/generated_mock_common.go
@@ -14,9 +14,6 @@ import (
 
 	netlink "github.com/vishvananda/netlink"
 	gomock "go.uber.org/mock/gomock"
-	v1 "kubevirt.io/api/core/v1"
-
-	cache "kubevirt.io/kubevirt/pkg/network/cache"
 )
 
 // MockNetworkHandler is a mock of NetworkHandler interface.
@@ -86,18 +83,4 @@ func (m *MockNetworkHandler) LinkByName(name string) (netlink.Link, error) {
 func (mr *MockNetworkHandlerMockRecorder) LinkByName(name any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "LinkByName", reflect.TypeOf((*MockNetworkHandler)(nil).LinkByName), name)
-}
-
-// StartDHCP mocks base method.
-func (m *MockNetworkHandler) StartDHCP(nic *cache.DHCPConfig, bridgeInterfaceName string, dhcpOptions *v1.DHCPOptions) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "StartDHCP", nic, bridgeInterfaceName, dhcpOptions)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// StartDHCP indicates an expected call of StartDHCP.
-func (mr *MockNetworkHandlerMockRecorder) StartDHCP(nic, bridgeInterfaceName, dhcpOptions any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "StartDHCP", reflect.TypeOf((*MockNetworkHandler)(nil).StartDHCP), nic, bridgeInterfaceName, dhcpOptions)
 }

--- a/pkg/network/setup/launcher/configurator_test.go
+++ b/pkg/network/setup/launcher/configurator_test.go
@@ -192,10 +192,6 @@ func (s stubNetworkHandler) LinkByName(name string) (netlink.Link, error) {
 	return nil, netlink.LinkNotFoundError{}
 }
 
-func (s stubNetworkHandler) StartDHCP(_ *cache.DHCPConfig, _ string, _ *v1.DHCPOptions) error {
-	return nil
-}
-
 func (s stubNetworkHandler) HasIPv4GlobalUnicastAddress(_ string) (bool, error) {
 	return false, nil
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
StartDHCP is only called from the dhcp configurator. Its logic — DNS resolution from resolv.conf, search domain preparation, and DHCP/DHCPv6 goroutine launching — belongs in the dhcp package, not in the shared network driver.

Move the function body into a startDHCP function in the dhcp package and call it from EnsureDHCPServerStarted through an injectable function field. The configurator no longer holds the NetworkHandler for this purpose.

The configurator_test.go tests reached into cfg.handler to mock StartDHCP on the NetworkHandler — they cannot compile after this change. Rewrite them to use the injectable function field instead: the same four behaviors are covered (successful start, idempotency, start failure propagation, IPAM-disabled skip) without the handler mock. The bridge/masquerade DescribeTable distinction is dropped because EnsureDHCPServerStarted does not differ between the two.

This removes the StartDHCP method from the NetworkHandler interface, taking a step toward eliminating that interface entirely.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

