### PR TITLE
migration: Expand migration configuration validation

### DIFF
--- a/pkg/util/migrations/BUILD.bazel
+++ b/pkg/util/migrations/BUILD.bazel
@@ -19,16 +19,22 @@ go_test(
 
 go_library(
     name = "go_default_library",
-    srcs = ["migrations.go"],
+    srcs = [
+        "migrations.go",
+        "validation.go",
+    ],
     importpath = "kubevirt.io/kubevirt/pkg/util/migrations",
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/controller:go_default_library",
         "//pkg/pointer:go_default_library",
         "//pkg/virt-config:go_default_library",
+        "//pkg/virt-config/featuregate:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],
 )

--- a/pkg/util/migrations/validation.go
+++ b/pkg/util/migrations/validation.go
@@ -102,6 +102,18 @@ func ValidateMigrationConfigurationOptions(
 		}
 	}
 
+	if didFieldChange(oldConfiguration, newConfiguration, func(c *v1.VMIMConfigurationOptions) any { return c.AllowPostCopy }) ||
+		didFieldChange(oldConfiguration, newConfiguration, func(c *v1.VMIMConfigurationOptions) any { return c.AllowWorkloadDisruption }) {
+		if newConfiguration.AllowPostCopy != nil && *newConfiguration.AllowPostCopy &&
+			(newConfiguration.AllowWorkloadDisruption != nil && !*newConfiguration.AllowWorkloadDisruption) {
+			causes = append(causes, metav1.StatusCause{
+				Type:    metav1.CauseTypeFieldValueInvalid,
+				Message: "AllowWorkloadDisruption must be true when AllowPostCopy is true",
+				Field:   sourceField.Child("allowWorkloadDisruption").String(),
+			})
+		}
+	}
+
 	// Note: Stall detector validation applies only when callers populate experimental options
 	// (MigrationPolicy today; KubeVirt CR MigrationConfiguration has no experimental field).
 	if didFieldChange(oldConfiguration, newConfiguration, stallDetectorAccessor) {

--- a/pkg/util/migrations/validation.go
+++ b/pkg/util/migrations/validation.go
@@ -1,0 +1,188 @@
+/*
+* This file is part of the KubeVirt project
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*
+* Copyright The KubeVirt Authors.
+*
+ */
+
+package migrations
+
+import (
+	"fmt"
+	"math"
+
+	"k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
+	v1 "kubevirt.io/api/core/v1"
+
+	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
+	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
+)
+
+// ValidateMigrationConfigurationOptions validates migration configuration fields.
+// When oldConfiguration is non-nil (update), only changed fields are validated
+// so that evolving validation criteria don't reject updates to unrelated fields.
+func ValidateMigrationConfigurationOptions(
+	sourceField *k8sfield.Path,
+	oldConfiguration *v1.VMIMConfigurationOptions,
+	newConfiguration *v1.VMIMConfigurationOptions,
+	devConfig *v1.DeveloperConfiguration,
+) []metav1.StatusCause {
+	var causes []metav1.StatusCause
+
+	if newConfiguration == nil {
+		return causes
+	}
+
+	if didFieldChange(oldConfiguration, newConfiguration, func(c *v1.VMIMConfigurationOptions) any { return c.CompletionTimeoutPerGiB }) {
+		if newConfiguration.CompletionTimeoutPerGiB != nil && *newConfiguration.CompletionTimeoutPerGiB < 0 {
+			causes = append(causes, metav1.StatusCause{
+				Type:    metav1.CauseTypeFieldValueInvalid,
+				Message: "must not be negative",
+				Field:   sourceField.Child("completionTimeoutPerGiB").String(),
+			})
+		}
+	}
+
+	if didFieldChange(oldConfiguration, newConfiguration, func(c *v1.VMIMConfigurationOptions) any { return c.ProgressTimeout }) {
+		if newConfiguration.ProgressTimeout != nil && *newConfiguration.ProgressTimeout < 0 {
+			causes = append(causes, metav1.StatusCause{
+				Type:    metav1.CauseTypeFieldValueInvalid,
+				Message: "must be greater or equal to zero",
+				Field:   sourceField.Child("progressTimeout").String(),
+			})
+		}
+	}
+
+	if didFieldChange(oldConfiguration, newConfiguration, func(c *v1.VMIMConfigurationOptions) any { return c.MaxDowntimeMs }) {
+		if newConfiguration.MaxDowntimeMs != nil && (*newConfiguration.MaxDowntimeMs == 0 || *newConfiguration.MaxDowntimeMs > QEMUMaxMigrationDowntimeMS) {
+			causes = append(causes, metav1.StatusCause{
+				Type:    metav1.CauseTypeFieldValueInvalid,
+				Message: fmt.Sprintf("must be in range 1-%d", QEMUMaxMigrationDowntimeMS),
+				Field:   sourceField.Child("maxDowntimeMs").String(),
+			})
+		}
+
+		if newConfiguration.MaxDowntimeMs != nil && !featuregate.IsEnabled(featuregate.MigrationStallDetection, devConfig) {
+			causes = append(causes, metav1.StatusCause{
+				Type:    metav1.CauseTypeFieldValueInvalid,
+				Field:   sourceField.Child("maxDowntimeMs").String(),
+				Message: fmt.Sprintf("maxDowntimeMs cannot be set without enabling the %s feature gate", featuregate.MigrationStallDetection),
+			})
+		}
+	}
+
+	if didFieldChange(oldConfiguration, newConfiguration, func(c *v1.VMIMConfigurationOptions) any { return c.BandwidthPerMigration }) {
+		if newConfiguration.BandwidthPerMigration != nil {
+			quantity, ok := newConfiguration.BandwidthPerMigration.AsInt64()
+			if !ok {
+				dec := newConfiguration.BandwidthPerMigration.AsDec()
+				quantity = int64(dec.Sign())
+			}
+			if quantity < 0 {
+				causes = append(causes, metav1.StatusCause{
+					Type:    metav1.CauseTypeFieldValueInvalid,
+					Message: "must not be negative",
+					Field:   sourceField.Child("bandwidthPerMigration").String(),
+				})
+			}
+		}
+	}
+
+	// Note: Stall detector validation applies only when callers populate experimental options
+	// (MigrationPolicy today; KubeVirt CR MigrationConfiguration has no experimental field).
+	if didFieldChange(oldConfiguration, newConfiguration, stallDetectorAccessor) {
+		sdField := sourceField.Child("experimental", "stallDetector")
+		if newConfiguration.ExperimentalMigrationOptions != nil &&
+			newConfiguration.ExperimentalMigrationOptions.StallDetector != nil {
+			sd := newConfiguration.ExperimentalMigrationOptions.StallDetector
+			if !featuregate.IsEnabled(featuregate.MigrationStallDetection, devConfig) {
+				causes = append(causes, metav1.StatusCause{
+					Type:    metav1.CauseTypeFieldValueInvalid,
+					Field:   sdField.String(),
+					Message: fmt.Sprintf("experimental.stallDetector cannot be set without enabling the %s feature gate", featuregate.MigrationStallDetection),
+				})
+			}
+			causes = append(causes, validateStallDetectorFactor(sdField.Child("ewmaAlpha"), sd.EwmaAlpha, 0, 1, true)...)
+			causes = append(causes, validateStallDetectorFactor(sdField.Child("precopyPossibleFactor"), sd.PrecopyPossibleFactor, 1, math.MaxFloat64, false)...)
+			causes = append(causes, validateStallDetectorFactor(sdField.Child("patienceWindowDecayFactor"), sd.PatienceWindowDecayFactor, 0, 1, false)...)
+			causes = append(causes, validateStallDetectorFactor(sdField.Child("completionTimeoutFactor"), sd.CompletionTimeoutFactor, 1, math.MaxFloat64, false)...)
+		}
+	}
+
+	return causes
+}
+
+func stallDetectorAccessor(c *v1.VMIMConfigurationOptions) any {
+	if c == nil || c.ExperimentalMigrationOptions == nil {
+		return nil
+	}
+	return c.ExperimentalMigrationOptions.StallDetector
+}
+
+func didFieldChange(
+	oldConfig *v1.VMIMConfigurationOptions,
+	newConfig *v1.VMIMConfigurationOptions,
+	accessor func(*v1.VMIMConfigurationOptions) any,
+) bool {
+	if oldConfig == nil {
+		return true
+	}
+	return !equality.Semantic.DeepEqual(accessor(oldConfig), accessor(newConfig))
+}
+
+// validateStallDetectorFactor validates a string-encoded floating-point stall
+// detector factor field. exclusiveMin=true enforces factor > 0 (ignores min).
+func validateStallDetectorFactor(field *k8sfield.Path, value *string, min, max float64, exclusiveMin bool) []metav1.StatusCause {
+	if value == nil {
+		return nil
+	}
+
+	factor, err := virtconfig.ParseFactor(*value, virtconfig.StallDetectorFactorPrecision)
+	if err != nil {
+		return []metav1.StatusCause{{
+			Type:    metav1.CauseTypeFieldValueInvalid,
+			Message: err.Error(),
+			Field:   field.String(),
+		}}
+	}
+
+	if exclusiveMin {
+		if factor <= 0 {
+			return []metav1.StatusCause{{
+				Type:    metav1.CauseTypeFieldValueInvalid,
+				Message: "must be greater than 0",
+				Field:   field.String(),
+			}}
+		}
+	} else if factor < min {
+		return []metav1.StatusCause{{
+			Type:    metav1.CauseTypeFieldValueInvalid,
+			Message: fmt.Sprintf("must be greater than or equal to %g", min),
+			Field:   field.String(),
+		}}
+	}
+
+	if factor > max {
+		return []metav1.StatusCause{{
+			Type:    metav1.CauseTypeFieldValueInvalid,
+			Message: fmt.Sprintf("must be less than or equal to %g", max),
+			Field:   field.String(),
+		}}
+	}
+
+	return nil
+}

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/migrationpolicy-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/migrationpolicy-admitter.go
@@ -23,19 +23,16 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"math"
 
 	admissionv1 "k8s.io/api/admission/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
-
+	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/api/migrations"
 	migrationsv1 "kubevirt.io/api/migrations/v1alpha1"
 
+	migrationutils "kubevirt.io/kubevirt/pkg/util/migrations"
 	webhookutils "kubevirt.io/kubevirt/pkg/util/webhooks"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
-	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 )
 
 // MigrationPolicyAdmitter validates MigrationPolicy resources
