### PR TITLE
converter: Add unit tests for HypervisorFeaturesDomainConfigurator

### DIFF
--- a/pkg/virt-launcher/virtwrap/converter/compute/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/converter/compute/BUILD.bazel
@@ -63,6 +63,7 @@ go_test(
         "cpu_test.go",
         "graphics_test.go",
         "host_device_test.go",
+        "hypervisor_features_test.go",
         "input_device_test.go",
         "iommufd_test.go",
         "iothreads_test.go",

--- a/pkg/virt-launcher/virtwrap/converter/compute/hypervisor_features.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/hypervisor_features.go
@@ -44,10 +44,7 @@ func (h HypervisorFeaturesDomainConfigurator) Configure(vmi *v1.VirtualMachineIn
 		return nil
 	}
 
-	err := convert_v1_Features_To_api_Features(vmi.Spec.Domain.Features, domain.Spec.Features, h.useLaunchSecurityTDX)
-	if err != nil {
-		return err
-	}
+	convert_v1_Features_To_api_Features(vmi.Spec.Domain.Features, domain.Spec.Features, h.useLaunchSecurityTDX)
 
 	if h.hasVMPort {
 		domain.Spec.Features.VMPort = &api.FeatureState{State: "off"}
@@ -56,7 +53,7 @@ func (h HypervisorFeaturesDomainConfigurator) Configure(vmi *v1.VirtualMachineIn
 	return nil
 }
 
-func convert_v1_Features_To_api_Features(source *v1.Features, features *api.Features, useLaunchSecurityTDX bool) error {
+func convert_v1_Features_To_api_Features(source *v1.Features, features *api.Features, useLaunchSecurityTDX bool) {
 	if source.ACPI.Enabled == nil || *source.ACPI.Enabled {
 		features.ACPI = &api.FeatureEnabled{}
 	}
@@ -72,10 +69,7 @@ func convert_v1_Features_To_api_Features(source *v1.Features, features *api.Feat
 	}
 	if source.Hyperv != nil {
 		features.Hyperv = &api.FeatureHyperv{}
-		err := convert_v1_FeatureHyperv_To_api_FeatureHyperv(source.Hyperv, features.Hyperv)
-		if err != nil {
-			return nil
-		}
+		convert_v1_FeatureHyperv_To_api_FeatureHyperv(source.Hyperv, features.Hyperv)
 	} else if source.HypervPassthrough != nil && *source.HypervPassthrough.Enabled {
 		features.Hyperv = &api.FeatureHyperv{
 			Mode: api.HypervModePassthrough,
@@ -99,11 +93,9 @@ func convert_v1_Features_To_api_Features(source *v1.Features, features *api.Feat
 			State: "off",
 		}
 	}
-
-	return nil
 }
 
-func convert_v1_FeatureHyperv_To_api_FeatureHyperv(source *v1.FeatureHyperv, hyperv *api.FeatureHyperv) error {
+func convert_v1_FeatureHyperv_To_api_FeatureHyperv(source *v1.FeatureHyperv, hyperv *api.FeatureHyperv) {
 	if source.Spinlocks != nil {
 		hyperv.Spinlocks = &api.FeatureSpinlocks{
 			State:   boolToOnOff(source.Spinlocks.Enabled, true),
@@ -129,7 +121,6 @@ func convert_v1_FeatureHyperv_To_api_FeatureHyperv(source *v1.FeatureHyperv, hyp
 	hyperv.TLBFlush = convertTLBFlushFeature(source.TLBFlush)
 	hyperv.IPI = convertFeatureState(source.IPI)
 	hyperv.EVMCS = convertFeatureState(source.EVMCS)
-	return nil
 }
 
 func convertFeatureState(source *v1.FeatureState) *api.FeatureState {

--- a/pkg/virt-launcher/virtwrap/converter/compute/hypervisor_features_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/hypervisor_features_test.go
@@ -1,0 +1,355 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package compute_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/libvmi"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter/compute"
+)
+
+var _ = Describe("HypervisorFeatures Domain Configurator", func() {
+	It("should initialize Features and return nil when VMI has no features", func() {
+		vmi := libvmi.New()
+		var domain api.Domain
+
+		configurator := compute.NewHypervisorFeaturesDomainConfigurator(false, false)
+		Expect(configurator.Configure(vmi, &domain)).To(Succeed())
+
+		Expect(domain).To(Equal(newDomainWithFeatures(&api.Features{})))
+	})
+
+	DescribeTable("should convert ACPI feature", func(enabled *bool, expectedFeatures *api.Features) {
+		vmi := libvmi.New(withFeatures(v1.Features{
+			ACPI: v1.FeatureState{Enabled: enabled},
+		}))
+		var domain api.Domain
+
+		configurator := compute.NewHypervisorFeaturesDomainConfigurator(false, false)
+		Expect(configurator.Configure(vmi, &domain)).To(Succeed())
+
+		Expect(domain).To(Equal(newDomainWithFeatures(expectedFeatures)))
+	},
+		Entry("nil (defaults to enabled)", nil, &api.Features{ACPI: &api.FeatureEnabled{}}),
+		Entry("explicitly enabled", new(true), &api.Features{ACPI: &api.FeatureEnabled{}}),
+		Entry("explicitly disabled", new(false), &api.Features{}),
+	)
+
+	DescribeTable("should convert SMM feature", func(enabled *bool, expectedFeatures *api.Features) {
+		vmi := libvmi.New(withFeatures(v1.Features{
+			SMM: &v1.FeatureState{Enabled: enabled},
+		}))
+		var domain api.Domain
+
+		configurator := compute.NewHypervisorFeaturesDomainConfigurator(false, false)
+		Expect(configurator.Configure(vmi, &domain)).To(Succeed())
+
+		Expect(domain).To(Equal(newDomainWithFeatures(expectedFeatures)))
+	},
+		Entry("nil (defaults to enabled)", nil, &api.Features{ACPI: &api.FeatureEnabled{}, SMM: &api.FeatureEnabled{}}),
+		Entry("explicitly enabled", new(true), &api.Features{ACPI: &api.FeatureEnabled{}, SMM: &api.FeatureEnabled{}}),
+		Entry("explicitly disabled", new(false), &api.Features{ACPI: &api.FeatureEnabled{}}),
+	)
+
+	DescribeTable("should convert APIC feature", func(enabled *bool, expectedFeatures *api.Features) {
+		vmi := libvmi.New(withFeatures(v1.Features{
+			APIC: &v1.FeatureAPIC{FeatureState: v1.FeatureState{Enabled: enabled}},
+		}))
+		var domain api.Domain
+
+		configurator := compute.NewHypervisorFeaturesDomainConfigurator(false, false)
+		Expect(configurator.Configure(vmi, &domain)).To(Succeed())
+
+		Expect(domain).To(Equal(newDomainWithFeatures(expectedFeatures)))
+	},
+		Entry("nil (defaults to enabled)", nil, &api.Features{ACPI: &api.FeatureEnabled{}, APIC: &api.FeatureEnabled{}}),
+		Entry("explicitly enabled", new(true), &api.Features{ACPI: &api.FeatureEnabled{}, APIC: &api.FeatureEnabled{}}),
+		Entry("explicitly disabled", new(false), &api.Features{ACPI: &api.FeatureEnabled{}}),
+	)
+
+	DescribeTable("should convert KVM hidden feature", func(hidden bool, expectedFeatures *api.Features) {
+		vmi := libvmi.New(withFeatures(v1.Features{
+			KVM: &v1.FeatureKVM{Hidden: hidden},
+		}))
+		var domain api.Domain
+
+		configurator := compute.NewHypervisorFeaturesDomainConfigurator(false, false)
+		Expect(configurator.Configure(vmi, &domain)).To(Succeed())
+
+		Expect(domain).To(Equal(newDomainWithFeatures(expectedFeatures)))
+	},
+		Entry("hidden true", true, &api.Features{
+			ACPI: &api.FeatureEnabled{},
+			KVM:  &api.FeatureKVM{Hidden: &api.FeatureState{State: "on"}},
+		}),
+		Entry("hidden false", false, &api.Features{
+			ACPI: &api.FeatureEnabled{},
+			KVM:  &api.FeatureKVM{Hidden: &api.FeatureState{State: "off"}},
+		}),
+	)
+
+	DescribeTable("should convert Pvspinlock feature", func(enabled *bool, expectedFeatures *api.Features) {
+		vmi := libvmi.New(withFeatures(v1.Features{
+			Pvspinlock: &v1.FeatureState{Enabled: enabled},
+		}))
+		var domain api.Domain
+
+		configurator := compute.NewHypervisorFeaturesDomainConfigurator(false, false)
+		Expect(configurator.Configure(vmi, &domain)).To(Succeed())
+
+		Expect(domain).To(Equal(newDomainWithFeatures(expectedFeatures)))
+	},
+		Entry("nil (defaults to on)", nil, &api.Features{
+			ACPI:       &api.FeatureEnabled{},
+			PVSpinlock: &api.FeaturePVSpinlock{State: "on"},
+		}),
+		Entry("explicitly enabled", new(true), &api.Features{
+			ACPI:       &api.FeatureEnabled{},
+			PVSpinlock: &api.FeaturePVSpinlock{State: "on"},
+		}),
+		Entry("explicitly disabled", new(false), &api.Features{
+			ACPI:       &api.FeatureEnabled{},
+			PVSpinlock: &api.FeaturePVSpinlock{State: "off"},
+		}),
+	)
+
+	Context("HypervPassthrough", func() {
+		It("should configure hyperv passthrough mode", func() {
+			vmi := libvmi.New(withFeatures(v1.Features{
+				HypervPassthrough: &v1.HyperVPassthrough{Enabled: new(true)},
+			}))
+			var domain api.Domain
+
+			configurator := compute.NewHypervisorFeaturesDomainConfigurator(false, false)
+			Expect(configurator.Configure(vmi, &domain)).To(Succeed())
+
+			Expect(domain).To(Equal(newDomainWithFeatures(&api.Features{
+				ACPI:   &api.FeatureEnabled{},
+				Hyperv: &api.FeatureHyperv{Mode: api.HypervModePassthrough},
+			})))
+		})
+
+		It("should not configure hyperv passthrough when disabled", func() {
+			vmi := libvmi.New(withFeatures(v1.Features{
+				HypervPassthrough: &v1.HyperVPassthrough{Enabled: new(false)},
+			}))
+			var domain api.Domain
+
+			configurator := compute.NewHypervisorFeaturesDomainConfigurator(false, false)
+			Expect(configurator.Configure(vmi, &domain)).To(Succeed())
+
+			Expect(domain).To(Equal(newDomainWithFeatures(&api.Features{ACPI: &api.FeatureEnabled{}})))
+		})
+	})
+
+	Context("Hyperv", func() {
+		It("should convert all hyperv features", func() {
+			retries := uint32(4096)
+			vmi := libvmi.New(withFeatures(v1.Features{
+				Hyperv: &v1.FeatureHyperv{
+					Relaxed:         &v1.FeatureState{Enabled: new(true)},
+					VAPIC:           &v1.FeatureState{Enabled: new(true)},
+					VPIndex:         &v1.FeatureState{Enabled: new(true)},
+					Runtime:         &v1.FeatureState{Enabled: new(true)},
+					SyNIC:           &v1.FeatureState{Enabled: new(true)},
+					Reset:           &v1.FeatureState{Enabled: new(true)},
+					Frequencies:     &v1.FeatureState{Enabled: new(true)},
+					Reenlightenment: &v1.FeatureState{Enabled: new(true)},
+					IPI:             &v1.FeatureState{Enabled: new(true)},
+					EVMCS:           &v1.FeatureState{Enabled: new(true)},
+					Spinlocks: &v1.FeatureSpinlocks{
+						FeatureState: v1.FeatureState{Enabled: new(true)},
+						Retries:      &retries,
+					},
+					VendorID: &v1.FeatureVendorID{
+						FeatureState: v1.FeatureState{Enabled: new(true)},
+						VendorID:     "myvendor",
+					},
+					SyNICTimer: &v1.SyNICTimer{
+						FeatureState: v1.FeatureState{Enabled: new(true)},
+						Direct:       &v1.FeatureState{Enabled: new(true)},
+					},
+					TLBFlush: &v1.TLBFlush{
+						FeatureState: v1.FeatureState{Enabled: new(true)},
+						Direct:       &v1.FeatureState{Enabled: new(true)},
+						Extended:     &v1.FeatureState{Enabled: new(true)},
+					},
+				},
+			}))
+			var domain api.Domain
+
+			configurator := compute.NewHypervisorFeaturesDomainConfigurator(false, false)
+			Expect(configurator.Configure(vmi, &domain)).To(Succeed())
+
+			Expect(domain).To(Equal(newDomainWithFeatures(&api.Features{
+				ACPI: &api.FeatureEnabled{},
+				Hyperv: &api.FeatureHyperv{
+					Relaxed:         &api.FeatureState{State: "on"},
+					VAPIC:           &api.FeatureState{State: "on"},
+					VPIndex:         &api.FeatureState{State: "on"},
+					Runtime:         &api.FeatureState{State: "on"},
+					SyNIC:           &api.FeatureState{State: "on"},
+					Reset:           &api.FeatureState{State: "on"},
+					Frequencies:     &api.FeatureState{State: "on"},
+					Reenlightenment: &api.FeatureState{State: "on"},
+					IPI:             &api.FeatureState{State: "on"},
+					EVMCS:           &api.FeatureState{State: "on"},
+					Spinlocks:       &api.FeatureSpinlocks{State: "on", Retries: &retries},
+					VendorID:        &api.FeatureVendorID{State: "on", Value: "myvendor"},
+					SyNICTimer: &api.SyNICTimer{
+						State:  "on",
+						Direct: &api.FeatureState{State: "on"},
+					},
+					TLBFlush: &api.TLBFlush{
+						State:    "on",
+						Direct:   &api.FeatureState{State: "on"},
+						Extended: &api.FeatureState{State: "on"},
+					},
+				},
+			})))
+		})
+
+		It("should default to on when Enabled is nil", func() {
+			vmi := libvmi.New(withFeatures(v1.Features{
+				Hyperv: &v1.FeatureHyperv{
+					Relaxed:    &v1.FeatureState{},
+					Spinlocks:  &v1.FeatureSpinlocks{},
+					SyNICTimer: &v1.SyNICTimer{},
+					TLBFlush:   &v1.TLBFlush{},
+				},
+			}))
+			var domain api.Domain
+
+			configurator := compute.NewHypervisorFeaturesDomainConfigurator(false, false)
+			Expect(configurator.Configure(vmi, &domain)).To(Succeed())
+
+			Expect(domain).To(Equal(newDomainWithFeatures(&api.Features{
+				ACPI: &api.FeatureEnabled{},
+				Hyperv: &api.FeatureHyperv{
+					Relaxed:    &api.FeatureState{State: "on"},
+					Spinlocks:  &api.FeatureSpinlocks{State: "on"},
+					SyNICTimer: &api.SyNICTimer{State: "on"},
+					TLBFlush:   &api.TLBFlush{State: "on"},
+				},
+			})))
+		})
+
+		It("should convert disabled features to off", func() {
+			vmi := libvmi.New(withFeatures(v1.Features{
+				Hyperv: &v1.FeatureHyperv{
+					Relaxed: &v1.FeatureState{Enabled: new(false)},
+					VAPIC:   &v1.FeatureState{Enabled: new(false)},
+				},
+			}))
+			var domain api.Domain
+
+			configurator := compute.NewHypervisorFeaturesDomainConfigurator(false, false)
+			Expect(configurator.Configure(vmi, &domain)).To(Succeed())
+
+			Expect(domain).To(Equal(newDomainWithFeatures(&api.Features{
+				ACPI: &api.FeatureEnabled{},
+				Hyperv: &api.FeatureHyperv{
+					Relaxed: &api.FeatureState{State: "off"},
+					VAPIC:   &api.FeatureState{State: "off"},
+				},
+			})))
+		})
+
+		It("should not set unspecified hyperv features", func() {
+			vmi := libvmi.New(withFeatures(v1.Features{
+				Hyperv: &v1.FeatureHyperv{},
+			}))
+			var domain api.Domain
+
+			configurator := compute.NewHypervisorFeaturesDomainConfigurator(false, false)
+			Expect(configurator.Configure(vmi, &domain)).To(Succeed())
+
+			Expect(domain).To(Equal(newDomainWithFeatures(&api.Features{
+				ACPI:   &api.FeatureEnabled{},
+				Hyperv: &api.FeatureHyperv{},
+			})))
+		})
+
+		It("should take precedence over HypervPassthrough", func() {
+			vmi := libvmi.New(withFeatures(v1.Features{
+				Hyperv: &v1.FeatureHyperv{
+					Relaxed: &v1.FeatureState{Enabled: new(true)},
+				},
+				HypervPassthrough: &v1.HyperVPassthrough{Enabled: new(true)},
+			}))
+			var domain api.Domain
+
+			configurator := compute.NewHypervisorFeaturesDomainConfigurator(false, false)
+			Expect(configurator.Configure(vmi, &domain)).To(Succeed())
+
+			Expect(domain).To(Equal(newDomainWithFeatures(&api.Features{
+				ACPI: &api.FeatureEnabled{},
+				Hyperv: &api.FeatureHyperv{
+					Relaxed: &api.FeatureState{State: "on"},
+				},
+			})))
+		})
+	})
+
+	It("should set VMPort off when hasVMPort is true", func() {
+		vmi := libvmi.New(withFeatures(v1.Features{}))
+		var domain api.Domain
+
+		configurator := compute.NewHypervisorFeaturesDomainConfigurator(true, false)
+		Expect(configurator.Configure(vmi, &domain)).To(Succeed())
+
+		Expect(domain).To(Equal(newDomainWithFeatures(&api.Features{
+			ACPI:   &api.FeatureEnabled{},
+			VMPort: &api.FeatureState{State: "off"},
+		})))
+	})
+
+	It("should set PMU off when useLaunchSecurityTDX is true", func() {
+		vmi := libvmi.New(withFeatures(v1.Features{}))
+		var domain api.Domain
+
+		configurator := compute.NewHypervisorFeaturesDomainConfigurator(false, true)
+		Expect(configurator.Configure(vmi, &domain)).To(Succeed())
+
+		Expect(domain).To(Equal(newDomainWithFeatures(&api.Features{
+			ACPI: &api.FeatureEnabled{},
+			PMU:  &api.FeatureState{State: "off"},
+		})))
+	})
+})
+
+func withFeatures(features v1.Features) libvmi.Option {
+	return func(vmi *v1.VirtualMachineInstance) {
+		vmi.Spec.Domain.Features = &features
+	}
+}
+
+func newDomainWithFeatures(features *api.Features) api.Domain {
+	return api.Domain{
+		Spec: api.DomainSpec{
+			Features: features,
+		},
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
HypervisorFeaturesDomainConfigurator had no unit tests. This PR adds tests covering all conversion paths (ACPI, SMM, APIC, KVM, Pvspinlock, Hyperv, HypervPassthrough, VMPort, and TDX launch security), and removes dead error-handling code that the tests surfaced as unreachable.

The second commit removes error returns from `convert_v1_Features_To_api_Features` and `convert_v1_FeatureHyperv_To_api_FeatureHyperv`. Both functions always return nil - the error plumbing was dead code. The tests in the first commit make this visible: all paths reach 100% coverage without ever triggering an error.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

