### PR TITLE
tests: remove cpumanager node pinning from hotplug tests

### DIFF
--- a/tests/storage/hotplug.go
+++ b/tests/storage/hotplug.go
@@ -793,23 +793,6 @@ var _ = Describe(SIG("Hotplug", func() {
 	})
 
 	Context("[storage-req]", decorators.StorageReq, func() {
-		findCPUManagerWorkerNode := func() string {
-			nodes, err := virtClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{
-				LabelSelector: "node-role.kubernetes.io/worker",
-			})
-			Expect(err).ToNot(HaveOccurred(), "failed to list nodes")
-			for _, node := range nodes.Items {
-				nodeLabels := node.GetLabels()
-
-				for label, val := range nodeLabels {
-					if label == v1.CPUManager && val == "true" {
-						return node.Name
-					}
-				}
-			}
-			return ""
-		}
-
 		validateDryRun := func(obj metav1.Object, addVolumeFunc addVolumeFunction, sc string, volumeMode k8sv1.PersistentVolumeMode) {
 			dv := createDataVolumeAndWaitForImport(sc, volumeMode)
 
@@ -836,12 +819,7 @@ var _ = Describe(SIG("Hotplug", func() {
 					Fail("Fail test when CSI storage class is not present")
 				}
 
-				node := findCPUManagerWorkerNode()
-				opts := []libvmi.Option{}
-				if node != "" {
-					opts = append(opts, libvmi.WithNodeSelectorFor(node))
-				}
-				vmi = libvmifact.NewAlpineWithTestTooling(opts...)
+				vmi = libvmifact.NewAlpineWithTestTooling()
 
 				vmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred(), "failed to create VMI %s/%s", vmi.Namespace, vmi.Name)
@@ -882,12 +860,7 @@ var _ = Describe(SIG("Hotplug", func() {
 					Fail("Fail test when CSI storage class is not present")
 				}
 
-				node := findCPUManagerWorkerNode()
-				opts := []libvmi.Option{}
-				if node != "" {
-					opts = append(opts, libvmi.WithNodeSelectorFor(node))
-				}
-				vmi := libvmifact.NewAlpineWithTestTooling(opts...)
+				vmi := libvmifact.NewAlpineWithTestTooling()
 
 				vm, err = virtClient.VirtualMachine(testsuite.GetTestNamespace(vmi)).Create(context.Background(), libvmi.NewVirtualMachine(vmi, libvmi.WithRunStrategy(v1.RunStrategyAlways)), metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred(), "failed to create VirtualMachine")


### PR DESCRIPTION



<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
findCPUManagerWorkerNode() pinned all hotplug VMs to a single node, causing scheduling failures on CPU-constrained node
#### After this PR:
cpumanager node pinning is removed as it is no longer needed.
### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