@@ -58,151 +55,43 @@ func (admitter *MigrationPolicyAdmitter) Admit(_ context.Context, ar *admissionv
 	}
 
 	policy := &migrationsv1.MigrationPolicy{}
-	err := json.Unmarshal(ar.Request.Object.Raw, policy)
-	if err != nil {
+	if err := json.Unmarshal(ar.Request.Object.Raw, policy); err != nil {
 		return webhookutils.ToAdmissionResponseError(err)
 	}
 
-	var causes []metav1.StatusCause
+	var oldOptions *v1.VMIMConfigurationOptions
+	if ar.Request.OldObject.Raw != nil {
+		oldPolicy := &migrationsv1.MigrationPolicy{}
+		if err := json.Unmarshal(ar.Request.OldObject.Raw, oldPolicy); err != nil {
+			return webhookutils.ToAdmissionResponseError(err)
+		}
+		oldOptions = policySpecToOptions(&oldPolicy.Spec)
+	}
 
+	newOptions := policySpecToOptions(&policy.Spec)
 	sourceField := k8sfield.NewPath("spec")
-
-	spec := policy.Spec
-	if spec.CompletionTimeoutPerGiB != nil && *spec.CompletionTimeoutPerGiB < 0 {
-		causes = append(causes, metav1.StatusCause{
-			Type:    metav1.CauseTypeFieldValueInvalid,
-			Message: "must not be negative",
-			Field:   sourceField.Child("completionTimeoutPerGiB").String(),
-		})
-	}
-	if spec.MaxDowntimeMs != nil {
-		var oldMaxDowntimeMs *uint64
-		if ar.Request.OldObject.Raw != nil {
-			oldPolicy := &migrationsv1.MigrationPolicy{}
-			if err := json.Unmarshal(ar.Request.OldObject.Raw, oldPolicy); err == nil {
-				oldMaxDowntimeMs = oldPolicy.Spec.MaxDowntimeMs
-			}
-		}
-		if !equality.Semantic.DeepEqual(oldMaxDowntimeMs, spec.MaxDowntimeMs) &&
-			!admitter.clusterConfig.MigrationStallDetectionEnabled() {
-			causes = append(causes, metav1.StatusCause{
-				Type:    metav1.CauseTypeFieldValueInvalid,
-				Message: fmt.Sprintf("maxDowntimeMs cannot be modified without enabling the %s feature gate", featuregate.MigrationStallDetection),
-				Field:   sourceField.Child("maxDowntimeMs").String(),
-			})
-		}
-	}
-
-	if spec.ExperimentalMigrationOptions != nil && spec.ExperimentalMigrationOptions.StallDetector != nil {
-		var oldStallDetector any
-		if ar.Request.OldObject.Raw != nil {
-			oldPolicy := &migrationsv1.MigrationPolicy{}
-			if err := json.Unmarshal(ar.Request.OldObject.Raw, oldPolicy); err == nil {
-				if oldPolicy.Spec.ExperimentalMigrationOptions != nil {
-					oldStallDetector = oldPolicy.Spec.ExperimentalMigrationOptions.StallDetector
-				}
-			}
-		}
-		if !equality.Semantic.DeepEqual(oldStallDetector, spec.ExperimentalMigrationOptions.StallDetector) &&
-			!admitter.clusterConfig.MigrationStallDetectionEnabled() {
-			causes = append(causes, metav1.StatusCause{
-				Type:    metav1.CauseTypeFieldValueInvalid,
-				Message: fmt.Sprintf("experimental.stallDetector cannot be modified without enabling the %s feature gate", featuregate.MigrationStallDetection),
-				Field:   sourceField.Child("experimental", "stallDetector").String(),
-			})
-		}
-
-		stallDetectorField := sourceField.Child("experimental", "stallDetector")
-		sd := spec.ExperimentalMigrationOptions.StallDetector
-		causes = append(causes, validateStallDetectorFactor(
-			stallDetectorField.Child("ewmaAlpha"),
-			sd.EwmaAlpha,
-			0, 1,
-			true,
-		)...)
-		causes = append(causes, validateStallDetectorFactor(
-			stallDetectorField.Child("precopyPossibleFactor"),
-			sd.PrecopyPossibleFactor,
-			1, math.MaxFloat64,
-			false,
-		)...)
-		causes = append(causes, validateStallDetectorFactor(
-			stallDetectorField.Child("patienceWindowDecayFactor"),
-			sd.PatienceWindowDecayFactor,
-			0, 1,
-			false,
-		)...)
-		causes = append(causes, validateStallDetectorFactor(
-			stallDetectorField.Child("completionTimeoutFactor"),
-			sd.CompletionTimeoutFactor,
-			1, math.MaxFloat64,
-			false,
-		)...)
-	}
-
-	if spec.BandwidthPerMigration != nil {
-		quantity, ok := spec.BandwidthPerMigration.AsInt64()
-		if !ok {
-			dec := spec.BandwidthPerMigration.AsDec()
-			quantity = int64(dec.Sign())
-		}
-
-		if quantity < 0 {
-			causes = append(causes, metav1.StatusCause{
-				Type:    metav1.CauseTypeFieldValueInvalid,
-				Message: "must not be negative",
-				Field:   sourceField.Child("bandwidthPerMigration").String(),
-			})
-		}
-	}
+	causes := migrationutils.ValidateMigrationConfigurationOptions(
+		sourceField,
+		oldOptions,
+		newOptions,
+		admitter.clusterConfig.GetConfig().DeveloperConfiguration,
+	)
 
 	if len(causes) > 0 {
 		return webhookutils.ToAdmissionResponse(causes)
 	}
 
-	reviewResponse := admissionv1.AdmissionResponse{
-		Allowed: true,
-	}
-	return &reviewResponse
+	return &admissionv1.AdmissionResponse{Allowed: true}
 }
 
