### PR TITLE
Add fg report to release artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -253,7 +253,7 @@ update-generated-api-testdata:
 
 feature-gate-report:
 	hack/dockerized "bazel build //tools/feature-gate-report && \
-		./bazel-bin/tools/feature-gate-report/feature-gate-report_/feature-gate-report"
+		./bazel-bin/tools/feature-gate-report/feature-gate-report_/feature-gate-report $(FEATURE_GATE_REPORT_ARGS)"
 
 vmlog-checker:
 	@echo "Building vmlog-checker..."

--- a/automation/release.sh
+++ b/automation/release.sh
@@ -41,6 +41,7 @@ function build_release_artifacts() {
     make manifests
     make olm-verify
     make prom-rules-verify
+    make feature-gate-report FEATURE_GATE_REPORT_ARGS="--output-format=json --output-file=_out/manifests/release/feature-gates.json"
 
     BUILD_ARCH="${BUILD_ARCH}" QUAY_REPOSITORY="kubevirt" PACKAGE_NAME="kubevirt-operatorhub" make bazel-push-images
 
@@ -67,6 +68,7 @@ function update_github_release() {
         _out/manifests/release/kubevirt-network-policies.yaml \
         _out/manifests/release/olm/kubevirt-operatorsource.yaml \
         "_out/manifests/release/olm/bundle/kubevirtoperator.$DOCKER_TAG.clusterserviceversion.yaml" \
+        _out/manifests/release/feature-gates.json \
         _out/tests/tests.test \
         _out/manifests/release/conformance.yaml \
         _out/manifests/testing/* \

--- a/tools/feature-gate-report/README.md
+++ b/tools/feature-gate-report/README.md
@@ -1,6 +1,6 @@
 # Feature Gate Report
 
-Prints a JSON summary of all registered KubeVirt feature gates (excluding GA and Discontinued).
+Prints a summary of all registered KubeVirt feature gates (excluding GA and Discontinued).
 
 ## Usage
 
@@ -8,9 +8,15 @@ Prints a JSON summary of all registered KubeVirt feature gates (excluding GA and
 make feature-gate-report
 ```
 
+## Options
+
+- `--output-format=json` (default) — JSON array sorted by state then name
+- `--output-format=md` — Markdown table sorted by state then name
+- `--output-file=PATH` — Write output to a file instead of stdout
+
 ## Output
 
-JSON array sorted by state then name:
+### JSON (default)
 
 ```json
 [
@@ -18,4 +24,16 @@ JSON array sorted by state then name:
   {"name": "MyBetaFeature", "state": "Beta"},
   {"name": "MyDeprecatedFeature", "state": "Deprecated"}
 ]
+```
+
+### Markdown
+
+```markdown
+# Feature Gate Report
+
+| Feature Gate | State |
+|---|---|
+| MyAlphaFeature | Alpha |
+| MyBetaFeature | Beta |
+| MyDeprecatedFeature | Deprecated |
 ```

--- a/tools/feature-gate-report/feature-gate-report.go
+++ b/tools/feature-gate-report/feature-gate-report.go
@@ -21,7 +21,9 @@ package main
 
 import (
 	"encoding/json"
+	"flag"
 	"fmt"
+	"io"
 	"os"
 	"sort"
 
@@ -33,7 +35,7 @@ type featureGateEntry struct {
 	State string `json:"state"`
 }
 
-func main() {
+func collectEntries() []featureGateEntry {
 	gates := featuregate.GetRegisteredFeatureGates()
 
 	var entries []featureGateEntry
@@ -54,10 +56,63 @@ func main() {
 		return entries[i].Name < entries[j].Name
 	})
 
+	return entries
+}
+
+func renderJSON(w io.Writer, entries []featureGateEntry) error {
 	data, err := json.MarshalIndent(entries, "", "  ")
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		return fmt.Errorf("marshaling JSON: %w", err)
+	}
+	if _, err = fmt.Fprintln(w, string(data)); err != nil {
+		return fmt.Errorf("writing output: %w", err)
+	}
+	return nil
+}
+
+func renderMarkdown(w io.Writer, entries []featureGateEntry) {
+	fmt.Fprintln(w, "# Feature Gate Report")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "| Feature Gate | State |")
+	fmt.Fprintln(w, "|---|---|")
+	for _, e := range entries {
+		fmt.Fprintf(w, "| %s | %s |\n", e.Name, e.State)
+	}
+}
+
+func main() {
+	outputFormat := flag.String("output-format", "json", "Output format: json or md")
+	outputFile := flag.String("output-file", "", "Output file path (default: stdout)")
+	flag.Parse()
+
+	entries := collectEntries()
+
+	w := io.Writer(os.Stdout)
+	if *outputFile != "" {
+		f, err := os.Create(*outputFile)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+		defer func() {
+			if err := f.Close(); err != nil {
+				fmt.Fprintf(os.Stderr, "Error closing file: %v\n", err)
+				os.Exit(1)
+			}
+		}()
+		w = f
+	}
+
+	switch *outputFormat {
+	case "json":
+		if err := renderJSON(w, entries); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+			os.Exit(1)
+		}
+	case "md":
+		renderMarkdown(w, entries)
+	default:
+		fmt.Fprintf(os.Stderr, "Error: unknown output format %q (supported: json, md)\n", *outputFormat)
 		os.Exit(1)
 	}
-	fmt.Println(string(data))
 }

--- a/tools/feature-gate-report/feature-gate-report_test.go
+++ b/tools/feature-gate-report/feature-gate-report_test.go
@@ -20,6 +20,9 @@
 package main
 
 import (
+	"bytes"
+	"encoding/json"
+	"strings"
 	"testing"
 
 	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
@@ -40,6 +43,65 @@ func TestFeatureGateReport(t *testing.T) {
 		}
 		if fg.State != featuregate.Alpha && fg.State != featuregate.Beta && fg.State != featuregate.Deprecated {
 			t.Errorf("feature gate %q has unexpected state %q", name, fg.State)
+		}
+	}
+}
+
+func TestRenderJSON(t *testing.T) {
+	entries := []featureGateEntry{
+		{Name: "FeatureA", State: "Alpha"},
+		{Name: "FeatureB", State: "Beta"},
+	}
+
+	var buf bytes.Buffer
+	if err := renderJSON(&buf, entries); err != nil {
+		t.Fatalf("renderJSON returned error: %v", err)
+	}
+
+	var got []featureGateEntry
+	if err := json.Unmarshal(buf.Bytes(), &got); err != nil {
+		t.Fatalf("output is not valid JSON: %v", err)
+	}
+
+	if len(got) != len(entries) {
+		t.Fatalf("expected %d entries, got %d", len(entries), len(got))
+	}
+	for i, e := range entries {
+		if got[i] != e {
+			t.Errorf("entry %d: expected %+v, got %+v", i, e, got[i])
+		}
+	}
+}
+
+func TestRenderMarkdown(t *testing.T) {
+	entries := []featureGateEntry{
+		{Name: "FeatureA", State: "Alpha"},
+		{Name: "FeatureB", State: "Beta"},
+		{Name: "FeatureC", State: "Deprecated"},
+	}
+
+	var buf bytes.Buffer
+	renderMarkdown(&buf, entries)
+	output := buf.String()
+
+	lines := strings.Split(strings.TrimRight(output, "\n"), "\n")
+
+	expectedLines := []string{
+		"# Feature Gate Report",
+		"",
+		"| Feature Gate | State |",
+		"|---|---|",
+		"| FeatureA | Alpha |",
+		"| FeatureB | Beta |",
+		"| FeatureC | Deprecated |",
+	}
+
+	if len(lines) != len(expectedLines) {
+		t.Fatalf("expected %d lines, got %d:\n%s", len(expectedLines), len(lines), output)
+	}
+	for i, expected := range expectedLines {
+		if lines[i] != expected {
+			t.Errorf("line %d: expected %q, got %q", i, expected, lines[i])
 		}
 	}
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
The `feature-gate-report` tool only outputs JSON and has no way to write directly to a file. The report is not included in release artifacts.

#### After this PR:
The tool supports `--output-format` (`json` or `md`) and `--output-file` flags. The `make feature-gate-report` target accepts `FEATURE_GATE_REPORT_ARGS` to pass these flags through. A json feature gate report is generated during the release build and included as a GitHub release asset. JSON was chosen to make it easier to use in the context 
of automation.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way

Including a human-readable feature gate report in release artifacts makes it easy for users and release managers to see which feature gates are available at each maturity level (Alpha, Beta, Deprecated) without inspecting the source code.

The `--output-file` flag was added because `hack/dockerized` mixes its own output (rsync, bazel) into stdout, making shell redirection unreliable for capturing clean output.

### Special notes for your reviewer

This works started from: https://github.com/kubevirt/kubevirt.github.io/pull/1027#discussion_r3530029059

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```

/cc @iholder101 @jean-edouard 
@xpivarc FYI