### PR TITLE
refactor: extract GPU/HostDevice validation into separate functions

### DIFF
--- a/pkg/virt-controller/services/renderresources.go
+++ b/pkg/virt-controller/services/renderresources.go
@@ -505,24 +505,8 @@ func validatePermittedHostDevices(spec *v1.VirtualMachineInstanceSpec, config *v
 		for _, dev := range hostDevs.USB {
 			supportedHostDevicesMap[dev.ResourceName] = true
 		}
-		for _, hostDev := range spec.Domain.Devices.GPUs {
-			// skip GPU devices backed by DRA claims, since they are validated via DRA instead of the permittedHostDevices config
-			if config.GPUsWithDRAGateEnabled() && hostDev.ClaimRequest != nil {
-				continue
-			}
-			if _, exist := supportedHostDevicesMap[hostDev.DeviceName]; !exist {
-				errors = append(errors, fmt.Sprintf("GPU %s is not permitted in permittedHostDevices configuration", hostDev.DeviceName))
-			}
-		}
-		for _, hostDev := range spec.Domain.Devices.HostDevices {
-			// skip host devices backed by DRA claims, since they are validated via DRA instead of the permittedHostDevices config
-			if config.HostDevicesWithDRAEnabled() && hostDev.ClaimRequest != nil {
-				continue
-			}
-			if _, exist := supportedHostDevicesMap[hostDev.DeviceName]; !exist {
-				errors = append(errors, fmt.Sprintf("HostDevice %s is not permitted in permittedHostDevices configuration", hostDev.DeviceName))
-			}
-		}
+		errors = append(errors, validateGPUs(spec.Domain.Devices.GPUs, config.GPUsWithDRAGateEnabled(), supportedHostDevicesMap)...)
+		errors = append(errors, validateHostDevices(spec.Domain.Devices.HostDevices, config.HostDevicesWithDRAEnabled(), supportedHostDevicesMap)...)
 	}
 
 	if len(errors) != 0 {
@@ -530,6 +514,32 @@ func validatePermittedHostDevices(spec *v1.VirtualMachineInstanceSpec, config *v
 	}
 
 	return nil
+}
+
+func validateGPUs(gpus []v1.GPU, draEnabled bool, supportedHostDevicesMap map[string]bool) (errors []string) {
+	for _, hostDev := range gpus {
+		// skip GPU devices backed by DRA claims, since they are validated via DRA instead of the permittedHostDevices config
+		if draEnabled && hostDev.ClaimRequest != nil {
+			continue
+		}
+		if _, exist := supportedHostDevicesMap[hostDev.DeviceName]; !exist {
+			errors = append(errors, fmt.Sprintf("GPU %s is not permitted in permittedHostDevices configuration", hostDev.DeviceName))
+		}
+	}
+	return errors
+}
+
+func validateHostDevices(hostDevs []v1.HostDevice, draEnabled bool, supportedHostDevicesMap map[string]bool) (errors []string) {
+	for _, hostDev := range hostDevs {
+		// skip host devices backed by DRA claims, since they are validated via DRA instead of the permittedHostDevices config
+		if draEnabled && hostDev.ClaimRequest != nil {
+			continue
+		}
+		if _, exist := supportedHostDevicesMap[hostDev.DeviceName]; !exist {
+			errors = append(errors, fmt.Sprintf("HostDevice %s is not permitted in permittedHostDevices configuration", hostDev.DeviceName))
+		}
+	}
+	return errors
 }
 
 func sidecarResources(vmi *v1.VirtualMachineInstance, config *virtconfig.ClusterConfig) k8sv1.ResourceRequirements {


### PR DESCRIPTION
Extract the GPU and host device permittedHostDevices validation loops from validatePermittedHostDevices into dedicated helper functions to improve readability.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

