### PR TITLE
emit panic metric with "isa" driver too

### DIFF
--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -31,6 +31,7 @@ import (
 	"runtime"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/opencontainers/cgroups"
@@ -114,6 +115,7 @@ type VirtualMachineController struct {
 	deviceManagerController  *deviceManager.DeviceController
 	heartBeat                *heartbeat.HeartBeat
 	heartBeatInterval        time.Duration
+	lastSeenPanicCount       sync.Map
 	netConf                  netconf
 	sriovHotplugExecutorPool *executor.RateLimitedExecutorPool
 	vmiExpectations          *controller.UIDTrackingControllerExpectations
@@ -1112,6 +1114,8 @@ func (c *VirtualMachineController) updateVMIStatus(oldStatus *v1.VirtualMachineI
 		return err
 	}
 
+	c.emitPanicMetricIfNeeded(domain, vmi)
+
 	// Update conditions on VMI Status
 	err = c.updateVMIConditions(vmi, domain, condManager)
 	if err != nil {
@@ -1595,6 +1599,7 @@ func (c *VirtualMachineController) processVmCleanup(vmi *v1.VirtualMachineInstan
 	vmiId := string(vmi.UID)
 
 	c.logger.Object(vmi).Infof("Performing final local cleanup for vmi with uid %s", vmiId)
+	c.lastSeenPanicCount.Delete(vmiId)
 
 	c.migrationProxy.StopTargetListener(vmiId)
 	c.migrationProxy.StopSourceListener(vmiId)
@@ -2257,33 +2262,34 @@ func (c *VirtualMachineController) setVmPhaseForStatusReason(domain *api.Domain,
 	if err != nil {
 		return err
 	}
-	if phase == v1.Failed && vmi.Status.Phase != v1.Failed {
-		panicInfo := c.getGuestPanicInfo(domain, vmi)
-		if panicInfo != nil {
-			panicType := "unknown"
-			if panicInfo.Type != "" {
-				panicType = panicInfo.Type
-			}
-			bugcheckCode := panicInfo.Arg1
-			vhmetrics.IncGuestOSPanic(vmi.Namespace, vmi.Name, panicType, bugcheckCode)
-		}
-	}
 	vmi.Status.Phase = phase
 	return nil
 }
 
-func (c *VirtualMachineController) getGuestPanicInfo(domain *api.Domain, vmi *v1.VirtualMachineInstance) *api.GuestPanicInfo {
-	if domain != nil {
-		return domain.Status.GuestPanicInfo
+// emitPanicMetricIfNeeded increments the panic metric once per new panic event.
+// We increment by 1 rather than by the delta (PanicCount - lastSeen) to avoid
+// over-counting on virt-handler restart: the Prometheus counter resets to 0 but
+// PanicCount persists, so a delta-based approach would re-count old panics.
+func (c *VirtualMachineController) emitPanicMetricIfNeeded(domain *api.Domain, vmi *v1.VirtualMachineInstance) {
+	if domain == nil || domain.Status.PanicCount == 0 {
+		return
 	}
-	obj, exists, err := c.domainStore.GetByKey(controller.VirtualMachineInstanceKey(vmi))
-	if err != nil || !exists {
-		return nil
+
+	key := string(vmi.UID)
+	if val, ok := c.lastSeenPanicCount.Load(key); ok && val.(int) >= domain.Status.PanicCount {
+		return
 	}
-	if d, ok := obj.(*api.Domain); ok {
-		return d.Status.GuestPanicInfo
+	c.lastSeenPanicCount.Store(key, domain.Status.PanicCount)
+
+	panicType := "unknown"
+	var bugcheckCode uint64
+	if info := domain.Status.GuestPanicInfo; info != nil {
+		if info.Type != "" {
+			panicType = info.Type
+		}
+		bugcheckCode = info.Arg1
 	}
-	return nil
+	vhmetrics.IncGuestOSPanic(vmi.Namespace, vmi.Name, panicType, bugcheckCode)
 }
 
 func vmiHasTerminationGracePeriod(vmi *v1.VirtualMachineInstance) bool {

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -1186,80 +1186,86 @@ var _ = Describe("VirtualMachineInstance", func() {
 				return vmi
 			}
 
-			newPanicDomain := func(panicInfo *api.GuestPanicInfo) *api.Domain {
+			newPanicDomain := func(panicInfo *api.GuestPanicInfo, panicCount int) *api.Domain {
 				domain := api.NewMinimalDomainWithUUID("testvmi", vmiTestUUID)
 				domain.Status.Status = api.Crashed
 				domain.Status.Reason = api.ReasonPanicked
 				domain.Status.GuestPanicInfo = panicInfo
+				domain.Status.PanicCount = panicCount
 				return domain
 			}
 
+			BeforeEach(func() {
+				vhmetrics.GetGuestOSPanicTotal().Reset()
+				controller.lastSeenPanicCount.Range(func(key, _ any) bool {
+					controller.lastSeenPanicCount.Delete(key)
+					return true
+				})
+			})
+
 			It("should increment counter on hyper-v panic with bugcheck code", func() {
 				vmi := newPanicVMI()
-				domain := newPanicDomain(&api.GuestPanicInfo{Type: "hyper-v", Arg1: 0x7e})
+				domain := newPanicDomain(&api.GuestPanicInfo{Type: "hyper-v", Arg1: 0x7e}, 1)
 
-				vhmetrics.GetGuestOSPanicTotal().Reset()
-				Expect(controller.setVmPhaseForStatusReason(domain, vmi)).To(Succeed())
-				Expect(vmi.Status.Phase).To(Equal(v1.Failed))
+				controller.emitPanicMetricIfNeeded(domain, vmi)
 				expectPanicMetricValue(vmi.Namespace, vmi.Name, "hyper-v", "0x7e", 1.0)
 			})
 
-			It("should not increment counter for non-panic crash reasons", func() {
+			It("should not increment counter when PanicCount is zero", func() {
 				vmi := newPanicVMI()
 
 				domain := api.NewMinimalDomainWithUUID("testvmi", vmiTestUUID)
 				domain.Status.Status = api.Crashed
 				domain.Status.Reason = api.ReasonCrashed
 
-				vhmetrics.GetGuestOSPanicTotal().Reset()
-				Expect(controller.setVmPhaseForStatusReason(domain, vmi)).To(Succeed())
-				Expect(vmi.Status.Phase).To(Equal(v1.Failed))
+				controller.emitPanicMetricIfNeeded(domain, vmi)
 				expectPanicMetricValue(vmi.Namespace, vmi.Name, "unknown", "", 0.0)
 			})
 
-			It("should not double-increment counter when already in Failed phase", func() {
+			It("should not double-increment counter when PanicCount unchanged", func() {
 				vmi := newPanicVMI()
-				vmi.Status.Phase = v1.Failed
-				domain := newPanicDomain(&api.GuestPanicInfo{Type: "hyper-v", Arg1: 0x7e})
+				domain := newPanicDomain(&api.GuestPanicInfo{Type: "hyper-v", Arg1: 0x7e}, 1)
 
-				vhmetrics.GetGuestOSPanicTotal().Reset()
-				Expect(controller.setVmPhaseForStatusReason(domain, vmi)).To(Succeed())
-				expectPanicMetricValue(vmi.Namespace, vmi.Name, "hyper-v", "0x7e", 0.0)
+				controller.emitPanicMetricIfNeeded(domain, vmi)
+				expectPanicMetricValue(vmi.Namespace, vmi.Name, "hyper-v", "0x7e", 1.0)
+
+				controller.emitPanicMetricIfNeeded(domain, vmi)
+				expectPanicMetricValue(vmi.Namespace, vmi.Name, "hyper-v", "0x7e", 1.0)
 			})
 
-			It("should default to unknown type and empty bugcheck code when GuestPanicInfo has no details", func() {
+			It("should increment again when PanicCount increases (CRASHLOADED)", func() {
 				vmi := newPanicVMI()
-				domain := newPanicDomain(&api.GuestPanicInfo{})
+				domain := newPanicDomain(&api.GuestPanicInfo{Type: "hyper-v", Arg1: 0x7e}, 1)
 
-				vhmetrics.GetGuestOSPanicTotal().Reset()
-				Expect(controller.setVmPhaseForStatusReason(domain, vmi)).To(Succeed())
-				Expect(vmi.Status.Phase).To(Equal(v1.Failed))
+				controller.emitPanicMetricIfNeeded(domain, vmi)
+				expectPanicMetricValue(vmi.Namespace, vmi.Name, "hyper-v", "0x7e", 1.0)
+
+				domain.Status.PanicCount = 2
+				controller.emitPanicMetricIfNeeded(domain, vmi)
+				expectPanicMetricValue(vmi.Namespace, vmi.Name, "hyper-v", "0x7e", 2.0)
+			})
+
+			It("should default to unknown type when GuestPanicInfo has no details", func() {
+				vmi := newPanicVMI()
+				domain := newPanicDomain(&api.GuestPanicInfo{}, 1)
+
+				controller.emitPanicMetricIfNeeded(domain, vmi)
 				expectPanicMetricValue(vmi.Namespace, vmi.Name, "unknown", "unknown", 1.0)
 			})
 
 			It("should preserve bugcheck code even when panic type falls back to unknown", func() {
 				vmi := newPanicVMI()
-				domain := newPanicDomain(&api.GuestPanicInfo{Type: "", Arg1: 0x50})
+				domain := newPanicDomain(&api.GuestPanicInfo{Type: "", Arg1: 0x50}, 1)
 
-				vhmetrics.GetGuestOSPanicTotal().Reset()
-				Expect(controller.setVmPhaseForStatusReason(domain, vmi)).To(Succeed())
-				Expect(vmi.Status.Phase).To(Equal(v1.Failed))
+				controller.emitPanicMetricIfNeeded(domain, vmi)
 				expectPanicMetricValue(vmi.Namespace, vmi.Name, "unknown", "0x50", 1.0)
 			})
 
-			It("should use domainStore fallback for GuestPanicInfo when domain is nil", func() {
+			It("should not increment when domain is nil", func() {
 				vmi := newPanicVMI()
-				domain := newPanicDomain(&api.GuestPanicInfo{Type: "hyper-v", Arg1: 0x7e})
-				Expect(controller.domainStore.Add(domain)).To(Succeed())
 
-				controller.launcherClients = &launcherclients.MockLauncherClientManager{
-					Initialized:  true,
-					UnResponsive: true,
-				}
-
-				vhmetrics.GetGuestOSPanicTotal().Reset()
-				Expect(controller.setVmPhaseForStatusReason(nil, vmi)).To(Succeed())
-				expectPanicMetricValue(vmi.Namespace, vmi.Name, "hyper-v", "0x7e", 1.0)
+				controller.emitPanicMetricIfNeeded(nil, vmi)
+				expectPanicMetricValue(vmi.Namespace, vmi.Name, "unknown", "unknown", 0.0)
 			})
 		})
 

--- a/pkg/virt-launcher/notify-client/client.go
+++ b/pkg/virt-launcher/notify-client/client.go
@@ -283,14 +283,16 @@ func (e *eventCaller) handleGuestPanicEvent(client *Notifier, vmi *v1.VirtualMac
 	panicInfo, err := util.ReadPanicInfoFromLog(logPath)
 
 	var eventMessage string
-	if err != nil {
-		log.Log.Reason(err).Warning("Failed to read panic info from log")
+	if panicInfo == nil || err != nil {
+		if err != nil {
+			log.Log.Reason(err).Warning("Failed to read panic info from log")
+		}
 		eventMessage = "GuestPanicked (details unavailable)"
 		panicInfo = &api.GuestPanicInfo{Type: "unknown"}
 	} else {
 		eventMessage = util.FormatGuestPanicInfo(panicInfo)
-		log.Log.Infof("Guest panic detected: %s", eventMessage)
 	}
+	log.Log.Infof("Guest panic detected: %s", eventMessage)
 
 	// Only mark as handled for PANICKED events. CRASHLOADED indicates kdump-based
 	// recovery where the guest reboots, so subsequent panic events should still fire.

--- a/pkg/virt-launcher/notify-client/client.go
+++ b/pkg/virt-launcher/notify-client/client.go
@@ -283,7 +283,7 @@ func (e *eventCaller) handleGuestPanicEvent(client *Notifier, vmi *v1.VirtualMac
 	panicInfo, err := util.ReadPanicInfoFromLog(logPath)
 
 	var eventMessage string
-	if panicInfo == nil || err != nil {
+	if panicInfo == nil || err != nil || panicInfo.Type == "" {
 		if err != nil {
 			log.Log.Reason(err).Warning("Failed to read panic info from log")
 		}
@@ -315,6 +315,7 @@ func (e *eventCaller) eventCallback(c cli.Connection, domain *api.Domain, libvir
 	if isGuestPanicEvent(libvirtEvent.Event) {
 		if panicInfo := e.handleGuestPanicEvent(client, vmi, metadataCache, libvirtEvent.Event.Detail, nonRoot); panicInfo != nil {
 			domain.Status.GuestPanicInfo = panicInfo
+			domain.Status.PanicCount++
 		}
 	}
 
@@ -469,11 +470,14 @@ func (n *Notifier) StartDomainNotifier(
 			case event := <-eventChan:
 				metadataCache.ResetNotification()
 				prevPanicInfo := (*api.GuestPanicInfo)(nil)
+				var prevPanicCount int
 				if domainCache != nil {
 					prevPanicInfo = domainCache.Status.GuestPanicInfo
+					prevPanicCount = domainCache.Status.PanicCount
 				}
 				domainCache = util.NewDomainFromName(event.Domain, vmi.UID)
 				domainCache.Status.GuestPanicInfo = prevPanicInfo
+				domainCache.Status.PanicCount = prevPanicCount
 				eventCaller.eventCallback(domainConn, domainCache, event, n, deleteNotificationSent, interfaceStatuses, guestOsInfo, vmi, fsFreezeStatus, metadataCache, nonRoot)
 				log.Log.Infof("Domain name event: %v", domainCache.Spec.Name)
 				agentPoller.UpdateFromEvent(event.Event, event.AgentEvent)
@@ -493,11 +497,13 @@ func (n *Notifier) StartDomainNotifier(
 				// libvirt event arrived (which creates the first domainCache).
 				if domainCache != nil {
 					prevPanicInfo := domainCache.Status.GuestPanicInfo
+					prevPanicCount := domainCache.Status.PanicCount
 					domainCache = util.NewDomainFromName(
 						util.DomainFromNamespaceName(domainCache.ObjectMeta.Namespace, domainCache.ObjectMeta.Name),
 						vmi.UID,
 					)
 					domainCache.Status.GuestPanicInfo = prevPanicInfo
+					domainCache.Status.PanicCount = prevPanicCount
 					eventCaller.eventCallback(
 						domainConn,
 						domainCache,

--- a/pkg/virt-launcher/virtwrap/api/schema.go
+++ b/pkg/virt-launcher/virtwrap/api/schema.go
@@ -123,6 +123,7 @@ type DomainStatus struct {
 	OSInfo         GuestOSInfo
 	FSFreezeStatus FSFreeze
 	GuestPanicInfo *GuestPanicInfo
+	PanicCount     int
 }
 
 // GuestPanicInfo contains details about a guest panic event from QEMU

--- a/pkg/virt-launcher/virtwrap/util/panic_info.go
+++ b/pkg/virt-launcher/virtwrap/util/panic_info.go
@@ -171,5 +171,5 @@ func ReadPanicInfoFromLog(logPath string) (*api.GuestPanicInfo, error) {
 		return info, nil
 	}
 
-	return &api.GuestPanicInfo{}, nil
+	return nil, nil
 }

--- a/pkg/virt-launcher/virtwrap/util/panic_info_test.go
+++ b/pkg/virt-launcher/virtwrap/util/panic_info_test.go
@@ -184,7 +184,7 @@ var _ = Describe("Panic Info", func() {
 			Expect(result.Arg1).To(Equal(uint64(0x5a)))
 		})
 
-		It("should return empty struct when no panic line found", func() {
+		It("should return nil when no panic line found", func() {
 			logFile := filepath.Join(tmpDir, "test.log")
 			content := `2024-09-30 16:30:48.000+0000: normal log line
 2024-09-30 16:30:50.000+0000: more log lines
@@ -195,8 +195,7 @@ var _ = Describe("Panic Info", func() {
 			result, err := ReadPanicInfoFromLog(logFile)
 
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result).NotTo(BeNil())
-			Expect(result.Type).To(Equal(""))
+			Expect(result).To(BeNil())
 		})
 
 		It("should return last panic info when multiple panics in log", func() {
@@ -213,6 +212,19 @@ panic hyper-v: arg1='0x3'
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).NotTo(BeNil())
 			Expect(result.Arg1).To(Equal(uint64(0x3)))
+		})
+
+		It("should return nil when log has no panic lines", func() {
+			logFile := filepath.Join(tmpDir, "test.log")
+			content := `2024-09-30T16:30:49.000000Z qemu-kvm: some normal log line
+2024-09-30T16:30:50.000000Z qemu-kvm: another normal line
+`
+			err := os.WriteFile(logFile, []byte(content), 0644)
+			Expect(err).NotTo(HaveOccurred())
+
+			result, err := ReadPanicInfoFromLog(logFile)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeNil())
 		})
 
 		It("should return error for non-existent file", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
when using "isa" pvpanic driver the VM needs time to do a crash dump, and then it internally reboots, i.e. it doesn't change state. We still want the panic metric to notice that.

#### Before this PR:
panic metric was only emitted on VM state changes

#### After this PR:
it works regardless if the guest is destroyed/shut down or the kdump reboots internally and continues running

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:
added a counter to avoid the need for virt-handler to notify back to virt-launcher that the panic was handled.

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [X] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [X] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [X] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [X] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [X] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [X] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [X] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
The `kubevirt_vmi_guest_os_panic_total` metric is now emitted
for all guest panic events, including when the guest recovers internally
(e.g. via kdump/crashdump with the ISA pvpanic driver)
```

