### PR TITLE
Changing low virt count alerts to use running instead of up

### DIFF
--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -1830,7 +1830,7 @@ tests:
   # LowVirtAPICount - should fire when less than 75% of desired virt-api pods are running
   - interval: 1m
     input_series:
-      - series: 'up{namespace="ci", pod="virt-api-1"}'
+      - series: 'kube_pod_status_phase{namespace="ci", pod="virt-api-1", phase="Running"}'
         values: '1+0x61'
       - series: 'kube_deployment_spec_replicas{deployment="virt-api", namespace="ci"}'
         values: '4+0x61'
@@ -1856,11 +1856,11 @@ tests:
   # LowVirtAPICount - should not fire when 75% or more of desired virt-api pods are running
   - interval: 1m
     input_series:
-      - series: 'up{namespace="ci", pod="virt-api-1"}'
+      - series: 'kube_pod_status_phase{namespace="ci", pod="virt-api-1", phase="Running"}'
         values: '1+0x61'
-      - series: 'up{namespace="ci", pod="virt-api-2"}'
+      - series: 'kube_pod_status_phase{namespace="ci", pod="virt-api-2", phase="Running"}'
         values: '1+0x61'
-      - series: 'up{namespace="ci", pod="virt-api-3"}'
+      - series: 'kube_pod_status_phase{namespace="ci", pod="virt-api-3", phase="Running"}'
         values: '1+0x61'
       - series: 'kube_deployment_spec_replicas{deployment="virt-api", namespace="ci"}'
         values: '4+0x61'
@@ -1870,10 +1870,10 @@ tests:
         alertname: LowVirtAPICount
         exp_alerts: []
 
-  # LowVirtControllersCount - should fire when less than 75% of desired virt-controller pods are up
+  # LowVirtControllersCount - should fire when less than 75% of desired virt-controller pods are running
   - interval: 1m
     input_series:
-      - series: 'up{namespace="ci", pod="virt-controller-1"}'
+      - series: 'kube_pod_status_phase{namespace="ci", pod="virt-controller-1", phase="Running"}'
         values: '1+0x11'
       - series: 'kube_deployment_spec_replicas{deployment="virt-controller", namespace="ci"}'
         values: '4+0x11'
@@ -1883,12 +1883,12 @@ tests:
       - eval_time: 9m
         alertname: LowVirtControllersCount
         exp_alerts: []
-      # should fire at 10m (1 out of 4 pods up = 25% < 75%)
+      # should fire at 10m (1 out of 4 pods running = 25% < 75%)
       - eval_time: 10m
         alertname: LowVirtControllersCount
         exp_alerts:
           - exp_annotations:
-              summary: "Less than 75% of desired virt-controller pods are ready."
+              summary: "Less than 75% of desired virt-controller pods are running."
               runbook_url: "https://kubevirt.io/monitoring/runbooks/LowVirtControllersCount"
             exp_labels:
               severity: "warning"
@@ -1896,14 +1896,14 @@ tests:
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
 
-  # LowVirtControllersCount - should not fire when 75% or more of desired virt-controller pods are up
+  # LowVirtControllersCount - should not fire when 75% or more of desired virt-controller pods are running
   - interval: 1m
     input_series:
-      - series: 'up{namespace="ci", pod="virt-controller-1"}'
+      - series: 'kube_pod_status_phase{namespace="ci", pod="virt-controller-1", phase="Running"}'
         values: '1+0x11'
-      - series: 'up{namespace="ci", pod="virt-controller-2"}'
+      - series: 'kube_pod_status_phase{namespace="ci", pod="virt-controller-2", phase="Running"}'
         values: '1+0x11'
-      - series: 'up{namespace="ci", pod="virt-controller-3"}'
+      - series: 'kube_pod_status_phase{namespace="ci", pod="virt-controller-3", phase="Running"}'
         values: '1+0x11'
       - series: 'kube_deployment_spec_replicas{deployment="virt-controller", namespace="ci"}'
         values: '4+0x11'
@@ -1916,7 +1916,7 @@ tests:
   # LowVirtOperatorCount - should fire when less than 75% of desired virt-operator pods are running
   - interval: 1m
     input_series:
-      - series: 'up{namespace="ci", pod="virt-operator-1"}'
+      - series: 'kube_pod_status_phase{namespace="ci", pod="virt-operator-1", phase="Running"}'
         values: '1+0x61'
       - series: 'kube_deployment_spec_replicas{deployment="virt-operator", namespace="ci"}'
         values: '4+0x61'
