### PR TITLE
Graduate HostDevices feature gate to Beta

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -95,9 +95,9 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 	disableFeatureGates := func() {
 		testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kv)
 	}
-	disableSEVFeatureGate := func() {
+	disableFeatureGate := func(featureGate string) {
 		kvConfig := kv.DeepCopy()
-		kvConfig.Spec.Configuration.DeveloperConfiguration.DisabledFeatureGates = []string{featuregate.WorkloadEncryptionSEV}
+		kvConfig.Spec.Configuration.DeveloperConfiguration.DisabledFeatureGates = []string{featureGate}
 		testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kvConfig)
 	}
 
@@ -1322,6 +1322,8 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 		)
 
 		It("should reject host devices when feature gate is disabled", func() {
+			disableFeatureGate(featuregate.HostDevicesGate)
+
 			vmi := api.NewMinimalVMI("testvm")
 			vmi.Spec.Domain.Devices.HostDevices = []v1.HostDevice{
 				{
@@ -1337,7 +1339,6 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 
 		It("should reject duplicate claimName/requestName between DRA network and DRA GPU", func() {
 			enableFeatureGates(featuregate.NetworkDevicesWithDRAGate, featuregate.GPUsWithDRAGate)
-			defer disableFeatureGates()
 			vmi := api.NewMinimalVMI("testvm")
 			vmi.Spec.Networks = []v1.Network{
 				{
@@ -1373,7 +1374,6 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 
 		It("should reject duplicate claimName/requestName between DRA network and DRA HostDevice", func() {
 			enableFeatureGates(featuregate.NetworkDevicesWithDRAGate, featuregate.HostDevicesGate, featuregate.HostDevicesWithDRAGate)
-			defer disableFeatureGates()
 			vmi := api.NewMinimalVMI("testvm")
 			vmi.Spec.Networks = []v1.Network{
 				{
@@ -2744,7 +2744,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 		})
 
 		It("should reject when the feature gate is disabled", func() {
-			disableSEVFeatureGate()
+			disableFeatureGate(featuregate.WorkloadEncryptionSEV)
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Message).To(ContainSubstring(fmt.Sprintf("%s feature gate is not enabled", featuregate.WorkloadEncryptionSEV)))
@@ -2827,7 +2827,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			})
 
 			It("should reject when the feature gate is disabled", func() {
-				disableSEVFeatureGate()
+				disableFeatureGate(featuregate.WorkloadEncryptionSEV)
 				causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
 				Expect(causes).To(HaveLen(1))
 				Expect(causes[0].Message).To(ContainSubstring(fmt.Sprintf("%s feature gate is not enabled", featuregate.WorkloadEncryptionSEV)))
@@ -4028,10 +4028,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 		})
 
 		It("should reject a DRA-GPU when the feature-gate is NOT enabled", func() {
-			kvConfig := kv.DeepCopy()
-			kvConfig.Spec.Configuration.DeveloperConfiguration.DisabledFeatureGates = []string{featuregate.GPUsWithDRAGate}
-			testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kvConfig)
-			defer disableFeatureGates()
+			disableFeatureGate(featuregate.GPUsWithDRAGate)
 
 			vmi := libvmi.New()
 			vmi.Spec.Domain.Devices.GPUs = []v1.GPU{

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -1373,7 +1373,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 		})
 
 		It("should reject duplicate claimName/requestName between DRA network and DRA HostDevice", func() {
-			enableFeatureGates(featuregate.NetworkDevicesWithDRAGate, featuregate.HostDevicesGate, featuregate.HostDevicesWithDRAGate)
+			enableFeatureGates(featuregate.NetworkDevicesWithDRAGate, featuregate.HostDevicesWithDRAGate)
 			vmi := api.NewMinimalVMI("testvm")
 			vmi.Spec.Networks = []v1.Network{
 				{
@@ -1409,7 +1409,6 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 
 		It("should accept host devices that are not permitted in the hostdev config", func() {
 			kvConfig := kv.DeepCopy()
-			kvConfig.Spec.Configuration.DeveloperConfiguration.FeatureGates = []string{featuregate.HostDevicesGate}
 			kvConfig.Spec.Configuration.PermittedHostDevices = &v1.PermittedHostDevices{
 				PciHostDevices: []v1.PciHostDevice{
 					{
@@ -1432,7 +1431,6 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 
 		It("should accept permitted host devices", func() {
 			kvConfig := kv.DeepCopy()
-			kvConfig.Spec.Configuration.DeveloperConfiguration.FeatureGates = []string{featuregate.HostDevicesGate}
 			kvConfig.Spec.Configuration.PermittedHostDevices = &v1.PermittedHostDevices{
 				PciHostDevices: []v1.PciHostDevice{
 					{

--- a/pkg/virt-config/featuregate/active.go
+++ b/pkg/virt-config/featuregate/active.go
@@ -24,7 +24,12 @@ const (
 	IgnitionGate          = "ExperimentalIgnitionSupport"
 	HypervStrictCheckGate = "HypervStrictCheck"
 	SidecarGate           = "Sidecar"
-	HostDevicesGate       = "HostDevices"
+
+	// HostDevicesGate allows users to create VMIs with generic PCI, mediated,
+	// and USB host devices listed under spec.domain.devices.hostDevices.
+	// Alpha: v0.36.0
+	// Beta: v1.9.0
+	HostDevicesGate = "HostDevices"
 
 	// Owner: sig-storage
 	// Alpha: v0.30.0
@@ -296,7 +301,7 @@ func init() {
 	RegisterFeatureGate(FeatureGate{Name: IgnitionGate, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: HypervStrictCheckGate, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: SidecarGate, State: Alpha})
-	RegisterFeatureGate(FeatureGate{Name: HostDevicesGate, State: Alpha})
+	RegisterFeatureGate(FeatureGate{Name: HostDevicesGate, State: Beta})
 	RegisterFeatureGate(FeatureGate{Name: SnapshotGate, State: Beta})
 	RegisterFeatureGate(FeatureGate{Name: HostDiskGate, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: DownwardMetricsFeatureGate, State: Alpha})

--- a/pkg/virt-handler/device-manager/mediated_device_test.go
+++ b/pkg/virt-handler/device-manager/mediated_device_test.go
@@ -38,7 +38,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/yaml"
 
 	"kubevirt.io/kubevirt/pkg/testutils"
-	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 )
 
 const (
@@ -213,7 +212,6 @@ var _ = Describe("Mediated Device", func() {
 
 			By("adding a host device to the cluster config")
 			kvConfig := kv.DeepCopy()
-			kvConfig.Spec.Configuration.DeveloperConfiguration.FeatureGates = []string{featuregate.HostDevicesGate}
 			kvConfig.Spec.Configuration.PermittedHostDevices = &v1.PermittedHostDevices{
 				MediatedDevices: []v1.MediatedHostDevice{
 					{

--- a/pkg/virt-handler/device-manager/pci_device_test.go
+++ b/pkg/virt-handler/device-manager/pci_device_test.go
@@ -37,7 +37,6 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 
 	"kubevirt.io/kubevirt/pkg/testutils"
-	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 )
 
 const (
@@ -154,7 +153,6 @@ pciHostDevices:
 
 		By("adding a host device to the cluster config")
 		kvConfig := kv.DeepCopy()
-		kvConfig.Spec.Configuration.DeveloperConfiguration.FeatureGates = []string{featuregate.HostDevicesGate}
 		kvConfig.Spec.Configuration.PermittedHostDevices = &v1.PermittedHostDevices{
 			PciHostDevices: []v1.PciHostDevice{
 				{

--- a/tests/storage/hotplug.go
+++ b/tests/storage/hotplug.go
@@ -2115,8 +2115,6 @@ var _ = Describe(SIG("Hotplug", func() {
 		const deviceName = "example.org/soundcard"
 
 		BeforeEach(func() {
-			kvconfig.EnableFeatureGate(featuregate.HostDevicesGate)
-
 			kv := libkubevirt.GetCurrentKv(virtClient)
 			config := kv.Spec.Configuration
 			config.PermittedHostDevices = &v1.PermittedHostDevices{
@@ -2135,7 +2133,6 @@ var _ = Describe(SIG("Hotplug", func() {
 			config := kv.Spec.Configuration
 			config.PermittedHostDevices = &v1.PermittedHostDevices{}
 			kvconfig.UpdateKubeVirtConfigValueAndWait(config)
-			kvconfig.DisableFeatureGate(featuregate.HostDevicesGate)
 		})
 
 		It("should restart a VM after hotplugging a block volume", decorators.RequiresBlockStorage, func() {

--- a/tests/usb/usb.go
+++ b/tests/usb/usb.go
@@ -14,10 +14,8 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 
-	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/decorators"
-	"kubevirt.io/kubevirt/tests/framework/checks"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/libkubevirt"
 	kvconfig "kubevirt.io/kubevirt/tests/libkubevirt/config"
@@ -37,15 +35,9 @@ var _ = Describe("[sig-compute][USB] [QUARANTINE] host USB Passthrough", Serial,
 		var virtClient kubecli.KubevirtClient
 		var config v1.KubeVirtConfiguration
 		var vmi *v1.VirtualMachineInstance
-		var fgWasOff bool
 
 		BeforeEach(func() {
 			virtClient = kubevirt.Client()
-
-			fgWasOff = !checks.HasFeature(featuregate.HostDevicesGate)
-			if fgWasOff {
-				kvconfig.EnableFeatureGate(featuregate.HostDevicesGate)
-			}
 
 			kv := libkubevirt.GetCurrentKv(virtClient)
 			config = kv.Spec.Configuration
@@ -71,9 +63,6 @@ var _ = Describe("[sig-compute][USB] [QUARANTINE] host USB Passthrough", Serial,
 
 			Expect(libwait.WaitForVirtualMachineToDisappearWithTimeout(vmi, deleteTimeout*time.Second)).To(Succeed())
 
-			if fgWasOff {
-				kvconfig.DisableFeatureGate(featuregate.HostDevicesGate)
-			}
 			kv := libkubevirt.GetCurrentKv(virtClient)
 			config = kv.Spec.Configuration
 			config.PermittedHostDevices = &v1.PermittedHostDevices{}

--- a/tests/vmi_hostdev_test.go
+++ b/tests/vmi_hostdev_test.go
@@ -16,11 +16,8 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 
-	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
-
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/decorators"
-	"kubevirt.io/kubevirt/tests/framework/checks"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/libkubevirt"
 	kvconfig "kubevirt.io/kubevirt/tests/libkubevirt/config"
@@ -38,25 +35,16 @@ var _ = Describe("[sig-compute]HostDevices", Serial, decorators.SigCompute, func
 	var (
 		virtClient kubecli.KubevirtClient
 		config     v1.KubeVirtConfiguration
-		fgWasOff   bool
 	)
 
 	BeforeEach(func() {
 		virtClient = kubevirt.Client()
-
-		fgWasOff = !checks.HasFeature(featuregate.HostDevicesGate)
-		if fgWasOff {
-			kvconfig.EnableFeatureGate(featuregate.HostDevicesGate)
-		}
 
 		kv := libkubevirt.GetCurrentKv(virtClient)
 		config = kv.Spec.Configuration
 	})
 
 	AfterEach(func() {
-		if fgWasOff {
-			kvconfig.DisableFeatureGate(featuregate.HostDevicesGate)
-		}
 		kv := libkubevirt.GetCurrentKv(virtClient)
 		config = kv.Spec.Configuration
 		if config.DeveloperConfiguration != nil {


### PR DESCRIPTION
### What this PR does
The HostDevices feature gate has been Alpha since its introduction in v0.36.0 without any major changes, and the newer HostDevicesWithDRA gate is already Beta. Promote it to Beta so generic PCI/mediated/USB host device passthrough is enabled by default; it can still be turned off via DisabledFeatureGates.

Update the admitter test that relied on the gate being off by default to explicitly disable it, via a new disableFeatureGate test helper that also replaces the previous single-purpose disableSEVFeatureGate helper and an ad-hoc inline equivalent in the DRA-GPU tests. Drop the redundant `defer disableFeatureGates()` calls in these and neighboring tests, since the suite's AfterEach already resets the feature-gate config after every spec.

Assisted-by: Claude (Anthropic AI assistant)

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
HostDevices is beta
```
