### PR TITLE
VEP-199: set Grace SMMUv3 address capabilities

### DIFF
--- a/pkg/virt-launcher/virtwrap/converter/grace.go
+++ b/pkg/virt-launcher/virtwrap/converter/grace.go
@@ -51,11 +51,16 @@ const (
 	pciBaseAddressMemoryType64   = uint64(0x00000004)
 	pciBaseAddressMemoryPrefetch = uint64(0x00000008)
 
-	graceDefaultIOMMUAccel   = "on"
-	graceDefaultIOMMUATS     = "on"
-	graceDefaultIOMMURIL     = "off"
-	graceSMMUv3IOMMUModel    = "smmuv3"
-	graceHostDeviceIOMMUFDOn = "yes"
+	graceDefaultIOMMUAccel = "on"
+	graceDefaultIOMMUATS   = "on"
+	graceDefaultIOMMURIL   = "off"
+	// Current Grace Blackwell and Vera Rubin systems support SSIDSize=20 and
+	// OAS=48. Keep these defaults explicit until host SMMU capability probing is
+	// available, then cap them to the host-supported values.
+	graceDefaultIOMMUSSIDSize = "20"
+	graceDefaultIOMMUOAS      = "48"
+	graceSMMUv3IOMMUModel     = "smmuv3"
+	graceHostDeviceIOMMUFDOn  = "yes"
 )
 
 type verifiedGraceHostDevice struct {
@@ -648,6 +653,12 @@ func (capabilities gracePCICapabilities) withDefaults() gracePCICapabilities {
 	if capabilities.RIL == "" {
 		capabilities.RIL = graceDefaultIOMMURIL
 	}
+	if capabilities.SSIDSize == "" {
+		capabilities.SSIDSize = graceDefaultIOMMUSSIDSize
+	}
+	if capabilities.OAS == "" {
+		capabilities.OAS = graceDefaultIOMMUOAS
+	}
 	return capabilities
 }
 
@@ -738,9 +749,12 @@ func (p sysfsGraceRuntimeInfoProvider) PCIHole64SizeBytes(bdf string) (uint64, e
 }
 
 func (p sysfsGraceRuntimeInfoProvider) PCICapabilities(_ string) (gracePCICapabilities, error) {
-	// TODO: Populate SSIDSize, OAS, and related SMMUv3 fields from PCI
-	// extended config space or IOMMUFD hardware info. Use Grace defaults until
-	// capability probing is wired into this focused Grace conversion path.
+	// Grace Blackwell and Vera Rubin systems require explicit SMMUv3 address
+	// capabilities, and the current platform values are SSIDSize=20 and OAS=48.
+	// Longer term, these must be capped by the host SMMU capabilities rather
+	// than hardcoded. OAS is visible in the arm-smmu-v3 probe log, while SSIDSize
+	// requires decoding the SMMU ID registers. Use the known Grace defaults until
+	// the kernel exposes these capabilities through a consumable interface.
 	return gracePCICapabilities{}.withDefaults(), nil
 }
 

--- a/pkg/virt-launcher/virtwrap/converter/grace_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/grace_test.go
@@ -283,6 +283,22 @@ var _ = Describe("Grace domain conversion", func() {
 		Expect(findGraceSibling(domainSpec.CPU.NUMA.Cells[1].Distances.Siblings, "0").Value).To(Equal(uint64(80)))
 	})
 
+	It("adds default SMMUv3 address capabilities", func() {
+		fakeRuntime.addGraceGPU("0000:81:00.0", 0, 16*1024*1024*1024)
+		fakeRuntime.giNodes = uint32Range(2, 9)
+		fakeRuntime.addDistances(append([]uint32{0}, fakeRuntime.giNodes...))
+		domainSpec := newGraceConversionDomain(
+			newGraceTestHostDevice("gpu-gpu0", api.HostDevicePCI, "0x0000", "0x81", "0x00", "0x0"),
+		)
+
+		err := configureGraceIOVirtualization(domainSpec, []string{"gpu-gpu0"}, true)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(domainSpec.Devices.IOMMU).To(HaveLen(1))
+		Expect(domainSpec.Devices.IOMMU[0].Driver.SSIDSize).To(Equal("20"))
+		Expect(domainSpec.Devices.IOMMU[0].Driver.OAS).To(Equal("48"))
+	})
+
 	It("creates an explicit PCIe root controller before placing Grace PCI devices", func() {
 		fakeRuntime.addGraceGPU("0000:81:00.0", 0, 16*1024*1024*1024)
 		fakeRuntime.giNodes = uint32Range(2, 9)


### PR DESCRIPTION
## What this PR does

This is a follow-up to #18011, as part of  **VEP-199 Grace I/O virtualization stack** (https://github.com/kubevirt/enhancements/issues/199) 
It implements the Layer6 of [NVIDIA Grace Virtualization Upstreaming Plan](https://docs.google.com/document/d/1pJBirt79ZJLb8qXNje1sKj_U8IdYjinkKInQLbV0Zjw/edit?tab=t.0#heading=h.czlquu3cqsra)

It sets explicit SMMUv3 address capabilities for Grace I/O Virtualization:

- `ssidSize="20"`
- `oas="48"`

These values are the current expected defaults for Grace Blackwell and Vera Rubin systems and are needed as part of the foundation Layer 6 Grace IOMMUFD passthrough support.

The generated domain XML should include:

```xml
<iommu model="smmuv3">
  <driver accel="on" ats="on" ril="off" ssidSize="20" oas="48"/>
</iommu>
```

## Why this is needed
Layer 6 already creates per-device SMMUv3 domains for Grace host devices. Without explicit SMMUv3 address capability values, the domain XML can be incomplete for the supported Grace platforms.
For now, KubeVirt uses the known platform defaults. Longer term, these values should be discovered from the host SMMU capabilities and capped to the host-supported values instead of being hardcoded.

For example, `OAS` can currently be observed from the arm-smmu-v3 probe log:

```text
arm-smmu-v3 arm-smmu-v3.19.auto: ias 48-bit, oas 48-bit
```
`SSIDSize` requires decoding SMMU ID registers. Kernel-side work is being upstreamed to make this capability discovery easier to consume, and a later PR can wire host capability probing into this conversion path.

## Testing
`make test` passed 

## Release Notes

```release-note
Set explicit SMMUv3 address capability defaults for Grace I/O Virtualization.
```