### PR TITLE
VEP 111: Graduate PodSecondaryInterfaceNamingUpgrade to GA

### DIFF
--- a/cmd/virt-launcher/virt-launcher.go
+++ b/cmd/virt-launcher/virt-launcher.go
@@ -358,7 +358,6 @@ func main() {
 	runWithNonRoot := pflag.Bool("run-as-nonroot", false, "Run virtqemud with the 'virt' user")
 	imageVolumeEnabled := pflag.Bool("image-volume", false, "Generated with ImageVolume instead of containerDisk") //remove this once ImageVolume is GAed
 	libvirtHooksServerAndClientEnabled := pflag.Bool("libvirt-hook-server-and-client", false, "Enable pre-migration hooks on the target virt-launcher pod")
-	ifacesOrdinalNamingUpgradeEnabled := pflag.Bool("upgrade-ordinal-ifaces", false, "Enable upgrade of ordinal ifaces naming scheme")
 	vGPUDedicatedHookEnabled := pflag.Bool("vgpu-dedicated-hook", false, "Enable target mdev UUID mutation for vGPU live migration")
 	vmStatsCollectorEnabled := pflag.Bool("vm-stats-collector", false, "Enable additional guest agent polling workers for VMStats monitoring data collection")
 	firmwareAutoSelectionEnabled := pflag.Bool("firmware-auto-selection", false, "Use libvirt firmware auto-selection for EFI Secure Boot")
@@ -449,9 +448,7 @@ func main() {
 	hookFuncs := []premigrationhookserver.HookFunc{
 		cpuhook.CPUDedicatedHook,
 		disk.DiskSourcePathHook,
-	}
-	if *ifacesOrdinalNamingUpgradeEnabled {
-		hookFuncs = append(hookFuncs, network.UpgradeOrdinalNamingScheme)
+		network.UpgradeOrdinalNamingScheme,
 	}
 	if *vGPUDedicatedHookEnabled {
 		hookFuncs = append(hookFuncs, vgpuhook.VGPULiveMigration)

--- a/cmd/virt-launcher/virt-launcher.go
+++ b/cmd/virt-launcher/virt-launcher.go
@@ -356,7 +356,6 @@ func main() {
 	allowCrossArchEmulation := pflag.Bool("allow-cross-arch-emulation", false, "Allow cross-architecture software emulation via QEMU TCG")
 	runWithNonRoot := pflag.Bool("run-as-nonroot", false, "Run virtqemud with the 'virt' user")
 	imageVolumeEnabled := pflag.Bool("image-volume", false, "Generated with ImageVolume instead of containerDisk") //remove this once ImageVolume is GAed
-	ifacesOrdinalNamingUpgradeEnabled := pflag.Bool("upgrade-ordinal-ifaces", false, "Enable upgrade of ordinal ifaces naming scheme")
 	vGPUDedicatedHookEnabled := pflag.Bool("vgpu-dedicated-hook", false, "Enable target mdev UUID mutation for vGPU live migration")
 	vmStatsCollectorEnabled := pflag.Bool("vm-stats-collector", false, "Enable additional guest agent polling workers for VMStats monitoring data collection")
 	firmwareAutoSelectionEnabled := pflag.Bool("firmware-auto-selection", false, "Use libvirt firmware auto-selection for EFI Secure Boot")
@@ -447,9 +446,7 @@ func main() {
 	hookFuncs := []premigrationhookserver.HookFunc{
 		cpuhook.CPUDedicatedHook,
 		disk.DiskSourcePathHook,
-	}
-	if *ifacesOrdinalNamingUpgradeEnabled {
-		hookFuncs = append(hookFuncs, network.UpgradeOrdinalNamingScheme)
+		network.UpgradeOrdinalNamingScheme,
 	}
 	if *vGPUDedicatedHookEnabled {
 		hookFuncs = append(hookFuncs, vgpuhook.VGPULiveMigration)

--- a/docs/network/ordinal-naming-scheme-upgrade.md
+++ b/docs/network/ordinal-naming-scheme-upgrade.md
@@ -1,8 +1,9 @@
-# Upgrading Secondary Interface Naming Scheme
+# Secondary Interface Naming Scheme Upgrade
 
 Release:
 
 - v1.8: Beta
+- v1.10: GA
 
 ## Overview
 
@@ -14,29 +15,28 @@ for predictable and stable interface names.
 
 To maintain network connectivity across live migrations and upgrades, KubeVirt
 has preserved the legacy ordinal naming for VMs that were already using it.
-However, the ordinal scheme is **incompatible with 
-[NIC hot-unplug](https://kubevirt.io/user-guide/network/hotplug_interfaces/#removing-an-interface-from-a-running-vm)** 
-and increases maintenance complexity.
+However, the ordinal scheme is **incompatible with NIC hot-unplug** and
+increases maintenance complexity.
 
-Starting with v1.8, KubeVirt provides an upgrade path to migrate these VMs
-from the ordinal naming scheme to the modern hashed naming scheme **without
-requiring a VM restart**.
+Starting with v1.10, KubeVirt automatically upgrades affected VMs from the
+ordinal naming scheme to the modern hashed naming scheme **without requiring
+a VM restart**. The upgrade is a one-time process that also **unblocks
+[NIC hot-unplug](https://kubevirt.io/user-guide/network/hotplug_interfaces/#removing-an-interface-from-a-running-vm)**
+functionality for the VM.
 
-## Feature Gate
+## Who Is Affected
 
-This feature requires the following
-[feature gates](https://kubevirt.io/user-guide/cluster_admin/activating_feature_gates/#how-to-activate-a-feature-gate):
+This upgrade only applies to VMs that were **originally created on KubeVirt
+versions prior to v1.0.0** and are still using the ordinal naming scheme for
+secondary network interfaces.
 
-- `PodSecondaryInterfaceNamingUpgrade` - controls the naming scheme upgrade
-  logic. Introduced in v1.8 at Beta stage, it must be explicitly enabled.
-- `LibvirtHooksServerAndClient` - enables the domain mutation hook mechanism
-  used to adjust tap device names during migration. GA since v1.10, always
-  enabled.
+VMs created or restarted on v1.0.0 or later already use the hashed naming
+scheme and are not affected.
 
 ## How It Works
 
-When the feature gate is enabled, the naming scheme upgrade is performed
-automatically during the next **live migration** of the VM:
+When a VM with ordinal-named interfaces is live migrated (e.g., as part of a
+KubeVirt update), the following happens:
 
 1. The target virt-launcher pod is created with the hashed naming scheme,
    regardless of the source pod's naming scheme.
@@ -46,40 +46,5 @@ automatically during the next **live migration** of the VM:
 3. After a successful migration, the VMI status is updated to reflect the new
    interface names.
 
-No manual intervention is required beyond triggering a live migration.
-
-## Who Is Affected
-
-This feature only applies to VMs that were **originally created on KubeVirt
-versions prior to v1.0.0** and are still using the ordinal naming scheme for
-secondary network interfaces.
-
-VMs created on v1.0.0 or later already use the hashed naming scheme and are
-not affected.
-
-> **Note**: If a VM was created prior to v1.0.0 but has been restarted on
-> v1.0.0 or above, it already uses the hashed naming scheme and does not
-> require this upgrade.
-
-## Upgrading a VM
-
-To upgrade a VM's interface naming scheme, ensure the
-`PodSecondaryInterfaceNamingUpgrade` feature gate is enabled, then live
-migrate the VM:
-
-```bash
-cat <<EOF | kubectl apply -f -
-apiVersion: kubevirt.io/v1
-kind: VirtualMachineInstanceMigration
-metadata:
-  name: upgrade-naming-scheme
-spec:
-  vmiName: <vm-name>
-EOF
-```
-
-Please refer to the [Live Migration](https://kubevirt.io/user-guide/compute/live_migration/) documentation
-for more information.
-
-Once the migration completes, the VM will use the hashed naming scheme. This
-also **unblocks NIC hot-unplug** functionality for the VM.
+No manual intervention is required. Once a VM has been upgraded, subsequent
+migrations proceed normally.

--- a/pkg/network/pod/annotations/generator.go
+++ b/pkg/network/pod/annotations/generator.go
@@ -37,7 +37,6 @@ import (
 
 type clusterConfigurer interface {
 	GetNetworkBindings() map[string]v1.InterfaceBindingPlugin
-	PodSecondaryInterfaceNamingUpgradeEnabled() bool
 }
 
 type Generator struct {
@@ -92,24 +91,7 @@ func (g Generator) Generate(vmi *v1.VirtualMachineInstance) (map[string]string, 
 
 // GenerateFromSource generates ordinal pod interfaces naming scheme for a migration target in case the migration source pod uses it
 func (g Generator) GenerateFromSource(vmi *v1.VirtualMachineInstance, sourcePod *k8scorev1.Pod) (map[string]string, error) {
-	if g.clusterConfigurer.PodSecondaryInterfaceNamingUpgradeEnabled() ||
-		!namescheme.PodHasOrdinalInterfaceName(multus.NetworkStatusesFromPod(sourcePod)) {
-		return nil, nil
-	}
-
-	ordinalNameScheme := namescheme.CreateOrdinalNetworkNameScheme(vmi.Spec.Networks)
-	multusNetworksAnnotation, err := multus.GenerateCNIAnnotationFromNameScheme(
-		vmi.Namespace,
-		vmi.Spec.Domain.Devices.Interfaces,
-		vmi.Spec.Networks,
-		ordinalNameScheme,
-		g.clusterConfigurer.GetNetworkBindings(),
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	return map[string]string{networkv1.NetworkAttachmentAnnot: multusNetworksAnnotation}, nil
+	return nil, nil
 }
 
 // GenerateFromActivePod generates additional pod annotations, bases on information that exists on a live virt-launcher pod

--- a/pkg/network/pod/annotations/generator.go
+++ b/pkg/network/pod/annotations/generator.go
@@ -89,11 +89,6 @@ func (g Generator) Generate(vmi *v1.VirtualMachineInstance) (map[string]string, 
 	return annotations, nil
 }
 
-// GenerateFromSource generates ordinal pod interfaces naming scheme for a migration target in case the migration source pod uses it
-func (g Generator) GenerateFromSource(vmi *v1.VirtualMachineInstance, sourcePod *k8scorev1.Pod) (map[string]string, error) {
-	return nil, nil
-}
-
 // GenerateFromActivePod generates additional pod annotations, bases on information that exists on a live virt-launcher pod
 func (g Generator) GenerateFromActivePod(vmi *v1.VirtualMachineInstance, pod *k8scorev1.Pod) map[string]string {
 	annotations := map[string]string{}

--- a/pkg/network/pod/annotations/generator_test.go
+++ b/pkg/network/pod/annotations/generator_test.go
@@ -157,82 +157,6 @@ var _ = Describe("Annotations Generator", func() {
 		)
 	})
 
-	Context("Network naming scheme conversion during migration", func() {
-		var vmi *v1.VirtualMachineInstance
-
-		const ordinalMultusNetworkStatus = `[
-							{"interface":"eth0", "name":"default"},
-							{"interface":"net1", "name":"test1", "namespace":"default"},
-							{"interface":"net2", "name":"test1", "namespace":"other-namespace"}
-						]`
-
-		BeforeEach(func() {
-			const (
-				networkName1                     = "blue"
-				networkAttachmentDefinitionName1 = "test1"
-
-				networkName2                     = "red"
-				networkAttachmentDefinitionName2 = "other-namespace/test1"
-			)
-
-			vmi = libvmi.New(
-				libvmi.WithNamespace(testNamespace),
-				libvmi.WithInterface(*v1.DefaultBridgeNetworkInterface()),
-				libvmi.WithInterface(libvmi.NewInterface(networkName1, libvmi.WithBridgeBinding())),
-				libvmi.WithInterface(libvmi.NewInterface(networkName2, libvmi.WithBridgeBinding())),
-				libvmi.WithNetwork(v1.DefaultPodNetwork()),
-				libvmi.WithNetwork(libvmi.MultusNetwork(networkName1, networkAttachmentDefinitionName1)),
-				libvmi.WithNetwork(libvmi.MultusNetwork(networkName2, networkAttachmentDefinitionName2)),
-			)
-		})
-
-		It("should convert the naming scheme when source pod has ordinal naming", func() {
-			sourcePodAnnotations := map[string]string{}
-			sourcePodAnnotations[networkv1.NetworkStatusAnnot] = ordinalMultusNetworkStatus
-
-			sourcePod := newStubVirtLauncherPod(vmi, sourcePodAnnotations)
-
-			generator := annotations.NewGenerator(stubClusterConfig{})
-			convertedAnnotations, err := generator.GenerateFromSource(vmi, sourcePod)
-			Expect(err).ToNot(HaveOccurred())
-
-			expectedMultusNetworksAnnotation := `[
-							{"interface":"net1", "name":"test1", "namespace":"default"},
-							{"interface":"net2", "name":"test1", "namespace":"other-namespace"}
-						]`
-
-			Expect(convertedAnnotations[networkv1.NetworkAttachmentAnnot]).To(MatchJSON(expectedMultusNetworksAnnotation))
-		})
-
-		It("should not convert the naming scheme when source pod does not have ordinal naming", func() {
-			sourcePodAnnotations := map[string]string{}
-			sourcePodAnnotations[networkv1.NetworkStatusAnnot] = `[
-							{"interface":"pod16477688c0e", "name":"test1", "namespace":"default"},
-							{"interface":"podb1f51a511f1", "name":"test1", "namespace":"other-namespace"}
-						]`
-
-			sourcePod := newStubVirtLauncherPod(vmi, sourcePodAnnotations)
-
-			generator := annotations.NewGenerator(stubClusterConfig{})
-			annotations, err := generator.GenerateFromSource(vmi, sourcePod)
-			Expect(err).ToNot(HaveOccurred())
-
-			Expect(annotations).To(BeEmpty())
-		})
-
-		It("should not convert the naming scheme when the upgrade mechanism is enabled", func() {
-			sourcePodAnnotations := map[string]string{}
-			sourcePodAnnotations[networkv1.NetworkStatusAnnot] = ordinalMultusNetworkStatus
-
-			sourcePod := newStubVirtLauncherPod(vmi, sourcePodAnnotations)
-
-			generator := annotations.NewGenerator(stubClusterConfig{podSecondaryIfaceNamingUpgradeEnabled: true})
-			convertedAnnotations, err := generator.GenerateFromSource(vmi, sourcePod)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(convertedAnnotations).To(BeNil())
-		})
-	})
-
 	Context("Network Info annotation", func() {
 		const (
 			networkName1                     = "boo"
@@ -798,14 +722,9 @@ func newStubVirtLauncherPod(vmi *v1.VirtualMachineInstance, podAnnotations map[s
 }
 
 type stubClusterConfig struct {
-	registeredPlugins                     map[string]v1.InterfaceBindingPlugin
-	podSecondaryIfaceNamingUpgradeEnabled bool
+	registeredPlugins map[string]v1.InterfaceBindingPlugin
 }
 
 func (s stubClusterConfig) GetNetworkBindings() map[string]v1.InterfaceBindingPlugin {
 	return s.registeredPlugins
-}
-
-func (s stubClusterConfig) PodSecondaryInterfaceNamingUpgradeEnabled() bool {
-	return s.podSecondaryIfaceNamingUpgradeEnabled
 }

--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -193,10 +193,6 @@ func (config *ClusterConfig) IncrementalBackupEnabled() bool {
 	return config.isFeatureGateEnabled(featuregate.IncrementalBackupGate)
 }
 
-func (config *ClusterConfig) PodSecondaryInterfaceNamingUpgradeEnabled() bool {
-	return config.isFeatureGateEnabled(featuregate.PodSecondaryInterfaceNamingUpgrade)
-}
-
 func (config *ClusterConfig) ExternalNetResourceInjectionEnabled() bool {
 	return config.isFeatureGateEnabled(featuregate.ExternalNetResourceInjection)
 }

--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -189,10 +189,6 @@ func (config *ClusterConfig) IncrementalBackupEnabled() bool {
 	return config.isFeatureGateEnabled(featuregate.IncrementalBackupGate)
 }
 
-func (config *ClusterConfig) PodSecondaryInterfaceNamingUpgradeEnabled() bool {
-	return config.isFeatureGateEnabled(featuregate.PodSecondaryInterfaceNamingUpgrade)
-}
-
 func (config *ClusterConfig) ExternalNetResourceInjectionEnabled() bool {
 	return config.isFeatureGateEnabled(featuregate.ExternalNetResourceInjection)
 }

--- a/pkg/virt-config/featuregate/active.go
+++ b/pkg/virt-config/featuregate/active.go
@@ -157,12 +157,6 @@ const (
 	// HypervisorConfigurations field in KubeVirtConfiguration.
 	ConfigurableHypervisor = "ConfigurableHypervisor"
 
-	// PodSecondaryInterfaceNamingUpgrade enables the upgrade mechanism for VMs
-	// stuck with the obsolete ordinal naming scheme for their pod secondary networks
-	// Owner: SIG network
-	// Beta: v1.8
-	PodSecondaryInterfaceNamingUpgrade = "PodSecondaryInterfaceNamingUpgrade"
-
 	// ExternalNetResourceInjection disables the VMI controller query of NetworkAttachmentDefinition objects and
 	// the deployment of related RBAC rules by virt-operator.
 	// Owner: SIG network
@@ -325,7 +319,6 @@ func init() {
 	RegisterFeatureGate(FeatureGate{Name: ConfigurableHypervisor, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: PasstBinding, State: Beta})
 	RegisterFeatureGate(FeatureGate{Name: IncrementalBackupGate, State: Alpha})
-	RegisterFeatureGate(FeatureGate{Name: PodSecondaryInterfaceNamingUpgrade, State: Beta})
 	RegisterFeatureGate(FeatureGate{Name: ExternalNetResourceInjection, State: Beta})
 	RegisterFeatureGate(FeatureGate{Name: RebootPolicy, State: Beta})
 	RegisterFeatureGate(FeatureGate{Name: Template, State: Beta})

--- a/pkg/virt-config/featuregate/active.go
+++ b/pkg/virt-config/featuregate/active.go
@@ -148,12 +148,6 @@ const (
 	// HypervisorConfigurations field in KubeVirtConfiguration.
 	ConfigurableHypervisor = "ConfigurableHypervisor"
 
-	// PodSecondaryInterfaceNamingUpgrade enables the upgrade mechanism for VMs
-	// stuck with the obsolete ordinal naming scheme for their pod secondary networks
-	// Owner: SIG network
-	// Beta: v1.8
-	PodSecondaryInterfaceNamingUpgrade = "PodSecondaryInterfaceNamingUpgrade"
-
 	// ExternalNetResourceInjection disables the VMI controller query of NetworkAttachmentDefinition objects and
 	// the deployment of related RBAC rules by virt-operator.
 	// Owner: SIG network
@@ -314,7 +308,6 @@ func init() {
 	RegisterFeatureGate(FeatureGate{Name: ConfigurableHypervisor, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: PasstBinding, State: Beta})
 	RegisterFeatureGate(FeatureGate{Name: IncrementalBackupGate, State: Alpha})
-	RegisterFeatureGate(FeatureGate{Name: PodSecondaryInterfaceNamingUpgrade, State: Beta})
 	RegisterFeatureGate(FeatureGate{Name: ExternalNetResourceInjection, State: Beta})
 	RegisterFeatureGate(FeatureGate{Name: RebootPolicy, State: Beta})
 	RegisterFeatureGate(FeatureGate{Name: Template, State: Beta})

--- a/pkg/virt-config/featuregate/inactive.go
+++ b/pkg/virt-config/featuregate/inactive.go
@@ -187,6 +187,13 @@ const (
 	// Beta: v1.8.0
 	// GA: v1.9.0
 	MigrationPriorityQueue = "MigrationPriorityQueue"
+
+	// PodSecondaryInterfaceNamingUpgrade enables the upgrade mechanism for VMs
+	// stuck with the obsolete ordinal naming scheme for their pod secondary networks
+	// Owner: SIG network
+	// Beta: v1.8.0
+	// GA: v1.10.0
+	PodSecondaryInterfaceNamingUpgrade = "PodSecondaryInterfaceNamingUpgrade"
 )
 
 func init() {
@@ -231,4 +238,5 @@ func init() {
 	RegisterFeatureGate(FeatureGate{Name: VideoConfig, State: GA})
 	RegisterFeatureGate(FeatureGate{Name: SecureExecution, State: GA})
 	RegisterFeatureGate(FeatureGate{Name: MigrationPriorityQueue, State: GA})
+	RegisterFeatureGate(FeatureGate{Name: PodSecondaryInterfaceNamingUpgrade, State: GA})
 }

--- a/pkg/virt-config/featuregate/inactive.go
+++ b/pkg/virt-config/featuregate/inactive.go
@@ -205,6 +205,13 @@ const (
 	// hooks on the target virt-launcher pod, allowing domain XML mutations to be applied
 	// on the target before migration starts.
 	LibvirtHooksServerAndClient = "LibvirtHooksServerAndClient"
+
+	// PodSecondaryInterfaceNamingUpgrade enables the upgrade mechanism for VMs
+	// stuck with the obsolete ordinal naming scheme for their pod secondary networks
+	// Owner: SIG network
+	// Beta: v1.8.0
+	// GA: v1.10.0
+	PodSecondaryInterfaceNamingUpgrade = "PodSecondaryInterfaceNamingUpgrade"
 )
 
 func init() {
@@ -251,4 +258,5 @@ func init() {
 	RegisterFeatureGate(FeatureGate{Name: MigrationPriorityQueue, State: GA})
 	RegisterFeatureGate(FeatureGate{Name: VmiMemoryOverheadReport, State: GA})
 	RegisterFeatureGate(FeatureGate{Name: LibvirtHooksServerAndClient, State: GA})
+	RegisterFeatureGate(FeatureGate{Name: PodSecondaryInterfaceNamingUpgrade, State: GA})
 }

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -481,9 +481,6 @@ func (t *TemplateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 		if t.clusterConfig.LibvirtHooksServerAndClientEnabled() {
 			args = append(args, "--libvirt-hook-server-and-client")
 		}
-		if t.clusterConfig.PodSecondaryInterfaceNamingUpgradeEnabled() {
-			args = append(args, "--upgrade-ordinal-ifaces")
-		}
 		if t.clusterConfig.VGPULiveMigrationEnabled() {
 			args = append(args, "--vgpu-dedicated-hook")
 		}

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -478,9 +478,6 @@ func (t *TemplateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 		if t.clusterConfig.ImageVolumeEnabled() {
 			args = append(args, "--image-volume")
 		}
-		if t.clusterConfig.PodSecondaryInterfaceNamingUpgradeEnabled() {
-			args = append(args, "--upgrade-ordinal-ifaces")
-		}
 		if t.clusterConfig.VGPULiveMigrationEnabled() {
 			args = append(args, "--vgpu-dedicated-hook")
 		}

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -130,10 +130,6 @@ type annotationsGenerator interface {
 	Generate(vmi *v1.VirtualMachineInstance) (map[string]string, error)
 }
 
-type targetAnnotationsGenerator interface {
-	GenerateFromSource(vmi *v1.VirtualMachineInstance, sourcePod *k8sv1.Pod) (map[string]string, error)
-}
-
 type TemplateService struct {
 	launcherImage              string
 	exporterImage              string
@@ -150,11 +146,10 @@ type TemplateService struct {
 	resourceQuotaStore         cache.Store
 	namespaceStore             cache.Store
 
-	sidecarCreators               []SidecarCreatorFunc
-	netMemoryCalculator           netMemoryCalculator
-	annotationsGenerators         []annotationsGenerator
-	netTargetAnnotationsGenerator targetAnnotationsGenerator
-	launcherHypervisorResources   hypervisor.LauncherHypervisorResources
+	sidecarCreators             []SidecarCreatorFunc
+	netMemoryCalculator         netMemoryCalculator
+	annotationsGenerators       []annotationsGenerator
+	launcherHypervisorResources hypervisor.LauncherHypervisorResources
 }
 
 func isFeatureStateEnabled(fs *v1.FeatureState) bool {
@@ -338,15 +333,6 @@ func (t *TemplateService) RenderMigrationManifest(vmi *v1.VirtualMachineInstance
 	targetPod, err := t.renderLaunchManifest(vmi, reproducibleImageIDs, backendStoragePVCName, false, memoryOverhead)
 	if err != nil {
 		return nil, err
-	}
-
-	if t.netTargetAnnotationsGenerator != nil {
-		netAnnotations, err := t.netTargetAnnotationsGenerator.GenerateFromSource(vmi, sourcePod)
-		if err != nil {
-			return nil, err
-		}
-
-		maps.Copy(targetPod.Annotations, netAnnotations)
 	}
 
 	return targetPod, err
@@ -1761,12 +1747,6 @@ func WithNetMemoryCalculator(netMemoryCalculator netMemoryCalculator) templateSe
 func WithAnnotationsGenerators(generators ...annotationsGenerator) templateServiceOption {
 	return func(service *TemplateService) {
 		service.annotationsGenerators = append(service.annotationsGenerators, generators...)
-	}
-}
-
-func WithNetTargetAnnotationsGenerator(generator targetAnnotationsGenerator) templateServiceOption {
-	return func(service *TemplateService) {
-		service.netTargetAnnotationsGenerator = generator
 	}
 }
 

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -130,10 +130,6 @@ type annotationsGenerator interface {
 	Generate(vmi *v1.VirtualMachineInstance) (map[string]string, error)
 }
 
-type targetAnnotationsGenerator interface {
-	GenerateFromSource(vmi *v1.VirtualMachineInstance, sourcePod *k8sv1.Pod) (map[string]string, error)
-}
-
 type TemplateService struct {
 	launcherImage              string
 	exporterImage              string
@@ -150,11 +146,10 @@ type TemplateService struct {
 	resourceQuotaStore         cache.Store
 	namespaceStore             cache.Store
 
-	sidecarCreators               []SidecarCreatorFunc
-	netMemoryCalculator           netMemoryCalculator
-	annotationsGenerators         []annotationsGenerator
-	netTargetAnnotationsGenerator targetAnnotationsGenerator
-	launcherHypervisorResources   hypervisor.LauncherHypervisorResources
+	sidecarCreators             []SidecarCreatorFunc
+	netMemoryCalculator         netMemoryCalculator
+	annotationsGenerators       []annotationsGenerator
+	launcherHypervisorResources hypervisor.LauncherHypervisorResources
 }
 
 func isFeatureStateEnabled(fs *v1.FeatureState) bool {
@@ -338,15 +333,6 @@ func (t *TemplateService) RenderMigrationManifest(vmi *v1.VirtualMachineInstance
 	targetPod, err := t.renderLaunchManifest(vmi, reproducibleImageIDs, backendStoragePVCName, false, memoryOverhead)
 	if err != nil {
 		return nil, err
-	}
-
-	if t.netTargetAnnotationsGenerator != nil {
-		netAnnotations, err := t.netTargetAnnotationsGenerator.GenerateFromSource(vmi, sourcePod)
-		if err != nil {
-			return nil, err
-		}
-
-		maps.Copy(targetPod.Annotations, netAnnotations)
 	}
 
 	return targetPod, err
@@ -1764,12 +1750,6 @@ func WithNetMemoryCalculator(netMemoryCalculator netMemoryCalculator) templateSe
 func WithAnnotationsGenerators(generators ...annotationsGenerator) templateServiceOption {
 	return func(service *TemplateService) {
 		service.annotationsGenerators = append(service.annotationsGenerators, generators...)
-	}
-}
-
-func WithNetTargetAnnotationsGenerator(generator targetAnnotationsGenerator) templateServiceOption {
-	return func(service *TemplateService) {
-		service.netTargetAnnotationsGenerator = generator
 	}
 }
 

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -529,7 +529,7 @@ var _ = Describe("Template", func() {
 
 			DescribeTable("should work", func(arch string, ovmfPath string) {
 				config, kvStore, svc = configFactory(arch)
-				disableFeatureGate(featuregate.ImageVolume, featuregate.PodSecondaryInterfaceNamingUpgrade)
+				disableFeatureGate(featuregate.ImageVolume)
 				trueVar := true
 				annotations := map[string]string{
 					hooks.HookSidecarListAnnotationName: `[{"image": "some-image:v1", "imagePullPolicy": "IfNotPresent"}]`,
@@ -1156,7 +1156,7 @@ var _ = Describe("Template", func() {
 		Context("with node selectors", func() {
 			DescribeTable("should add node selectors to template", func(arch string, ovmfPath string) {
 				config, kvStore, svc = configFactory(arch)
-				disableFeatureGate(featuregate.ImageVolume, featuregate.PodSecondaryInterfaceNamingUpgrade)
+				disableFeatureGate(featuregate.ImageVolume)
 
 				nodeSelector := map[string]string{
 					k8sv1.LabelHostname: "master",

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -6268,88 +6268,6 @@ var _ = Describe("Template", func() {
 		})
 	})
 
-	Context("Network target annotations generation", func() {
-		const (
-			testNamespace = "default"
-
-			testKey = "netAnnotation"
-
-			initialValue = "netAnnotationInitial"
-			updatedValue = "netAnnotationUpdated"
-		)
-
-		It("Should call network target annotations generator when templating a migration target pod", func() {
-			generator := stubTargetAnnotationsGenerator{
-				annotations: map[string]string{testKey: updatedValue},
-			}
-
-			svc = NewTemplateService("kubevirt/virt-launcher",
-				240,
-				"/var/run/kubevirt",
-				"/var/run/kubevirt-ephemeral-disks",
-				"/var/run/kubevirt/container-disks",
-				v1.HotplugDiskDir,
-				"pull-secret-1",
-				pvcCache,
-				virtClient,
-				config,
-				qemuGid,
-				"kubevirt/vmexport",
-				resourceQuotaStore,
-				namespaceStore,
-				WithNetTargetAnnotationsGenerator(generator),
-			)
-
-			vmi := libvmi.New(libvmi.WithNamespace(testNamespace))
-
-			sourcePod, err := svc.RenderLaunchManifest(vmi)
-			Expect(err).ToNot(HaveOccurred())
-
-			sourcePod.Annotations[testKey] = initialValue
-
-			targetPod, err := svc.RenderMigrationManifest(vmi, nil, sourcePod)
-			Expect(err).ToNot(HaveOccurred())
-
-			Expect(targetPod.Annotations).To(HaveKeyWithValue(testKey, updatedValue))
-		})
-
-		It("Should fail templating a migration target pod when network target annotations generator fails", func() {
-			expectedErr := errors.New("some err")
-
-			generator := stubTargetAnnotationsGenerator{
-				annotations:   map[string]string{testKey: updatedValue},
-				generationErr: expectedErr,
-			}
-
-			svc = NewTemplateService("kubevirt/virt-launcher",
-				240,
-				"/var/run/kubevirt",
-				"/var/run/kubevirt-ephemeral-disks",
-				"/var/run/kubevirt/container-disks",
-				v1.HotplugDiskDir,
-				"pull-secret-1",
-				pvcCache,
-				virtClient,
-				config,
-				qemuGid,
-				"kubevirt/vmexport",
-				resourceQuotaStore,
-				namespaceStore,
-				WithNetTargetAnnotationsGenerator(generator),
-			)
-
-			vmi := libvmi.New(libvmi.WithNamespace(testNamespace))
-
-			sourcePod, err := svc.RenderLaunchManifest(vmi)
-			Expect(err).ToNot(HaveOccurred())
-
-			sourcePod.Annotations[testKey] = initialValue
-
-			_, err = svc.RenderMigrationManifest(vmi, nil, sourcePod)
-			Expect(err).To(MatchError(expectedErr))
-		})
-	})
-
 	Context("NAD query disablement", func() {
 		It("Should not query NAD when ExternalNetResourceInjection is enabled", func() {
 			config, kvStore, svc = configFactory(defaultArch)
@@ -6587,13 +6505,4 @@ type stubAnnotationsGenerator struct {
 
 func (sag stubAnnotationsGenerator) Generate(_ *v1.VirtualMachineInstance) (map[string]string, error) {
 	return sag.annotations, sag.generationErr
-}
-
-type stubTargetAnnotationsGenerator struct {
-	annotations   map[string]string
-	generationErr error
-}
-
-func (stag stubTargetAnnotationsGenerator) GenerateFromSource(_ *v1.VirtualMachineInstance, _ *k8sv1.Pod) (map[string]string, error) {
-	return stag.annotations, stag.generationErr
 }

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -6266,88 +6266,6 @@ var _ = Describe("Template", func() {
 		})
 	})
 
-	Context("Network target annotations generation", func() {
-		const (
-			testNamespace = "default"
-
-			testKey = "netAnnotation"
-
-			initialValue = "netAnnotationInitial"
-			updatedValue = "netAnnotationUpdated"
-		)
-
-		It("Should call network target annotations generator when templating a migration target pod", func() {
-			generator := stubTargetAnnotationsGenerator{
-				annotations: map[string]string{testKey: updatedValue},
-			}
-
-			svc = NewTemplateService("kubevirt/virt-launcher",
-				240,
-				"/var/run/kubevirt",
-				"/var/run/kubevirt-ephemeral-disks",
-				"/var/run/kubevirt/container-disks",
-				v1.HotplugDiskDir,
-				"pull-secret-1",
-				pvcCache,
-				virtClient,
-				config,
-				qemuGid,
-				"kubevirt/vmexport",
-				resourceQuotaStore,
-				namespaceStore,
-				WithNetTargetAnnotationsGenerator(generator),
-			)
-
-			vmi := libvmi.New(libvmi.WithNamespace(testNamespace))
-
-			sourcePod, err := svc.RenderLaunchManifest(vmi)
-			Expect(err).ToNot(HaveOccurred())
-
-			sourcePod.Annotations[testKey] = initialValue
-
-			targetPod, err := svc.RenderMigrationManifest(vmi, nil, sourcePod)
-			Expect(err).ToNot(HaveOccurred())
-
-			Expect(targetPod.Annotations).To(HaveKeyWithValue(testKey, updatedValue))
-		})
-
-		It("Should fail templating a migration target pod when network target annotations generator fails", func() {
-			expectedErr := errors.New("some err")
-
-			generator := stubTargetAnnotationsGenerator{
-				annotations:   map[string]string{testKey: updatedValue},
-				generationErr: expectedErr,
-			}
-
-			svc = NewTemplateService("kubevirt/virt-launcher",
-				240,
-				"/var/run/kubevirt",
-				"/var/run/kubevirt-ephemeral-disks",
-				"/var/run/kubevirt/container-disks",
-				v1.HotplugDiskDir,
-				"pull-secret-1",
-				pvcCache,
-				virtClient,
-				config,
-				qemuGid,
-				"kubevirt/vmexport",
-				resourceQuotaStore,
-				namespaceStore,
-				WithNetTargetAnnotationsGenerator(generator),
-			)
-
-			vmi := libvmi.New(libvmi.WithNamespace(testNamespace))
-
-			sourcePod, err := svc.RenderLaunchManifest(vmi)
-			Expect(err).ToNot(HaveOccurred())
-
-			sourcePod.Annotations[testKey] = initialValue
-
-			_, err = svc.RenderMigrationManifest(vmi, nil, sourcePod)
-			Expect(err).To(MatchError(expectedErr))
-		})
-	})
-
 	Context("NAD query disablement", func() {
 		It("Should not query NAD when ExternalNetResourceInjection is enabled", func() {
 			config, kvStore, svc = configFactory(defaultArch)
@@ -6585,13 +6503,4 @@ type stubAnnotationsGenerator struct {
 
 func (sag stubAnnotationsGenerator) Generate(_ *v1.VirtualMachineInstance) (map[string]string, error) {
 	return sag.annotations, sag.generationErr
-}
-
-type stubTargetAnnotationsGenerator struct {
-	annotations   map[string]string
-	generationErr error
-}
-
-func (stag stubTargetAnnotationsGenerator) GenerateFromSource(_ *v1.VirtualMachineInstance, _ *k8sv1.Pod) (map[string]string, error) {
-	return stag.annotations, stag.generationErr
 }

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -529,7 +529,7 @@ var _ = Describe("Template", func() {
 
 			DescribeTable("should work", func(arch string, ovmfPath string) {
 				config, kvStore, svc = configFactory(arch)
-				disableFeatureGate(featuregate.ImageVolume, featuregate.PodSecondaryInterfaceNamingUpgrade)
+				disableFeatureGate(featuregate.ImageVolume)
 				trueVar := true
 				annotations := map[string]string{
 					hooks.HookSidecarListAnnotationName: `[{"image": "some-image:v1", "imagePullPolicy": "IfNotPresent"}]`,
@@ -1155,7 +1155,7 @@ var _ = Describe("Template", func() {
 		Context("with node selectors", func() {
 			DescribeTable("should add node selectors to template", func(arch string, ovmfPath string) {
 				config, kvStore, svc = configFactory(arch)
-				disableFeatureGate(featuregate.ImageVolume, featuregate.PodSecondaryInterfaceNamingUpgrade)
+				disableFeatureGate(featuregate.ImageVolume)
 
 				nodeSelector := map[string]string{
 					k8sv1.LabelHostname: "master",

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -718,7 +718,6 @@ func (vca *VirtControllerApp) initCommon() {
 		services.WithSidecarCreator(netbinding.NetBindingPluginSidecarList),
 		services.WithNetMemoryCalculator(netresources.MemoryCalculator{}),
 		services.WithAnnotationsGenerators(netAnnotationsGenerator, storageannotations.Generator{}),
-		services.WithNetTargetAnnotationsGenerator(netAnnotationsGenerator),
 	)
 
 	topologyHinter := topology.NewTopologyHinter(vca.nodeInformer.GetStore(), vca.vmiInformer.GetStore(), vca.clusterConfig)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
As part of VEP 111, the obsolete ordinal network interface naming scheme will be removed. This PR graduates the `PodSecondaryInterfaceNamingUpgrade` feature gate from Beta (since v1.8) to GA. Migration targets will no
longer preserve ordinal pod interface names from the source pod - the hashed scheme is always used. The pre-migration hook that converts ordinal tap names to hashed equivalents now runs unconditionally, ensuring all VMs
transition to hashed naming during migration so ordinal naming code can be safely dropped in a future release.
With the gate always enabled, the `--upgrade-ordinal-ifaces` flag, `GenerateFromSource`, and all its template plumbing become dead code and are removed.

### References
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/111

### Why we need it and why it was done in this way
Graduating the gate is the first step in VEP 111: once the hook runs unconditionally for a full release, every VM will have transitioned to hashed naming during its next migration, and the remaining ordinal naming code can be safely removed.
 
The flag removal is safe because virt-operator deploys virt-controller and virt-launcher together, so no version-skew scenario exists. The hook itself is safe to run unconditionally - it only rewrites tap devices matching the ordinal pattern (`tap\d+`) and is a no-op for VMs already using hashed naming.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

~~Depends on https://github.com/kubevirt/kubevirt/pull/18687, please review only the last three commits.~~

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Graduate the PodSecondaryInterfaceNamingUpgrade feature gate to GA. The pre-migration hook that converts ordinal network interface names to hashed equivalents now runs unconditionally.
```

