### PR TITLE
DNM: instrument virt-operator deletion to debug CRD finalizer timeout

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -141,6 +141,7 @@ case "$TARGET" in
     export KUBEVIRT_PROVIDER=${TARGET/-sig-operator*/}
     export KUBEVIRT_WITH_CNAO=true
     export KUBEVIRT_NUM_SECONDARY_NICS=1
+    export KUBEVIRT_COLLECT_LOGS=true
     ;;
   *sig-monitoring*)
     export KUBEVIRT_PROVIDER=${TARGET/-sig-monitoring/}

--- a/pkg/virt-operator/kubevirt.go
+++ b/pkg/virt-operator/kubevirt.go
@@ -1169,6 +1169,8 @@ func (c *KubeVirtController) syncDeletion(kv *v1.KubeVirt) error {
 
 	// If we still have cached objects around, more deletions need to take place.
 	if !c.stores.AllEmpty() {
+		c.stores.LogNonEmptyStores()
+
 		_, pending, err := c.loadInstallStrategy(kv)
 		if err != nil {
 			return err

--- a/pkg/virt-operator/resource/apply/delete.go
+++ b/pkg/virt-operator/resource/apply/delete.go
@@ -116,7 +116,22 @@ func DeleteAll(kv *v1.KubeVirt,
 	}
 
 	if !util.IsStoreEmpty(stores.OperatorCrdCache) {
-		// wait until CRDs are gone
+		crdKeys := stores.OperatorCrdCache.ListKeys()
+		log.Log.Infof("DeleteAll: waiting on %d CRDs to be removed from cache: %v", len(crdKeys), crdKeys)
+		for _, obj := range stores.OperatorCrdCache.List() {
+			if crd, ok := obj.(*extv1.CustomResourceDefinition); ok {
+				dt := "nil"
+				if crd.DeletionTimestamp != nil {
+					dt = crd.DeletionTimestamp.String()
+				}
+				var conditions []string
+				for _, c := range crd.Status.Conditions {
+					conditions = append(conditions, fmt.Sprintf("%s=%s(%s)", c.Type, c.Status, c.Reason))
+				}
+				log.Log.Infof("DeleteAll: CRD %s deletionTimestamp=%s finalizers=%v conditions=%v",
+					crd.Name, dt, crd.Finalizers, conditions)
+			}
+		}
 		return nil
 	}
 

--- a/pkg/virt-operator/util/types.go
+++ b/pkg/virt-operator/util/types.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	v1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/log"
 
 	"kubevirt.io/kubevirt/pkg/controller"
 )
@@ -91,6 +92,41 @@ func (s *Stores) AllEmpty() bool {
 
 	// Don't add InstallStrategyConfigMapCache to this list. The install
 	// strategies persist even after deletion and updates.
+}
+
+func (s *Stores) LogNonEmptyStores() {
+	type namedStore struct {
+		name  string
+		store cache.Store
+	}
+	stores := []namedStore{
+		{"ServiceAccountCache", s.ServiceAccountCache},
+		{"ClusterRoleCache", s.ClusterRoleCache},
+		{"ClusterRoleBindingCache", s.ClusterRoleBindingCache},
+		{"RoleCache", s.RoleCache},
+		{"RoleBindingCache", s.RoleBindingCache},
+		{"OperatorCrdCache", s.OperatorCrdCache},
+		{"ServiceCache", s.ServiceCache},
+		{"DeploymentCache", s.DeploymentCache},
+		{"DaemonSetCache", s.DaemonSetCache},
+		{"ValidationWebhookCache", s.ValidationWebhookCache},
+		{"MutatingWebhookCache", s.MutatingWebhookCache},
+		{"APIServiceCache", s.APIServiceCache},
+		{"PodDisruptionBudgetCache", s.PodDisruptionBudgetCache},
+		{"RouteCache", s.RouteCache},
+		{"ServiceMonitorCache", s.ServiceMonitorCache},
+		{"PrometheusRuleCache", s.PrometheusRuleCache},
+		{"SecretCache", s.SecretCache},
+		{"ConfigMapCache", s.ConfigMapCache},
+		{"ValidatingAdmissionPolicyBindingCache", s.ValidatingAdmissionPolicyBindingCache},
+		{"ValidatingAdmissionPolicyCache", s.ValidatingAdmissionPolicyCache},
+	}
+	for _, ns := range stores {
+		count := len(ns.store.ListKeys())
+		if count > 0 {
+			log.Log.Infof("Non-empty store during deletion: %s (%d items)", ns.name, count)
+		}
+	}
 }
 
 func IsStoreEmpty(store cache.Store) bool {

--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -1046,7 +1046,7 @@ var _ = Describe("[sig-operator]Operator", Serial, decorators.SigOperator, func(
 			By("Deleting KubeVirt object")
 			deleteAllKvAndWait(false, originalKv.Name)
 		},
-			Entry("from previous y release by patching KubeVirt CR", fromY, false),
+			FEntry("from previous y release by patching KubeVirt CR", fromY, false),
 			Entry("from previous y release by updating virt-operator", fromY, true),
 			Entry("from previous z release by patching KubeVirt CR", fromZ, false),
 			Entry("from previous z release by updating virt-operator", fromZ, true),


### PR DESCRIPTION
### What this PR does
#### Before this PR:

When KubeVirt CR deletion hangs due to the CRD finalizer timeout on k8s 1.36, the virt-operator logs only show `"Handling deletion"` → `"Processed deletion for this round"` with no indication of *what* is stuck.

#### After this PR:

The virt-operator logs which informer caches still have items during each deletion round, and logs per-CRD detail (deletionTimestamp, finalizers, status conditions) when `DeleteAll` returns early on the CRD gate. This will show:

- Which caches are blocking `AllEmpty()`
- Whether the CRDs have `InstanceDeletionCompleted` condition set (or are stuck waiting for it)
- The CRD finalizer state

Example output:
```
Non-empty store during deletion: OperatorCrdCache (10 items)
Non-empty store during deletion: DeploymentCache (5 items)
Non-empty store during deletion: ServiceCache (7 items)
DeleteAll: waiting on 10 CRDs to be removed from cache: [virtualmachineinstances.kubevirt.io ...]
DeleteAll: CRD virtualmachineinstances.kubevirt.io deletionTimestamp=2026-06-30T04:57:22Z finalizers=[kubevirt.io/virtOperatorComponent] conditions=[Terminating=True(InstanceDeletionInProgress)]
```

### References

- Partially addresses https://github.com/kubevirt/kubevirt/issues/18309

### Why we need it and why it was done in this way

The sig-operator upgrade tests fail on k8s 1.36 (18% failure rate) but pass on k8s 1.34 (0%). The root cause is the k8s CRD finalizer controller's etcd Range call timing out after 60 seconds when listing VMI instances, which was introduced as a regression by [kubernetes/kubernetes#135278](https://github.com/kubernetes/kubernetes/pull/135278).

This instrumentation will confirm whether the same etcd Range call is also slow on k8s <1.36 (where it succeeds because the old code had no context deadline) by showing how long the CRD caches take to drain. Running this against both `pull-kubevirt-e2e-k8s-1.34-sig-operator` and `pull-kubevirt-e2e-k8s-1.36-sig-operator` will let us compare the behaviour.

The following alternatives were considered:

- Instrumenting the k8s API server itself — not feasible for a quick test, would require a custom kubevirtci provider build

### Special notes for your reviewer

**DO NOT MERGE** — this is a debug-only change for investigating #18309. Please trigger `pull-kubevirt-e2e-k8s-1.34-sig-operator` and `pull-kubevirt-e2e-k8s-1.36-sig-operator` lanes to compare.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
NONE
```