### PR TITLE
converter: Let controllers configurator derive IOMMU driver internally

### DIFF
--- a/pkg/virt-launcher/virtwrap/converter/compute/controllers.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/controllers.go
@@ -39,7 +39,8 @@ type ControllersDomainConfigurator struct {
 	isUSBNeeded               bool
 	scsiModel                 string
 	autoThreads               uint
-	controllerDriver          *api.ControllerDriver
+	useLaunchSecuritySEV      bool
+	useLaunchSecurityPV       bool
 	supportPCIHole64Disabling bool
 	virtioSerialModel         string
 }
@@ -59,8 +60,15 @@ func NewControllersDomainConfigurator(options ...controllersOption) ControllersD
 func (c ControllersDomainConfigurator) Configure(vmi *v1.VirtualMachineInstance, domain *api.Domain) error {
 	domain.Spec.Devices.Controllers = append(domain.Spec.Devices.Controllers, newUSBController(c.isUSBNeeded))
 
+	var controllerDriver *api.ControllerDriver
+	if c.useLaunchSecuritySEV || c.useLaunchSecurityPV {
+		controllerDriver = &api.ControllerDriver{
+			IOMMU: "on",
+		}
+	}
+
 	if requiresSCSIController(vmi) {
-		scsiControllerDriver := assignSCSIControllerIOThread(vmi, uint(c.autoThreads), c.controllerDriver.DeepCopy())
+		scsiControllerDriver := assignSCSIControllerIOThread(vmi, uint(c.autoThreads), controllerDriver.DeepCopy())
 		domain.Spec.Devices.Controllers = append(domain.Spec.Devices.Controllers, newSCSIController(c.scsiModel, scsiControllerDriver))
 	}
 
@@ -69,7 +77,7 @@ func (c ControllersDomainConfigurator) Configure(vmi *v1.VirtualMachineInstance,
 	}
 
 	if requiresVirtioSerialController(vmi) {
-		domain.Spec.Devices.Controllers = append(domain.Spec.Devices.Controllers, newVirtioSerialController(c.virtioSerialModel, c.controllerDriver))
+		domain.Spec.Devices.Controllers = append(domain.Spec.Devices.Controllers, newVirtioSerialController(c.virtioSerialModel, controllerDriver))
 	}
 
 	return nil
@@ -93,9 +101,15 @@ func ControllersWithSCSIIOThreads(autoThreads uint) controllersOption {
 	}
 }
 
