### PR TITLE
fix: use BUILD_ARCH to derive architecture in virt-template push-images

### DIFF
--- a/hack/virt-template/push-images.sh
+++ b/hack/virt-template/push-images.sh
@@ -23,6 +23,8 @@ source hack/common.sh
 source hack/config.sh
 source hack/virt-template/default.sh
 
+ARCHITECTURE=$(format_archname "${BUILD_ARCH:-$(uname -m)}")
+
 virt_template_targets="virt-template-apiserver virt-template-controller"
 
 for target in ${virt_template_targets}; do


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Fixes `hack/virt-template/push-images.sh` to correctly derive the target architecture from `BUILD_ARCH` during cross-builds, so the right platform-specific virt-template image is pushed.

#### Before this PR:
`hack/virt-template/push-images.sh` used `ARCHITECTURE` from `hack/common.sh`, which defaults to `$(uname -m)`. When called during cross-builds (e.g. `BUILD_ARCH=crossbuild-s390x`), the script always resolved `ARCHITECTURE=x86_64` (the host architecture of the amd64 builder), causing the amd64 virt-template image to be pushed regardless of the target architecture.
This resulted in `exec format error` on s390x (and arm64 cross-build) clusters


#### After this PR:
`ARCHITECTURE` is derived from `BUILD_ARCH` using `format_archname`, consistent with how `hack/multi-arch.sh` handles it for the main KubeVirt images. Cross-builds now push the correct architecture-specific virt-template image.



### References
- Partially addresses #18306
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
The fix only changes behavior when `BUILD_ARCH` is set (cross-build scenarios). When `BUILD_ARCH` is unset (default local dev on amd64), the fallback `$(uname -m)` produces the same result as before.

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
     None.

```

