### PR TITLE
Bug fix: Skip domain stats collection during live migration

### DIFF
--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -2370,7 +2370,7 @@ func (l *LibvirtDomainManager) getDeviceAliasMap() map[string]string {
 
 func (l *LibvirtDomainManager) getDomainStats() ([]*stats.DomainStats, error) {
 	statsTypes := libvirt.DOMAIN_STATS_BALLOON | libvirt.DOMAIN_STATS_CPU_TOTAL | libvirt.DOMAIN_STATS_VCPU | libvirt.DOMAIN_STATS_INTERFACE | libvirt.DOMAIN_STATS_BLOCK | libvirt.DOMAIN_STATS_DIRTYRATE
-	flags := libvirt.CONNECT_GET_ALL_DOMAINS_STATS_RUNNING | libvirt.CONNECT_GET_ALL_DOMAINS_STATS_PAUSED
+	flags := libvirt.CONNECT_GET_ALL_DOMAINS_STATS_RUNNING | libvirt.CONNECT_GET_ALL_DOMAINS_STATS_PAUSED | libvirt.CONNECT_GET_ALL_DOMAINS_STATS_NOWAIT
 
 	domstats, err := l.virConn.GetDomainStats(statsTypes, l.domainInfoStats, flags)
 	if err != nil {

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -2854,7 +2854,7 @@ var _ = Describe("Manager", func() {
 					libvirt.DOMAIN_STATS_INTERFACE |
 					libvirt.DOMAIN_STATS_BLOCK |
 					libvirt.DOMAIN_STATS_DIRTYRATE
-				flags = libvirt.CONNECT_GET_ALL_DOMAINS_STATS_RUNNING | libvirt.CONNECT_GET_ALL_DOMAINS_STATS_PAUSED
+				flags = libvirt.CONNECT_GET_ALL_DOMAINS_STATS_RUNNING | libvirt.CONNECT_GET_ALL_DOMAINS_STATS_PAUSED | libvirt.CONNECT_GET_ALL_DOMAINS_STATS_NOWAIT
 			)
 			fakeDomainStats := []*stats.DomainStats{
 				{},
@@ -2878,7 +2878,7 @@ var _ = Describe("Manager", func() {
 				libvirt.DOMAIN_STATS_INTERFACE |
 				libvirt.DOMAIN_STATS_BLOCK |
 				libvirt.DOMAIN_STATS_DIRTYRATE
-			flags = libvirt.CONNECT_GET_ALL_DOMAINS_STATS_RUNNING | libvirt.CONNECT_GET_ALL_DOMAINS_STATS_PAUSED
+			flags = libvirt.CONNECT_GET_ALL_DOMAINS_STATS_RUNNING | libvirt.CONNECT_GET_ALL_DOMAINS_STATS_PAUSED | libvirt.CONNECT_GET_ALL_DOMAINS_STATS_NOWAIT
 		)
 
 		It("should inject aliases from cached map into net and block stats", func() {
@@ -2927,7 +2927,7 @@ var _ = Describe("Manager", func() {
 					libvirt.DOMAIN_STATS_INTERFACE |
 					libvirt.DOMAIN_STATS_BLOCK |
 					libvirt.DOMAIN_STATS_DIRTYRATE
-				flags = libvirt.CONNECT_GET_ALL_DOMAINS_STATS_RUNNING | libvirt.CONNECT_GET_ALL_DOMAINS_STATS_PAUSED
+				flags = libvirt.CONNECT_GET_ALL_DOMAINS_STATS_RUNNING | libvirt.CONNECT_GET_ALL_DOMAINS_STATS_PAUSED | libvirt.CONNECT_GET_ALL_DOMAINS_STATS_NOWAIT
 			)
 			fakeDomainStats := []*stats.DomainStats{}
 
@@ -2937,6 +2937,34 @@ var _ = Describe("Manager", func() {
 
 			Expect(domStats).To(BeNil())
 			Expect(err).To(MatchError("empty DomainStats"))
+		})
+	})
+
+	Context("when live migration is in progress", func() {
+		It("should still collect stats using NOWAIT flag", func() {
+			const (
+				domainStats = libvirt.DOMAIN_STATS_BALLOON |
+					libvirt.DOMAIN_STATS_CPU_TOTAL |
+					libvirt.DOMAIN_STATS_VCPU |
+					libvirt.DOMAIN_STATS_INTERFACE |
+					libvirt.DOMAIN_STATS_BLOCK |
+					libvirt.DOMAIN_STATS_DIRTYRATE
+				flags = libvirt.CONNECT_GET_ALL_DOMAINS_STATS_RUNNING | libvirt.CONNECT_GET_ALL_DOMAINS_STATS_PAUSED | libvirt.CONNECT_GET_ALL_DOMAINS_STATS_NOWAIT
+			)
+
+			now := metav1.Now()
+			migrationMetadata, _ := metadataCache.Migration.Load()
+			migrationMetadata.StartTimestamp = &now
+			metadataCache.Migration.Store(migrationMetadata)
+
+			fakeDomainStats := []*stats.DomainStats{{}}
+			mockLibvirt.ConnectionEXPECT().GetDomainStats(domainStats, gomock.Any(), flags).Return(fakeDomainStats, nil)
+
+			manager, _ := newLibvirtDomainManagerDefault()
+			domStats, err := manager.GetDomainStats()
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(domStats).ToNot(BeNil())
 		})
 	})
 


### PR DESCRIPTION
### What this PR does
#### Before this PR:

During live migration, `GetDomainStats()` calls libvirt's `GetAllDomainStats()`, which attempts to acquire the domain job lock. Since the migration already holds this lock, the call blocks for up to 30 seconds until it times out. This produces error logs and disrupts OCP upgrade flows that monitor virt-launcher health.

#### After this PR:

The `NOWAIT` flag is added to the `GetAllDomainStats` call so that libvirt skips locked domains instead of blocking for up to 30 seconds. Stats collection still proceeds normally - the flag only affects behavior when a domain's job lock is held (e.g. during migration).

### References

- Fixes [CNV-87617](https://redhat.atlassian.net/browse/CNV-87617)

### Why we need it and why it was done in this way
The following tradeoffs were made:

- With `NOWAIT`, if the domain's job lock is held during migration, libvirt may return partial or empty stats instead of blocking. The TimeDefinedCache serves the previously cached value in this case, so consumers are unaffected.
- When the domain is skipped due to `NOWAIT`, `reCalcDomainStats` treats the empty result as an error ("empty DomainStats"), which KeepValueUpdated logs every ~3.25s during migration. This is a significant improvement over the previous 30-second blocking timeout, and the cached stats continue to be served to all consumers. The error-level logging during migration is a known, acceptable side effect.
- The flag is applied unconditionally (not just during migration) to keep the implementation simple and to protect against any job-lock contention scenario, not just migration.

The following alternatives were considered:

- Adding a Go-level migration guard to skip stats collection entirely: this was tried initially but broke storage migration metrics reporting and introduced noisy "empty DomainStats" error logging through the cache layer.
- Acquiring a shorter timeout or retrying: adds complexity without solving the root cause.

### Special notes for your reviewer

- The `CONNECT_GET_ALL_DOMAINS_STATS_NOWAIT` flag is a standard libvirt option that tells `virConnectGetAllDomainStats` to skip domains whose job lock cannot be acquired immediately.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] ~~Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required~~
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] ~~Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)~~
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] ~~Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.~~
- [ ] ~~Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered~~
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
Bug fix: During live migration, domain stats collection no longer blocks on the libvirt job lock for up to 30 seconds. The NOWAIT flag is used to skip locked domains instead of waiting, avoiding lock contention and disruptive error logs.
```
