### PR TITLE
fix: replace errors.New(fmt.Sprintf()) with fmt.Errorf

### DIFF
--- a/pkg/ignition/ignition.go
+++ b/pkg/ignition/ignition.go
@@ -20,7 +20,6 @@
 package ignition
 
 import (
-	"errors"
 	"fmt"
 
 	v1 "kubevirt.io/api/core/v1"
@@ -43,14 +42,14 @@ func GetIgnitionSource(vmi *v1.VirtualMachineInstance) string {
 func SetLocalDirectory(dir string) error {
 	err := util.MkdirAllWithNosec(dir)
 	if err != nil {
-		return errors.New(fmt.Sprintf("Unable to initialize Ignition local cache directory (%s). %v", dir, err))
+		return fmt.Errorf("Unable to initialize Ignition local cache directory (%s): %w", dir, err)
 	}
 
 	exists, err := diskutils.FileExists(dir)
 	if err != nil {
-		return errors.New(fmt.Sprintf("Ignition local cache directory (%s) does not exist or is inaccessible. %v", dir, err))
+		return fmt.Errorf("Ignition local cache directory (%s) does not exist or is inaccessible: %w", dir, err)
 	} else if exists == false {
-		return errors.New(fmt.Sprintf("Ignition local cache directory (%s) does not exist or is inaccessible.", dir))
+		return fmt.Errorf("Ignition local cache directory (%s) does not exist or is inaccessible", dir)
 	}
 
 	ignitionLocalDir = dir

--- a/pkg/virt-api/rest/dialers.go
+++ b/pkg/virt-api/rest/dialers.go
@@ -20,7 +20,6 @@
 package rest
 
 import (
-	"errors"
 	"fmt"
 	"net"
 
@@ -126,7 +125,7 @@ func (app *SubresourceAPIApp) getVirtHandlerFor(vmi *v1.VirtualMachineInstance, 
 
 func (app *SubresourceAPIApp) getVirtHandlerConnForVMI(vmi *v1.VirtualMachineInstance) (kubecli.VirtHandlerConn, error) {
 	if !vmi.IsRunning() && !vmi.IsScheduled() {
-		return nil, errors.New(fmt.Sprintf("Unable to connect to VirtualMachineInstance because phase is %s instead of %s or %s", vmi.Status.Phase, v1.Running, v1.Scheduled))
+		return nil, fmt.Errorf("Unable to connect to VirtualMachineInstance because phase is %s instead of %s or %s", vmi.Status.Phase, v1.Running, v1.Scheduled)
 	}
 	return kubecli.NewVirtHandlerClient(app.virtCli, app.handlerHttpClient).Port(app.consoleServerPort).ForNode(vmi.Status.NodeName), nil
 }


### PR DESCRIPTION
### What this PR does
#### Before this PR:
Several error constructions use the `errors.New(fmt.Sprintf(...))` pattern, which prevents error wrapping with %w.

#### After this PR:
These are replaced with `fmt.Errorf`, enabling proper error wrapping where an underlying error exists.

### Why we need it and why it was done in this way
`fmt.Errorf` with `%w` enables `errors.Is` and `errors.As` to work correctly on wrapped errors.

### Checklist
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)

```release-note
NONE
```