### PR TITLE
validator: fix incorrect path for maxDowntimeMs field validation

### DIFF
--- a/pkg/virt-operator/webhooks/kubevirt-update-admitter.go
+++ b/pkg/virt-operator/webhooks/kubevirt-update-admitter.go
@@ -585,7 +585,7 @@ func validateMigrationConfiguration(oldConfig, newConfig *v1.KubeVirtConfigurati
 			!hasFeatureGateEnabled(newConfig, featuregate.MigrationStallDetection) {
 			causes = append(causes, metav1.StatusCause{
 				Type:    metav1.CauseTypeFieldValueInvalid,
-				Field:   "spec.configuration.migrations.maxDowntimeMs",
+				Field:   "spec.configuration.migrationConfiguration.maxDowntimeMs",
 				Message: fmt.Sprintf("maxDowntimeMs cannot be modified without enabling the %s feature gate", featuregate.MigrationStallDetection),
 			})
 		}

--- a/pkg/virt-operator/webhooks/kubevirt-update-admitter_test.go
+++ b/pkg/virt-operator/webhooks/kubevirt-update-admitter_test.go
@@ -168,7 +168,7 @@ var _ = Describe("Validating KubeVirtUpdate Admitter", func() {
 		if expectError {
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Type).To(Equal(metav1.CauseTypeFieldValueInvalid))
-			Expect(causes[0].Field).To(Equal("spec.configuration.migrations.maxDowntimeMs"))
+			Expect(causes[0].Field).To(Equal("spec.configuration.migrationConfiguration.maxDowntimeMs"))
 		} else {
 			Expect(causes).To(BeEmpty())
 		}


### PR DESCRIPTION
### What this PR does
This hotfix is mostly cosmetic where when field validation failed, it would previously report an incorrect path for the offending field.

Would be good to also backport it.

VEP: https://github.com/kubevirt/enhancements/issues/248