### PR TITLE
converter, clock: reach full test coverage on clock configurator

### DIFF
--- a/pkg/virt-launcher/virtwrap/converter/compute/clock.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/clock.go
@@ -34,10 +34,7 @@ func (c ClockDomainConfigurator) Configure(vmi *v1.VirtualMachineInstance, domai
 	if vmi.Spec.Domain.Clock != nil {
 		clock := vmi.Spec.Domain.Clock
 		newClock := &api.Clock{}
-		err := convert_v1_Clock_To_api_Clock(clock, newClock)
-		if err != nil {
-			return err
-		}
+		convert_v1_Clock_To_api_Clock(clock, newClock)
 		domain.Spec.Clock = newClock
 	}
 
@@ -55,7 +52,7 @@ func (c ClockDomainConfigurator) Configure(vmi *v1.VirtualMachineInstance, domai
 	return nil
 }
 
-func convert_v1_Clock_To_api_Clock(source *v1.Clock, clock *api.Clock) error {
+func convert_v1_Clock_To_api_Clock(source *v1.Clock, clock *api.Clock) {
 	if source.UTC != nil {
 		clock.Offset = "utc"
 		if source.UTC.OffsetSeconds != nil {
@@ -99,8 +96,6 @@ func convert_v1_Clock_To_api_Clock(source *v1.Clock, clock *api.Clock) error {
 			clock.Timer = append(clock.Timer, newTimer)
 		}
 	}
-
-	return nil
 }
 
 func boolToYesNo(value *bool, defaultYes bool) string {

--- a/pkg/virt-launcher/virtwrap/converter/compute/clock_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/clock_test.go
@@ -26,13 +26,14 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
+	libvmistatus "kubevirt.io/kubevirt/pkg/libvmi/status"
 	"kubevirt.io/kubevirt/pkg/pointer"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter/compute"
 )
 
 var _ = Describe("Clock Domain Configurator", func() {
-	It("Should not set clock domain attribute when clock is unspecified on the VMI", func() {
+	It("should not set clock when clock is unspecified on the VMI", func() {
 		vmi := libvmi.New()
 
 		var domain api.Domain
@@ -41,30 +42,193 @@ var _ = Describe("Clock Domain Configurator", func() {
 		Expect(domain).To(Equal(api.Domain{}))
 	})
 
-	It("Should set timezone attribute when timezone is specified on the VMI", func() {
-		const expectedTimezone = "America/New_York"
-		clock := v1.Clock{
-			ClockOffset: v1.ClockOffset{
-				Timezone: pointer.P(v1.ClockOffsetTimezone(expectedTimezone)),
+	DescribeTable("should configure the domain clock from the VMI spec",
+		func(vmi *v1.VirtualMachineInstance, expectedClock *api.Clock) {
+			var domain api.Domain
+
+			Expect(compute.ClockDomainConfigurator{}.Configure(vmi, &domain)).To(Succeed())
+
+			expectedDomain := newDomainWithClock(expectedClock)
+			Expect(domain).To(Equal(expectedDomain))
+		},
+		Entry("timezone offset",
+			libvmi.New(libvmi.WithClock(v1.Clock{
+				ClockOffset: v1.ClockOffset{
+					Timezone: pointer.P(v1.ClockOffsetTimezone("America/New_York")),
+				},
+			})),
+			&api.Clock{
+				Offset:   "timezone",
+				Timezone: "America/New_York",
 			},
-			Timer: &v1.Timer{},
-		}
-		vmi := libvmi.New(libvmi.WithClock(clock))
-
-		var domain api.Domain
-
-		Expect(compute.ClockDomainConfigurator{}.Configure(vmi, &domain)).To(Succeed())
-
-		expectedDomain := api.Domain{
-			Spec: api.DomainSpec{
-				Clock: &api.Clock{
-					Offset:     "timezone",
-					Timezone:   expectedTimezone,
-					Adjustment: "",
-					Timer:      nil,
+		),
+		Entry("utc offset with adjustment=reset when no offset seconds",
+			libvmi.New(libvmi.WithClock(v1.Clock{
+				ClockOffset: v1.ClockOffset{
+					UTC: &v1.ClockOffsetUTC{},
+				},
+			})),
+			&api.Clock{
+				Offset:     "utc",
+				Adjustment: "reset",
+			},
+		),
+		Entry("utc offset with seconds adjustment",
+			libvmi.New(libvmi.WithClock(v1.Clock{
+				ClockOffset: v1.ClockOffset{
+					UTC: &v1.ClockOffsetUTC{
+						OffsetSeconds: pointer.P(3600),
+					},
+				},
+			})),
+			&api.Clock{
+				Offset:     "utc",
+				Adjustment: "3600",
+			},
+		),
+		Entry("RTC timer",
+			libvmi.New(libvmi.WithClock(v1.Clock{
+				Timer: &v1.Timer{
+					RTC: &v1.RTCTimer{
+						Track:      v1.TrackGuest,
+						TickPolicy: v1.RTCTickPolicyCatchup,
+						Enabled:    pointer.P(true),
+					},
+				},
+			})),
+			&api.Clock{
+				Timer: []api.Timer{
+					{Name: "rtc", Track: "guest", TickPolicy: "catchup", Present: "yes"},
 				},
 			},
-		}
-		Expect(domain).To(Equal(expectedDomain))
-	})
+		),
+		Entry("PIT timer with disabled state",
+			libvmi.New(libvmi.WithClock(v1.Clock{
+				Timer: &v1.Timer{
+					PIT: &v1.PITTimer{
+						TickPolicy: v1.PITTickPolicyDelay,
+						Enabled:    pointer.P(false),
+					},
+				},
+			})),
+			&api.Clock{
+				Timer: []api.Timer{
+					{Name: "pit", TickPolicy: "delay", Present: "no"},
+				},
+			},
+		),
+		Entry("KVM timer",
+			libvmi.New(libvmi.WithClock(v1.Clock{
+				Timer: &v1.Timer{
+					KVM: &v1.KVMTimer{},
+				},
+			})),
+			&api.Clock{
+				Timer: []api.Timer{
+					{Name: "kvmclock", Present: "yes"},
+				},
+			},
+		),
+		Entry("HPET timer",
+			libvmi.New(libvmi.WithClock(v1.Clock{
+				Timer: &v1.Timer{
+					HPET: &v1.HPETTimer{
+						TickPolicy: v1.HPETTickPolicyDelay,
+						Enabled:    pointer.P(true),
+					},
+				},
+			})),
+			&api.Clock{
+				Timer: []api.Timer{
+					{Name: "hpet", TickPolicy: "delay", Present: "yes"},
+				},
+			},
+		),
+		Entry("Hyperv timer",
+			libvmi.New(libvmi.WithClock(v1.Clock{
+				Timer: &v1.Timer{
+					Hyperv: &v1.HypervTimer{
+						Enabled: pointer.P(true),
+					},
+				},
+			})),
+			&api.Clock{
+				Timer: []api.Timer{
+					{Name: "hypervclock", Present: "yes"},
+				},
+			},
+		),
+		Entry("all timers together",
+			libvmi.New(libvmi.WithClock(v1.Clock{
+				ClockOffset: v1.ClockOffset{
+					UTC: &v1.ClockOffsetUTC{},
+				},
+				Timer: &v1.Timer{
+					RTC:    &v1.RTCTimer{Track: v1.TrackWall, TickPolicy: v1.RTCTickPolicyDelay},
+					PIT:    &v1.PITTimer{TickPolicy: v1.PITTickPolicyCatchup},
+					KVM:    &v1.KVMTimer{Enabled: pointer.P(true)},
+					HPET:   &v1.HPETTimer{TickPolicy: v1.HPETTickPolicyCatchup},
+					Hyperv: &v1.HypervTimer{},
+				},
+			})),
+			&api.Clock{
+				Offset:     "utc",
+				Adjustment: "reset",
+				Timer: []api.Timer{
+					{Name: "rtc", Track: "wall", TickPolicy: "delay", Present: "yes"},
+					{Name: "pit", TickPolicy: "catchup", Present: "yes"},
+					{Name: "kvmclock", Present: "yes"},
+					{Name: "hpet", TickPolicy: "catchup", Present: "yes"},
+					{Name: "hypervclock", Present: "yes"},
+				},
+			},
+		),
+		Entry("TSC timer without existing clock",
+			libvmi.New(
+				libvmi.WithCPUFeature("invtsc", "require"),
+				libvmistatus.WithStatus(libvmistatus.New(withTSCFrequency(1234567890))),
+			),
+			&api.Clock{
+				Timer: []api.Timer{
+					{Name: "tsc", Frequency: "1234567890"},
+				},
+			},
+		),
+		Entry("TSC timer appended to existing clock timers",
+			libvmi.New(
+				libvmi.WithClock(v1.Clock{
+					ClockOffset: v1.ClockOffset{
+						UTC: &v1.ClockOffsetUTC{},
+					},
+					Timer: &v1.Timer{
+						KVM: &v1.KVMTimer{},
+					},
+				}),
+				libvmi.WithCPUFeature("invtsc", "require"),
+				libvmistatus.WithStatus(libvmistatus.New(withTSCFrequency(9999))),
+			),
+			&api.Clock{
+				Offset:     "utc",
+				Adjustment: "reset",
+				Timer: []api.Timer{
+					{Name: "kvmclock", Present: "yes"},
+					{Name: "tsc", Frequency: "9999"},
+				},
+			},
+		),
+	)
 })
+
+func newDomainWithClock(clock *api.Clock) api.Domain {
+	return api.Domain{
+		Spec: api.DomainSpec{
+			Clock: clock,
+		},
+	}
+}
+
+func withTSCFrequency(freq int64) libvmistatus.Option {
+	return func(vmiStatus *v1.VirtualMachineInstanceStatus) {
+		vmiStatus.TopologyHints = &v1.TopologyHints{TSCFrequency: &freq}
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
The clock configurator tests only covered two code paths — nil clock and timezone offset — meaning regressions in timer conversion or TSC frequency injection would go undetected by unit tests. This PR adds coverage for all remaining paths: UTC offset (with and without seconds), each timer type (RTC, PIT, KVM, HPET, Hyperv), all timers combined, and TSC frequency injection. It also removes an unused error return from `convert_v1_Clock_To_api_Clock` that made full coverage impossible.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->
https://github.com/kubevirt/kubevirt/pull/16138#pullrequestreview-3489912659

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

