### PR TITLE
network admitter: Reject interfaces without exactly one binding

### DIFF
--- a/pkg/network/admitter/admit_test.go
+++ b/pkg/network/admitter/admit_test.go
@@ -63,8 +63,9 @@ var _ = Describe("Validating VMI network spec", func() {
 				NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}},
 			}),
 			libvmi.WithInterface(v1.Interface{
-				Name:  "foo",
-				State: v1.InterfaceState("foo"),
+				Name:                   "foo",
+				State:                  v1.InterfaceState("foo"),
+				InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}},
 			}),
 		)
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vm.Spec, stubClusterConfigChecker{})

--- a/pkg/network/admitter/binding.go
+++ b/pkg/network/admitter/binding.go
@@ -46,21 +46,37 @@ func validateInterfaceBinding(
 }
 
 func validateInterfaceBindingExists(fieldPath *field.Path, idx int, iface v1.Interface) []metav1.StatusCause {
-	if iface.Binding != nil && hasInterfaceBindingMethod(iface) {
+	count := countInterfaceBindings(iface)
+	ifacePath := fieldPath.Child("domain", "devices", "interfaces").Index(idx)
+
+	if count != 1 {
 		return []metav1.StatusCause{{
 			Type:    metav1.CauseTypeFieldValueInvalid,
-			Message: fmt.Sprintf("logical %s interface cannot have both binding plugin and interface binding method", iface.Name),
-			Field:   fieldPath.Child("domain", "devices", "interfaces").Index(idx).Child("binding").String(),
+			Message: fmt.Sprintf("logical %s interface must have exactly one binding method or binding plugin", iface.Name),
+			Field:   ifacePath.String(),
 		}}
 	}
 	return nil
 }
 
-func hasInterfaceBindingMethod(iface v1.Interface) bool {
-	return iface.InterfaceBindingMethod.Bridge != nil ||
-		iface.InterfaceBindingMethod.Masquerade != nil ||
-		iface.InterfaceBindingMethod.SRIOV != nil ||
-		iface.InterfaceBindingMethod.PasstBinding != nil
+func countInterfaceBindings(iface v1.Interface) int {
+	count := 0
+	if iface.InterfaceBindingMethod.Bridge != nil {
+		count++
+	}
+	if iface.InterfaceBindingMethod.Masquerade != nil {
+		count++
+	}
+	if iface.InterfaceBindingMethod.SRIOV != nil {
+		count++
+	}
+	if iface.InterfaceBindingMethod.PasstBinding != nil {
+		count++
+	}
+	if iface.Binding != nil {
+		count++
+	}
+	return count
 }
 
 func validateMasqueradeBinding(fieldPath *field.Path, idx int, iface v1.Interface, net v1.Network) []metav1.StatusCause {

--- a/pkg/network/admitter/binding_test.go
+++ b/pkg/network/admitter/binding_test.go
@@ -50,8 +50,8 @@ var _ = Describe("Validating network binding combinations", func() {
 		Expect(validator.Validate()).To(
 			ConsistOf(metav1.StatusCause{
 				Type:    "FieldValueInvalid",
-				Message: "logical foo interface cannot have both binding plugin and interface binding method",
-				Field:   "fake.domain.devices.interfaces[0].binding",
+				Message: "logical foo interface must have exactly one binding method or binding plugin",
+				Field:   "fake.domain.devices.interfaces[0]",
 			}))
 	})
 
@@ -69,6 +69,50 @@ var _ = Describe("Validating network binding combinations", func() {
 		clusterConfig := stubClusterConfigChecker{}
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vm.Spec, clusterConfig)
 		Expect(validator.Validate()).To(BeEmpty())
+	})
+
+	It("network interface has neither binding plugin nor interface binding method", func() {
+		vm := libvmi.New(
+			libvmi.WithInterface(v1.Interface{
+				Name: "foo",
+			}),
+			libvmi.WithNetwork(&v1.Network{
+				Name:          "foo",
+				NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}},
+			}),
+		)
+		clusterConfig := stubClusterConfigChecker{}
+		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vm.Spec, clusterConfig)
+		Expect(validator.Validate()).To(
+			ConsistOf(metav1.StatusCause{
+				Type:    "FieldValueInvalid",
+				Message: "logical foo interface must have exactly one binding method or binding plugin",
+				Field:   "fake.domain.devices.interfaces[0]",
+			}))
+	})
+
+	It("network interface has more than one binding method", func() {
+		vm := libvmi.New(
+			libvmi.WithInterface(v1.Interface{
+				Name: "foo",
+				InterfaceBindingMethod: v1.InterfaceBindingMethod{
+					Bridge:     &v1.InterfaceBridge{},
+					Masquerade: &v1.InterfaceMasquerade{},
+				},
+			}),
+			libvmi.WithNetwork(&v1.Network{
+				Name:          "foo",
+				NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}},
+			}),
+		)
+		clusterConfig := stubClusterConfigChecker{bridgeBindingOnPodNetEnabled: true}
+		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vm.Spec, clusterConfig)
+		Expect(validator.Validate()).To(
+			ConsistOf(metav1.StatusCause{
+				Type:    "FieldValueInvalid",
+				Message: "logical foo interface must have exactly one binding method or binding plugin",
+				Field:   "fake.domain.devices.interfaces[0]",
+			}))
 	})
 
 	It("network interface has only binding method", func() {

--- a/pkg/network/admitter/netsource_test.go
+++ b/pkg/network/admitter/netsource_test.go
@@ -77,7 +77,7 @@ var _ = Describe("Validate network source", func() {
 			NetworkSource: v1.NetworkSource{},
 			Name:          "testnet1",
 		}
-		iface1 := v1.Interface{Name: net1.Name}
+		iface1 := v1.Interface{Name: net1.Name, InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}}
 		spec.Networks = []v1.Network{net1}
 		spec.Domain.Devices.Interfaces = []v1.Interface{iface1}
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{})

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -2785,7 +2785,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
 			bootOrder := uint(1)
 			vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{
-				{Name: vmi.Spec.Networks[0].Name, BootOrder: &bootOrder},
+				{Name: vmi.Spec.Networks[0].Name, BootOrder: &bootOrder, InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}}},
 			}
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
 			Expect(causes).To(HaveLen(len(vmi.Spec.Domain.Devices.Interfaces)))
