### PR TITLE
check the actual compression ratio in zstd live migration

### DIFF
--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -2181,6 +2181,8 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 				By("Verifying compression was applied via launcher logs")
 				logs := getSourceLauncherLogs(virtClient, vmi)
 				Expect(logs).To(ContainSubstring("Migration compression enabled: method=zstd"))
+				// let's check for >1.00 at least, in CI it's typically around 3.00
+				Expect(logs).To(MatchRegexp(`CompressionRatio:([2-9]\d*|1\.\d*[1-9])\d*x`))
 			})
 
 			It("should migrate with compression, autoconverge, and postcopy combined", func() {
@@ -2237,6 +2239,8 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 				By("Verifying compression via launcher logs")
 				logs := getSourceLauncherLogs(virtClient, vmi)
 				Expect(logs).To(ContainSubstring("Migration compression enabled: method=zstd"))
+				// let's check for >1.00 at least, in CI it's typically around 3.00
+				Expect(logs).To(MatchRegexp(`CompressionRatio:([2-9]\d*|1\.\d*[1-9])\d*x`))
 			})
 		})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
improves e2e test to prove compression achieves some savings

### References
- Follow-up to: #17509 

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

https://github.com/kubevirt/kubevirt/pull/17509#discussion_r3508763280

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

