### PR TITLE
network admitter: Block link state spec for passtBinding

### DIFF
--- a/pkg/network/admitter/admit.go
+++ b/pkg/network/admitter/admit.go
@@ -32,42 +32,56 @@ import (
 
 func validateInterfaceStateValue(field *k8sfield.Path, spec *v1.VirtualMachineInstanceSpec) []metav1.StatusCause {
 	var causes []metav1.StatusCause
+	defaultNetwork := vmispec.LookUpDefaultNetwork(spec.Networks)
 	for idx, iface := range spec.Domain.Devices.Interfaces {
-		if iface.State != "" &&
-			iface.State != v1.InterfaceStateAbsent &&
-			iface.State != v1.InterfaceStateLinkDown &&
-			iface.State != v1.InterfaceStateLinkUp {
-			causes = append(causes, metav1.StatusCause{
-				Type:    metav1.CauseTypeFieldValueInvalid,
-				Message: fmt.Sprintf("logical %s interface state value is unsupported: %s", iface.Name, iface.State),
-				Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("state").String(),
-			})
-		}
-
-		if iface.SRIOV != nil &&
-			(iface.State == v1.InterfaceStateLinkDown || iface.State == v1.InterfaceStateLinkUp) {
-			causes = append(causes, metav1.StatusCause{
-				Type:    metav1.CauseTypeFieldValueInvalid,
-				Message: fmt.Sprintf("%q interface's state %q is not supported for SR-IOV NICs", iface.Name, iface.State),
-				Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("state").String(),
-			})
-		}
-
-		if iface.State == v1.InterfaceStateAbsent && iface.Bridge == nil {
-			causes = append(causes, metav1.StatusCause{
-				Type:    metav1.CauseTypeFieldValueInvalid,
-				Message: fmt.Sprintf("%q interface's state %q is supported only for bridge binding", iface.Name, iface.State),
-				Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("state").String(),
-			})
-		}
-		defaultNetwork := vmispec.LookUpDefaultNetwork(spec.Networks)
-		if iface.State == v1.InterfaceStateAbsent && defaultNetwork != nil && defaultNetwork.Name == iface.Name {
-			causes = append(causes, metav1.StatusCause{
-				Type:    metav1.CauseTypeFieldValueInvalid,
-				Message: fmt.Sprintf("%q interface's state %q is not supported on default networks", iface.Name, iface.State),
-				Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("state").String(),
-			})
-		}
+		causes = append(causes, validateSingleInterfaceState(field, idx, iface, defaultNetwork)...)
 	}
+	return causes
+}
+
+func validateSingleInterfaceState(field *k8sfield.Path, idx int, iface v1.Interface, defaultNetwork *v1.Network) []metav1.StatusCause {
+	if iface.State == "" {
+		return nil
+	}
+
+	stateField := field.Child("domain", "devices", "interfaces").Index(idx).Child("state").String()
+
+	if iface.State != v1.InterfaceStateAbsent &&
+		iface.State != v1.InterfaceStateLinkDown &&
+		iface.State != v1.InterfaceStateLinkUp {
+		return []metav1.StatusCause{{
+			Type:    metav1.CauseTypeFieldValueInvalid,
+			Message: fmt.Sprintf("logical %s interface state value is unsupported: %s", iface.Name, iface.State),
+			Field:   stateField,
+		}}
+	}
+
+	var causes []metav1.StatusCause
+
+	if iface.SRIOV != nil &&
+		(iface.State == v1.InterfaceStateLinkDown || iface.State == v1.InterfaceStateLinkUp) {
+		causes = append(causes, metav1.StatusCause{
+			Type:    metav1.CauseTypeFieldValueInvalid,
+			Message: fmt.Sprintf("%q interface's state %q is not supported for SR-IOV NICs", iface.Name, iface.State),
+			Field:   stateField,
+		})
+	}
+
+	if iface.State == v1.InterfaceStateAbsent && iface.Bridge == nil {
+		causes = append(causes, metav1.StatusCause{
+			Type:    metav1.CauseTypeFieldValueInvalid,
+			Message: fmt.Sprintf("%q interface's state %q is supported only for bridge binding", iface.Name, iface.State),
+			Field:   stateField,
+		})
+	}
+
+	if iface.State == v1.InterfaceStateAbsent && defaultNetwork != nil && defaultNetwork.Name == iface.Name {
+		causes = append(causes, metav1.StatusCause{
+			Type:    metav1.CauseTypeFieldValueInvalid,
+			Message: fmt.Sprintf("%q interface's state %q is not supported on default networks", iface.Name, iface.State),
+			Field:   stateField,
+		})
+	}
+
 	return causes
 }

--- a/pkg/network/admitter/admit.go
+++ b/pkg/network/admitter/admit.go
@@ -58,11 +58,11 @@ func validateSingleInterfaceState(field *k8sfield.Path, idx int, iface v1.Interf
 
 	var causes []metav1.StatusCause
 
-	if iface.SRIOV != nil &&
+	if iface.Bridge == nil && iface.Masquerade == nil && iface.Binding == nil &&
 		(iface.State == v1.InterfaceStateLinkDown || iface.State == v1.InterfaceStateLinkUp) {
 		causes = append(causes, metav1.StatusCause{
 			Type:    metav1.CauseTypeFieldValueInvalid,
-			Message: fmt.Sprintf("%q interface's state %q is not supported for SR-IOV NICs", iface.Name, iface.State),
+			Message: fmt.Sprintf("%q interface's state %q is not supported for this binding type", iface.Name, iface.State),
 			Field:   stateField,
 		})
 	}

--- a/pkg/network/admitter/admit_test.go
+++ b/pkg/network/admitter/admit_test.go
@@ -35,25 +35,43 @@ import (
 )
 
 var _ = Describe("Validating VMI network spec", func() {
-	DescribeTable("network interface state valid value", func(value v1.InterfaceState) {
-		vm := libvmi.New(
-			libvmi.WithInterface(v1.Interface{
-				Name:                   "foo",
-				State:                  value,
-				InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}},
-			}),
-			libvmi.WithNetwork(&v1.Network{
-				Name:          "foo",
-				NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{NetworkName: "net"}},
-			}),
-		)
-		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vm.Spec, stubClusterConfigChecker{})
-		Expect(validator.Validate()).To(BeEmpty())
-	},
-		Entry("is empty", v1.InterfaceState("")),
-		Entry("is absent when bridge binding is used", v1.InterfaceStateAbsent),
-		Entry("is up when bridge binding is used", v1.InterfaceStateLinkUp),
-		Entry("is down when bridge binding is used", v1.InterfaceStateLinkDown),
+	DescribeTable("link state is supported for bridge, masquerade, and binding plugin interfaces",
+		func(iface v1.Interface, network *v1.Network) {
+			vm := libvmi.New(
+				libvmi.WithInterface(iface),
+				libvmi.WithNetwork(network),
+			)
+			causes := admitter.NewValidator(k8sfield.NewPath("fake"), &vm.Spec, stubClusterConfigChecker{}).Validate()
+			Expect(causes).To(BeEmpty())
+		},
+		Entry("masquerade up",
+			libvmi.NewInterface("foo", libvmi.WithMasqueradeBinding(), libvmi.WithState(v1.InterfaceStateLinkUp)),
+			&v1.Network{Name: "foo", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}},
+		),
+		Entry("masquerade down",
+			libvmi.NewInterface("foo", libvmi.WithMasqueradeBinding(), libvmi.WithState(v1.InterfaceStateLinkDown)),
+			&v1.Network{Name: "foo", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}},
+		),
+		Entry("bridge up",
+			libvmi.NewInterface("foo", libvmi.WithBridgeBinding(), libvmi.WithState(v1.InterfaceStateLinkUp)),
+			libvmi.MultusNetwork("foo", "net"),
+		),
+		Entry("bridge down",
+			libvmi.NewInterface("foo", libvmi.WithBridgeBinding(), libvmi.WithState(v1.InterfaceStateLinkDown)),
+			libvmi.MultusNetwork("foo", "net"),
+		),
+		Entry("bridge absent",
+			libvmi.NewInterface("foo", libvmi.WithBridgeBinding(), libvmi.WithState(v1.InterfaceStateAbsent)),
+			libvmi.MultusNetwork("foo", "net"),
+		),
+		Entry("binding plugin up",
+			libvmi.NewInterface("foo", libvmi.WithBindingPlugin(v1.PluginBinding{Name: "test"}), libvmi.WithState(v1.InterfaceStateLinkUp)),
+			libvmi.MultusNetwork("foo", "net"),
+		),
+		Entry("binding plugin down",
+			libvmi.NewInterface("foo", libvmi.WithBindingPlugin(v1.PluginBinding{Name: "test"}), libvmi.WithState(v1.InterfaceStateLinkDown)),
+			libvmi.MultusNetwork("foo", "net"),
+		),
 	)
 
 	It("network interface state value is invalid", func() {
@@ -77,29 +95,50 @@ var _ = Describe("Validating VMI network spec", func() {
 			}))
 	})
 
