### PR TITLE
fix(repeated_test.sh): cluster-down must not fail

### DIFF
--- a/automation/repeated_test.sh
+++ b/automation/repeated_test.sh
@@ -201,7 +201,7 @@ fi
 # TODO: check whether no test with label `RequiresTwoWorkerNodesWithCPUManager` is present, in that case use two nodes
 KUBEVIRT_NUM_NODES=3
 
-trap '{ make cluster-down; }' EXIT SIGINT SIGTERM
+trap '{ make cluster-down || true; }' EXIT SIGINT SIGTERM
 
 # Give the nodes enough memory to run tests in parallel, including tests which involve fedora
 export KUBEVIRT_MEMORY_SIZE='9216M'


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:

`cluster-down` is actually a cleanup mechanism - similar to what is being done in hack/dockerized. In CI `podman` suffers from being unable to remove containers every now and then [1] inside the repeated_test.sh script. Failing the build for that reason is especially tragic when being run inside a batch.

[1]: https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/batch/pull-kubevirt-check-tests-for-flakes/2072684400146911232#1:build-log.txt%3A4784
#### After this PR:

We avoid letting cluster-down fail the build to conserve the test results. Reasoning here is that the result of the repeated testing is more valuable that seeing a failed cleanup.

See also:
* https://github.com/kubevirt/kubevirt/blob/7f6aafda23840435042a54afe29873b6a7c4341b/hack/dockerized#L91
* https://github.com/kubevirt/kubevirt/blob/added5c7aecca0791553d2416355f8bdbebf8cbd/automation/test.sh#L355

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

