### PR TITLE
pkg/instancetype/infer: refactor label threading into volumeHandler

### DIFF
--- a/pkg/instancetype/infer/handler.go
+++ b/pkg/instancetype/infer/handler.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 
 	virtv1 "kubevirt.io/api/core/v1"
-	api "kubevirt.io/api/instancetype"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
 )
@@ -30,12 +29,14 @@ import (
 const logVerbosityLevel = 3
 
 type handler struct {
-	virtClient kubecli.KubevirtClient
+	instancetypeHandler *volumeHandler
+	preferenceHandler   *volumeHandler
 }
 
 func New(virtClient kubecli.KubevirtClient) *handler {
 	return &handler{
-		virtClient: virtClient,
+		instancetypeHandler: newInstancetypeVolumeHandler(virtClient),
+		preferenceHandler:   newPreferenceVolumeHandler(virtClient),
 	}
 }
 
@@ -63,8 +64,7 @@ func (h *handler) Instancetype(vm *virtv1.VirtualMachine) error {
 	}
 
 	ignoreFailure := shouldIgnoreFailure(vm.Spec.Instancetype.InferFromVolumeFailurePolicy)
-	defaultName, defaultKind, err := h.fromVolumes(
-		vm, vm.Spec.Instancetype.InferFromVolume, api.DefaultInstancetypeLabel, api.DefaultInstancetypeKindLabel)
+	defaultName, defaultKind, err := h.instancetypeHandler.fromVolumes(vm)
 	if err != nil {
 		var ignoreableInferenceErr *IgnoreableInferenceError
 		if errors.As(err, &ignoreableInferenceErr) && ignoreFailure {
@@ -96,8 +96,7 @@ func (h *handler) Preference(vm *virtv1.VirtualMachine) error {
 	}
 
 	ignoreFailure := shouldIgnoreFailure(vm.Spec.Preference.InferFromVolumeFailurePolicy)
-	defaultName, defaultKind, err := h.fromVolumes(
-		vm, vm.Spec.Preference.InferFromVolume, api.DefaultPreferenceLabel, api.DefaultPreferenceKindLabel)
+	defaultName, defaultKind, err := h.preferenceHandler.fromVolumes(vm)
 	if err != nil {
 		var ignoreableInferenceErr *IgnoreableInferenceError
 		if errors.As(err, &ignoreableInferenceErr) && ignoreFailure {

--- a/pkg/instancetype/infer/volume.go
+++ b/pkg/instancetype/infer/volume.go
@@ -28,6 +28,8 @@ import (
 	cdiv1beta1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
 	virtv1 "kubevirt.io/api/core/v1"
+	api "kubevirt.io/api/instancetype"
+	"kubevirt.io/client-go/kubecli"
 )
 
 const (
@@ -38,6 +40,35 @@ const (
 	missingDataSourceSource           = "unable to infer defaults from DataSource that doesn't provide " +
 		"DataVolumeSourcePVC or DataVolumeSourceSnapshot"
 )
+
+type volumeHandler struct {
+	virtClient          kubecli.KubevirtClient
+	defaultNameLabel    string
+	defaultKindLabel    string
+	inferFromVolumeName func(*virtv1.VirtualMachine) string
+}
+
+func newInstancetypeVolumeHandler(virtClient kubecli.KubevirtClient) *volumeHandler {
+	return &volumeHandler{
+		virtClient:       virtClient,
+		defaultNameLabel: api.DefaultInstancetypeLabel,
+		defaultKindLabel: api.DefaultInstancetypeKindLabel,
+		inferFromVolumeName: func(vm *virtv1.VirtualMachine) string {
+			return vm.Spec.Instancetype.InferFromVolume
+		},
+	}
+}
+
+func newPreferenceVolumeHandler(virtClient kubecli.KubevirtClient) *volumeHandler {
+	return &volumeHandler{
+		virtClient:       virtClient,
+		defaultNameLabel: api.DefaultPreferenceLabel,
+		defaultKindLabel: api.DefaultPreferenceKindLabel,
+		inferFromVolumeName: func(vm *virtv1.VirtualMachine) string {
+			return vm.Spec.Preference.InferFromVolume
+		},
+	}
+}
 
 /*
 Defaults will be inferred from the following combinations of DataVolumeSources, DataVolumeTemplates, DataSources, PVCs and VolumeSnapshots:
@@ -55,53 +86,54 @@ Volume -> DataVolumeSource -> DataVolumeTemplate -> DataVolumeSourceRef -> DataS
 Volume -> DataVolumeSource -> DataVolumeTemplate -> DataVolumeSourceRef -> DataSource -> PersistentVolumeClaim
 Volume -> DataVolumeSource -> DataVolumeTemplate -> DataVolumeSourceRef -> DataSource -> VolumeSnapshot
 */
-func (h *handler) fromVolumes(
-	vm *virtv1.VirtualMachine, inferFromVolumeName, defaultNameLabel, defaultKindLabel string,
+func (h *volumeHandler) fromVolumes(
+	vm *virtv1.VirtualMachine,
 ) (defaultName, defaultKind string, err error) {
+	inferFromVolumeName := h.inferFromVolumeName(vm)
 	for _, volume := range vm.Spec.Template.Spec.Volumes {
 		if volume.Name != inferFromVolumeName {
 			continue
 		}
 		if volume.PersistentVolumeClaim != nil {
-			return h.fromPVC(volume.PersistentVolumeClaim.ClaimName, vm.Namespace, defaultNameLabel, defaultKindLabel)
+			return h.fromPVC(volume.PersistentVolumeClaim.ClaimName, vm.Namespace)
 		}
 		if volume.DataVolume != nil {
-			return h.fromDataVolume(vm, volume.DataVolume.Name, defaultNameLabel, defaultKindLabel)
+			return h.fromDataVolume(vm, volume.DataVolume.Name)
 		}
 		return "", "", NewIgnoreableInferenceError(fmt.Errorf(unsupportedVolumeTypeFmt, inferFromVolumeName))
 	}
 	return "", "", fmt.Errorf("unable to find volume %s to infer defaults", inferFromVolumeName)
 }
 
-func fromLabels(labels map[string]string, defaultNameLabel, defaultKindLabel string) (defaultName, defaultKind string, err error) {
-	defaultName, hasLabel := labels[defaultNameLabel]
+func (h *volumeHandler) fromLabels(labels map[string]string) (defaultName, defaultKind string, err error) {
+	defaultName, hasLabel := labels[h.defaultNameLabel]
 	if !hasLabel {
-		return "", "", NewIgnoreableInferenceError(fmt.Errorf(missingLabelFmt, defaultNameLabel))
+		return "", "", NewIgnoreableInferenceError(fmt.Errorf(missingLabelFmt, h.defaultNameLabel))
 	}
-	return defaultName, labels[defaultKindLabel], nil
+	return defaultName, labels[h.defaultKindLabel], nil
 }
 
-func (h *handler) fromPVC(pvcName, pvcNamespace, defaultNameLabel, defaultKindLabel string) (defaultName, defaultKind string, err error) {
+func (h *volumeHandler) fromPVC(pvcName, pvcNamespace string) (defaultName, defaultKind string, err error) {
 	pvc, err := h.virtClient.CoreV1().PersistentVolumeClaims(pvcNamespace).Get(context.Background(), pvcName, metav1.GetOptions{})
 	if err != nil {
 		return "", "", err
 	}
-	return fromLabels(pvc.Labels, defaultNameLabel, defaultKindLabel)
+	return h.fromLabels(pvc.Labels)
 }
 
-func (h *handler) fromVolumeSnapshot(
-	snapshotName, snapshotNamespace, defaultNameLabel, defaultKindLabel string,
+func (h *volumeHandler) fromVolumeSnapshot(
+	snapshotName, snapshotNamespace string,
 ) (defaultName, defaultKind string, err error) {
 	snapshot, err := h.virtClient.KubernetesSnapshotClient().SnapshotV1().VolumeSnapshots(snapshotNamespace).Get(
 		context.Background(), snapshotName, metav1.GetOptions{})
 	if err != nil {
 		return "", "", err
 	}
-	return fromLabels(snapshot.Labels, defaultNameLabel, defaultKindLabel)
+	return h.fromLabels(snapshot.Labels)
 }
 
-func (h *handler) fromDataVolume(
-	vm *virtv1.VirtualMachine, dvName, defaultNameLabel, defaultKindLabel string,
+func (h *volumeHandler) fromDataVolume(
+	vm *virtv1.VirtualMachine, dvName string,
 ) (defaultName, defaultKind string, err error) {
 	if len(vm.Spec.DataVolumeTemplates) > 0 {
 		for _, dvt := range vm.Spec.DataVolumeTemplates {
@@ -109,46 +141,45 @@ func (h *handler) fromDataVolume(
 				continue
 			}
 			dvtSpec := dvt.Spec
-			return h.fromDataVolumeSpec(&dvtSpec, defaultNameLabel, defaultKindLabel, vm.Namespace)
+			return h.fromDataVolumeSpec(&dvtSpec, vm.Namespace)
 		}
 	}
 	dv, err := h.virtClient.CdiClient().CdiV1beta1().DataVolumes(vm.Namespace).Get(context.Background(), dvName, metav1.GetOptions{})
 	if err != nil {
 		// Handle garbage collected DataVolumes by attempting to lookup the PVC using the name of the DataVolume in the VM namespace
 		if k8serrors.IsNotFound(err) {
-			return h.fromPVC(dvName, vm.Namespace, defaultNameLabel, defaultKindLabel)
+			return h.fromPVC(dvName, vm.Namespace)
 		}
 		return "", "", err
 	}
 	// Check the DataVolume for any labels before checking the underlying PVC
-	defaultName, defaultKind, err = fromLabels(dv.Labels, defaultNameLabel, defaultKindLabel)
+	defaultName, defaultKind, err = h.fromLabels(dv.Labels)
 	if err == nil {
 		return defaultName, defaultKind, nil
 	}
-	return h.fromDataVolumeSpec(&dv.Spec, defaultNameLabel, defaultKindLabel, vm.Namespace)
+	return h.fromDataVolumeSpec(&dv.Spec, vm.Namespace)
 }
 
-func (h *handler) fromDataVolumeSpec(
-	dataVolumeSpec *cdiv1beta1.DataVolumeSpec, defaultNameLabel, defaultKindLabel, vmNameSpace string,
+func (h *volumeHandler) fromDataVolumeSpec(
+	dataVolumeSpec *cdiv1beta1.DataVolumeSpec, vmNameSpace string,
 ) (defaultName, defaultKind string, err error) {
 	if dataVolumeSpec != nil && dataVolumeSpec.Source != nil {
 		if dataVolumeSpec.Source.PVC != nil {
-			return h.fromPVC(dataVolumeSpec.Source.PVC.Name, dataVolumeSpec.Source.PVC.Namespace, defaultNameLabel, defaultKindLabel)
+			return h.fromPVC(dataVolumeSpec.Source.PVC.Name, dataVolumeSpec.Source.PVC.Namespace)
 		}
 		if dataVolumeSpec.Source.Snapshot != nil {
 			return h.fromVolumeSnapshot(
-				dataVolumeSpec.Source.Snapshot.Name, dataVolumeSpec.Source.Snapshot.Namespace,
-				defaultNameLabel, defaultKindLabel)
+				dataVolumeSpec.Source.Snapshot.Name, dataVolumeSpec.Source.Snapshot.Namespace)
 		}
 	}
 	if dataVolumeSpec != nil && dataVolumeSpec.SourceRef != nil {
-		return h.fromDataVolumeSourceRef(dataVolumeSpec.SourceRef, defaultNameLabel, defaultKindLabel, vmNameSpace)
+		return h.fromDataVolumeSourceRef(dataVolumeSpec.SourceRef, vmNameSpace)
 	}
 	return "", "", NewIgnoreableInferenceError(errors.New(unsupportedDataVolumeSource))
 }
 
-func (h *handler) fromDataSource(
-	dataSourceName, dataSourceNamespace, defaultNameLabel, defaultKindLabel string,
+func (h *volumeHandler) fromDataSource(
+	dataSourceName, dataSourceNamespace string,
 ) (defaultName, defaultKind string, err error) {
 	ds, err := h.virtClient.CdiClient().CdiV1beta1().DataSources(dataSourceNamespace).Get(
 		context.Background(), dataSourceName, metav1.GetOptions{})
@@ -156,21 +187,21 @@ func (h *handler) fromDataSource(
 		return "", "", err
 	}
 	// Check the DataSource for any labels before checking the underlying PVC
-	defaultName, defaultKind, err = fromLabels(ds.Labels, defaultNameLabel, defaultKindLabel)
+	defaultName, defaultKind, err = h.fromLabels(ds.Labels)
 	if err == nil {
 		return defaultName, defaultKind, nil
 	}
 	if ds.Spec.Source.PVC != nil {
-		return h.fromPVC(ds.Spec.Source.PVC.Name, ds.Spec.Source.PVC.Namespace, defaultNameLabel, defaultKindLabel)
+		return h.fromPVC(ds.Spec.Source.PVC.Name, ds.Spec.Source.PVC.Namespace)
 	}
 	if ds.Spec.Source.Snapshot != nil {
-		return h.fromVolumeSnapshot(ds.Spec.Source.Snapshot.Name, ds.Spec.Source.Snapshot.Namespace, defaultNameLabel, defaultKindLabel)
+		return h.fromVolumeSnapshot(ds.Spec.Source.Snapshot.Name, ds.Spec.Source.Snapshot.Namespace)
 	}
 	return "", "", NewIgnoreableInferenceError(errors.New(missingDataSourceSource))
 }
 
-func (h *handler) fromDataVolumeSourceRef(
-	sourceRef *cdiv1beta1.DataVolumeSourceRef, defaultNameLabel, defaultKindLabel, vmNameSpace string,
+func (h *volumeHandler) fromDataVolumeSourceRef(
+	sourceRef *cdiv1beta1.DataVolumeSourceRef, vmNameSpace string,
 ) (defaultName, defaultKind string, err error) {
 	if sourceRef.Kind == "DataSource" {
 		// The namespace can be left blank here with the assumption that the DataSource is in the same namespace as the VM
@@ -178,7 +209,7 @@ func (h *handler) fromDataVolumeSourceRef(
 		if sourceRef.Namespace != nil {
 			namespace = *sourceRef.Namespace
 		}
-		return h.fromDataSource(sourceRef.Name, namespace, defaultNameLabel, defaultKindLabel)
+		return h.fromDataSource(sourceRef.Name, namespace)
 	}
 	return "", "", NewIgnoreableInferenceError(fmt.Errorf(unsupportedDataVolumeSourceRefFmt, sourceRef.Kind))
 }


### PR DESCRIPTION
### What this PR does
#### Before this PR:

The `defaultNameLabel` and `defaultKindLabel` string parameters were threaded through every function in the volume inference call chain (`fromVolumes` → `fromPVC` → `fromDataVolume` → `fromDataVolumeSpec` → `fromDataSource` → `fromDataVolumeSourceRef` → `fromLabels`), along with the `inferFromVolumeName` string.

#### After this PR:

These values are stored on a `volumeHandler` struct, with separate constructors for instancetype and preference inference. The `handler` struct owns two `volumeHandler` instances and delegates to the appropriate one. This eliminates parameter threading and makes the call signatures cleaner.

### Why we need it and why it was done in this way
The following tradeoffs were made:
- A function field (`inferFromVolumeName`) is used on `volumeHandler` to extract the volume name from the VM spec, since the instancetype and preference paths access structurally different fields (`vm.Spec.Instancetype.InferFromVolume` vs `vm.Spec.Preference.InferFromVolume`).

The following alternatives were considered:
- Passing a boolean/enum discriminator instead of a function field — rejected as it would push conditional logic into `fromVolumes` rather than keeping it at the handler boundary.
- Passing the label strings as parameters (current approach before this PR) — this is what's being refactored away.

### Special notes for your reviewer

Pure refactoring, no behavior change. All existing tests pass unmodified.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
NONE
```