### PR TITLE
Enforce KubeVirtTestSuiteSetup usage in unit test suites

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -234,6 +234,7 @@ format:
 fmt: format
 
 lint:
+	hack/dockerized "hack/lint-suite-test-setup.sh"
 	hack/dockerized "hack/lint-test-cleanup-label.sh"
 	hack/dockerized "hack/lint-newcirros-deprecation.sh"
 	hack/dockerized "hack/golangci-lint.sh"

--- a/hack/lint-suite-test-setup.sh
+++ b/hack/lint-suite-test-setup.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+#
+# This file is part of the KubeVirt project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright the KubeVirt Authors.
+#
+# Ensures all Ginkgo test suite files use KubeVirtTestSuiteSetup instead of
+# the plain ginkgo bootstrap (RegisterFailHandler + RunSpecs). The shared
+# setup provides log redirection, gomega format settings, and bazel JUnit
+# XML integration.
+#
+# See https://github.com/kubevirt/kubevirt/issues/15675
+
+set -eo pipefail
+
+# Files that legitimately cannot use KubeVirtTestSuiteSetup:
+#   - tests/tests_suite_test.go: functional test suite with its own setup
+#   - staging/.../apitesting: not a ginkgo suite (regular go test)
+#   - staging/.../client-go/log: inlines the logic to avoid circular import
+EXCLUDE_FILES="
+tests/tests_suite_test.go
+staging/src/kubevirt.io/api/apitesting/apitesting_suite_test.go
+staging/src/kubevirt.io/client-go/log/log_suite_test.go
+"
+
+exit_code=0
+
+for f in $(find . -name '*_suite_test.go' -not -path './vendor/*' | sed 's|^\./||' | sort); do
+    if echo "$EXCLUDE_FILES" | grep -Fqx -- "$f"; then
+        continue
+    fi
+
+    if ! grep -q 'KubeVirtTestSuiteSetup' "$f"; then
+        echo "ERROR: $f does not use testutils.KubeVirtTestSuiteSetup(t)"
+        echo "       Replace the plain ginkgo bootstrap with:"
+        echo "           testutils.KubeVirtTestSuiteSetup(t)"
+        echo "       See https://github.com/kubevirt/kubevirt/issues/15675"
+        echo ""
+        exit_code=1
+    fi
+done
+
+if [ "$exit_code" -ne 0 ]; then
+    exit 1
+fi
+
+echo "All suite test files use KubeVirtTestSuiteSetup."

--- a/pkg/virt-handler/notify-server/BUILD.bazel
+++ b/pkg/virt-handler/notify-server/BUILD.bazel
@@ -35,6 +35,7 @@ go_test(
     race = "on",
     deps = [
         ":go_default_library",
+        "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/watch:go_default_library",

--- a/pkg/virt-handler/notify-server/notify_server_suite_test.go
+++ b/pkg/virt-handler/notify-server/notify_server_suite_test.go
@@ -22,11 +22,9 @@ package eventsserver_test
 import (
 	"testing"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	"kubevirt.io/client-go/testutils"
 )
 
 func TestNotifyServer(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "Notify Server Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }

--- a/pkg/virt-launcher/premigration-hook-server/vgpuhook/BUILD.bazel
+++ b/pkg/virt-launcher/premigration-hook-server/vgpuhook/BUILD.bazel
@@ -26,6 +26,7 @@ go_test(
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//pkg/virt-launcher/virtwrap/converter/types:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/pkg/virt-launcher/premigration-hook-server/vgpuhook/vpguhook_suite_test.go
+++ b/pkg/virt-launcher/premigration-hook-server/vgpuhook/vpguhook_suite_test.go
@@ -3,11 +3,9 @@ package vgpuhook_test
 import (
 	"testing"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	"kubevirt.io/client-go/testutils"
 )
 
 func TestVGPUHook(t *testing.T) {
-	RegisterFailHandler(Fail)
-	RunSpecs(t, "vGPUHook Suite")
+	testutils.KubeVirtTestSuiteSetup(t)
 }


### PR DESCRIPTION
### What this PR does
#### Before this PR:

Two unit test suites used the plain ginkgo bootstrap (`RegisterFailHandler` + `RunSpecs`) instead of `testutils.KubeVirtTestSuiteSetup`, missing log redirection to `GinkgoWriter`, gomega format settings, and bazel JUnit XML integration. New suites could be introduced without `KubeVirtTestSuiteSetup` with no CI check to catch it.

#### After this PR:

The two remaining offending suites are fixed, and a new lint check (`hack/lint-suite-test-setup.sh`) is wired into `make lint` to prevent regressions. The lint script has exclusions for the three files that legitimately cannot use `KubeVirtTestSuiteSetup`:
- `tests/tests_suite_test.go` — functional test suite with its own setup
- `staging/.../apitesting/apitesting_suite_test.go` — not a ginkgo suite
- `staging/.../client-go/log/log_suite_test.go` — inlines the logic to avoid circular import

### References

- Fixes https://github.com/kubevirt/kubevirt/issues/15675

### Why we need it and why it was done in this way

`hack/bootstrap-ginkgo.sh` runs `ginkgo bootstrap` which generates the plain pattern by default, making it easy for new suites to be introduced without `KubeVirtTestSuiteSetup`. A shell-based lint script follows the same pattern as the existing `hack/lint-test-cleanup-label.sh` and `hack/lint-newcirros-deprecation.sh`.

### Special notes for your reviewer

The original issue listed 31 offending files. Most were fixed in prior PRs. This PR addresses the last 2 fixable files and adds the lint gate to prevent future regressions.

### Checklist

- [ ] ~~Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required~~
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] ~~Upgrade: Impact of this change on upgrade flows was considered and addressed if required~~
- [ ] ~~Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test~~
- [ ] ~~Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required.~~
- [ ] ~~Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered~~
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
NONE
```