### PR TITLE
Add AutoattachPanicDevice API field and preference

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -14712,6 +14712,10 @@
       "description": "Whether to attach the Memory balloon device with default period. Period can be adjusted in virt-config. Defaults to true.",
       "type": "boolean"
      },
+     "autoattachPanicDevice": {
+      "description": "Whether to attach a Panic Device. Defaults to false.",
+      "type": "boolean"
+     },
      "autoattachPodInterface": {
       "description": "Whether to attach a pod network interface. Defaults to true.",
       "type": "boolean"
@@ -21330,6 +21334,10 @@
      },
      "preferredAutoattachMemBalloon": {
       "description": "PreferredAutoattachMemBalloon optionally defines the preferred value of AutoattachMemBalloon",
+      "type": "boolean"
+     },
+     "preferredAutoattachPanicDevice": {
+      "description": "PreferredAutoattachPanicDevice optionally defines the preferred value of AutoattachPanicDevice",
       "type": "boolean"
      },
      "preferredAutoattachPodInterface": {

--- a/pkg/instancetype/preference/apply/device.go
+++ b/pkg/instancetype/preference/apply/device.go
@@ -41,6 +41,7 @@ func ApplyAutoAttachPreferences(preferenceSpec *v1beta1.VirtualMachinePreference
 		{preferenceSpec.Devices.PreferredAutoattachPodInterface, &vmiSpec.Domain.Devices.AutoattachPodInterface},
 		{preferenceSpec.Devices.PreferredAutoattachSerialConsole, &vmiSpec.Domain.Devices.AutoattachSerialConsole},
 		{preferenceSpec.Devices.PreferredAutoattachInputDevice, &vmiSpec.Domain.Devices.AutoattachInputDevice},
+		{preferenceSpec.Devices.PreferredAutoattachPanicDevice, &vmiSpec.Domain.Devices.AutoattachPanicDevice},
 	}
 	for _, field := range autoAttachFields {
 		if field.preference != nil && *field.vmi == nil {

--- a/pkg/instancetype/preference/apply/device_test.go
+++ b/pkg/instancetype/preference/apply/device_test.go
@@ -382,6 +382,10 @@ var _ = Describe("Preference.Devices", func() {
 				&preferenceSpec.Devices.PreferredAutoattachInputDevice,
 				&vmi.Spec.Domain.Devices.AutoattachInputDevice,
 			},
+			"PreferredAutoattachPanicDevice": {
+				&preferenceSpec.Devices.PreferredAutoattachPanicDevice,
+				&vmi.Spec.Domain.Devices.AutoattachPanicDevice,
+			},
 		}
 		for name, f := range autoAttachFields {
 			*f.preference = preferenceValue

--- a/pkg/virt-controller/watch/vm/vm.go
+++ b/pkg/virt-controller/watch/vm/vm.go
@@ -1309,6 +1309,7 @@ func (c *Controller) startVMI(vm *virtv1.VirtualMachine) (*virtv1.VirtualMachine
 	cbt.SetChangedBlockTrackingOnVMI(vm, vmi, c.clusterConfig, c.namespaceStore)
 
 	AutoAttachInputDevice(vmi)
+	AutoAttachPanicDevice(vmi)
 
 	err = netvmispec.SetDefaultNetworkInterface(c.clusterConfig, &vmi.Spec)
 	if err != nil {
@@ -3438,6 +3439,17 @@ func AutoAttachInputDevice(vmi *virtv1.VirtualMachineInstance) {
 		virtv1.Input{
 			Name: "default-0",
 		},
+	)
+}
+
+func AutoAttachPanicDevice(vmi *virtv1.VirtualMachineInstance) {
+	autoAttachPanic := vmi.Spec.Domain.Devices.AutoattachPanicDevice
+	if autoAttachPanic == nil || !*autoAttachPanic || len(vmi.Spec.Domain.Devices.PanicDevices) > 0 {
+		return
+	}
+	vmi.Spec.Domain.Devices.PanicDevices = append(
+		vmi.Spec.Domain.Devices.PanicDevices,
+		virtv1.PanicDevice{},
 	)
 }
 

--- a/pkg/virt-controller/watch/vm/vm_test.go
+++ b/pkg/virt-controller/watch/vm/vm_test.go
@@ -5166,6 +5166,136 @@ var _ = Describe("VirtualMachine", func() {
 					Expect(err).To(Succeed())
 					Expect(vm.Status.PreferenceRef.ControllerRevisionRef.Name).To(Equal(expectedPreferenceRevision.Name))
 				})
+
+				It("should apply preferences to AutoattachPanicDevice attached panic device", func() {
+
+					panicDevicePreference := &instancetypev1beta1.VirtualMachinePreference{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:       "panicDevicePreference",
+							Namespace:  vm.Namespace,
+							UID:        resourceUID,
+							Generation: resourceGeneration,
+						},
+						Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{
+							Devices: &instancetypev1beta1.DevicePreferences{
+								PreferredPanicDeviceModel: pointer.P(v1.Pvpanic),
+							},
+						},
+					}
+					_, err := virtClient.VirtualMachinePreference(vm.Namespace).Create(context.Background(), panicDevicePreference, metav1.CreateOptions{})
+					Expect(err).NotTo(HaveOccurred())
+
+					vm.Spec.Preference = &v1.PreferenceMatcher{
+						Name: panicDevicePreference.Name,
+						Kind: instancetypeapi.SingularPreferenceResourceName,
+					}
+
+					vm.Spec.Template.Spec.Domain.Devices.AutoattachPanicDevice = pointer.P(true)
+
+					expectedPreferenceRevision, err := revision.CreateControllerRevision(vm, panicDevicePreference)
+					Expect(err).ToNot(HaveOccurred())
+
+					vm, err := virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Create(context.TODO(), vm, metav1.CreateOptions{})
+					Expect(err).To(Succeed())
+					addVirtualMachine(vm)
+
+					sanityExecute(vm)
+
+					vmi, err := virtFakeClient.KubevirtV1().VirtualMachineInstances(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(vmi.Spec.Domain.Devices.PanicDevices).To(HaveLen(1))
+					Expect(vmi.Spec.Domain.Devices.PanicDevices[0].Model).To(Equal(pointer.P(v1.Pvpanic)))
+
+					vm, err = virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
+					Expect(err).To(Succeed())
+					Expect(vm.Status.PreferenceRef.ControllerRevisionRef.Name).To(Equal(expectedPreferenceRevision.Name))
+				})
+
+				It("should apply preferredAutoattachPanicDevice and add default panic device", func() {
+
+					autoattachPanicDevicePreference := &instancetypev1beta1.VirtualMachinePreference{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:       "autoattachPanicDevicePreference",
+							Namespace:  vm.Namespace,
+							UID:        resourceUID,
+							Generation: resourceGeneration,
+						},
+						Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{
+							Devices: &instancetypev1beta1.DevicePreferences{
+								PreferredAutoattachPanicDevice: pointer.P(true),
+								PreferredPanicDeviceModel:      pointer.P(v1.Pvpanic),
+							},
+						},
+					}
+					_, err := virtClient.VirtualMachinePreference(vm.Namespace).Create(context.Background(), autoattachPanicDevicePreference, metav1.CreateOptions{})
+					Expect(err).NotTo(HaveOccurred())
+
+					vm.Spec.Preference = &v1.PreferenceMatcher{
+						Name: autoattachPanicDevicePreference.Name,
+						Kind: instancetypeapi.SingularPreferenceResourceName,
+					}
+
+					expectedPreferenceRevision, err := revision.CreateControllerRevision(vm, autoattachPanicDevicePreference)
+					Expect(err).ToNot(HaveOccurred())
+
+					vm, err := virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Create(context.TODO(), vm, metav1.CreateOptions{})
+					Expect(err).To(Succeed())
+					addVirtualMachine(vm)
+
+					sanityExecute(vm)
+
+					vmi, err := virtFakeClient.KubevirtV1().VirtualMachineInstances(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(vmi.Spec.Domain.Devices.PanicDevices).To(HaveLen(1))
+					Expect(vmi.Spec.Domain.Devices.PanicDevices[0].Model).To(Equal(pointer.P(v1.Pvpanic)))
+
+					vm, err = virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
+					Expect(err).To(Succeed())
+					Expect(vm.Status.PreferenceRef.ControllerRevisionRef.Name).To(Equal(expectedPreferenceRevision.Name))
+				})
+
+				It("should apply preferredAutoattachPanicDevice and skip adding default panic device", func() {
+
+					autoattachPanicDevicePreference := &instancetypev1beta1.VirtualMachinePreference{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:       "preferredAutoattachPanicDevicePreference",
+							Namespace:  vm.Namespace,
+							UID:        resourceUID,
+							Generation: resourceGeneration,
+						},
+						Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{
+							Devices: &instancetypev1beta1.DevicePreferences{
+								PreferredAutoattachPanicDevice: pointer.P(false),
+							},
+						},
+					}
+
+					_, err := virtClient.VirtualMachinePreference(vm.Namespace).Create(context.Background(), autoattachPanicDevicePreference, metav1.CreateOptions{})
+					Expect(err).NotTo(HaveOccurred())
+
+					vm.Spec.Preference = &v1.PreferenceMatcher{
+						Name: autoattachPanicDevicePreference.Name,
+						Kind: instancetypeapi.SingularPreferenceResourceName,
+					}
+
+					vm, err := virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Create(context.TODO(), vm, metav1.CreateOptions{})
+					Expect(err).To(Succeed())
+					addVirtualMachine(vm)
+
+					expectedPreferenceRevision, err := revision.CreateControllerRevision(vm, autoattachPanicDevicePreference)
+					Expect(err).ToNot(HaveOccurred())
+
+					sanityExecute(vm)
+
+					vmi, err := virtFakeClient.KubevirtV1().VirtualMachineInstances(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
+					Expect(err).NotTo(HaveOccurred())
+					Expect(*vmi.Spec.Domain.Devices.AutoattachPanicDevice).To(BeFalse())
+					Expect(vmi.Spec.Domain.Devices.PanicDevices).To(BeEmpty())
+
+					vm, err = virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
+					Expect(err).To(Succeed())
+					Expect(vm.Status.PreferenceRef.ControllerRevisionRef.Name).To(Equal(expectedPreferenceRevision.Name))
+				})
 			})
 		})
 
@@ -5356,6 +5486,34 @@ var _ = Describe("VirtualMachine", func() {
 				ContainElement(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
 					"Name": Equal("existing-0"),
 				}))),