@@ -2963,7 +2963,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
 			bootOrder := uint(1)
 			vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{
-				{Name: vmi.Spec.Networks[0].Name, BootOrder: &bootOrder},
+				{Name: vmi.Spec.Networks[0].Name, BootOrder: &bootOrder, InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}}},
 			}
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
 			Expect(causes).To(HaveLen(len(vmi.Spec.Domain.Devices.Interfaces)))
@@ -4125,7 +4125,7 @@ var _ = Describe("additional tests", func() {
 			Name: "testnet",
 		}
 		order := uint(1)
-		iface := v1.Interface{Name: net.Name, BootOrder: &order}
+		iface := v1.Interface{Name: net.Name, BootOrder: &order, InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}}}
 		spec.Networks = []v1.Network{net}
 		spec.Domain.Devices.Interfaces = []v1.Interface{iface}
 		causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), spec, config)
@@ -4141,7 +4141,7 @@ var _ = Describe("additional tests", func() {
 			Name: "testnet",
 		}
 		order := uint(0)
-		iface := v1.Interface{Name: net.Name, BootOrder: &order}
+		iface := v1.Interface{Name: net.Name, BootOrder: &order, InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}}}
 		spec.Networks = []v1.Network{net}
 		spec.Domain.Devices.Interfaces = []v1.Interface{iface}
 		causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), spec, config)
@@ -4158,7 +4158,7 @@ var _ = Describe("additional tests", func() {
 			Name: "testnet",
 		}
 		order1 := uint(7)
-		iface := v1.Interface{Name: net.Name, BootOrder: &order1}
+		iface := v1.Interface{Name: net.Name, BootOrder: &order1, InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}}}
 		spec.Networks = []v1.Network{net}
 		spec.Domain.Devices.Interfaces = []v1.Interface{iface}
 		order2 := uint(77)
@@ -4193,7 +4193,7 @@ var _ = Describe("additional tests", func() {
 			Name: "testnet",
 		}
 		order := uint(7)
-		iface := v1.Interface{Name: net.Name, BootOrder: &order}
+		iface := v1.Interface{Name: net.Name, BootOrder: &order, InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}}}
 		spec.Networks = []v1.Network{net}
 		spec.Domain.Devices.Interfaces = []v1.Interface{iface}
 		disk := v1.Disk{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Previously, an interface that specified neither a binding method (bridge, masquerade, SR-IOV, passt) nor a binding plugin was silently accepted by the validating webhook. At runtime, virt-handler hits the default branch in NetPod.discover [1] which returns "undefined binding method". This causes every sync attempt to fail, virt-handler re-enqueues the VMI indefinitely, and the VM never starts.

Similarly, multiple binding methods on the same interface (e.g. bridge and masquerade) passed admission but caused inconsistent behavior across code paths, where each switch/if-else chain picks a different winner.

Validate that each interface has exactly one binding — either a single binding method or a binding plugin — and reject at admission otherwise.

Note: countInterfaceBindings does not cover the deprecated bindings (slirp, passt, macvtap). An interface with only a deprecated binding would receive both a "must have a binding" and a "has been discontinued" cause. This is pre-existing behavior and not addressed here.

[1] https://github.com/kubevirt/kubevirt/blob/b9539ec6274bd029e1b92d522f0f6de3243977e0/pkg/network/setup/netpod/discover.go#L99

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed missing validation for network interface bindings: interfaces with no binding or multiple bindings are now rejected at admission instead of failing silently at runtime.
```

