### PR TITLE
read lastRaw under lock in ca manager GetCurrentRaw

### DIFF
--- a/pkg/util/tls/ca-manager.go
+++ b/pkg/util/tls/ca-manager.go
@@ -132,6 +132,8 @@ func (m *manager) GetCurrentRaw() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	m.lock.Lock()
+	defer m.lock.Unlock()
 	return m.lastRaw, nil
 }
 

--- a/pkg/util/tls/ca-manager_test.go
+++ b/pkg/util/tls/ca-manager_test.go
@@ -1,6 +1,8 @@
 package tls
 
 import (
+	"fmt"
+	"sync"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -91,6 +93,61 @@ var _ = Describe("CaManager", func() {
 		cert, err := manager.GetCurrent()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(cert.Subjects()[0]).To(ContainSubstring("first"))
+	})
+
+	It("should not race between GetCurrentRaw and a concurrent CA rotation", func() {
+		newCA := func(rev string) *k8sv1.ConfigMap {
+			ca, err := triple.NewCA("rotating", time.Hour)
+			Expect(err).ToNot(HaveOccurred())
+			return &k8sv1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            util.ExtensionAPIServerAuthenticationConfigMap,
+					Namespace:       metav1.NamespaceSystem,
+					ResourceVersion: rev,
+				},
+				Data: map[string]string{
+					util.RequestHeaderClientCAFileKey: string(cert.EncodeCertPEM(ca.Cert)),
+				},
+			}
+		}
+
+		var wg sync.WaitGroup
+		stop := make(chan struct{})
+
+		// Churn the resource version so GetCurrent keeps taking the update path
+		// that writes lastRaw under the lock.
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 2; ; i++ {
+				select {
+				case <-stop:
+					return
+				default:
+					_ = store.Update(newCA(fmt.Sprintf("%d", i)))
+				}
+			}
+		}()
+
+		// Readers hit GetCurrentRaw, which must read lastRaw under the same lock.
+		for g := 0; g < 8; g++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				for {
+					select {
+					case <-stop:
+						return
+					default:
+						_, _ = manager.GetCurrentRaw()
+					}
+				}
+			}()
+		}
+
+		time.Sleep(200 * time.Millisecond)
+		close(stop)
+		wg.Wait()
 	})
 })
 

--- a/pkg/util/tls/ca-manager_test.go
+++ b/pkg/util/tls/ca-manager_test.go
@@ -95,6 +95,8 @@ var _ = Describe("CaManager", func() {
 		Expect(cert.Subjects()[0]).To(ContainSubstring("first"))
 	})
 
+	// This test relies on the race detector: it has no assertions and only
+	// fails under `go test -race`, which is how CI runs the unit tests.
 	It("should not race between GetCurrentRaw and a concurrent CA rotation", func() {
 		newCA := func(rev string) *k8sv1.ConfigMap {
 			ca, err := triple.NewCA("rotating", time.Hour)
@@ -130,7 +132,10 @@ var _ = Describe("CaManager", func() {
 		}()
 
 		// Readers hit GetCurrentRaw, which must read lastRaw under the same lock.
-		for g := 0; g < 8; g++ {
+		// At least two readers are needed: the write to lastRaw happens inside a
+		// reader's own GetCurrent call, so a single reader never produces a
+		// cross-goroutine access pair for the race detector to flag.
+		for g := 0; g < 4; g++ {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
@@ -145,7 +150,7 @@ var _ = Describe("CaManager", func() {
 			}()
 		}
 
-		time.Sleep(200 * time.Millisecond)
+		time.Sleep(100 * time.Millisecond)
 		close(stop)
 		wg.Wait()
 	})


### PR DESCRIPTION
### What this PR does
#### Before this PR:
`manager.GetCurrentRaw` reads the shared `lastRaw` client-CA bundle after the lock held by its internal `GetCurrent` call has already been released. `GetCurrent` runs on every TLS handshake through the `GetConfigForClient` / `VerifyPeerCertificate` callbacks in `tls.go`, and on a CA rotation it rewrites `lastRaw` under `m.lock`. A reader in `GetCurrentRaw` can therefore observe the slice header mid-write. `go test -race` reports the write in `GetCurrent` (ca-manager.go:178) against the unlocked read in `GetCurrentRaw` (ca-manager.go:135).

#### After this PR:
`GetCurrentRaw` takes `m.lock` around the read of `lastRaw`, so the read is synchronized with the guarded writer. The bundle is consumed by `pkg/vsock/system` and `pkg/storage/cbt` to build trust material, so a torn read there is worth closing.

### Why we need it and why it was done in this way
The read and the write touch the same field, so the read belongs under the same lock the writer already holds. Returning the raw bytes directly from `GetCurrent` was the alternative; taking the lock in `GetCurrentRaw` keeps the change local and leaves the `GetCurrent` signature untouched.

### Special notes for your reviewer
The added test drives four concurrent `GetCurrentRaw` readers for 100ms against a ConfigMap whose resource version keeps rotating, which exercises the update path that writes `lastRaw`. Under `-race` it fails before the change and passes after; without `-race` it has no assertions, which is called out in a comment.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Testing: New code requires new unit tests

### Release note
```release-note
Fix a data race between GetCurrentRaw and concurrent CA rotation in the client CA manager
```