+		)
+
+		DescribeTable("AutoattachPanicDevice should ", func(autoAttach *bool, existingPanicDevices []v1.PanicDevice, matcher gomegatypes.GomegaMatcher) {
+			vm, _ := watchtesting.DefaultVirtualMachine(true)
+			vm.Spec.Template.Spec.Domain.Devices.AutoattachPanicDevice = autoAttach
+			vm.Spec.Template.Spec.Domain.Devices.PanicDevices = existingPanicDevices
+
+			vm, err := virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Create(context.TODO(), vm, metav1.CreateOptions{})
+			Expect(err).To(Succeed())
+			addVirtualMachine(vm)
+
+			sanityExecute(vm)
+
+			vmi, err := virtFakeClient.KubevirtV1().VirtualMachineInstances(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(vmi.Spec.Domain.Devices.PanicDevices).To(matcher)
+		},
+			Entry("add default panic device when enabled in VirtualMachine", pointer.P(true), []v1.PanicDevice{},
+				HaveLen(1)),
+			Entry("not add default panic device when disabled by VirtualMachine", pointer.P(false), []v1.PanicDevice{},
+				BeEmpty()),
+			Entry("not add default panic device by default", nil, []v1.PanicDevice{},
+				BeEmpty()),
+			Entry("not add default panic device when devices already present in VirtualMachine", pointer.P(true),
+				[]v1.PanicDevice{{Model: pointer.P(v1.Hyperv)}},
+				And(HaveLen(1), ContainElement(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+					"Model": Equal(pointer.P(v1.Hyperv)),
+				})))),
 		)
 
 		Context("Live update features", func() {

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -6447,6 +6447,11 @@ var CRDsValidation map[string]string = map[string]string{
                             Period can be adjusted in virt-config.
                             Defaults to true.
                           type: boolean
+                        autoattachPanicDevice:
+                          description: |-
+                            Whether to attach a Panic Device.
+                            Defaults to false.
+                          type: boolean
                         autoattachPodInterface:
                           description: Whether to attach a pod network interface.
                             Defaults to true.
@@ -10447,6 +10452,10 @@ var CRDsValidation map[string]string = map[string]string{
               description: PreferredAutoattachMemBalloon optionally defines the preferred
                 value of AutoattachMemBalloon
               type: boolean
+            preferredAutoattachPanicDevice:
+              description: PreferredAutoattachPanicDevice optionally defines the preferred
+                value of AutoattachPanicDevice
+              type: boolean
             preferredAutoattachPodInterface:
               description: PreferredAutoattachPodInterface optionally defines the
                 preferred value of AutoattachPodInterface
@@ -12647,6 +12656,11 @@ var CRDsValidation map[string]string = map[string]string{
                     Whether to attach the Memory balloon device with default period.
                     Period can be adjusted in virt-config.
                     Defaults to true.
+                  type: boolean
+                autoattachPanicDevice:
+                  description: |-
+                    Whether to attach a Panic Device.
+                    Defaults to false.
                   type: boolean
                 autoattachPodInterface:
                   description: Whether to attach a pod network interface. Defaults
@@ -16581,6 +16595,11 @@ var CRDsValidation map[string]string = map[string]string{
                     Period can be adjusted in virt-config.
                     Defaults to true.
                   type: boolean
+                autoattachPanicDevice:
+                  description: |-
+                    Whether to attach a Panic Device.
+                    Defaults to false.
+                  type: boolean
                 autoattachPodInterface:
                   description: Whether to attach a pod network interface. Defaults
                     to true.
@@ -19137,6 +19156,11 @@ var CRDsValidation map[string]string = map[string]string{
                             Whether to attach the Memory balloon device with default period.
                             Period can be adjusted in virt-config.
                             Defaults to true.
+                          type: boolean
+                        autoattachPanicDevice:
+                          description: |-
+                            Whether to attach a Panic Device.
+                            Defaults to false.
                           type: boolean
                         autoattachPodInterface:
                           description: Whether to attach a pod network interface.
@@ -24271,6 +24295,11 @@ var CRDsValidation map[string]string = map[string]string{
                                     Period can be adjusted in virt-config.
                                     Defaults to true.
                                   type: boolean
+                                autoattachPanicDevice:
+                                  description: |-
+                                    Whether to attach a Panic Device.
+                                    Defaults to false.
+                                  type: boolean
                                 autoattachPodInterface:
                                   description: Whether to attach a pod network interface.
                                     Defaults to true.
@@ -26881,6 +26910,10 @@ var CRDsValidation map[string]string = map[string]string{
             preferredAutoattachMemBalloon:
               description: PreferredAutoattachMemBalloon optionally defines the preferred
                 value of AutoattachMemBalloon
+              type: boolean
+            preferredAutoattachPanicDevice:
+              description: PreferredAutoattachPanicDevice optionally defines the preferred
+                value of AutoattachPanicDevice
               type: boolean
             preferredAutoattachPodInterface:
               description: PreferredAutoattachPodInterface optionally defines the
@@ -29911,6 +29944,11 @@ var CRDsValidation map[string]string = map[string]string{
                                         Whether to attach the Memory balloon device with default period.
                                         Period can be adjusted in virt-config.
                                         Defaults to true.
+                                      type: boolean
+                                    autoattachPanicDevice:
+                                      description: |-
+                                        Whether to attach a Panic Device.
+                                        Defaults to false.
                                       type: boolean
                                     autoattachPodInterface:
                                       description: Whether to attach a pod network

--- a/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachine.json
+++ b/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachine.json
@@ -387,6 +387,7 @@
             "autoattachMemBalloon": true,
             "autoattachInputDevice": true,
             "autoattachVSOCK": true,
+            "autoattachPanicDevice": true,
             "rng": {},
             "blockMultiQueue": true,
             "networkInterfaceMultiqueue": true,

--- a/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachine.yaml
+++ b/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachine.yaml
@@ -431,6 +431,7 @@ spec:
           autoattachGraphicsDevice: true
           autoattachInputDevice: true
           autoattachMemBalloon: true
+          autoattachPanicDevice: true
           autoattachPodInterface: true
           autoattachSerialConsole: true
           autoattachVSOCK: true

--- a/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachineInstance.json
+++ b/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachineInstance.json
@@ -327,6 +327,7 @@
         "autoattachMemBalloon": true,
         "autoattachInputDevice": true,
         "autoattachVSOCK": true,
+        "autoattachPanicDevice": true,
         "rng": {},
         "blockMultiQueue": true,
         "networkInterfaceMultiqueue": true,

--- a/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachineInstance.yaml
+++ b/staging/src/kubevirt.io/api/apitesting/testdata/HEAD/kubevirt.io.v1.VirtualMachineInstance.yaml
@@ -234,6 +234,7 @@ spec:
       autoattachGraphicsDevice: true
       autoattachInputDevice: true
       autoattachMemBalloon: true
+      autoattachPanicDevice: true
       autoattachPodInterface: true
       autoattachSerialConsole: true
       autoattachVSOCK: true

--- a/staging/src/kubevirt.io/api/core/v1/deepcopy_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/deepcopy_generated.go
@@ -1151,6 +1151,11 @@ func (in *Devices) DeepCopyInto(out *Devices) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.AutoattachPanicDevice != nil {
+		in, out := &in.AutoattachPanicDevice, &out.AutoattachPanicDevice
+		*out = new(bool)
+		**out = **in
+	}
 	if in.Rng != nil {
 		in, out := &in.Rng, &out.Rng
 		*out = new(Rng)

--- a/staging/src/kubevirt.io/api/core/v1/schema.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema.go
@@ -570,6 +570,10 @@ type Devices struct {
 	// Whether to attach the VSOCK CID to the VM or not.
 	// VSOCK access will be available if set to true. Defaults to false.
 	AutoattachVSOCK *bool `json:"autoattachVSOCK,omitempty"`
+	// Whether to attach a Panic Device.
+	// Defaults to false.
+	// +optional
+	AutoattachPanicDevice *bool `json:"autoattachPanicDevice,omitempty"`
 	// Whether to have random number generator from host
 	// +optional
 	Rng *Rng `json:"rng,omitempty"`

--- a/staging/src/kubevirt.io/api/core/v1/schema_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/schema_swagger_generated.go
@@ -278,6 +278,7 @@ func (Devices) SwaggerDoc() map[string]string {
 		"autoattachMemBalloon":       "Whether to attach the Memory balloon device with default period.\nPeriod can be adjusted in virt-config.\nDefaults to true.\n+optional",
 		"autoattachInputDevice":      "Whether to attach an Input Device.\nDefaults to false.\n+optional",
 		"autoattachVSOCK":            "Whether to attach the VSOCK CID to the VM or not.\nVSOCK access will be available if set to true. Defaults to false.",
+		"autoattachPanicDevice":      "Whether to attach a Panic Device.\nDefaults to false.\n+optional",
 		"rng":                        "Whether to have random number generator from host\n+optional",
 		"blockMultiQueue":            "Whether or not to enable virtio multi-queue for block devices.\nDefaults to false.\n+optional",
 		"networkInterfaceMultiqueue": "If specified, virtual network interfaces configured with a virtio bus will also enable the vhost multiqueue feature for network devices. The number of queues created depends on additional factors of the VirtualMachineInstance, like the number of guest CPUs.\n+optional",

--- a/staging/src/kubevirt.io/api/instancetype/v1beta1/deepcopy_generated.go
+++ b/staging/src/kubevirt.io/api/instancetype/v1beta1/deepcopy_generated.go
@@ -175,6 +175,11 @@ func (in *DevicePreferences) DeepCopyInto(out *DevicePreferences) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.PreferredAutoattachPanicDevice != nil {
+		in, out := &in.PreferredAutoattachPanicDevice, &out.PreferredAutoattachPanicDevice
+		*out = new(bool)
+		**out = **in
+	}
 	if in.PreferredDisableHotplug != nil {
 		in, out := &in.PreferredDisableHotplug, &out.PreferredDisableHotplug
 		*out = new(bool)

--- a/staging/src/kubevirt.io/api/instancetype/v1beta1/types.go
+++ b/staging/src/kubevirt.io/api/instancetype/v1beta1/types.go
@@ -440,6 +440,11 @@ type DevicePreferences struct {
 	// +optional
 	PreferredAutoattachInputDevice *bool `json:"preferredAutoattachInputDevice,omitempty"`
 
+	// PreferredAutoattachPanicDevice optionally defines the preferred value of AutoattachPanicDevice
+	//
+	// +optional
+	PreferredAutoattachPanicDevice *bool `json:"preferredAutoattachPanicDevice,omitempty"`
+
 	// PreferredDisableHotplug optionally defines the preferred value of DisableHotplug
 	//
 	// +optional

--- a/staging/src/kubevirt.io/api/instancetype/v1beta1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/instancetype/v1beta1/types_swagger_generated.go
@@ -145,6 +145,7 @@ func (DevicePreferences) SwaggerDoc() map[string]string {
 		"preferredAutoattachPodInterface":     "PreferredAutoattachPodInterface optionally defines the preferred value of AutoattachPodInterface\n\n+optional",
 		"preferredAutoattachSerialConsole":    "PreferredAutoattachSerialConsole optionally defines the preferred value of AutoattachSerialConsole\n\n+optional",
 		"preferredAutoattachInputDevice":      "PreferredAutoattachInputDevice optionally defines the preferred value of AutoattachInputDevice\n\n+optional",
+		"preferredAutoattachPanicDevice":      "PreferredAutoattachPanicDevice optionally defines the preferred value of AutoattachPanicDevice\n\n+optional",
 		"preferredDisableHotplug":             "PreferredDisableHotplug optionally defines the preferred value of DisableHotplug\n\n+optional",
 		"preferredVirtualGPUOptions":          "PreferredVirtualGPUOptions optionally defines the preferred value of VirtualGPUOptions\n\n+optional",
 		"preferredSoundModel":                 "PreferredSoundModel optionally defines the preferred model for Sound devices.\n\n+optional",

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -20311,6 +20311,13 @@ func schema_kubevirtio_api_core_v1_Devices(ref common.ReferenceCallback) common.
 							Format:      "",
 						},
 					},
+					"autoattachPanicDevice": {
+						SchemaProps: spec.SchemaProps{
+							Description: "Whether to attach a Panic Device. Defaults to false.",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
 					"rng": {
 						SchemaProps: spec.SchemaProps{
 							Description: "Whether to have random number generator from host",
@@ -31846,6 +31853,13 @@ func schema_kubevirtio_api_instancetype_v1beta1_DevicePreferences(ref common.Ref
 					"preferredAutoattachInputDevice": {
 						SchemaProps: spec.SchemaProps{
 							Description: "PreferredAutoattachInputDevice optionally defines the preferred value of AutoattachInputDevice",
+							Type:        []string{"boolean"},
+							Format:      "",
+						},
+					},
+					"preferredAutoattachPanicDevice": {
+						SchemaProps: spec.SchemaProps{
+							Description: "PreferredAutoattachPanicDevice optionally defines the preferred value of AutoattachPanicDevice",
 							Type:        []string{"boolean"},
 							Format:      "",
 						},


### PR DESCRIPTION
### What this PR does
#### Before this PR:

Panic devices must be explicitly added to the VMI spec by the user. The `PreferredPanicDeviceModel` preference can only set the model on already-existing panic devices — it cannot create them. This means common-instancetypes cannot express "VMs of this type should have a panic device" without the user also adding one manually.

#### After this PR:

A new `AutoattachPanicDevice *bool` field is added to the `Devices` struct in the core API. When set to `true`, a default panic device is automatically injected into the VMI at runtime. The device is created with a nil model so that `PreferredPanicDeviceModel` can set it via preferences, or the hypervisor picks a default based on guest architecture.

A corresponding `PreferredAutoattachPanicDevice *bool` field is added to `DevicePreferences` in the instancetype v1beta1 API, allowing this to be set within common-instancetypes.

### References

- Fixes #18305

### Why we need it and why it was done in this way

This follows the established `AutoattachInputDevice` pattern exactly:
- A `*bool` pointer field on `Devices` that defaults to false
- An `AutoAttachPanicDevice` function in the VM controller that injects a device when enabled and no panic devices already exist
- The preference is wired into `ApplyAutoAttachPreferences` using the existing table-driven approach

The following tradeoffs were made:
- The auto-attached panic device has a nil model, relying on `PreferredPanicDeviceModel` or hypervisor defaults. This mirrors how `AutoattachInputDevice` leaves bus/type nil for preferences to fill in.
- No s390x guard in the auto-attach logic — the existing `validatePanicDevices` webhook admitter already rejects panic devices on s390x.

The following alternatives were considered:
- Adding the panic device directly in the preference apply code rather than the VM controller. Rejected because it would break the pattern where preferences only set attributes on existing objects, not create new ones.

### Special notes for your reviewer

The `AutoAttachPanicDevice` function is called after `AutoAttachInputDevice` and before `ApplyToVMI` in the VM controller, ensuring the preference boolean is resolved first, the device is injected, and then the model preference is applied.

### Checklist

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
Add AutoattachPanicDevice API field to automatically attach a panic device to VMIs at runtime, with a corresponding PreferredAutoattachPanicDevice preference for use in common-instancetypes.
```