-func ControllersWithControllerDriver(controllerDriver *api.ControllerDriver) controllersOption {
+func ControllersWithUseLaunchSecuritySEV(useLaunchSecuritySEV bool) controllersOption {
 	return func(c *ControllersDomainConfigurator) {
-		c.controllerDriver = controllerDriver
+		c.useLaunchSecuritySEV = useLaunchSecuritySEV
+	}
+}
+
+func ControllersWithUseLaunchSecurityPV(useLaunchSecurityPV bool) controllersOption {
+	return func(c *ControllersDomainConfigurator) {
+		c.useLaunchSecurityPV = useLaunchSecurityPV
 	}
 }
 

--- a/pkg/virt-launcher/virtwrap/converter/compute/controllers_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/controllers_test.go
@@ -44,7 +44,8 @@ var _ = Describe("Controllers Domain Configurator", func() {
 			compute.ControllersWithUSBNeeded(isUSBNeeded),
 			compute.ControllersWithSCSIModel("test-model"),
 			compute.ControllersWithSCSIIOThreads(uint(autoThreads)),
-			compute.ControllersWithControllerDriver(nil),
+			compute.ControllersWithUseLaunchSecuritySEV(false),
+			compute.ControllersWithUseLaunchSecurityPV(false),
 			compute.ControllersWithVirtioSerialModel("virtio-test-model"),
 		).Configure(vmi, &domain)).To(Succeed())
 
@@ -182,7 +183,8 @@ var _ = Describe("Controllers Domain Configurator", func() {
 			compute.ControllersWithUSBNeeded(!usbNeeded),
 			compute.ControllersWithSCSIModel("test-model"),
 			compute.ControllersWithSCSIIOThreads(0),
-			compute.ControllersWithControllerDriver(nil),
+			compute.ControllersWithUseLaunchSecuritySEV(false),
+			compute.ControllersWithUseLaunchSecurityPV(false),
 			compute.ControllersWithSupportPCIHole64Disabling(supportPCIHole64Disabling),
 			compute.ControllersWithVirtioSerialModel("virtio-test-model"),
 		)
@@ -233,6 +235,53 @@ var _ = Describe("Controllers Domain Configurator", func() {
 			}),
 	)
 
+	DescribeTable("should set IOMMU on SCSI and virtio-serial controllers when launch security is active",
+		func(useLaunchSecuritySEV, useLaunchSecurityPV bool, vmi *v1.VirtualMachineInstance, autoThreads int, expectedDomain api.Domain) {
+			var domain api.Domain
+
+			Expect(compute.NewControllersDomainConfigurator(
+				compute.ControllersWithUSBNeeded(false),
+				compute.ControllersWithSCSIModel("test-model"),
+				compute.ControllersWithSCSIIOThreads(uint(autoThreads)),
+				compute.ControllersWithUseLaunchSecuritySEV(useLaunchSecuritySEV),
+				compute.ControllersWithUseLaunchSecurityPV(useLaunchSecurityPV),
+				compute.ControllersWithVirtioSerialModel("virtio-test-model"),
+			).Configure(vmi, &domain)).To(Succeed())
+
+			Expect(domain).To(Equal(expectedDomain))
+		},
+		Entry("when SEV is active, SCSI and virtio-serial get IOMMU driver",
+			true, false,
+			libvmi.New(),
+			0,
+			newDomainWithControllers([]api.Controller{
+				{Type: "usb", Index: "0", Model: "none"},
+				{Type: "scsi", Index: "0", Model: "test-model", Driver: &api.ControllerDriver{IOMMU: "on"}},
+				{Type: "virtio-serial", Index: "0", Model: "virtio-test-model", Driver: &api.ControllerDriver{IOMMU: "on"}},
+			})),
+		Entry("when PV is active, SCSI and virtio-serial get IOMMU driver",
+			false, true,
+			libvmi.New(),
+			0,
+			newDomainWithControllers([]api.Controller{
+				{Type: "usb", Index: "0", Model: "none"},
+				{Type: "scsi", Index: "0", Model: "test-model", Driver: &api.ControllerDriver{IOMMU: "on"}},
+				{Type: "virtio-serial", Index: "0", Model: "virtio-test-model", Driver: &api.ControllerDriver{IOMMU: "on"}},
+			})),
+		Entry("when SEV is active with SCSI IOThreads, IOMMU is preserved alongside IOThread and Queues",
+			true, false,
+			libvmi.New(
+				libvmi.WithDisk("scsi-disk", v1.DiskBusSCSI, libvmi.WithDedicatedIOThreads(true)),
+				libvmi.WithDisk("virtio-disk", v1.DiskBusVirtio),
+			),
+			4,
+			newDomainWithControllers([]api.Controller{
+				{Type: "usb", Index: "0", Model: "none"},
+				{Type: "scsi", Index: "0", Model: "test-model", Driver: &api.ControllerDriver{IOMMU: "on", Queues: pointer.P[uint](1), IOThread: pointer.P[uint](2)}},
+				{Type: "virtio-serial", Index: "0", Model: "virtio-test-model", Driver: &api.ControllerDriver{IOMMU: "on"}},
+			})),
+	)
+
 	DescribeTable("should configure virtio-serial controller based on serial console setting", func(vmiOpts []libvmi.Option, expectedControllers []api.Controller) {
 		var domain api.Domain
 
@@ -244,7 +293,8 @@ var _ = Describe("Controllers Domain Configurator", func() {
 		configurator := compute.NewControllersDomainConfigurator(
 			compute.ControllersWithUSBNeeded(!usbNeeded),
 			compute.ControllersWithVirtioSerialModel("virtio-test-model"),
-			compute.ControllersWithControllerDriver(nil),
+			compute.ControllersWithUseLaunchSecuritySEV(false),
+			compute.ControllersWithUseLaunchSecurityPV(false),
 		)
 		Expect(configurator.Configure(vmi, &domain)).To(Succeed())
 

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -969,13 +969,6 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 	precond.MustNotBeNil(domain)
 	precond.MustNotBeNil(c)
 
-	var controllerDriver *api.ControllerDriver
-	if c.UseLaunchSecuritySEV || c.UseLaunchSecurityPV {
-		controllerDriver = &api.ControllerDriver{
-			IOMMU: "on",
-		}
-	}
-
 	hasIOThreads := iothreads.HasIOThreads(vmi)
 	var ioThreadCount, autoThreads int
 	if hasIOThreads {
@@ -1035,7 +1028,8 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 			compute.ControllersWithUSBNeeded(c.Architecture.IsUSBNeeded(vmi)),
 			compute.ControllersWithSCSIModel(scsiControllerModel),
 			compute.ControllersWithSCSIIOThreads(uint(autoThreads)),
-			compute.ControllersWithControllerDriver(controllerDriver),
+			compute.ControllersWithUseLaunchSecuritySEV(c.UseLaunchSecuritySEV),
+			compute.ControllersWithUseLaunchSecurityPV(c.UseLaunchSecurityPV),
 			compute.ControllersWithSupportPCIHole64Disabling(c.Architecture.SupportPCIHole64Disabling()),
 			compute.ControllersWithVirtioSerialModel(virtioModel),
 		),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
After PR #16575 moved the virtio-serial controller into `ControllersDomainConfigurator`, the `controllerDriver` variable in `Convert_v1_VirtualMachineInstance_To_api_Domain` was only used to pass a pre-built `ControllerDriver` into the configurator option. The converter no longer needs to know how the IOMMU driver is constructed — it only needs to express which launch security modes are active.

Other configurators (Balloon, RNG) already follow this pattern: they accept launch-security booleans and construct the IOMMU driver internally rather than receiving a pre-built one.

Adopt the same pattern: replace `ControllersWithControllerDriver` with ControllersWithUseLaunchSecuritySEV/PV options so the configurator builds the ControllerDriver{IOMMU: "on"} in its Configure method, removing the now-unnecessary variable from the converter.

Add test coverage for the IOMMU path to verify that SCSI and virtio-serial controllers receive the IOMMU driver when launch security is active.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