-func validateStallDetectorFactor(field *k8sfield.Path, value *string, min, max float64, exclusiveMin bool) []metav1.StatusCause {
-	if value == nil {
-		return nil
+func policySpecToOptions(spec *migrationsv1.MigrationPolicySpec) *v1.VMIMConfigurationOptions {
+	return &v1.VMIMConfigurationOptions{
+		AllowAutoConverge:            spec.AllowAutoConverge,
+		BandwidthPerMigration:        spec.BandwidthPerMigration,
+		CompletionTimeoutPerGiB:      spec.CompletionTimeoutPerGiB,
+		MaxDowntimeMs:                spec.MaxDowntimeMs,
+		AllowPostCopy:                spec.AllowPostCopy,
+		AllowWorkloadDisruption:      spec.AllowWorkloadDisruption,
+		ExperimentalMigrationOptions: spec.ExperimentalMigrationOptions,
 	}
-
-	factor, err := virtconfig.ParseFactor(*value, virtconfig.StallDetectorFactorPrecision)
-	if err != nil {
-		return []metav1.StatusCause{{
-			Type:    metav1.CauseTypeFieldValueInvalid,
-			Message: err.Error(),
-			Field:   field.String(),
-		}}
-	}
-
-	if exclusiveMin {
-		if factor <= 0 {
-			return []metav1.StatusCause{{
-				Type:    metav1.CauseTypeFieldValueInvalid,
-				Message: "must be greater than 0",
-				Field:   field.String(),
-			}}
-		}
-	} else if factor < min {
-		return []metav1.StatusCause{{
-			Type:    metav1.CauseTypeFieldValueInvalid,
-			Message: fmt.Sprintf("must be greater than or equal to %g", min),
-			Field:   field.String(),
-		}}
-	}
-
-	if factor > max {
-		return []metav1.StatusCause{{
-			Type:    metav1.CauseTypeFieldValueInvalid,
-			Message: fmt.Sprintf("must be less than or equal to %g", max),
-			Field:   field.String(),
-		}}
-	}
-
-	return nil
 }

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/migrationpolicy-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/migrationpolicy-admitter_test.go
@@ -134,6 +134,13 @@ var _ = Describe("Validating MigrationPolicy Admitter", func() {
 				},
 			},
 		),
+
+		Entry("allowPostCopy true and allowWorkloadDisruption false",
+			migrationsv1.MigrationPolicySpec{
+				AllowPostCopy:           pointer.P(true),
+				AllowWorkloadDisruption: pointer.P(false),
+			},
+		),
 	)
 
 	DescribeTable("should accept migration policy with", func(policySpec migrationsv1.MigrationPolicySpec) {
@@ -184,6 +191,19 @@ var _ = Describe("Validating MigrationPolicy Admitter", func() {
 						PrecopyPossibleFactor: pointer.P("2"),
 					},
 				},
+			},
+		),
+
+		Entry("allowPostCopy true and allowWorkloadDisruption true",
+			migrationsv1.MigrationPolicySpec{
+				AllowPostCopy:           pointer.P(true),
+				AllowWorkloadDisruption: pointer.P(true),
+			},
+		),
+
+		Entry("allowPostCopy true and allowWorkloadDisruption nil",
+			migrationsv1.MigrationPolicySpec{
+				AllowPostCopy: pointer.P(true),
 			},
 		),
 