-	DescribeTable("network interface state ", func(state v1.InterfaceState, messageRegex types.GomegaMatcher) {
-		vm := libvmi.New(
-			libvmi.WithInterface(v1.Interface{
-				Name:                   "foo",
-				State:                  state,
-				InterfaceBindingMethod: v1.InterfaceBindingMethod{SRIOV: &v1.InterfaceSRIOV{}},
-			}),
-			libvmi.WithNetwork(&v1.Network{
-				Name:          "foo",
-				NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{NetworkName: "net"}},
-			}),
-		)
-		statusCause := admitter.NewValidator(k8sfield.NewPath("fake"), &vm.Spec, stubClusterConfigChecker{}).Validate()
-		Expect(statusCause).To(HaveLen(1))
-		Expect(statusCause[0]).To(MatchAllFields(Fields{
-			"Type":    Equal(metav1.CauseType("FieldValueInvalid")),
-			"Field":   Equal("fake.domain.devices.interfaces[0].state"),
-			"Message": messageRegex,
-		}))
-	},
-		Entry("down is not supported for sriov", v1.InterfaceStateLinkDown, MatchRegexp("down.+SR-IOV")),
-		Entry("up is not supported for sriov", v1.InterfaceStateLinkUp, MatchRegexp("up.+SR-IOV")),
-		Entry("absent is not supported when bridge-binding is not used", v1.InterfaceStateAbsent, MatchRegexp("absent.+bridge")),
+	DescribeTable("network interface state is not supported",
+		func(iface v1.Interface, network *v1.Network, clusterConfig stubClusterConfigChecker, messageRegex types.GomegaMatcher) {
+			vm := libvmi.New(
+				libvmi.WithInterface(iface),
+				libvmi.WithNetwork(network),
+			)
+			statusCause := admitter.NewValidator(k8sfield.NewPath("fake"), &vm.Spec, clusterConfig).Validate()
+			Expect(statusCause).To(HaveLen(1))
+			Expect(statusCause[0]).To(MatchAllFields(Fields{
+				"Type":    Equal(metav1.CauseType("FieldValueInvalid")),
+				"Field":   Equal("fake.domain.devices.interfaces[0].state"),
+				"Message": messageRegex,
+			}))
+		},
+		Entry("down is not supported for sriov",
+			libvmi.NewInterface("foo", libvmi.WithSRIOVBinding(), libvmi.WithState(v1.InterfaceStateLinkDown)),
+			libvmi.MultusNetwork("foo", "net"),
+			stubClusterConfigChecker{},
+			MatchRegexp("down.+binding type"),
+		),
+		Entry("up is not supported for sriov",
+			libvmi.NewInterface("foo", libvmi.WithSRIOVBinding(), libvmi.WithState(v1.InterfaceStateLinkUp)),
+			libvmi.MultusNetwork("foo", "net"),
+			stubClusterConfigChecker{},
+			MatchRegexp("up.+binding type"),
+		),
+		Entry("absent is not supported when bridge-binding is not used",
+			libvmi.NewInterface("foo", libvmi.WithSRIOVBinding(), libvmi.WithState(v1.InterfaceStateAbsent)),
+			libvmi.MultusNetwork("foo", "net"),
+			stubClusterConfigChecker{},
+			MatchRegexp("absent.+bridge"),
+		),
+		Entry("down is not supported for passt",
+			libvmi.NewInterface("foo", libvmi.WithPasstBinding(), libvmi.WithState(v1.InterfaceStateLinkDown)),
+			&v1.Network{Name: "foo", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}},
+			stubClusterConfigChecker{passtBindingFeatureGateEnabled: true},
+			MatchRegexp("down.+binding type"),
+		),
+		Entry("up is not supported for passt",
+			libvmi.NewInterface("foo", libvmi.WithPasstBinding(), libvmi.WithState(v1.InterfaceStateLinkUp)),
+			&v1.Network{Name: "foo", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}},
+			stubClusterConfigChecker{passtBindingFeatureGateEnabled: true},
+			MatchRegexp("up.+binding type"),
+		),
 	)
 
 	It("network interface state value of absent is not supported on the default network", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
KubeVirt does not support setting the link state of passtBinding interfaces. This cannot be supported until we use libvirt v12.3.0 and above, which contains the fix to RHEL-152533 [1].

Currently, only bridge, masquerade, and binding plugin interfaces support setting link state to up or down.
Binding plugins can optionally implement this functionality.

Use an allowlist instead of a denylist to validate link state support.
This effectively blocks passtBinding (and any future binding types) by default, without needing to extend the condition for each new unsupported binding.

The old "valid value" table is replaced by a broader positive table that covers all allowed binding types. The empty state case is implicitly covered since every validation check guards on a specific non-empty state value.

[1] https://redhat.atlassian.net/browse/RHEL-152533

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