@@ -1942,11 +1942,11 @@ tests:
   # LowVirtOperatorCount - should not fire when 75% or more of desired virt-operator pods are running
   - interval: 1m
     input_series:
-      - series: 'up{namespace="ci", pod="virt-operator-1"}'
+      - series: 'kube_pod_status_phase{namespace="ci", pod="virt-operator-1", phase="Running"}'
         values: '1+0x61'
-      - series: 'up{namespace="ci", pod="virt-operator-2"}'
+      - series: 'kube_pod_status_phase{namespace="ci", pod="virt-operator-2", phase="Running"}'
         values: '1+0x61'
-      - series: 'up{namespace="ci", pod="virt-operator-3"}'
+      - series: 'kube_pod_status_phase{namespace="ci", pod="virt-operator-3", phase="Running"}'
         values: '1+0x61'
       - series: 'kube_deployment_spec_replicas{deployment="virt-operator", namespace="ci"}'
         values: '4+0x61'

--- a/pkg/monitoring/rules/alerts/virt-api.go
+++ b/pkg/monitoring/rules/alerts/virt-api.go
@@ -70,7 +70,9 @@ func virtAPIAlerts(namespace string) []promv1.Rule {
 		{
 			Alert: "LowVirtAPICount",
 			Expr: intstr.FromString(fmt.Sprintf(
-				"cluster:kubevirt_virt_api_up:sum / on() kube_deployment_spec_replicas{deployment='virt-api', namespace='%s'} < 0.75", namespace,
+				"cluster:kubevirt_virt_api_pods_running:count / on() "+
+					"kube_deployment_spec_replicas{deployment='virt-api', namespace='%s'} < 0.75",
+				namespace,
 			)),
 			For: ptr.To(promv1.Duration("60m")),
 			Annotations: map[string]string{

--- a/pkg/monitoring/rules/alerts/virt-controller.go
+++ b/pkg/monitoring/rules/alerts/virt-controller.go
@@ -82,12 +82,13 @@ func virtControllerAlerts(namespace string) []promv1.Rule {
 		{
 			Alert: "LowVirtControllersCount",
 			Expr: intstr.FromString(fmt.Sprintf(
-				"cluster:kubevirt_virt_controller_up:sum / on() kube_deployment_spec_replicas{deployment='virt-controller', namespace='%s'} < 0.75",
+				"cluster:kubevirt_virt_controller_pods_running:count / on() "+
+					"kube_deployment_spec_replicas{deployment='virt-controller', namespace='%s'} < 0.75",
 				namespace,
 			)),
 			For: ptr.To(promv1.Duration("10m")),
 			Annotations: map[string]string{
-				summaryAnnotationKey: "Less than 75% of desired virt-controller pods are ready.",
+				summaryAnnotationKey: "Less than 75% of desired virt-controller pods are running.",
 			},
 			Labels: map[string]string{
 				severityAlertLabelKey:        "warning",

--- a/pkg/monitoring/rules/alerts/virt-operator.go
+++ b/pkg/monitoring/rules/alerts/virt-operator.go
@@ -42,13 +42,11 @@ func virtOperatorAlerts(namespace string) []promv1.Rule {
 		},
 		{
 			Alert: "LowVirtOperatorCount",
-			Expr: intstr.FromString(
-				fmt.Sprintf(
-					"cluster:kubevirt_virt_operator_up:sum / on() "+
-						"kube_deployment_spec_replicas{deployment='virt-operator', namespace='%s'} < 0.75",
-					namespace,
-				),
-			),
+			Expr: intstr.FromString(fmt.Sprintf(
+				"cluster:kubevirt_virt_operator_pods_running:count / on() "+
+					"kube_deployment_spec_replicas{deployment='virt-operator', namespace='%s'} < 0.75",
+				namespace,
+			)),
 			For: ptr.To(promv1.Duration("60m")),
 			Annotations: map[string]string{
 				summaryAnnotationKey: "Less than 75% of desired virt-operator pods are running.",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
All low virt count alerts used up rule instead of running 
#### After this PR:
All low virt count alerts use running rule instead of up  
### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://redhat.atlassian.net/browse/CNV-84168
```

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Low virt count alerts are using running rule intead of up rule 
```