@@ -258,6 +278,47 @@ var _ = Describe("Validating MigrationPolicy Admitter", func() {
 		Entry("reject changing value on update", true,
 			&v1.StallDetectorOptions{StallMargin: pointer.P(int64(4))},
 			&v1.StallDetectorOptions{StallMargin: pointer.P(int64(8))},
+			false,
+		),
+	)
+
+	DescribeTable("allowPostCopy + allowWorkloadDisruption ratcheting on update",
+		func(oldSpec, newSpec migrationsv1.MigrationPolicySpec, expectAllowed bool) {
+			oldPolicy := kubecli.NewMinimalMigrationPolicy(policyName)
+			oldPolicy.Spec = oldSpec
+			newPolicy := kubecli.NewMinimalMigrationPolicy(policyName)
+			newPolicy.Spec = newSpec
+			admitter.admitUpdateAndExpect(oldPolicy, newPolicy, expectAllowed)
+		},
+		Entry("grandfather invalid combo when unrelated field changes",
+			migrationsv1.MigrationPolicySpec{
+				AllowPostCopy:           pointer.P(true),
+				AllowWorkloadDisruption: pointer.P(false),
+			},
+			migrationsv1.MigrationPolicySpec{
+				AllowPostCopy:           pointer.P(true),
+				AllowWorkloadDisruption: pointer.P(false),
+				CompletionTimeoutPerGiB: pointer.P(int64(120)),
+			},
+			true,
+		),
+		Entry("allow correcting invalid combo to valid",
+			migrationsv1.MigrationPolicySpec{
+				AllowPostCopy:           pointer.P(true),
+				AllowWorkloadDisruption: pointer.P(false),
+			},
+			migrationsv1.MigrationPolicySpec{
+				AllowPostCopy:           pointer.P(true),
+				AllowWorkloadDisruption: pointer.P(true),
+			},
+			true,
+		),
+		Entry("reject introducing invalid combo on update",
+			migrationsv1.MigrationPolicySpec{},
+			migrationsv1.MigrationPolicySpec{
+				AllowPostCopy:           pointer.P(true),
+				AllowWorkloadDisruption: pointer.P(false),
+			},
 			false,
 		),
 	)

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/migrationpolicy-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/migrationpolicy-admitter_test.go
@@ -22,6 +22,7 @@ package admitters
 import (
 	"context"
 	"encoding/json"
+	"reflect"
 
 	"k8s.io/apimachinery/pkg/api/resource"
 
@@ -150,7 +151,6 @@ var _ = Describe("Validating MigrationPolicy Admitter", func() {
 		Entry("greater than zero CompletionTimeoutPerGiB",
 			migrationsv1.MigrationPolicySpec{CompletionTimeoutPerGiB: pointer.P(int64(1))},
 		),
-
 		Entry("zero CompletionTimeoutPerGiB",
 			migrationsv1.MigrationPolicySpec{CompletionTimeoutPerGiB: pointer.P(int64(0))},
 		),
@@ -182,6 +182,20 @@ var _ = Describe("Validating MigrationPolicy Admitter", func() {
 				ExperimentalMigrationOptions: &v1.ExperimentalMigrationOptions{
 					StallDetector: &v1.StallDetectorOptions{
 						PrecopyPossibleFactor: pointer.P("2"),
+					},
+				},
+			},
+		),
+
+		Entry("valid experimental options",
+			migrationsv1.MigrationPolicySpec{
+				ExperimentalMigrationOptions: &v1.ExperimentalMigrationOptions{
+					StallDetector: &v1.StallDetectorOptions{
+						StallMargin:               pointer.P(int64(4)),
+						EwmaAlpha:                 pointer.P("0.4"),
+						PatienceWindowDecayFactor: pointer.P("0.5"),
+						PrecopyPossibleFactor:     pointer.P("1.5"),
+						CompletionTimeoutFactor:   pointer.P("2"),
 					},
 				},
 			},
@@ -247,6 +261,15 @@ var _ = Describe("Validating MigrationPolicy Admitter", func() {
 			false,
 		),
 	)
+
+	It("policySpecToOptions maps every MigrationPolicySpec field", func() {
+		src := testutils.WithAllFieldsSet(reflect.TypeOf(migrationsv1.MigrationPolicySpec{})).(*migrationsv1.MigrationPolicySpec)
+		oracle := testutils.CopyByJSONTag(src, reflect.TypeOf(v1.VMIMConfigurationOptions{})).(*v1.VMIMConfigurationOptions)
+
+		got := policySpecToOptions(src)
+
+		Expect(*got).To(BeComparableTo(*oracle))
+	})
 
 })
 

--- a/pkg/virt-operator/webhooks/BUILD.bazel
+++ b/pkg/virt-operator/webhooks/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/pointer:go_default_library",
+        "//pkg/util/migrations:go_default_library",
         "//pkg/util/tls:go_default_library",
         "//pkg/util/webhooks:go_default_library",
         "//pkg/util/webhooks/validating-webhooks:go_default_library",
@@ -44,6 +45,7 @@ go_test(
         "//pkg/apimachinery/patch:go_default_library",
         "//pkg/pointer:go_default_library",
         "//pkg/testutils:go_default_library",
+        "//pkg/util/migrations:go_default_library",
         "//pkg/virt-config/featuregate:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
@@ -54,6 +56,7 @@ go_test(
         "//vendor/go.uber.org/mock/gomock:go_default_library",
         "//vendor/k8s.io/api/admission/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",

--- a/pkg/virt-operator/webhooks/kubevirt-update-admitter.go
+++ b/pkg/virt-operator/webhooks/kubevirt-update-admitter.go
@@ -45,6 +45,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 
 	"kubevirt.io/kubevirt/pkg/pointer"
+	migrationutils "kubevirt.io/kubevirt/pkg/util/migrations"
 	webhookutils "kubevirt.io/kubevirt/pkg/util/webhooks"
 	validating_webhooks "kubevirt.io/kubevirt/pkg/util/webhooks/validating-webhooks"
 	"kubevirt.io/kubevirt/pkg/virt-operator/resource/apply"
@@ -82,10 +83,20 @@ func (admitter *KubeVirtUpdateAdmitter) Admit(ctx context.Context, ar *admission
 	results = append(results, validateGuestToRequestHeadroom(newKV.Spec.Configuration.AdditionalGuestMemoryOverheadRatio)...)
 	results = append(results, validateVirtTemplateDeployment(&newKV.Spec.Configuration)...)
 	results = append(results, validateRoleAggregationStrategy(&newKV.Spec.Configuration)...)
-	results = append(results, validateMigrationConfiguration(
-		&currKV.Spec.Configuration,
-		&newKV.Spec.Configuration,
-	)...)
+
+	if newKV.Spec.Configuration.MigrationConfiguration != nil {
+		sourceConfig := field.NewPath("spec").Child("configuration", "migrationConfiguration")
+		var oldMigrationOptions *v1.VMIMConfigurationOptions
+		if currKV != nil && currKV.Spec.Configuration.MigrationConfiguration != nil {
+			oldMigrationOptions = migrationutils.ToVMIMConfigurationOptions(currKV.Spec.Configuration.MigrationConfiguration)
+		}
+		results = append(results, migrationutils.ValidateMigrationConfigurationOptions(
+			sourceConfig,
+			oldMigrationOptions,
+			migrationutils.ToVMIMConfigurationOptions(newKV.Spec.Configuration.MigrationConfiguration),
+			newKV.Spec.Configuration.DeveloperConfiguration,
+		)...)
+	}
 
 	if !equality.Semantic.DeepEqual(currKV.Spec.Configuration.TLSConfiguration, newKV.Spec.Configuration.TLSConfiguration) {
 		if newKV.Spec.Configuration.TLSConfiguration != nil {
@@ -566,30 +577,4 @@ func validateRoleAggregationStrategy(config *v1.KubeVirtConfiguration) []metav1.
 		Field:   "spec.configuration.roleAggregationStrategy",
 		Message: fmt.Sprintf("RoleAggregationStrategy cannot be set to Manual without enabling the %s feature gate", featuregate.OptOutRoleAggregation),
 	}}
-}
-
-func validateMigrationConfiguration(oldConfig, newConfig *v1.KubeVirtConfiguration) []metav1.StatusCause {
-	if newConfig.MigrationConfiguration == nil {
-		return nil
-	}
-
-	var causes []metav1.StatusCause
-	newMigrationConfig := newConfig.MigrationConfiguration
-
-	if newMigrationConfig.MaxDowntimeMs != nil {
-		var oldMaxDowntimeMs *uint64
-		if oldConfig.MigrationConfiguration != nil {
-			oldMaxDowntimeMs = oldConfig.MigrationConfiguration.MaxDowntimeMs
-		}
-		if !equality.Semantic.DeepEqual(oldMaxDowntimeMs, newMigrationConfig.MaxDowntimeMs) &&
-			!hasFeatureGateEnabled(newConfig, featuregate.MigrationStallDetection) {
-			causes = append(causes, metav1.StatusCause{
-				Type:    metav1.CauseTypeFieldValueInvalid,
-				Field:   "spec.configuration.migrationConfiguration.maxDowntimeMs",
-				Message: fmt.Sprintf("maxDowntimeMs cannot be modified without enabling the %s feature gate", featuregate.MigrationStallDetection),
-			})
-		}
-	}
-
-	return causes
 }

--- a/pkg/virt-operator/webhooks/kubevirt-update-admitter_test.go
+++ b/pkg/virt-operator/webhooks/kubevirt-update-admitter_test.go
@@ -28,6 +28,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	admissionv1 "k8s.io/api/admission/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -36,6 +37,7 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/pointer"
 	"kubevirt.io/kubevirt/pkg/testutils"
+	migrationutils "kubevirt.io/kubevirt/pkg/util/migrations"
 	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 )
 
@@ -163,50 +165,57 @@ var _ = Describe("Validating KubeVirtUpdate Admitter", func() {
 		),
 	)
 
-	DescribeTable("validateMigrationConfiguration", func(oldConfig, newConfig *v1.KubeVirtConfiguration, expectError bool) {
-		causes := validateMigrationConfiguration(oldConfig, newConfig)
-		if expectError {
-			Expect(causes).To(HaveLen(1))
+	DescribeTable("ValidateMigrationConfigurationOptions", func(
+		oldOptions *v1.VMIMConfigurationOptions,
+		newOptions *v1.VMIMConfigurationOptions,
+		devConfig *v1.DeveloperConfiguration,
+		expectedCauses int,
+		expectedField string,
+	) {
+		sourceField := field.NewPath("spec", "configuration", "migrationConfiguration")
+		causes := migrationutils.ValidateMigrationConfigurationOptions(sourceField, oldOptions, newOptions, devConfig)
+		Expect(causes).To(HaveLen(expectedCauses))
+		if expectedCauses > 0 {
 			Expect(causes[0].Type).To(Equal(metav1.CauseTypeFieldValueInvalid))
-			Expect(causes[0].Field).To(Equal("spec.configuration.migrationConfiguration.maxDowntimeMs"))
-		} else {
-			Expect(causes).To(BeEmpty())
+			Expect(causes[0].Field).To(Equal(sourceField.Child(expectedField).String()))
 		}
 	},
-		Entry("should reject when MaxDowntimeMs is newly set without feature gate",
-			&v1.KubeVirtConfiguration{},
-			&v1.KubeVirtConfiguration{
-				MigrationConfiguration: &v1.MigrationConfiguration{MaxDowntimeMs: pointer.P(uint64(900))},
-			},
-			true,
+		Entry("allow MaxDowntimeMs with feature gate enabled",
+			nil,
+			&v1.VMIMConfigurationOptions{MaxDowntimeMs: pointer.P(uint64(900))},
+			&v1.DeveloperConfiguration{FeatureGates: []string{featuregate.MigrationStallDetection}},
+			0, "",
 		),
-		Entry("should allow when MaxDowntimeMs is set with feature gate",
-			&v1.KubeVirtConfiguration{},
-			&v1.KubeVirtConfiguration{
-				MigrationConfiguration: &v1.MigrationConfiguration{MaxDowntimeMs: pointer.P(uint64(900))},
-				DeveloperConfiguration: &v1.DeveloperConfiguration{
-					FeatureGates: []string{featuregate.MigrationStallDetection},
-				},
-			},
-			false,
+		Entry("grandfather unchanged MaxDowntimeMs when feature gate is disabled",
+			&v1.VMIMConfigurationOptions{MaxDowntimeMs: pointer.P(uint64(900))},
+			&v1.VMIMConfigurationOptions{MaxDowntimeMs: pointer.P(uint64(900))},
+			nil,
+			0, "",
 		),
-		Entry("should allow unrelated update when MaxDowntimeMs is unchanged and feature gate is disabled",
-			&v1.KubeVirtConfiguration{
-				MigrationConfiguration: &v1.MigrationConfiguration{MaxDowntimeMs: pointer.P(uint64(900))},
-			},
-			&v1.KubeVirtConfiguration{
-				MigrationConfiguration: &v1.MigrationConfiguration{MaxDowntimeMs: pointer.P(uint64(900))},
-			},
-			false,
+		Entry("reject changing MaxDowntimeMs when feature gate is disabled",
+			&v1.VMIMConfigurationOptions{MaxDowntimeMs: pointer.P(uint64(500))},
+			&v1.VMIMConfigurationOptions{MaxDowntimeMs: pointer.P(uint64(900))},
+			nil,
+			1, "maxDowntimeMs",
 		),
-		Entry("should reject changing MaxDowntimeMs when feature gate is disabled",
-			&v1.KubeVirtConfiguration{
-				MigrationConfiguration: &v1.MigrationConfiguration{MaxDowntimeMs: pointer.P(uint64(500))},
-			},
-			&v1.KubeVirtConfiguration{
-				MigrationConfiguration: &v1.MigrationConfiguration{MaxDowntimeMs: pointer.P(uint64(900))},
-			},
-			true,
+
+		Entry("grandfather unchanged negative CompletionTimeoutPerGiB",
+			&v1.VMIMConfigurationOptions{CompletionTimeoutPerGiB: pointer.P(int64(-1))},
+			&v1.VMIMConfigurationOptions{CompletionTimeoutPerGiB: pointer.P(int64(-1))},
+			nil,
+			0, "",
+		),
+		Entry("grandfather unchanged negative ProgressTimeout",
+			&v1.VMIMConfigurationOptions{ProgressTimeout: pointer.P(int64(-1))},
+			&v1.VMIMConfigurationOptions{ProgressTimeout: pointer.P(int64(-1))},
+			nil,
+			0, "",
+		),
+		Entry("grandfather unchanged negative BandwidthPerMigration",
+			&v1.VMIMConfigurationOptions{BandwidthPerMigration: resource.NewScaledQuantity(-123, 1)},
+			&v1.VMIMConfigurationOptions{BandwidthPerMigration: resource.NewScaledQuantity(-123, 1)},
+			nil,
+			0, "",
 		),
 	)
 


### PR DESCRIPTION
### What this PR does

The primary functional addition in this PR is that we now reject configurations that set:
AllowPostCopy=true
AllowWorkloadDisruption=false

This makes sense because currently we require both AllowPostCopy to AllowWorkloadDisruptions to be true in order to use post copy.

Move shared migration validation into pkg/util/migrations and use it from the MigrationPolicy and KubeVirt update webhooks. Validate only changed fields on update so existing configurations are not rejected when rules evolve. Gate experimental.stallDetector on the MigrationStallDetection feature gate.

#### Before this PR:
* `AllowPostCopy=true` and `AllowWorkloadDisruption=false` was accepted but the `AllowPostCopy=true` was silently ignored leaving some users to wonder why post copy didn't work.
* If user only set `AllowPostCopy=true` with no explicit value for `AllowWorkloadDisruption`, we implicitly updated `AllowWorkloadDisruption` to true.

#### After this PR:
* Preserved implicit behavior of upgrading `AllowWorkloadDisruption` to true if it is unset and is explicitly set `AllowPostCopy=true`.
* Reject `AllowPostCopy=true` and `AllowWorkloadDisruption=false` as invalid
* Preserve backward compatibility by only rejecting configuration changes if they actively modify relevant fields. This means if a cluster had an "invalid config" before upgrade, and after upgrade the attempt to modify `completionTimeoutPerGiB=42`, we **won't** block changes since `completionTimeoutPerGiB` is an irrelevant field. This is called Validation Ratcheting.
* Overall, restructuring of migration validations with shared logic between Kubevirt CR and MigrationPolicy avoiding duplication.
* Expanded Validation Ratcheting to existing fields that we validate just for consistency. This also allows us to change validation criteria in the future without risking "freezing" the entire CRD object from modifications.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
* Side note: the validation ratcheting approach is consistent with how kubebuilder validations are supposed to function.
* Known gap: there is a related pre-existing gap on the ratcheting logic in kubebuilder where existing webhook admitters against the CR call webhookutils.ValidateSchema to validate kubebuilder validations. But this added validation, while useful for unit tests, don't support ratcheting logic for validations added via kubebuilder. This should be addressed in a followup.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Improved validation for migration config: Reject AllowPostCopy=true and AllowWorkloadDisruption=false as invalid
```

