### PR TITLE
cmd-client: handle gRPC status errors with backward-compatible fallback and normalize inconsistent methods

### DIFF
--- a/pkg/virt-handler/cmd-client/BUILD.bazel
+++ b/pkg/virt-handler/cmd-client/BUILD.bazel
@@ -50,6 +50,8 @@ go_test(
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/go.uber.org/mock/gomock:go_default_library",
         "//vendor/google.golang.org/grpc:go_default_library",
+        "//vendor/google.golang.org/grpc/codes:go_default_library",
+        "//vendor/google.golang.org/grpc/status:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
     ],
 )

--- a/pkg/virt-handler/cmd-client/client.go
+++ b/pkg/virt-handler/cmd-client/client.go
@@ -722,14 +722,11 @@ func (c *VirtLauncherClient) Exec(domainName, command string, args []string, tim
 	defer cancel()
 
 	resp, err := c.v1client.Exec(ctx, request)
-	if resp == nil {
-		return exitCode, stdOut, err
+	if resp != nil {
+		exitCode = int(resp.ExitCode)
+		stdOut = resp.StdOut
 	}
-
-	exitCode = int(resp.ExitCode)
-	stdOut = resp.StdOut
-
-	return exitCode, stdOut, err
+	return exitCode, stdOut, handleError(err, "Exec", resp.GetResponse())
 }
 
 func (c *VirtLauncherClient) GuestPing(domainName string, timeoutSeconds int32) error {
@@ -745,8 +742,8 @@ func (c *VirtLauncherClient) GuestPing(domainName string, timeoutSeconds int32) 
 	)
 	defer cancel()
 
-	_, err := c.v1client.GuestPing(ctx, request)
-	return err
+	resp, err := c.v1client.GuestPing(ctx, request)
+	return handleError(err, "GuestPing", resp.GetResponse())
 }
 
 func (c *VirtLauncherClient) GetScreenshot(vmi *v1.VirtualMachineInstance) (*cmdv1.ScreenshotResponse, error) {
@@ -764,7 +761,12 @@ func (c *VirtLauncherClient) GetScreenshot(vmi *v1.VirtualMachineInstance) (*cmd
 	ctx, cancel := context.WithTimeout(context.Background(), shortTimeout)
 	defer cancel()
 
-	return c.v1client.GetScreenshot(ctx, request)
+	resp, err := c.v1client.GetScreenshot(ctx, request)
+	err = handleError(err, "GetScreenshot", resp.GetResponse())
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
 }
 
 func (c *VirtLauncherClient) GetSEVInfo() (*v1.SEVPlatformInfo, error) {
@@ -892,13 +894,11 @@ func (c *VirtLauncherClient) RedefineCheckpoint(vmi *v1.VirtualMachineInstance, 
 	ctx, cancel := context.WithTimeout(context.Background(), longTimeout)
 	defer cancel()
 	response, err := c.v1client.RedefineCheckpoint(ctx, request)
-	if err != nil {
-		return false, fmt.Errorf("RedefineCheckpoint call failed: %v", err)
+	if err = handleError(err, "RedefineCheckpoint", response.GetResponse()); err != nil {
+		if response != nil {
+			return response.CheckpointInvalid, err
+		}
+		return false, err
 	}
-
-	if response.Response != nil && !response.Response.Success {
-		return response.CheckpointInvalid, fmt.Errorf("RedefineCheckpoint failed: %s", response.Response.Message)
-	}
-
 	return false, nil
 }

--- a/pkg/virt-handler/cmd-client/client_test.go
+++ b/pkg/virt-handler/cmd-client/client_test.go
@@ -22,6 +22,7 @@ package cmdclient
 import (
 	"context"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -30,6 +31,8 @@ import (
 	gomock "go.uber.org/mock/gomock"
 
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 	"k8s.io/apimachinery/pkg/types"
 
 	"kubevirt.io/client-go/api"
@@ -220,8 +223,183 @@ var _ = Describe("Virt remote commands", func() {
 				err := client.GuestPing(testDomainName, testTimeoutSeconds)
 				Expect(err).ToNot(HaveOccurred())
 			})
+
+			It("Exec should propagate gRPC status errors", func() {
+				expectExec().Times(1).Return(
+					nil, status.Errorf(codes.InvalidArgument, "bad exec request"),
+				)
+				_, _, err := client.Exec(testDomainName, testCommand, testArgs, testTimeoutSeconds)
+				Expect(err).To(MatchError(ContainSubstring("InvalidArgument")))
+			})
+
+			It("Exec should return legacy Response.Success errors", func() {
+				expectExec().Times(1).Return(&cmdv1.ExecResponse{
+					Response: &cmdv1.Response{Success: false, Message: "legacy exec error"},
+				}, nil)
+				_, _, err := client.Exec(testDomainName, testCommand, testArgs, testTimeoutSeconds)
+				Expect(err).To(MatchError(ContainSubstring("legacy exec error")))
+			})
+
+			It("Exec should return exitCode and stdOut even on legacy error", func() {
+				expectExec().Times(1).Return(&cmdv1.ExecResponse{
+					ExitCode: 42,
+					StdOut:   "partial output",
+					Response: &cmdv1.Response{Success: false, Message: "exec failed"},
+				}, nil)
+				exitCode, stdOut, err := client.Exec(testDomainName, testCommand, testArgs, testTimeoutSeconds)
+				Expect(err).To(HaveOccurred())
+				Expect(exitCode).To(Equal(42))
+				Expect(stdOut).To(Equal("partial output"))
+			})
+
+			It("GuestPing should propagate gRPC status errors", func() {
+				expectGuestPing().Times(1).Return(
+					nil, status.Errorf(codes.Internal, "ping failed"),
+				)
+				err := client.GuestPing(testDomainName, testTimeoutSeconds)
+				Expect(err).To(MatchError(ContainSubstring("Internal")))
+			})
+
+			It("GuestPing should return legacy Response.Success errors", func() {
+				expectGuestPing().Times(1).Return(&cmdv1.GuestPingResponse{
+					Response: &cmdv1.Response{Success: false, Message: "not available"},
+				}, nil)
+				err := client.GuestPing(testDomainName, testTimeoutSeconds)
+				Expect(err).To(MatchError(ContainSubstring("not available")))
+			})
+
+			It("GetScreenshot should succeed", func() {
+				mockCmdClient.EXPECT().GetScreenshot(gomock.Any(), gomock.Any()).Return(
+					&cmdv1.ScreenshotResponse{
+						Response: &cmdv1.Response{Success: true},
+						Data:     []byte("data"),
+					}, nil,
+				)
+				vmi := api.NewMinimalVMI("test")
+				resp, err := client.GetScreenshot(vmi)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(resp.Data).To(Equal([]byte("data")))
+			})
+
+			It("GetScreenshot should propagate gRPC status errors", func() {
+				mockCmdClient.EXPECT().GetScreenshot(gomock.Any(), gomock.Any()).Return(
+					nil, status.Errorf(codes.Internal, "screenshot failed"),
+				)
+				vmi := api.NewMinimalVMI("test")
+				_, err := client.GetScreenshot(vmi)
+				Expect(err).To(MatchError(ContainSubstring("Internal")))
+			})
+
+			It("GetScreenshot should return legacy Response.Success errors", func() {
+				mockCmdClient.EXPECT().GetScreenshot(gomock.Any(), gomock.Any()).Return(
+					&cmdv1.ScreenshotResponse{
+						Response: &cmdv1.Response{Success: false, Message: "no display"},
+					}, nil,
+				)
+				vmi := api.NewMinimalVMI("test")
+				_, err := client.GetScreenshot(vmi)
+				Expect(err).To(MatchError(ContainSubstring("no display")))
+			})
+
+			It("RedefineCheckpoint should succeed", func() {
+				mockCmdClient.EXPECT().RedefineCheckpoint(gomock.Any(), gomock.Any()).Return(
+					&cmdv1.RedefineCheckpointResponse{
+						Response: &cmdv1.Response{Success: true},
+					}, nil,
+				)
+				vmi := api.NewMinimalVMI("test")
+				checkpointInvalid, err := client.RedefineCheckpoint(vmi, nil)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(checkpointInvalid).To(BeFalse())
+			})
+
+			It("RedefineCheckpoint should propagate gRPC status errors", func() {
+				mockCmdClient.EXPECT().RedefineCheckpoint(gomock.Any(), gomock.Any()).Return(
+					nil, status.Errorf(codes.Internal, "checkpoint error"),
+				)
+				vmi := api.NewMinimalVMI("test")
+				checkpointInvalid, err := client.RedefineCheckpoint(vmi, nil)
+				Expect(err).To(MatchError(ContainSubstring("Internal")))
+				Expect(checkpointInvalid).To(BeFalse())
+			})
+
+			It("RedefineCheckpoint should return legacy error with CheckpointInvalid", func() {
+				mockCmdClient.EXPECT().RedefineCheckpoint(gomock.Any(), gomock.Any()).Return(
+					&cmdv1.RedefineCheckpointResponse{
+						Response:          &cmdv1.Response{Success: false, Message: "invalid checkpoint"},
+						CheckpointInvalid: true,
+					}, nil,
+				)
+				vmi := api.NewMinimalVMI("test")
+				checkpointInvalid, err := client.RedefineCheckpoint(vmi, nil)
+				Expect(err).To(MatchError(ContainSubstring("invalid checkpoint")))
+				Expect(checkpointInvalid).To(BeTrue())
+			})
 		})
 	})
+
+	Describe("handleError", func() {
+		DescribeTable("should handle errors correctly",
+			func(err error, response *cmdv1.Response, expectNil bool, expectSubstring string) {
+				result := handleError(err, "TestCommand", response)
+				if expectNil {
+					Expect(result).ToNot(HaveOccurred())
+				} else {
+					Expect(result).To(MatchError(ContainSubstring(expectSubstring)))
+				}
+			},
+			Entry("nil error and nil response",
+				nil, nil, true, ""),
+			Entry("nil error and successful response",
+				nil, &cmdv1.Response{Success: true}, true, ""),
+			Entry("legacy server error via Response.Success",
+				nil, &cmdv1.Response{Success: false, Message: "legacy failure"},
+				false, "legacy failure"),
+			Entry("response with Success false but empty Message should not error",
+				nil, &cmdv1.Response{Success: false, Message: ""},
+				true, ""),
+			Entry("gRPC InvalidArgument error",
+				status.Errorf(codes.InvalidArgument, "bad request"),
+				nil, false, "InvalidArgument"),
+			Entry("gRPC Internal error",
+				status.Errorf(codes.Internal, "server crashed"),
+				nil, false, "Internal"),
+			Entry("non-gRPC error",
+				errors.New("something went wrong"),
+				nil, false, "something went wrong"),
+		)
+
+		It("should pass through disconnected errors unchanged", func() {
+			err := handleError(io.EOF, "TestCommand", nil)
+			Expect(err).To(MatchError(io.EOF))
+		})
+
+		It("should pass through unimplemented errors unchanged", func() {
+			grpcErr := status.Errorf(codes.Unimplemented, "not implemented")
+			err := handleError(grpcErr, "TestCommand", nil)
+			Expect(err).To(Equal(grpcErr))
+		})
+
+		It("should include the command name in error messages", func() {
+			err := handleError(
+				status.Errorf(codes.Internal, "internal error"), "SyncVirtualMachine", nil,
+			)
+			Expect(err).To(MatchError(ContainSubstring("SyncVirtualMachine")))
+		})
+
+		It("should wrap gRPC errors preserving the error chain", func() {
+			grpcErr := status.Errorf(codes.InvalidArgument, "bad request")
+			err := handleError(grpcErr, "TestCommand", nil)
+			Expect(errors.Is(err, grpcErr)).To(BeTrue())
+		})
+
+		It("should wrap non-gRPC errors preserving the error chain", func() {
+			originalErr := errors.New("custom error")
+			err := handleError(originalErr, "TestCommand", nil)
+			Expect(errors.Is(err, originalErr)).To(BeTrue())
+		})
+	})
+
 	Describe("Version mismatch", func() {
 		It("Should report error when server version mismatches", func() {
 			infoClient := info.NewMockCmdInfoClient(gomock.NewController(GinkgoT()))

--- a/pkg/virt-handler/cmd-client/errors.go
+++ b/pkg/virt-handler/cmd-client/errors.go
@@ -47,10 +47,16 @@ func handleError(err error, cmdName string, response *cmdv1.Response) error {
 		return err
 	} else if IsUnimplemented(err) {
 		return err
-	} else if err != nil {
-		msg := fmt.Sprintf("unknown error encountered sending command %s: %s", cmdName, err.Error())
-		return fmt.Errorf("%s", msg)
-	} else if response != nil && !response.Success {
+	}
+
+	st, _ := status.FromError(err)
+	if st.Code() != codes.OK {
+		return fmt.Errorf("command %s failed with %s: %w", cmdName, st.Code(), err)
+	}
+
+	// Fallback for old servers that embed errors in Response instead of using gRPC status codes
+	// This check can be removed once all servers are migrated
+	if response != nil && !response.Success && response.Message != "" {
 		return fmt.Errorf("server error. command %s failed: %q", cmdName, response.Message)
 	}
 	return nil

--- a/tests/network/sriov.go
+++ b/tests/network/sriov.go
@@ -765,7 +765,7 @@ func waitVMI(vmi *v1.VirtualMachineInstance) (*v1.VirtualMachineInstance, error)
 		// Running multi sriov jobs with Kind, DinD is resource extensive, causing DeadlineExceeded transient warning
 		// Kubevirt re-enqueue the request once it happens, so its safe to ignore this warning.
 		// see https://github.com/kubevirt/kubevirt/issues/5027
-		"unknown error encountered sending command SyncVMI: rpc error: code = DeadlineExceeded desc = context deadline exceeded",
+		"command SyncVMI failed with DeadlineExceeded: rpc error: code = DeadlineExceeded desc = context deadline exceeded",
 
 		// SR-IOV tests run on Kind cluster in a docker-in-docker CI environment which is resource extensive,
 		// causing general slowness in the cluster.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
The cmd-client in virt-handler uses the same antipattern as the notify-client (fixed [here](https://github.com/kubevirt/kubevirt/pull/18340)): the `handleError` function wraps gRPC errors as "unknown error", losing information about the gRPC status code. Moreover 4 methods (`Exec`, `GuestPing`, `GetScreenshot`, `RedefineCheckpoint`) are not using the `handleError` methods creating inconsistencies in error handling.
#### After this PR:
As part of the multi-release migration planned [here](https://github.com/kubevirt/kubevirt/issues/18285#issuecomment-4867601530), the cmd-client is updated to:
- Extract gRPC status codes in handleError, while keeping the Response.Success check as a fallback for backward compatibility with old servers.
- Normalize the 4 inconsistent methods (`Exec`, `GuestPing`, `GetScreenshot`, `RedefineCheckpoint`) to go through handleError like all other methods.
In this way all the cmd-client methods follow the same error handling path and are ready to work with both old servers (using Response.Success) and future migrated servers (using standard gRPC status errors).
### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
- Partially addresses #18285
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:
- Same multi-release approach as [notify-client](https://github.com/kubevirt/kubevirt/pull/18340): clients are updated first, servers will be migrated in a subsequent release, and the fallback will be removed in a final cleanup release.
- Error messages in handleError changed from "unknown error encountered sending command..." to "command ... failed with <gRPC status code>: ...". This propagates to Kubernetes warning events, so the SR-IOV e2e test warning ignore list has been updated accordingly.

The following alternatives were considered:

Links to places where the discussion took place: https://github.com/kubevirt/kubevirt/issues/18285

### Special notes for your reviewer
The 4 normalized methods were previously inconsistent (not using the `handleError` method):
- `Exec` and `GuestPing` ignored Response.Success entirely
- `GetScreenshot` returned the raw response without any error checking
- `RedefineCheckpoint` had a custom inline Response.Success check instead of using handleError
All 4 methods now go through `handleError`, which also preserves the error chain.

The existing unit tests pass without modification, ensuring no regression. New unit tests have been added for `handleError` itself (previously untested) and for the 4 normalized methods, covering gRPC status errors, legacy Response.Success errors, and success cases.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [X] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [X] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [X] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [X] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [X] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

