### PR TITLE
tests: remove explicit enablement of Beta feature gates

### DIFF
--- a/pkg/storage/export/export/vmtemplate-source_test.go
+++ b/pkg/storage/export/export/vmtemplate-source_test.go
@@ -56,7 +56,6 @@ import (
 	"kubevirt.io/kubevirt/pkg/certificates/bootstrap"
 	virtcontroller "kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/testutils"
-	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"
 	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/components"
 )
@@ -114,11 +113,7 @@ var _ = Describe("VMTemplate source", func() {
 		fakeCertManager, err := bootstrap.NewMockCertificateManager()
 		Expect(err).ToNot(HaveOccurred())
 
-		config, _, _ := testutils.NewFakeClusterConfigUsingKVConfig(&virtv1.KubeVirtConfiguration{
-			DeveloperConfiguration: &virtv1.DeveloperConfiguration{
-				FeatureGates: []string{featuregate.Template},
-			},
-		})
+		config, _, _ := testutils.NewFakeClusterConfigUsingKVConfig(&virtv1.KubeVirtConfiguration{})
 		k8sClient = k8sfake.NewSimpleClientset()
 		vmExportClient = kubevirtfake.NewSimpleClientset()
 		recorder = record.NewFakeRecorder(100)

--- a/pkg/virt-api/rest/sev_test.go
+++ b/pkg/virt-api/rest/sev_test.go
@@ -46,7 +46,6 @@ import (
 	"kubevirt.io/kubevirt/pkg/libvmi"
 	libvmistatus "kubevirt.io/kubevirt/pkg/libvmi/status"
 	"kubevirt.io/kubevirt/pkg/testutils"
-	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 )
 
 var _ = Describe("SEV Subresources", func() {
@@ -63,13 +62,6 @@ var _ = Describe("SEV Subresources", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "kubevirt",
 				Namespace: "kubevirt",
-			},
-			Spec: v1.KubeVirtSpec{
-				Configuration: v1.KubeVirtConfiguration{
-					DeveloperConfiguration: &v1.DeveloperConfiguration{
-						FeatureGates: []string{featuregate.WorkloadEncryptionSEV},
-					},
-				},
 			},
 			Status: v1.KubeVirtStatus{
 				Phase: v1.KubeVirtPhaseDeploying,

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmclone-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmclone-admitter_test.go
@@ -62,18 +62,6 @@ var _ = Describe("Validating VirtualMachineClone Admitter", func() {
 	var vmInterface *kubecli.MockVirtualMachineInterface
 	var vm *v1.VirtualMachine
 
-	enableFeatureGate := func(featureGate string) {
-		testutils.UpdateFakeKubeVirtClusterConfig(kvStore, &v1.KubeVirt{
-			Spec: v1.KubeVirtSpec{
-				Configuration: v1.KubeVirtConfiguration{
-					DeveloperConfiguration: &v1.DeveloperConfiguration{
-						FeatureGates: []string{featureGate},
-					},
-				},
-			},
-		})
-	}
-
 	disableFeatureGates := func() {
 		testutils.UpdateFakeKubeVirtClusterConfig(kvStore, &v1.KubeVirt{
 			Spec: v1.KubeVirtSpec{
@@ -202,8 +190,6 @@ var _ = Describe("Validating VirtualMachineClone Admitter", func() {
 			}
 			return true, contents, nil
 		})
-
-		enableFeatureGate("Snapshot")
 	})
 
 	AfterEach(func() {

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -629,7 +629,6 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				Name: "testdisk",
 			})
 
-			enableFeatureGates(featuregate.DeclarativeHotplugVolumesGate)
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
 			Expect(causes).To(BeEmpty())
 		})
@@ -1336,8 +1335,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 		})
 
 		It("should reject duplicate claimName/requestName between DRA network and DRA GPU", func() {
-			enableFeatureGates(featuregate.NetworkDevicesWithDRAGate, featuregate.GPUsWithDRAGate)
-			defer disableFeatureGates()
+			enableFeatureGates(featuregate.NetworkDevicesWithDRAGate)
 			vmi := api.NewMinimalVMI("testvm")
 			vmi.Spec.Networks = []v1.Network{
 				{
@@ -1372,7 +1370,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 		})
 
 		It("should reject duplicate claimName/requestName between DRA network and DRA HostDevice", func() {
-			enableFeatureGates(featuregate.NetworkDevicesWithDRAGate, featuregate.HostDevicesGate, featuregate.HostDevicesWithDRAGate)
+			enableFeatureGates(featuregate.NetworkDevicesWithDRAGate, featuregate.HostDevicesGate)
 			defer disableFeatureGates()
 			vmi := api.NewMinimalVMI("testvm")
 			vmi.Spec.Networks = []v1.Network{
@@ -2735,7 +2733,6 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 			vmi.Spec.Architecture = "amd64"
-			enableFeatureGates(featuregate.WorkloadEncryptionSEV)
 		})
 
 		It("should accept when the feature gate is enabled and OVMF is configured", func() {
@@ -3999,7 +3996,6 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 		})
 
 		It("should reject a GPU that sets both deviceName and claimRequest", func() {
-			enableFeatureGates(featuregate.GPUsWithDRAGate)
 			vmi := libvmi.New(
 				libvmi.WithArchitecture(runtime.GOARCH),
 				libvmi.WithResourceMemory("128M"),
@@ -4060,8 +4056,6 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 		})
 
 		It("should reject a DRA-GPU if its claim is missing from spec.resourceClaims", func() {
-			enableFeatureGates(featuregate.GPUsWithDRAGate)
-
 			vmi := libvmi.New()
 			vmi.Spec.Domain.Devices.GPUs = []v1.GPU{
 				{
@@ -4082,8 +4076,6 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 		})
 
 		It("should accept a DRA-GPU when the gate is enabled and the claim is listed", func() {
-			enableFeatureGates(featuregate.GPUsWithDRAGate)
-
 			vmi := libvmi.New(
 				libvmi.WithArchitecture(runtime.GOARCH),
 				libvmi.WithResourceMemory("128M"),

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -629,7 +629,6 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				Name: "testdisk",
 			})
 
-			enableFeatureGates(featuregate.DeclarativeHotplugVolumesGate)
 			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), &vmi.Spec, config)
 			Expect(causes).To(BeEmpty())
 		})
@@ -1384,8 +1383,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 		})
 
 		It("should reject duplicate claimName/requestName between DRA network and DRA GPU", func() {
-			enableFeatureGates(featuregate.NetworkDevicesWithDRAGate, featuregate.GPUsWithDRAGate)
-			defer disableFeatureGates()
+			enableFeatureGates(featuregate.NetworkDevicesWithDRAGate)
 			vmi := api.NewMinimalVMI("testvm")
 			vmi.Spec.Networks = []v1.Network{
 				{
@@ -1420,7 +1418,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 		})
 
 		It("should reject duplicate claimName/requestName between DRA network and DRA HostDevice", func() {
-			enableFeatureGates(featuregate.NetworkDevicesWithDRAGate, featuregate.HostDevicesGate, featuregate.HostDevicesWithDRAGate)
+			enableFeatureGates(featuregate.NetworkDevicesWithDRAGate, featuregate.HostDevicesGate)
 			defer disableFeatureGates()
 			vmi := api.NewMinimalVMI("testvm")
 			vmi.Spec.Networks = []v1.Network{
@@ -2783,7 +2781,6 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 			vmi.Spec.Architecture = "amd64"
-			enableFeatureGates(featuregate.WorkloadEncryptionSEV)
 		})
 
 		It("should accept when the feature gate is enabled and OVMF is configured", func() {
@@ -4047,7 +4044,6 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 		})
 
 		It("should reject a GPU that sets both deviceName and claimRequest", func() {
-			enableFeatureGates(featuregate.GPUsWithDRAGate)
 			vmi := libvmi.New(
 				libvmi.WithArchitecture(runtime.GOARCH),
 				libvmi.WithResourceMemory("128M"),
@@ -4108,8 +4104,6 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 		})
 
 		It("should reject a DRA-GPU if its claim is missing from spec.resourceClaims", func() {
-			enableFeatureGates(featuregate.GPUsWithDRAGate)
-
 			vmi := libvmi.New()
 			vmi.Spec.Domain.Devices.GPUs = []v1.GPU{
 				{
@@ -4130,8 +4124,6 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 		})
 
 		It("should accept a DRA-GPU when the gate is enabled and the claim is listed", func() {
-			enableFeatureGates(featuregate.GPUsWithDRAGate)
-
 			vmi := libvmi.New(
 				libvmi.WithArchitecture(runtime.GOARCH),
 				libvmi.WithResourceMemory("128M"),

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-update-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-update-admitter_test.go
@@ -64,11 +64,6 @@ var _ = Describe("Validating VMIUpdate Admitter", func() {
 	config, _, kvStore := testutils.NewFakeClusterConfigUsingKV(kv)
 	vmiUpdateAdmitter := NewVMIUpdateAdmitter(config, webhooks.KubeVirtServiceAccounts(kubeVirtNamespace))
 
-	enableFeatureGate := func(featureGate string) {
-		kvConfig := kv.DeepCopy()
-		kvConfig.Spec.Configuration.DeveloperConfiguration.FeatureGates = []string{featureGate}
-		testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kvConfig)
-	}
 	disableFeatureGates := func() {
 		testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kv)
 	}
@@ -117,8 +112,6 @@ var _ = Describe("Validating VMIUpdate Admitter", func() {
 		}
 
 		Context("with Node Restriction feature gate enabled", func() {
-			BeforeEach(func() { enableFeatureGate(featuregate.NodeRestrictionGate) })
-
 			shouldNotAllowCrossNodeRequest := And(
 				WithTransform(func(resp *admissionv1.AdmissionResponse) bool { return resp.Allowed },
 					BeFalse(),

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter_test.go
@@ -1445,7 +1445,6 @@ var _ = Describe("Validating VM Admitter", func() {
 					Message: "Memory hotplug is not compatible with realtime VMs",
 				}),
 				Entry("launchSecurity is configured", func(vm *v1.VirtualMachine) {
-					enableFeatureGate(featuregate.WorkloadEncryptionSEV)
 					vm.Spec.Template.Spec.Domain.LaunchSecurity = &v1.LaunchSecurity{}
 				}, metav1.StatusCause{
 					Type:    metav1.CauseTypeFieldValueInvalid,

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter_test.go
@@ -1478,7 +1478,6 @@ var _ = Describe("Validating VM Admitter", func() {
 					Message: "Memory hotplug is not compatible with realtime VMs",
 				}),
 				Entry("launchSecurity is configured", func(vm *v1.VirtualMachine) {
-					enableFeatureGate(featuregate.WorkloadEncryptionSEV)
 					vm.Spec.Template.Spec.Domain.LaunchSecurity = &v1.LaunchSecurity{}
 				}, metav1.StatusCause{
 					Type:    metav1.CauseTypeFieldValueInvalid,

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -4066,7 +4066,6 @@ var _ = Describe("Template", func() {
 		Context("with ImageVolume", func() {
 			BeforeEach(func() {
 				config, kvStore, svc = configFactory(defaultArch)
-				enableFeatureGate(featuregate.ImageVolume)
 			})
 
 			DescribeTable("should not define additional containers expect the noop init containers for digest", func(vmi *v1.VirtualMachineInstance) {
@@ -6304,7 +6303,6 @@ var _ = Describe("Template", func() {
 	Context("NAD query disablement", func() {
 		It("Should not query NAD when ExternalNetResourceInjection is enabled", func() {
 			config, kvStore, svc = configFactory(defaultArch)
-			enableFeatureGate(featuregate.ExternalNetResourceInjection)
 
 			svc = NewTemplateService("kubevirt/virt-launcher",
 				240,

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -4070,7 +4070,6 @@ var _ = Describe("Template", func() {
 		Context("with ImageVolume", func() {
 			BeforeEach(func() {
 				config, kvStore, svc = configFactory(defaultArch)
-				enableFeatureGate(featuregate.ImageVolume)
 			})
 
 			DescribeTable("should not define additional containers expect the noop init containers for digest", func(vmi *v1.VirtualMachineInstance) {

--- a/pkg/virt-handler/migration-source_test.go
+++ b/pkg/virt-handler/migration-source_test.go
@@ -165,9 +165,7 @@ var _ = Describe("VirtualMachineInstance migration target", func() {
 		virtClient.EXPECT().CoreV1().Return(k8sfakeClient.CoreV1()).AnyTimes()
 		virtClient.EXPECT().VirtualMachineInstance(metav1.NamespaceDefault).Return(virtfakeClient.KubevirtV1().VirtualMachineInstances(metav1.NamespaceDefault)).AnyTimes()
 		kv := &v1.KubeVirtConfiguration{
-			DeveloperConfiguration: &v1.DeveloperConfiguration{
-				FeatureGates: []string{featuregate.PasstBinding},
-			},
+			DeveloperConfiguration: &v1.DeveloperConfiguration{},
 		}
 		config, _, _ := testutils.NewFakeClusterConfigUsingKVConfig(kv)
 
@@ -598,7 +596,7 @@ var _ = Describe("VirtualMachineInstance migration target", func() {
 	It("should set StallDetectionEnabled to true when MigrationStallDetection feature gate is enabled", func() {
 		kv := &v1.KubeVirtConfiguration{
 			DeveloperConfiguration: &v1.DeveloperConfiguration{
-				FeatureGates: []string{featuregate.PasstBinding, featuregate.MigrationStallDetection},
+				FeatureGates: []string{featuregate.MigrationStallDetection},
 			},
 		}
 		controller.clusterConfig, _, _ = testutils.NewFakeClusterConfigUsingKVConfig(kv)

--- a/pkg/virt-handler/migration-source_test.go
+++ b/pkg/virt-handler/migration-source_test.go
@@ -156,9 +156,7 @@ var _ = Describe("VirtualMachineInstance migration target", func() {
 		virtClient = kubecli.NewMockKubevirtClient(ctrl)
 		virtClient.EXPECT().VirtualMachineInstance(metav1.NamespaceDefault).Return(virtfakeClient.KubevirtV1().VirtualMachineInstances(metav1.NamespaceDefault)).AnyTimes()
 		kv := &v1.KubeVirtConfiguration{
-			DeveloperConfiguration: &v1.DeveloperConfiguration{
-				FeatureGates: []string{featuregate.PasstBinding},
-			},
+			DeveloperConfiguration: &v1.DeveloperConfiguration{},
 		}
 		config, _, _ := testutils.NewFakeClusterConfigUsingKVConfig(kv)
 
@@ -715,7 +713,7 @@ var _ = Describe("VirtualMachineInstance migration target", func() {
 	It("should put StallDetectorOptions on the wire when MigrationStallDetection feature gate is enabled", func() {
 		kv := &v1.KubeVirtConfiguration{
 			DeveloperConfiguration: &v1.DeveloperConfiguration{
-				FeatureGates: []string{featuregate.PasstBinding, featuregate.MigrationStallDetection},
+				FeatureGates: []string{featuregate.MigrationStallDetection},
 			},
 		}
 		controller.clusterConfig, _, _ = testutils.NewFakeClusterConfigUsingKVConfig(kv)

--- a/pkg/virt-handler/migration-target_test.go
+++ b/pkg/virt-handler/migration-target_test.go
@@ -59,7 +59,6 @@ import (
 	"kubevirt.io/kubevirt/pkg/safepath"
 	"kubevirt.io/kubevirt/pkg/storage/cbt"
 	"kubevirt.io/kubevirt/pkg/testutils"
-	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 	virtcache "kubevirt.io/kubevirt/pkg/virt-handler/cache"
 	cmdclient "kubevirt.io/kubevirt/pkg/virt-handler/cmd-client"
 	hotplugvolume "kubevirt.io/kubevirt/pkg/virt-handler/hotplug-disk"
@@ -192,9 +191,7 @@ var _ = Describe("VirtualMachineInstance migration target", func() {
 		virtClient.EXPECT().CoreV1().Return(k8sfakeClient.CoreV1()).AnyTimes()
 		virtClient.EXPECT().VirtualMachineInstance(metav1.NamespaceDefault).Return(virtfakeClient.KubevirtV1().VirtualMachineInstances(metav1.NamespaceDefault)).AnyTimes()
 		kv := &v1.KubeVirtConfiguration{
-			DeveloperConfiguration: &v1.DeveloperConfiguration{
-				FeatureGates: []string{featuregate.PasstBinding},
-			},
+			DeveloperConfiguration: &v1.DeveloperConfiguration{},
 		}
 
 		config, _, _ := testutils.NewFakeClusterConfigUsingKVConfig(kv)

--- a/pkg/virt-handler/migration-target_test.go
+++ b/pkg/virt-handler/migration-target_test.go
@@ -59,7 +59,6 @@ import (
 	"kubevirt.io/kubevirt/pkg/safepath"
 	"kubevirt.io/kubevirt/pkg/storage/cbt"
 	"kubevirt.io/kubevirt/pkg/testutils"
-	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 	virtcache "kubevirt.io/kubevirt/pkg/virt-handler/cache"
 	cmdclient "kubevirt.io/kubevirt/pkg/virt-handler/cmd-client"
 	container_disk "kubevirt.io/kubevirt/pkg/virt-handler/container-disk"
@@ -190,9 +189,7 @@ var _ = Describe("VirtualMachineInstance migration target", func() {
 		virtClient = kubecli.NewMockKubevirtClient(ctrl)
 		virtClient.EXPECT().VirtualMachineInstance(metav1.NamespaceDefault).Return(virtfakeClient.KubevirtV1().VirtualMachineInstances(metav1.NamespaceDefault)).AnyTimes()
 		kv := &v1.KubeVirtConfiguration{
-			DeveloperConfiguration: &v1.DeveloperConfiguration{
-				FeatureGates: []string{featuregate.PasstBinding},
-			},
+			DeveloperConfiguration: &v1.DeveloperConfiguration{},
 		}
 
 		config, _, _ := testutils.NewFakeClusterConfigUsingKVConfig(kv)

--- a/pkg/virt-operator/webhooks/kubevirt-update-admitter_test.go
+++ b/pkg/virt-operator/webhooks/kubevirt-update-admitter_test.go
@@ -69,9 +69,6 @@ var _ = Describe("Validating KubeVirtUpdate Admitter", func() {
 		Entry("should allow when VirtTemplateDeployment enabled with Template feature gate",
 			v1.KubeVirtSpec{
 				Configuration: v1.KubeVirtConfiguration{
-					DeveloperConfiguration: &v1.DeveloperConfiguration{
-						FeatureGates: []string{featuregate.Template},
-					},
 					VirtTemplateDeployment: &v1.VirtTemplateDeployment{
 						Enabled: pointer.P(true),
 					},

--- a/tests/compute/BUILD.bazel
+++ b/tests/compute/BUILD.bazel
@@ -24,7 +24,6 @@ go_library(
         "//pkg/libvmi:go_default_library",
         "//pkg/libvmi/cloudinit:go_default_library",
         "//pkg/pointer:go_default_library",
-        "//pkg/virt-config/featuregate:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubevirt/typed/core/v1:go_default_library",

--- a/tests/compute/BUILD.bazel
+++ b/tests/compute/BUILD.bazel
@@ -25,7 +25,6 @@ go_library(
         "//pkg/libvmi:go_default_library",
         "//pkg/libvmi/cloudinit:go_default_library",
         "//pkg/pointer:go_default_library",
-        "//pkg/virt-config/featuregate:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubevirt/typed/core/v1:go_default_library",

--- a/tests/compute/vmi_memory_overhead.go
+++ b/tests/compute/vmi_memory_overhead.go
@@ -34,25 +34,21 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
 	"kubevirt.io/kubevirt/pkg/libvmi"
-	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/flags"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	. "kubevirt.io/kubevirt/tests/framework/matcher"
-	kvconfig "kubevirt.io/kubevirt/tests/libkubevirt/config"
 	"kubevirt.io/kubevirt/tests/libmigration"
 	"kubevirt.io/kubevirt/tests/libnet"
 	"kubevirt.io/kubevirt/tests/libvmifact"
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-// TODO: remove the Serial once VmiMemoryOverheadReport is enabled by default
-var _ = Describe(SIG("VMI Memory Overhead Reporting", decorators.RequiresTwoSchedulableNodes, Serial, func() {
+var _ = Describe(SIG("VMI Memory Overhead Reporting", decorators.RequiresTwoSchedulableNodes, func() {
 	var virtClient kubecli.KubevirtClient
 
 	BeforeEach(func() {
 		virtClient = kubevirt.Client()
-		kvconfig.EnableFeatureGate(featuregate.VmiMemoryOverheadReport)
 	})
 
 	DescribeTable("memory overhead after CPU hotplug and migration", func(migrationShouldFail bool) {

--- a/tests/dryrun_test.go
+++ b/tests/dryrun_test.go
@@ -42,11 +42,9 @@ import (
 	"kubevirt.io/client-go/kubecli"
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
-	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/libkubevirt"
-	"kubevirt.io/kubevirt/tests/libkubevirt/config"
 	"kubevirt.io/kubevirt/tests/libmigration"
 	"kubevirt.io/kubevirt/tests/libvmifact"
 	"kubevirt.io/kubevirt/tests/testsuite"
@@ -534,7 +532,6 @@ var _ = Describe("[sig-compute]Dry-Run requests", decorators.SigCompute, decorat
 		var snap *snapshotv1.VirtualMachineSnapshot
 
 		BeforeEach(func() {
-			config.EnableFeatureGate(featuregate.SnapshotGate)
 			vm := libvmi.NewVirtualMachine(libvmifact.NewAlpine())
 			vm, err = virtClient.VirtualMachine(testsuite.GetTestNamespace(nil)).Create(context.Background(), vm, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
@@ -613,8 +610,6 @@ var _ = Describe("[sig-compute]Dry-Run requests", decorators.SigCompute, decorat
 		var restore *snapshotv1.VirtualMachineRestore
 
 		BeforeEach(func() {
-			config.EnableFeatureGate(featuregate.SnapshotGate)
-
 			vm := libvmi.NewVirtualMachine(libvmifact.NewAlpine())
 			vm, err = virtClient.VirtualMachine(testsuite.GetTestNamespace(nil)).Create(context.Background(), vm, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())

--- a/tests/infrastructure/BUILD.bazel
+++ b/tests/infrastructure/BUILD.bazel
@@ -25,7 +25,6 @@ go_library(
         "//pkg/libvmi:go_default_library",
         "//pkg/libvmi/replicaset:go_default_library",
         "//pkg/util/tls:go_default_library",
-        "//pkg/virt-config/featuregate:go_default_library",
         "//pkg/virt-handler/node-labeller/util:go_default_library",
         "//pkg/virt-operator/resource/generate/components:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",

--- a/tests/infrastructure/security.go
+++ b/tests/infrastructure/security.go
@@ -31,25 +31,21 @@ import (
 
 	"kubevirt.io/client-go/kubecli"
 
-	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
-
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/exec"
 	"kubevirt.io/kubevirt/tests/flags"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
-	"kubevirt.io/kubevirt/tests/libkubevirt/config"
 	"kubevirt.io/kubevirt/tests/libnode"
 	"kubevirt.io/kubevirt/tests/libvmifact"
 	"kubevirt.io/kubevirt/tests/libvmops"
 )
 
-var _ = Describe(SIGSerial("Node Restriction", decorators.RequiresTwoSchedulableNodes, func() {
+var _ = Describe(SIG("Node Restriction", decorators.RequiresTwoSchedulableNodes, func() {
 	var virtClient kubecli.KubevirtClient
 	const minNodesWithVirtHandler = 2
 
 	BeforeEach(func() {
 		virtClient = kubevirt.Client()
-		config.EnableFeatureGate(featuregate.NodeRestrictionGate)
 	})
 
 	It("Should disallow to modify VMs on different node", func() {

--- a/tests/infrastructure/security.go
+++ b/tests/infrastructure/security.go
@@ -31,24 +31,20 @@ import (
 
 	"kubevirt.io/client-go/kubecli"
 
-	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
-
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/exec"
 	"kubevirt.io/kubevirt/tests/flags"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
-	"kubevirt.io/kubevirt/tests/libkubevirt/config"
 	"kubevirt.io/kubevirt/tests/libnode"
 	"kubevirt.io/kubevirt/tests/libvmifact"
 	"kubevirt.io/kubevirt/tests/libvmops"
 )
 
-var _ = Describe(SIGSerial("Node Restriction", decorators.RequiresTwoSchedulableNodes, func() {
+var _ = Describe(SIG("Node Restriction", decorators.RequiresTwoSchedulableNodes, func() {
 	var virtClient kubecli.KubevirtClient
 
 	BeforeEach(func() {
 		virtClient = kubevirt.Client()
-		config.EnableFeatureGate(featuregate.NodeRestrictionGate)
 	})
 
 	It("Should disallow to modify VMs on different node", func() {

--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -891,13 +891,6 @@ var _ = Describe("[sig-operator]Operator", Serial, decorators.SigOperator, func(
 			By("Setting RoleAggregationStrategy to Manual after upgrade")
 			currentKV := libkubevirt.GetCurrentKv(virtClient)
 			savedConfig := currentKV.Spec.Configuration.DeepCopy()
-			if currentKV.Spec.Configuration.DeveloperConfiguration == nil {
-				currentKV.Spec.Configuration.DeveloperConfiguration = &v1.DeveloperConfiguration{}
-			}
-			currentKV.Spec.Configuration.DeveloperConfiguration.FeatureGates = append(
-				currentKV.Spec.Configuration.DeveloperConfiguration.FeatureGates,
-				featuregate.OptOutRoleAggregation,
-			)
 			currentKV.Spec.Configuration.RoleAggregationStrategy = pointer.P(v1.RoleAggregationStrategyManual)
 			kvconfig.UpdateKubeVirtConfigValueAndWait(currentKV.Spec.Configuration)
 

--- a/tests/storage/export.go
+++ b/tests/storage/export.go
@@ -2486,11 +2486,6 @@ var _ = Describe(SIG("Export", func() {
 		})
 
 		It("should export VirtualMachineTemplate as OCI artifact", func() {
-			if !checks.HasFeature(featuregate.Template) {
-				kvconfig.EnableFeatureGate(featuregate.Template)
-				defer kvconfig.DisableFeatureGate(featuregate.Template)
-			}
-
 			By("Creating a stopped VM with DataVolume")
 			vm := createStoppedVM()
 

--- a/tests/testsuite/kubevirtresource.go
+++ b/tests/testsuite/kubevirtresource.go
@@ -116,12 +116,9 @@ func AdjustKubeVirtResource() {
 		featuregate.HostDiskGate,
 		featuregate.VirtIOFSStorageVolumeGate,
 		featuregate.DownwardMetricsFeatureGate,
-		featuregate.WorkloadEncryptionSEV,
 		featuregate.ObjectGraph,
-		featuregate.DeclarativeHotplugVolumesGate,
 		featuregate.DecentralizedLiveMigration,
 		featuregate.UtilityVolumesGate,
-		featuregate.RebootPolicy,
 		featuregate.ContainerPathVolumesGate,
 	)
 

--- a/tests/testsuite/kubevirtresource.go
+++ b/tests/testsuite/kubevirtresource.go
@@ -115,12 +115,9 @@ func AdjustKubeVirtResource() {
 		featuregate.HostDiskGate,
 		featuregate.VirtIOFSStorageVolumeGate,
 		featuregate.DownwardMetricsFeatureGate,
-		featuregate.WorkloadEncryptionSEV,
 		featuregate.ObjectGraph,
-		featuregate.DeclarativeHotplugVolumesGate,
 		featuregate.DecentralizedLiveMigration,
 		featuregate.UtilityVolumesGate,
-		featuregate.RebootPolicy,
 		featuregate.ContainerPathVolumesGate,
 	} {
 		if !unsupportedGates[gate] {


### PR DESCRIPTION
### What this PR does
#### Before this PR:
Several unit and e2e tests explicitly enabled feature gates that are already Beta (i.e. enabled by default), either via the KubeVirt CR's `FeatureGates` list or `EnableFeatureGate`. This was dead-weight boilerplate left over from before each gate graduated to Beta. Two e2e suites (`VMI Memory Overhead Reporting`, `Node Restriction`) also carried a `Serial` decorator purely to safely toggle one of these now-default-on gates.

#### After this PR:
- Removed redundant explicit enablement of Beta feature gates across unit and e2e tests, including the shared e2e default config in `tests/testsuite/kubevirtresource.go`. Cases where a gate is genuinely toggled to exercise its enabled/disabled transition (e.g. seccomp profile install/uninstall, legacy hotplug fallback) or where compatibility with a pre-Beta release is being tested (operator upgrade tests) were left untouched.
- Dropped `Serial` from `VMI Memory Overhead Reporting` and `Node Restriction`, since neither suite mutates any shared cluster-wide state once the redundant gate enablement is gone, so they can now run in parallel with the rest of the e2e suite.

### Why we need it and why it was done in this way
Keeping unnecessary feature-gate setup around makes tests harder to read and obscures which gates actually need explicit toggling to exercise non-default behavior. Removing it also lets two previously-`Serial` e2e suites run in parallel, saving CI time.

### Special notes for your reviewer
No behavior change is expected: every removed call only requested a state the affected gate was already on by default.  
Split into two commits: the first is purely behavior-preserving boilerplate removal, the second separately calls out the two `Serial` removals along with the reasoning for why parallel execution is safe.

### Checklist
- [x] Design: not applicable (test-only cleanup)
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and keep it simple
- [x] Refactor: Left the code cleaner than found (Boy Scout Rule)
- [x] Upgrade: No upgrade impact (test-only change)
- [x] Testing: No new tests required; existing coverage is unchanged in behavior
- [x] Documentation: Not applicable
- [ ] Community: Not applicable
- [x] AI Contributions: The PR abides by the KubeVirt AI Contribution Policy

### Release note
```release-note
NONE
```
