### PR TITLE
lint: reintroduce goconst linter and fix issues that are raised from the reintroduction

### DIFF
--- a/cmd/sidecars/network-passt-binding/domain/configurator_test.go
+++ b/cmd/sidecars/network-passt-binding/domain/configurator_test.go
@@ -33,6 +33,19 @@ import (
 const (
 	ifaceTypeVhostUser = "vhostuser"
 
+	defaultNetworkName        = "default"
+	passtPluginBindingName    = "passt-plugin"
+	passtBindingName          = "passt"
+	tcpProtocol               = "tcp"
+	udpProtocol               = "udp"
+	virtioNonTransitionalMode = "virtio-non-transitional"
+	e1000Model                = "e1000"
+	secondaryNetworkName      = "secondary"
+	optionalPodIfaceName      = "ovn-udn1"
+	sharedAccessMode          = "shared"
+	testMACAddress            = "02:02:02:02:02:02"
+	excludedPort              = "yes"
+
 	defaultPrimaryPodIfaceName = "eth0"
 )
 
@@ -52,43 +65,57 @@ var _ = Describe("pod network configurator", func() {
 			},
 			Entry("no pod network",
 				nil,
-				[]vmschema.Network{{Name: "default", NetworkSource: vmschema.NetworkSource{Multus: &vmschema.MultusNetwork{}}}},
+				[]vmschema.Network{{Name: defaultNetworkName, NetworkSource: vmschema.NetworkSource{Multus: &vmschema.MultusNetwork{}}}},
 				nil,
 			),
 			Entry("no corresponding iface",
-				[]vmschema.Interface{{Name: "not-default", Binding: &vmschema.PluginBinding{Name: "passt-plugin"}}},
+				[]vmschema.Interface{{Name: "not-default", Binding: &vmschema.PluginBinding{Name: passtPluginBindingName}}},
 				[]vmschema.Network{*vmschema.DefaultPodNetwork()},
 				nil,
 			),
 			Entry("interface with no passt binding method",
-				[]vmschema.Interface{{Name: "default", InterfaceBindingMethod: vmschema.InterfaceBindingMethod{Bridge: &vmschema.InterfaceBridge{}}}},
+				[]vmschema.Interface{{
+					Name: defaultNetworkName,
+					InterfaceBindingMethod: vmschema.InterfaceBindingMethod{
+						Bridge: &vmschema.InterfaceBridge{},
+					},
+				}},
 				[]vmschema.Network{*vmschema.DefaultPodNetwork()},
-				[]vmschema.VirtualMachineInstanceNetworkInterface{{Name: "default", PodInterfaceName: defaultPrimaryPodIfaceName}},
+				[]vmschema.VirtualMachineInstanceNetworkInterface{{
+					Name:             defaultNetworkName,
+					PodInterfaceName: defaultPrimaryPodIfaceName,
+				}},
 			),
 			Entry("interface with no passt binding plugin",
-				[]vmschema.Interface{{Name: "default", Binding: &vmschema.PluginBinding{Name: "no-passt"}}},
+				[]vmschema.Interface{{Name: defaultNetworkName, Binding: &vmschema.PluginBinding{Name: "no-passt"}}},
 				[]vmschema.Network{*vmschema.DefaultPodNetwork()},
-				[]vmschema.VirtualMachineInstanceNetworkInterface{{Name: "default", PodInterfaceName: defaultPrimaryPodIfaceName}},
+				[]vmschema.VirtualMachineInstanceNetworkInterface{{
+					Name:             defaultNetworkName,
+					PodInterfaceName: defaultPrimaryPodIfaceName,
+				}},
 			),
 			Entry("Interface with no matching status entry",
-				[]vmschema.Interface{{Name: "default", Binding: &vmschema.PluginBinding{Name: "passt-plugin"}}},
+				[]vmschema.Interface{{Name: defaultNetworkName, Binding: &vmschema.PluginBinding{Name: passtPluginBindingName}}},
 				[]vmschema.Network{*vmschema.DefaultPodNetwork()},
 				nil,
 			),
 			Entry("Interface with an empty PodInterfaceName",
-				[]vmschema.Interface{{Name: "default", Binding: &vmschema.PluginBinding{Name: "passt-plugin"}}},
+				[]vmschema.Interface{{Name: defaultNetworkName, Binding: &vmschema.PluginBinding{Name: passtPluginBindingName}}},
 				[]vmschema.Network{*vmschema.DefaultPodNetwork()},
-				[]vmschema.VirtualMachineInstanceNetworkInterface{{Name: "default", PodInterfaceName: ""}},
+				[]vmschema.VirtualMachineInstanceNetworkInterface{{Name: defaultNetworkName, PodInterfaceName: ""}},
 			),
 		)
 
 		It("should fail given interface with invalid PCI address", func() {
 			ifaces := []vmschema.Interface{{
-				Name: "default", Binding: &vmschema.PluginBinding{Name: "passt-plugin"},
+				Name: defaultNetworkName, Binding: &vmschema.PluginBinding{Name: passtPluginBindingName},
 				PciAddress: "invalid-pci-address",
 			}}
 			networks := []vmschema.Network{*vmschema.DefaultPodNetwork()}
-			ifaceStatuses := []vmschema.VirtualMachineInstanceNetworkInterface{{Name: "default", PodInterfaceName: defaultPrimaryPodIfaceName}}
+			ifaceStatuses := []vmschema.VirtualMachineInstanceNetworkInterface{{
+				Name:             defaultNetworkName,
+				PodInterfaceName: defaultPrimaryPodIfaceName,
+			}}
 
 			testMutator, err := domain.NewPasstNetworkConfigurator(
 				ifaces,
@@ -107,7 +134,10 @@ var _ = Describe("pod network configurator", func() {
 			func(iface *vmschema.Interface, expectedDomainIface *domainschema.Interface) {
 				ifaces := []vmschema.Interface{*iface}
 				networks := []vmschema.Network{*vmschema.DefaultPodNetwork()}
-				ifaceStatuses := []vmschema.VirtualMachineInstanceNetworkInterface{{Name: "default", PodInterfaceName: defaultPrimaryPodIfaceName}}
+				ifaceStatuses := []vmschema.VirtualMachineInstanceNetworkInterface{{
+					Name:             defaultNetworkName,
+					PodInterfaceName: defaultPrimaryPodIfaceName,
+				}}
 
 				testMutator, err := domain.NewPasstNetworkConfigurator(
 					ifaces,
@@ -123,91 +153,91 @@ var _ = Describe("pod network configurator", func() {
 				Expect(mutatedDomSpec.Devices.Interfaces).To(Equal([]domainschema.Interface{*expectedDomainIface}))
 			},
 			Entry("passt binding plugin",
-				&vmschema.Interface{Name: "default", Binding: &vmschema.PluginBinding{Name: "passt-plugin"}},
+				&vmschema.Interface{Name: defaultNetworkName, Binding: &vmschema.PluginBinding{Name: passtPluginBindingName}},
 				&domainschema.Interface{
-					Alias:       domainschema.NewUserDefinedAlias("default"),
+					Alias:       domainschema.NewUserDefinedAlias(defaultNetworkName),
 					Type:        ifaceTypeVhostUser,
-					Source:      domainschema.InterfaceSource{Device: "eth0"},
-					Backend:     &domainschema.InterfaceBackend{Type: "passt", LogFile: domain.PasstLogFilePath},
-					PortForward: []domainschema.InterfacePortForward{{Proto: "tcp"}, {Proto: "udp"}},
-					Model:       &domainschema.Model{Type: "virtio-non-transitional"},
+					Source:      domainschema.InterfaceSource{Device: defaultPrimaryPodIfaceName},
+					Backend:     &domainschema.InterfaceBackend{Type: passtBindingName, LogFile: domain.PasstLogFilePath},
+					PortForward: []domainschema.InterfacePortForward{{Proto: tcpProtocol}, {Proto: udpProtocol}},
+					Model:       &domainschema.Model{Type: virtioNonTransitionalMode},
 				},
 			),
 			Entry("PCI address",
 				&vmschema.Interface{
-					Name: "default", Binding: &vmschema.PluginBinding{Name: "passt-plugin"},
+					Name: defaultNetworkName, Binding: &vmschema.PluginBinding{Name: passtPluginBindingName},
 					PciAddress: "0000:02:02.0",
 				},
 				&domainschema.Interface{
-					Alias:       domainschema.NewUserDefinedAlias("default"),
+					Alias:       domainschema.NewUserDefinedAlias(defaultNetworkName),
 					Type:        ifaceTypeVhostUser,
-					Source:      domainschema.InterfaceSource{Device: "eth0"},
-					Backend:     &domainschema.InterfaceBackend{Type: "passt", LogFile: domain.PasstLogFilePath},
-					PortForward: []domainschema.InterfacePortForward{{Proto: "tcp"}, {Proto: "udp"}},
-					Model:       &domainschema.Model{Type: "virtio-non-transitional"},
+					Source:      domainschema.InterfaceSource{Device: defaultPrimaryPodIfaceName},
+					Backend:     &domainschema.InterfaceBackend{Type: passtBindingName, LogFile: domain.PasstLogFilePath},
+					PortForward: []domainschema.InterfacePortForward{{Proto: tcpProtocol}, {Proto: udpProtocol}},
+					Model:       &domainschema.Model{Type: virtioNonTransitionalMode},
 					Address:     &domainschema.Address{Type: "pci", Domain: "0x0000", Bus: "0x02", Slot: "0x02", Function: "0x0"},
 				},
 			),
 			Entry("MAC address",
 				&vmschema.Interface{
-					Name: "default", Binding: &vmschema.PluginBinding{Name: "passt-plugin"},
-					MacAddress: "02:02:02:02:02:02",
+					Name: defaultNetworkName, Binding: &vmschema.PluginBinding{Name: passtPluginBindingName},
+					MacAddress: testMACAddress,
 				},
 				&domainschema.Interface{
-					Alias:       domainschema.NewUserDefinedAlias("default"),
+					Alias:       domainschema.NewUserDefinedAlias(defaultNetworkName),
 					Type:        ifaceTypeVhostUser,
-					Source:      domainschema.InterfaceSource{Device: "eth0"},
-					Backend:     &domainschema.InterfaceBackend{Type: "passt", LogFile: domain.PasstLogFilePath},
-					PortForward: []domainschema.InterfacePortForward{{Proto: "tcp"}, {Proto: "udp"}},
-					Model:       &domainschema.Model{Type: "virtio-non-transitional"},
-					MAC:         &domainschema.MAC{MAC: "02:02:02:02:02:02"},
+					Source:      domainschema.InterfaceSource{Device: defaultPrimaryPodIfaceName},
+					Backend:     &domainschema.InterfaceBackend{Type: passtBindingName, LogFile: domain.PasstLogFilePath},
+					PortForward: []domainschema.InterfacePortForward{{Proto: tcpProtocol}, {Proto: udpProtocol}},
+					Model:       &domainschema.Model{Type: virtioNonTransitionalMode},
+					MAC:         &domainschema.MAC{MAC: testMACAddress},
 				},
 			),
 			Entry("ACPI address",
 				&vmschema.Interface{
-					Name: "default", Binding: &vmschema.PluginBinding{Name: "passt-plugin"},
+					Name: defaultNetworkName, Binding: &vmschema.PluginBinding{Name: passtPluginBindingName},
 					ACPIIndex: 2,
 				},
 				&domainschema.Interface{
-					Alias:       domainschema.NewUserDefinedAlias("default"),
+					Alias:       domainschema.NewUserDefinedAlias(defaultNetworkName),
 					Type:        ifaceTypeVhostUser,
-					Source:      domainschema.InterfaceSource{Device: "eth0"},
-					Backend:     &domainschema.InterfaceBackend{Type: "passt", LogFile: domain.PasstLogFilePath},
-					PortForward: []domainschema.InterfacePortForward{{Proto: "tcp"}, {Proto: "udp"}},
-					Model:       &domainschema.Model{Type: "virtio-non-transitional"},
+					Source:      domainschema.InterfaceSource{Device: defaultPrimaryPodIfaceName},
+					Backend:     &domainschema.InterfaceBackend{Type: passtBindingName, LogFile: domain.PasstLogFilePath},
+					PortForward: []domainschema.InterfacePortForward{{Proto: tcpProtocol}, {Proto: udpProtocol}},
+					Model:       &domainschema.Model{Type: virtioNonTransitionalMode},
 					ACPI:        &domainschema.ACPI{Index: uint(2)},
 				},
 			),
 			Entry("non virtio model",
 				&vmschema.Interface{
-					Name: "default", Binding: &vmschema.PluginBinding{Name: "passt-plugin"},
-					Model: "e1000",
+					Name: defaultNetworkName, Binding: &vmschema.PluginBinding{Name: passtPluginBindingName},
+					Model: e1000Model,
 				},
 				&domainschema.Interface{
-					Alias:       domainschema.NewUserDefinedAlias("default"),
+					Alias:       domainschema.NewUserDefinedAlias(defaultNetworkName),
 					Type:        ifaceTypeVhostUser,
-					Source:      domainschema.InterfaceSource{Device: "eth0"},
-					Backend:     &domainschema.InterfaceBackend{Type: "passt", LogFile: domain.PasstLogFilePath},
-					PortForward: []domainschema.InterfacePortForward{{Proto: "tcp"}, {Proto: "udp"}},
-					Model:       &domainschema.Model{Type: "e1000"},
+					Source:      domainschema.InterfaceSource{Device: defaultPrimaryPodIfaceName},
+					Backend:     &domainschema.InterfaceBackend{Type: passtBindingName, LogFile: domain.PasstLogFilePath},
+					PortForward: []domainschema.InterfacePortForward{{Proto: tcpProtocol}, {Proto: udpProtocol}},
+					Model:       &domainschema.Model{Type: e1000Model},
 				},
 			),
 			Entry("tcp ports (should forward tcp ports only)",
 				newInterface(
-					"default",
+					defaultNetworkName,
 					withPasstBindingPlugin(),
 					withOpenPort("TCP", 1),
 					withOpenPort("TCP", 4),
 				),
 				&domainschema.Interface{
-					Alias:   domainschema.NewUserDefinedAlias("default"),
+					Alias:   domainschema.NewUserDefinedAlias(defaultNetworkName),
 					Type:    ifaceTypeVhostUser,
-					Source:  domainschema.InterfaceSource{Device: "eth0"},
-					Backend: &domainschema.InterfaceBackend{Type: "passt", LogFile: domain.PasstLogFilePath},
-					Model:   &domainschema.Model{Type: "virtio-non-transitional"},
+					Source:  domainschema.InterfaceSource{Device: defaultPrimaryPodIfaceName},
+					Backend: &domainschema.InterfaceBackend{Type: passtBindingName, LogFile: domain.PasstLogFilePath},
+					Model:   &domainschema.Model{Type: virtioNonTransitionalMode},
 					PortForward: []domainschema.InterfacePortForward{
 						{
-							Proto: "tcp",
+							Proto: tcpProtocol,
 							Ranges: []domainschema.InterfacePortForwardRange{
 								{Start: 1}, {Start: 4},
 							},
@@ -217,20 +247,20 @@ var _ = Describe("pod network configurator", func() {
 			),
 			Entry("udp ports (should forward udp ports only)",
 				newInterface(
-					"default",
+					defaultNetworkName,
 					withPasstBindingPlugin(),
 					withOpenPort("UDP", 2),
 					withOpenPort("UDP", 3),
 				),
 				&domainschema.Interface{
-					Alias:   domainschema.NewUserDefinedAlias("default"),
+					Alias:   domainschema.NewUserDefinedAlias(defaultNetworkName),
 					Type:    ifaceTypeVhostUser,
-					Source:  domainschema.InterfaceSource{Device: "eth0"},
-					Backend: &domainschema.InterfaceBackend{Type: "passt", LogFile: domain.PasstLogFilePath},
-					Model:   &domainschema.Model{Type: "virtio-non-transitional"},
+					Source:  domainschema.InterfaceSource{Device: defaultPrimaryPodIfaceName},
+					Backend: &domainschema.InterfaceBackend{Type: passtBindingName, LogFile: domain.PasstLogFilePath},
+					Model:   &domainschema.Model{Type: virtioNonTransitionalMode},
 					PortForward: []domainschema.InterfacePortForward{
 						{
-							Proto: "udp",
+							Proto: udpProtocol,
 							Ranges: []domainschema.InterfacePortForwardRange{
 								{Start: 2}, {Start: 3},
 							},
@@ -240,7 +270,7 @@ var _ = Describe("pod network configurator", func() {
 			),
 			Entry("both tcp and udp ports",
 				newInterface(
-					"default",
+					defaultNetworkName,
 					withPasstBindingPlugin(),
 					withOpenPort("", 1),
 					withOpenPort("UDP", 2),
@@ -248,20 +278,20 @@ var _ = Describe("pod network configurator", func() {
 					withOpenPort("TCP", 4),
 				),
 				&domainschema.Interface{
-					Alias:   domainschema.NewUserDefinedAlias("default"),
+					Alias:   domainschema.NewUserDefinedAlias(defaultNetworkName),
 					Type:    ifaceTypeVhostUser,
-					Source:  domainschema.InterfaceSource{Device: "eth0"},
-					Backend: &domainschema.InterfaceBackend{Type: "passt", LogFile: domain.PasstLogFilePath},
-					Model:   &domainschema.Model{Type: "virtio-non-transitional"},
+					Source:  domainschema.InterfaceSource{Device: defaultPrimaryPodIfaceName},
+					Backend: &domainschema.InterfaceBackend{Type: passtBindingName, LogFile: domain.PasstLogFilePath},
+					Model:   &domainschema.Model{Type: virtioNonTransitionalMode},
 					PortForward: []domainschema.InterfacePortForward{
 						{
-							Proto: "tcp",
+							Proto: tcpProtocol,
 							Ranges: []domainschema.InterfacePortForwardRange{
 								{Start: 1}, {Start: 4},
 							},
 						},
 						{
-							Proto: "udp",
+							Proto: udpProtocol,
 							Ranges: []domainschema.InterfacePortForwardRange{
 								{Start: 2}, {Start: 3},
 							},
@@ -273,9 +303,12 @@ var _ = Describe("pod network configurator", func() {
 
 		DescribeTable("should add interface to domain spec given iface given the option",
 			func(opts *domain.NetworkConfiguratorOptions, expectedDomainIface *domainschema.Interface) {
-				ifaces := []vmschema.Interface{{Name: "default", Binding: &vmschema.PluginBinding{Name: "passt-plugin"}}}
+				ifaces := []vmschema.Interface{{Name: defaultNetworkName, Binding: &vmschema.PluginBinding{Name: passtPluginBindingName}}}
 				networks := []vmschema.Network{*vmschema.DefaultPodNetwork()}
-				ifaceStatuses := []vmschema.VirtualMachineInstanceNetworkInterface{{Name: "default", PodInterfaceName: defaultPrimaryPodIfaceName}}
+				ifaceStatuses := []vmschema.VirtualMachineInstanceNetworkInterface{{
+					Name:             defaultNetworkName,
+					PodInterfaceName: defaultPrimaryPodIfaceName,
+				}}
 
 				testMutator, err := domain.NewPasstNetworkConfigurator(ifaces, networks, ifaceStatuses, "passt-plugin", *opts)
 				Expect(err).ToNot(HaveOccurred())
@@ -287,34 +320,34 @@ var _ = Describe("pod network configurator", func() {
 			Entry("virtio transitional enabled",
 				&domain.NetworkConfiguratorOptions{UseVirtioTransitional: true},
 				&domainschema.Interface{
-					Alias:       domainschema.NewUserDefinedAlias("default"),
+					Alias:       domainschema.NewUserDefinedAlias(defaultNetworkName),
 					Type:        ifaceTypeVhostUser,
-					Source:      domainschema.InterfaceSource{Device: "eth0"},
-					Backend:     &domainschema.InterfaceBackend{Type: "passt", LogFile: domain.PasstLogFilePath},
-					PortForward: []domainschema.InterfacePortForward{{Proto: "tcp"}, {Proto: "udp"}},
+					Source:      domainschema.InterfaceSource{Device: defaultPrimaryPodIfaceName},
+					Backend:     &domainschema.InterfaceBackend{Type: passtBindingName, LogFile: domain.PasstLogFilePath},
+					PortForward: []domainschema.InterfacePortForward{{Proto: tcpProtocol}, {Proto: udpProtocol}},
 					Model:       &domainschema.Model{Type: "virtio-transitional"},
 				},
 			),
 			Entry("isitio proxy injection enabled",
 				&domain.NetworkConfiguratorOptions{IstioProxyInjectionEnabled: true},
 				&domainschema.Interface{
-					Alias:   domainschema.NewUserDefinedAlias("default"),
+					Alias:   domainschema.NewUserDefinedAlias(defaultNetworkName),
 					Type:    ifaceTypeVhostUser,
-					Source:  domainschema.InterfaceSource{Device: "eth0"},
-					Backend: &domainschema.InterfaceBackend{Type: "passt", LogFile: domain.PasstLogFilePath},
-					Model:   &domainschema.Model{Type: "virtio-non-transitional"},
+					Source:  domainschema.InterfaceSource{Device: defaultPrimaryPodIfaceName},
+					Backend: &domainschema.InterfaceBackend{Type: passtBindingName, LogFile: domain.PasstLogFilePath},
+					Model:   &domainschema.Model{Type: virtioNonTransitionalMode},
 					PortForward: []domainschema.InterfacePortForward{
-						{Proto: "tcp", Ranges: []domainschema.InterfacePortForwardRange{
-							{Start: 15000, Exclude: "yes"},
-							{Start: 15001, Exclude: "yes"},
-							{Start: 15004, Exclude: "yes"},
-							{Start: 15006, Exclude: "yes"},
-							{Start: 15008, Exclude: "yes"},
-							{Start: 15009, Exclude: "yes"},
-							{Start: 15020, Exclude: "yes"},
-							{Start: 15021, Exclude: "yes"},
-							{Start: 15053, Exclude: "yes"},
-							{Start: 15090, Exclude: "yes"},
+						{Proto: tcpProtocol, Ranges: []domainschema.InterfacePortForwardRange{
+							{Start: 15000, Exclude: excludedPort},
+							{Start: 15001, Exclude: excludedPort},
+							{Start: 15004, Exclude: excludedPort},
+							{Start: 15006, Exclude: excludedPort},
+							{Start: 15008, Exclude: excludedPort},
+							{Start: 15009, Exclude: excludedPort},
+							{Start: 15020, Exclude: excludedPort},
+							{Start: 15021, Exclude: excludedPort},
+							{Start: 15053, Exclude: excludedPort},
+							{Start: 15090, Exclude: excludedPort},
 						}},
 					},
 				},
@@ -324,22 +357,25 @@ var _ = Describe("pod network configurator", func() {
 		It("should not override other interfaces", func() {
 			networks := []vmschema.Network{
 				*vmschema.DefaultPodNetwork(),
-				{Name: "secondary", NetworkSource: vmschema.NetworkSource{Multus: &vmschema.MultusNetwork{NetworkName: "sec"}}},
+				{Name: secondaryNetworkName, NetworkSource: vmschema.NetworkSource{Multus: &vmschema.MultusNetwork{NetworkName: "sec"}}},
 			}
 			ifaces := []vmschema.Interface{
-				{Name: "default", Binding: &vmschema.PluginBinding{Name: "passt-plugin"}},
-				{Name: "secondary", InterfaceBindingMethod: vmschema.InterfaceBindingMethod{Bridge: &vmschema.InterfaceBridge{}}},
+				{Name: defaultNetworkName, Binding: &vmschema.PluginBinding{Name: passtPluginBindingName}},
+				{Name: secondaryNetworkName, InterfaceBindingMethod: vmschema.InterfaceBindingMethod{Bridge: &vmschema.InterfaceBridge{}}},
 			}
 
-			ifaceStatuses := []vmschema.VirtualMachineInstanceNetworkInterface{{Name: "default", PodInterfaceName: defaultPrimaryPodIfaceName}}
+			ifaceStatuses := []vmschema.VirtualMachineInstanceNetworkInterface{{
+				Name:             defaultNetworkName,
+				PodInterfaceName: defaultPrimaryPodIfaceName,
+			}}
 
 			expectedDomainIface := &domainschema.Interface{
-				Alias:       domainschema.NewUserDefinedAlias("default"),
+				Alias:       domainschema.NewUserDefinedAlias(defaultNetworkName),
 				Type:        ifaceTypeVhostUser,
-				Source:      domainschema.InterfaceSource{Device: "eth0"},
-				Backend:     &domainschema.InterfaceBackend{Type: "passt", LogFile: domain.PasstLogFilePath},
-				PortForward: []domainschema.InterfacePortForward{{Proto: "tcp"}, {Proto: "udp"}},
-				Model:       &domainschema.Model{Type: "virtio-non-transitional"},
+				Source:      domainschema.InterfaceSource{Device: defaultPrimaryPodIfaceName},
+				Backend:     &domainschema.InterfaceBackend{Type: passtBindingName, LogFile: domain.PasstLogFilePath},
+				PortForward: []domainschema.InterfacePortForward{{Proto: tcpProtocol}, {Proto: udpProtocol}},
+				Model:       &domainschema.Model{Type: virtioNonTransitionalMode},
 			}
 
 			testMutator, err := domain.NewPasstNetworkConfigurator(
@@ -363,18 +399,22 @@ var _ = Describe("pod network configurator", func() {
 			Expect(mutatedDomSpec.Devices.Interfaces).To(Equal([]domainschema.Interface{*existingIface, *expectedDomainIface}))
 		})
 
+		//nolint:dupl
 		It("should set domain interface correctly when executed more than once", func() {
 			networks := []vmschema.Network{*vmschema.DefaultPodNetwork()}
-			ifaces := []vmschema.Interface{{Name: "default", Binding: &vmschema.PluginBinding{Name: "passt-plugin"}}}
-			ifaceStatuses := []vmschema.VirtualMachineInstanceNetworkInterface{{Name: "default", PodInterfaceName: defaultPrimaryPodIfaceName}}
+			ifaces := []vmschema.Interface{{Name: defaultNetworkName, Binding: &vmschema.PluginBinding{Name: passtPluginBindingName}}}
+			ifaceStatuses := []vmschema.VirtualMachineInstanceNetworkInterface{{
+				Name:             defaultNetworkName,
+				PodInterfaceName: defaultPrimaryPodIfaceName,
+			}}
 
 			expectedDomainIface := &domainschema.Interface{
-				Alias:       domainschema.NewUserDefinedAlias("default"),
+				Alias:       domainschema.NewUserDefinedAlias(defaultNetworkName),
 				Type:        ifaceTypeVhostUser,
-				Source:      domainschema.InterfaceSource{Device: "eth0"},
-				Backend:     &domainschema.InterfaceBackend{Type: "passt", LogFile: domain.PasstLogFilePath},
-				PortForward: []domainschema.InterfacePortForward{{Proto: "tcp"}, {Proto: "udp"}},
-				Model:       &domainschema.Model{Type: "virtio-non-transitional"},
+				Source:      domainschema.InterfaceSource{Device: defaultPrimaryPodIfaceName},
+				Backend:     &domainschema.InterfaceBackend{Type: passtBindingName, LogFile: domain.PasstLogFilePath},
+				PortForward: []domainschema.InterfacePortForward{{Proto: tcpProtocol}, {Proto: udpProtocol}},
+				Model:       &domainschema.Model{Type: virtioNonTransitionalMode},
 			}
 
 			testMutator, err := domain.NewPasstNetworkConfigurator(
@@ -394,18 +434,19 @@ var _ = Describe("pod network configurator", func() {
 
 			Expect(testMutator.Mutate(mutatedDomSpec)).To(Equal(mutatedDomSpec))
 		})
+		//nolint:dupl
 		It("should set domain interface source link to the optional one if exists", func() {
 			networks := []vmschema.Network{*vmschema.DefaultPodNetwork()}
-			ifaces := []vmschema.Interface{{Name: "default", Binding: &vmschema.PluginBinding{Name: "passt-plugin"}}}
-			ifaceStatuses := []vmschema.VirtualMachineInstanceNetworkInterface{{Name: "default", PodInterfaceName: "ovn-udn1"}}
+			ifaces := []vmschema.Interface{{Name: defaultNetworkName, Binding: &vmschema.PluginBinding{Name: passtPluginBindingName}}}
+			ifaceStatuses := []vmschema.VirtualMachineInstanceNetworkInterface{{Name: defaultNetworkName, PodInterfaceName: optionalPodIfaceName}}
 
 			expectedDomainIface := &domainschema.Interface{
-				Alias:       domainschema.NewUserDefinedAlias("default"),
+				Alias:       domainschema.NewUserDefinedAlias(defaultNetworkName),
 				Type:        ifaceTypeVhostUser,
-				Source:      domainschema.InterfaceSource{Device: "ovn-udn1"},
-				Backend:     &domainschema.InterfaceBackend{Type: "passt", LogFile: domain.PasstLogFilePath},
-				PortForward: []domainschema.InterfacePortForward{{Proto: "tcp"}, {Proto: "udp"}},
-				Model:       &domainschema.Model{Type: "virtio-non-transitional"},
+				Source:      domainschema.InterfaceSource{Device: optionalPodIfaceName},
+				Backend:     &domainschema.InterfaceBackend{Type: passtBindingName, LogFile: domain.PasstLogFilePath},
+				PortForward: []domainschema.InterfacePortForward{{Proto: tcpProtocol}, {Proto: udpProtocol}},
+				Model:       &domainschema.Model{Type: virtioNonTransitionalMode},
 			}
 			testMutator, err := domain.NewPasstNetworkConfigurator(
 				ifaces,
@@ -429,8 +470,11 @@ var _ = Describe("pod network configurator", func() {
 		var testMutator *domain.PasstNetworkConfigurator
 		BeforeEach(func() {
 			networks := []vmschema.Network{*vmschema.DefaultPodNetwork()}
-			ifaces := []vmschema.Interface{{Name: "default", Binding: &vmschema.PluginBinding{Name: "passt-plugin"}}}
-			ifaceStatuses := []vmschema.VirtualMachineInstanceNetworkInterface{{Name: "default", PodInterfaceName: defaultPrimaryPodIfaceName}}
+			ifaces := []vmschema.Interface{{Name: defaultNetworkName, Binding: &vmschema.PluginBinding{Name: passtPluginBindingName}}}
+			ifaceStatuses := []vmschema.VirtualMachineInstanceNetworkInterface{{
+				Name:             defaultNetworkName,
+				PodInterfaceName: defaultPrimaryPodIfaceName,
+			}}
 
 			var err error
 			testMutator, err = domain.NewPasstNetworkConfigurator(
@@ -446,7 +490,7 @@ var _ = Describe("pod network configurator", func() {
 		It("should set shared memfd when clean domain", func() {
 			expectedMemoryBacking := &domainschema.MemoryBacking{
 				Access: &domainschema.MemoryBackingAccess{
-					Mode: "shared",
+					Mode: sharedAccessMode,
 				},
 				Source: &domainschema.MemoryBackingSource{
 					Type: "memfd",
@@ -470,7 +514,7 @@ var _ = Describe("pod network configurator", func() {
 		It("should use other configs of backing memory as long as they are shared", func() {
 			domainWithOtherSharedMem := &domainschema.DomainSpec{
 				MemoryBacking: &domainschema.MemoryBacking{
-					Access: &domainschema.MemoryBackingAccess{Mode: "shared"},
+					Access: &domainschema.MemoryBackingAccess{Mode: sharedAccessMode},
 					Source: &domainschema.MemoryBackingSource{Type: "file"},
 				},
 			}
@@ -498,7 +542,7 @@ func newInterface(name string, options ...option) *vmschema.Interface {
 func withPasstBindingPlugin() option {
 	return func(iface *vmschema.Interface) {
 		iface.Binding = &vmschema.PluginBinding{
-			Name: "passt-plugin",
+			Name: passtPluginBindingName,
 		}
 	}
 }

--- a/hack/linter/.golangci.yml
+++ b/hack/linter/.golangci.yml
@@ -11,9 +11,7 @@ linters:
     - forbidigo
     - funlen
     - gochecknoinits
-    # TODO: Re-enable goconst in a follow-up PR after addressing the larger
-    # finding set introduced by newer golangci-lint
-    # - goconst
+    - goconst
     - gocritic
     - gocyclo
     - goheader
@@ -54,9 +52,9 @@ linters:
     funlen:
       lines: 100
       statements: 50
-    # goconst:
-    #   min-len: 2
-    #   min-occurrences: 2
+    goconst:
+      min-len: 2
+      min-occurrences: 2
     gocritic:
       disabled-checks:
         - dupImport # https://github.com/go-critic/go-critic/issues/845

--- a/pkg/downwardmetrics/scraper/hostmetrics_test.go
+++ b/pkg/downwardmetrics/scraper/hostmetrics_test.go
@@ -29,6 +29,8 @@ import (
 )
 
 var _ = Describe("Hostmetrics", func() {
+	const socket0CoreSiblingsList = "0-5"
+
 	var tempSysDir string
 
 	BeforeEach(func() {
@@ -44,32 +46,32 @@ var _ = Describe("Hostmetrics", func() {
 		for i, cpuTopology := range []topology{{
 			coreID:             "0",
 			physicalPackageID:  "0",
-			coreSiblingsList:   "0-5",
+			coreSiblingsList:   socket0CoreSiblingsList,
 			threadSiblingsList: "0,4",
 		}, {
 			coreID:             "1",
 			physicalPackageID:  "0",
-			coreSiblingsList:   "0-5",
+			coreSiblingsList:   socket0CoreSiblingsList,
 			threadSiblingsList: "1,5",
 		}, {
 			coreID:             "2",
 			physicalPackageID:  "0",
-			coreSiblingsList:   "0-5",
+			coreSiblingsList:   socket0CoreSiblingsList,
 			threadSiblingsList: "2",
 		}, {
 			coreID:             "3",
 			physicalPackageID:  "0",
-			coreSiblingsList:   "0-5",
+			coreSiblingsList:   socket0CoreSiblingsList,
 			threadSiblingsList: "3",
 		}, {
 			coreID:             "0",
 			physicalPackageID:  "0",
-			coreSiblingsList:   "0-5",
+			coreSiblingsList:   socket0CoreSiblingsList,
 			threadSiblingsList: "1,4",
 		}, {
 			coreID:             "1",
 			physicalPackageID:  "0",
-			coreSiblingsList:   "0-5",
+			coreSiblingsList:   socket0CoreSiblingsList,
 			threadSiblingsList: "2,5",
 		}, {
 			coreID:             "2",

--- a/pkg/dra/admitter/dra_admitter.go
+++ b/pkg/dra/admitter/dra_admitter.go
@@ -34,6 +34,11 @@ import (
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 )
 
+const (
+	atMostOneClaimMsg = "at most one of resourceClaimName or resourceClaimTemplateName may be specified"
+	mustSpecifyOneMsg = "must specify one of: resourceClaimName, resourceClaimTemplateName"
+)
+
 type Validator struct {
 	field         *k8sfield.Path
 	vmiSpec       *v1.VirtualMachineInstanceSpec
@@ -145,14 +150,14 @@ func validateResourceClaims(field *k8sfield.Path, resourceClaims []v1.VirtualMac
 		if claim.ResourceClaimName != nil && claim.ResourceClaimTemplateName != nil {
 			causes = append(causes, metav1.StatusCause{
 				Type:    metav1.CauseTypeFieldValueInvalid,
-				Message: "at most one of resourceClaimName or resourceClaimTemplateName may be specified",
+				Message: atMostOneClaimMsg,
 				Field:   claimField.String(),
 			})
 		}
 		if claim.ResourceClaimName == nil && claim.ResourceClaimTemplateName == nil {
 			causes = append(causes, metav1.StatusCause{
 				Type:    metav1.CauseTypeFieldValueInvalid,
-				Message: "must specify one of: resourceClaimName, resourceClaimTemplateName",
+				Message: mustSpecifyOneMsg,
 				Field:   claimField.String(),
 			})
 		}

--- a/pkg/dra/admitter/dra_admitter_test.go
+++ b/pkg/dra/admitter/dra_admitter_test.go
@@ -32,11 +32,22 @@ import (
 )
 
 const (
-	claim1    = "claim1"
-	claim2    = "claim2"
-	req1      = "req1"
-	req2      = "req2"
-	template1 = "template1"
+	claim1                 = "claim1"
+	claim2                 = "claim2"
+	dpHostDeviceName       = "dp-hd"
+	gpu1Name               = "gpu1"
+	hostDevice1Name        = "hd1"
+	req1                   = "req1"
+	req2                   = "req2"
+	sharedClaimName        = "shared-claim"
+	template1              = "template1"
+	vfioHostDeviceResource = "vfio.device.example.com"
+	resourceClaimsField    = "spec.resourceClaims[0]"
+	draHDInvalidName       = "dra-hd-invalid"
+	dpHD2Name              = "dp-hd-2"
+	gpuClaimName           = "gpu-claim"
+	hdClaimName            = "hd-claim"
+	sharedReqName          = "shared-req"
 )
 
 type fakeConfigChecker struct {
@@ -260,8 +271,8 @@ var _ = Describe("DRA Admitter", func() {
 			causes := validateCreationDRA(field, spec, checker)
 			Expect(causes).To(ContainElement(metav1.StatusCause{
 				Type:    metav1.CauseTypeFieldValueInvalid,
-				Message: "at most one of resourceClaimName or resourceClaimTemplateName may be specified",
-				Field:   "spec.resourceClaims[0]",
+				Message: atMostOneClaimMsg,
+				Field:   resourceClaimsField,
 			}))
 		})
 
@@ -275,8 +286,8 @@ var _ = Describe("DRA Admitter", func() {
 			causes := validateCreationDRA(field, spec, checker)
 			Expect(causes).To(ContainElement(metav1.StatusCause{
 				Type:    metav1.CauseTypeFieldValueInvalid,
-				Message: "must specify one of: resourceClaimName, resourceClaimTemplateName",
-				Field:   "spec.resourceClaims[0]",
+				Message: mustSpecifyOneMsg,
+				Field:   resourceClaimsField,
 			}))
 		})
 	})
@@ -288,12 +299,12 @@ var _ = Describe("DRA Admitter", func() {
 		},
 		Entry("GPU",
 			func() *v1.VirtualMachineInstanceSpec {
-				return gpuSpec(nil, gpuWithDeviceName("gpu1", "vfio.gpu.example.com"))
+				return gpuSpec(nil, gpuWithDeviceName(gpu1Name, "vfio.gpu.example.com"))
 			},
 		),
 		Entry("HostDevice",
 			func() *v1.VirtualMachineInstanceSpec {
-				return hostDeviceSpec(nil, hostDeviceWithDeviceName("hd1", "vfio.device.example.com"))
+				return hostDeviceSpec(nil, hostDeviceWithDeviceName(hostDevice1Name, vfioHostDeviceResource))
 			},
 		),
 	)
@@ -309,14 +320,14 @@ var _ = Describe("DRA Admitter", func() {
 		Entry("GPU",
 			func() { checker.gpuDRAEnabled = true },
 			func() *v1.VirtualMachineInstanceSpec {
-				return gpuSpec(nil, gpuWithDeviceNameAndClaimRequest("gpu1", "vfio.gpu.example.com", claimRequest(claim1, req1)))
+				return gpuSpec(nil, gpuWithDeviceNameAndClaimRequest(gpu1Name, "vfio.gpu.example.com", claimRequest(claim1, req1)))
 			},
 			"spec.domain.devices.gpus",
 		),
 		Entry("HostDevice",
 			func() { checker.hostDeviceDRAEnabled = true },
 			func() *v1.VirtualMachineInstanceSpec {
-				return hostDeviceSpec(nil, hostDeviceWithDeviceNameAndClaimRequest("hd1", "vfio.device.example.com", claimRequest(claim1, req1)))
+				return hostDeviceSpec(nil, hostDeviceWithDeviceNameAndClaimRequest(hostDevice1Name, vfioHostDeviceResource, claimRequest(claim1, req1)))
 			},
 			"spec.domain.devices.hostDevices",
 		),
@@ -325,7 +336,7 @@ var _ = Describe("DRA Admitter", func() {
 	Context("DRA GPUs with feature gate disabled", func() {
 		It("should reject DRA GPUs when the feature gate is off", func() {
 			checker.gpuDRAEnabled = false
-			spec := gpuSpec(nil, gpuWithClaimRequest("gpu1", claim1, req1))
+			spec := gpuSpec(nil, gpuWithClaimRequest(gpu1Name, claim1, req1))
 			causes := validateCreationDRA(field, spec, checker)
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Message).To(ContainSubstring("feature gate is not enabled"))
@@ -347,7 +358,7 @@ var _ = Describe("DRA Admitter", func() {
 			func() { checker.gpuDRAEnabled = true },
 			func(claimRequest *v1.ClaimRequest) *v1.VirtualMachineInstanceSpec {
 				return gpuSpec([]v1.VirtualMachineInstanceResourceClaim{resourceClaim(claim1)}, v1.GPU{
-					Name:         "gpu1",
+					Name:         gpu1Name,
 					ClaimRequest: claimRequest,
 				})
 			},
@@ -357,7 +368,7 @@ var _ = Describe("DRA Admitter", func() {
 			func() { checker.hostDeviceDRAEnabled = true },
 			func(claimRequest *v1.ClaimRequest) *v1.VirtualMachineInstanceSpec {
 				return hostDeviceSpec([]v1.VirtualMachineInstanceResourceClaim{resourceClaim(claim1)}, v1.HostDevice{
-					Name:         "hd1",
+					Name:         hostDevice1Name,
 					ClaimRequest: claimRequest,
 				})
 			},
@@ -379,7 +390,7 @@ var _ = Describe("DRA Admitter", func() {
 			func() { checker.gpuDRAEnabled = true },
 			func(claimRequest *v1.ClaimRequest) *v1.VirtualMachineInstanceSpec {
 				return gpuSpec([]v1.VirtualMachineInstanceResourceClaim{resourceClaim(claim1)}, v1.GPU{
-					Name:         "gpu1",
+					Name:         gpu1Name,
 					ClaimRequest: claimRequest,
 				})
 			},
@@ -389,7 +400,7 @@ var _ = Describe("DRA Admitter", func() {
 			func() { checker.hostDeviceDRAEnabled = true },
 			func(claimRequest *v1.ClaimRequest) *v1.VirtualMachineInstanceSpec {
 				return hostDeviceSpec([]v1.VirtualMachineInstanceResourceClaim{resourceClaim(claim1)}, v1.HostDevice{
-					Name:         "hd1",
+					Name:         hostDevice1Name,
 					ClaimRequest: claimRequest,
 				})
 			},
@@ -410,7 +421,7 @@ var _ = Describe("DRA Admitter", func() {
 			func() { checker.gpuDRAEnabled = true },
 			func(claimRequest *v1.ClaimRequest) *v1.VirtualMachineInstanceSpec {
 				return gpuSpec([]v1.VirtualMachineInstanceResourceClaim{resourceClaim(claim1)}, v1.GPU{
-					Name:         "gpu1",
+					Name:         gpu1Name,
 					ClaimRequest: claimRequest,
 				})
 			},
@@ -420,7 +431,7 @@ var _ = Describe("DRA Admitter", func() {
 			func() { checker.hostDeviceDRAEnabled = true },
 			func(claimRequest *v1.ClaimRequest) *v1.VirtualMachineInstanceSpec {
 				return hostDeviceSpec([]v1.VirtualMachineInstanceResourceClaim{resourceClaim(claim1)}, v1.HostDevice{
-					Name:         "hd1",
+					Name:         hostDevice1Name,
 					ClaimRequest: claimRequest,
 				})
 			},
@@ -439,7 +450,7 @@ var _ = Describe("DRA Admitter", func() {
 					resourceClaim(claim1),
 					resourceClaim(claim1),
 				},
-				gpuWithClaimRequest("gpu1", claim1, req1),
+				gpuWithClaimRequest(gpu1Name, claim1, req1),
 			)
 			causes := validateCreationDRA(field, spec, checker)
 			Expect(causes).To(HaveLen(1))
@@ -451,7 +462,7 @@ var _ = Describe("DRA Admitter", func() {
 		It("should reject when GPU claimName is not listed in spec.resourceClaims", func() {
 			spec := gpuSpec(
 				[]v1.VirtualMachineInstanceResourceClaim{resourceClaim("other-claim")},
-				gpuWithClaimRequest("gpu1", claim1, req1),
+				gpuWithClaimRequest(gpu1Name, claim1, req1),
 			)
 			causes := validateCreationDRA(field, spec, checker)
 			Expect(causes).To(HaveLen(1))
@@ -462,7 +473,7 @@ var _ = Describe("DRA Admitter", func() {
 		It("should reject when one of multiple claims is missing from spec.resourceClaims", func() {
 			spec := gpuSpec(
 				[]v1.VirtualMachineInstanceResourceClaim{resourceClaim(claim1)},
-				gpuWithClaimRequest("gpu1", claim1, req1),
+				gpuWithClaimRequest(gpu1Name, claim1, req1),
 				gpuWithClaimRequest("gpu2", claim2, req2),
 			)
 			causes := validateCreationDRA(field, spec, checker)
@@ -517,7 +528,7 @@ var _ = Describe("DRA Admitter", func() {
 		Entry("GPU",
 			func() { checker.gpuDRAEnabled = true },
 			func() *v1.VirtualMachineInstanceSpec {
-				return gpuSpec([]v1.VirtualMachineInstanceResourceClaim{resourceClaim(claim1)}, gpuWithClaimRequest("gpu1", claim1, req1))
+				return gpuSpec([]v1.VirtualMachineInstanceResourceClaim{resourceClaim(claim1)}, gpuWithClaimRequest(gpu1Name, claim1, req1))
 			},
 			func(
 				resourceClaims []v1.VirtualMachineInstanceResourceClaim,
@@ -528,7 +539,7 @@ var _ = Describe("DRA Admitter", func() {
 			) *v1.VirtualMachineInstanceSpec {
 				return gpuSpec(
 					resourceClaims,
-					gpuWithClaimRequest("gpu1", firstClaim, firstRequest),
+					gpuWithClaimRequest(gpu1Name, firstClaim, firstRequest),
 					gpuWithClaimRequest("gpu2", secondClaim, secondRequest),
 				)
 			},
@@ -539,7 +550,7 @@ var _ = Describe("DRA Admitter", func() {
 			func() *v1.VirtualMachineInstanceSpec {
 				return hostDeviceSpec(
 					[]v1.VirtualMachineInstanceResourceClaim{resourceClaim(claim1)},
-					hostDeviceWithClaimRequest("hd1", claim1, req1),
+					hostDeviceWithClaimRequest(hostDevice1Name, claim1, req1),
 				)
 			},
 			func(
@@ -551,7 +562,7 @@ var _ = Describe("DRA Admitter", func() {
 			) *v1.VirtualMachineInstanceSpec {
 				return hostDeviceSpec(
 					resourceClaims,
-					hostDeviceWithClaimRequest("hd1", firstClaim, firstRequest),
+					hostDeviceWithClaimRequest(hostDevice1Name, firstClaim, firstRequest),
 					hostDeviceWithClaimRequest("hd2", secondClaim, secondRequest),
 				)
 			},
@@ -574,7 +585,7 @@ var _ = Describe("DRA Admitter", func() {
 								Name: "dra-gpu",
 								ClaimRequest: &v1.ClaimRequest{
 									ClaimName:   claim1,
-									RequestName: "req1",
+									RequestName: req1,
 								},
 							},
 						},
@@ -602,20 +613,20 @@ var _ = Describe("DRA Admitter", func() {
 						GPUs: []v1.GPU{
 							{
 								Name:         "gpu-invalid",
-								ClaimRequest: &v1.ClaimRequest{RequestName: "req1"},
+								ClaimRequest: &v1.ClaimRequest{RequestName: req1},
 							},
 							{
 								Name: "gpu-a",
 								ClaimRequest: &v1.ClaimRequest{
 									ClaimName:   claim1,
-									RequestName: "req1",
+									RequestName: req1,
 								},
 							},
 							{
 								Name: "gpu-dup",
 								ClaimRequest: &v1.ClaimRequest{
 									ClaimName:   claim1,
-									RequestName: "req1",
+									RequestName: req1,
 								},
 							},
 						},
@@ -645,7 +656,7 @@ var _ = Describe("DRA Admitter", func() {
 	Context("DRA HostDevices with feature gate disabled", func() {
 		It("should reject DRA HostDevices when the feature gate is off", func() {
 			checker.hostDeviceDRAEnabled = false
-			spec := hostDeviceSpec(nil, hostDeviceWithClaimRequest("hd1", claim1, req1))
+			spec := hostDeviceSpec(nil, hostDeviceWithClaimRequest(hostDevice1Name, claim1, req1))
 			causes := validateCreationDRA(field, spec, checker)
 			Expect(causes).To(HaveLen(1))
 			Expect(causes[0].Message).To(ContainSubstring("feature gate is not enabled"))
@@ -661,7 +672,7 @@ var _ = Describe("DRA Admitter", func() {
 		It("should reject when HostDevice claimName is not listed in spec.resourceClaims", func() {
 			spec := hostDeviceSpec(
 				[]v1.VirtualMachineInstanceResourceClaim{resourceClaim("other-claim")},
-				hostDeviceWithClaimRequest("hd1", claim1, req1),
+				hostDeviceWithClaimRequest(hostDevice1Name, claim1, req1),
 			)
 			causes := validateCreationDRA(field, spec, checker)
 			Expect(causes).To(HaveLen(1))
@@ -679,14 +690,14 @@ var _ = Describe("DRA Admitter", func() {
 					Devices: v1.Devices{
 						HostDevices: []v1.HostDevice{
 							{
-								Name:       "dp-hd",
-								DeviceName: "vfio.device.example.com",
+								Name:       dpHostDeviceName,
+								DeviceName: vfioHostDeviceResource,
 							},
 							{
 								Name: "dra-hd",
 								ClaimRequest: &v1.ClaimRequest{
 									ClaimName:   claim1,
-									RequestName: "req1",
+									RequestName: req1,
 								},
 							},
 						},
@@ -710,12 +721,12 @@ var _ = Describe("DRA Admitter", func() {
 					Devices: v1.Devices{
 						HostDevices: []v1.HostDevice{
 							{
-								Name:       "dp-hd",
-								DeviceName: "vfio.device.example.com",
+								Name:       dpHostDeviceName,
+								DeviceName: vfioHostDeviceResource,
 							},
 							{
-								Name:         "dra-hd-invalid",
-								ClaimRequest: &v1.ClaimRequest{RequestName: "req1"},
+								Name:         draHDInvalidName,
+								ClaimRequest: &v1.ClaimRequest{RequestName: req1},
 							},
 						},
 					},
@@ -735,25 +746,25 @@ var _ = Describe("DRA Admitter", func() {
 					Devices: v1.Devices{
 						HostDevices: []v1.HostDevice{
 							{
-								Name:       "dp-hd",
-								DeviceName: "vfio.device.example.com",
+								Name:       dpHostDeviceName,
+								DeviceName: vfioHostDeviceResource,
 							},
 							{
 								Name: "dra-hd-a",
 								ClaimRequest: &v1.ClaimRequest{
 									ClaimName:   claim1,
-									RequestName: "req1",
+									RequestName: req1,
 								},
 							},
 							{
-								Name:       "dp-hd-2",
+								Name:       dpHD2Name,
 								DeviceName: "another.device.example.com",
 							},
 							{
 								Name: "dra-hd-dup",
 								ClaimRequest: &v1.ClaimRequest{
 									ClaimName:   claim1,
-									RequestName: "req1",
+									RequestName: req1,
 								},
 							},
 						},
@@ -778,11 +789,11 @@ var _ = Describe("DRA Admitter", func() {
 								DeviceName: "vfio.device1.example.com",
 							},
 							{
-								Name:       "dp-hd-2",
+								Name:       dpHD2Name,
 								DeviceName: "vfio.device2.example.com",
 							},
 							{
-								Name:         "dra-hd-invalid",
+								Name:         draHDInvalidName,
 								ClaimRequest: &v1.ClaimRequest{},
 							},
 						},
@@ -811,17 +822,17 @@ var _ = Describe("DRA Admitter", func() {
 				Domain: v1.DomainSpec{
 					Devices: v1.Devices{
 						GPUs: []v1.GPU{{
-							Name: "gpu1",
+							Name: gpu1Name,
 							ClaimRequest: &v1.ClaimRequest{
-								ClaimName:   "gpu-claim",
-								RequestName: "req1",
+								ClaimName:   gpuClaimName,
+								RequestName: req1,
 							},
 						}},
 						HostDevices: []v1.HostDevice{{
-							Name: "hd1",
+							Name: hostDevice1Name,
 							ClaimRequest: &v1.ClaimRequest{
-								ClaimName:   "hd-claim",
-								RequestName: "req1",
+								ClaimName:   hdClaimName,
+								RequestName: req1,
 							},
 						}},
 					},
@@ -839,17 +850,17 @@ var _ = Describe("DRA Admitter", func() {
 				Domain: v1.DomainSpec{
 					Devices: v1.Devices{
 						GPUs: []v1.GPU{{
-							Name: "gpu1",
+							Name: gpu1Name,
 							ClaimRequest: &v1.ClaimRequest{
-								ClaimName:   "gpu-claim",
-								RequestName: "req1",
+								ClaimName:   gpuClaimName,
+								RequestName: req1,
 							},
 						}},
 						HostDevices: []v1.HostDevice{{
-							Name: "hd1",
+							Name: hostDevice1Name,
 							ClaimRequest: &v1.ClaimRequest{
-								ClaimName:   "hd-claim",
-								RequestName: "req1",
+								ClaimName:   hdClaimName,
+								RequestName: req1,
 							},
 						}},
 					},
@@ -864,21 +875,21 @@ var _ = Describe("DRA Admitter", func() {
 		It("should accept when GPUs and HostDevices share the same claim", func() {
 			spec := &v1.VirtualMachineInstanceSpec{
 				ResourceClaims: []v1.VirtualMachineInstanceResourceClaim{
-					resourceClaim("shared-claim"),
+					resourceClaim(sharedClaimName),
 				},
 				Domain: v1.DomainSpec{
 					Devices: v1.Devices{
 						GPUs: []v1.GPU{{
-							Name: "gpu1",
+							Name: gpu1Name,
 							ClaimRequest: &v1.ClaimRequest{
-								ClaimName:   "shared-claim",
+								ClaimName:   sharedClaimName,
 								RequestName: "gpu-req",
 							},
 						}},
 						HostDevices: []v1.HostDevice{{
-							Name: "hd1",
+							Name: hostDevice1Name,
 							ClaimRequest: &v1.ClaimRequest{
-								ClaimName:   "shared-claim",
+								ClaimName:   sharedClaimName,
 								RequestName: "hd-req",
 							},
 						}},
@@ -891,19 +902,19 @@ var _ = Describe("DRA Admitter", func() {
 
 		It("should reject when GPU and HostDevice share the same claimName/requestName pair", func() {
 			vmi := libvmi.New(
-				libvmi.WithResourceClaim(resourceClaim("shared-claim")),
+				libvmi.WithResourceClaim(resourceClaim(sharedClaimName)),
 				libvmi.WithGPU(v1.GPU{
-					Name: "gpu1",
+					Name: gpu1Name,
 					ClaimRequest: &v1.ClaimRequest{
-						ClaimName:   "shared-claim",
-						RequestName: "shared-req",
+						ClaimName:   sharedClaimName,
+						RequestName: sharedReqName,
 					},
 				}),
 				libvmi.WithHostDevice(v1.HostDevice{
-					Name: "hd1",
+					Name: hostDevice1Name,
 					ClaimRequest: &v1.ClaimRequest{
-						ClaimName:   "shared-claim",
-						RequestName: "shared-req",
+						ClaimName:   sharedClaimName,
+						RequestName: sharedReqName,
 					},
 				}),
 			)
@@ -924,10 +935,10 @@ var _ = Describe("DRA Admitter", func() {
 				Domain: v1.DomainSpec{
 					Devices: v1.Devices{
 						GPUs: []v1.GPU{{
-							Name: "gpu1",
+							Name: gpu1Name,
 							ClaimRequest: &v1.ClaimRequest{
 								ClaimName:   claim1,
-								RequestName: "req1",
+								RequestName: req1,
 							},
 						}},
 					},
@@ -944,10 +955,10 @@ var _ = Describe("DRA Admitter", func() {
 				Domain: v1.DomainSpec{
 					Devices: v1.Devices{
 						GPUs: []v1.GPU{{
-							Name: "gpu1",
+							Name: gpu1Name,
 							ClaimRequest: &v1.ClaimRequest{
 								ClaimName:   claim1,
-								RequestName: "req1",
+								RequestName: req1,
 							},
 						}},
 					},

--- a/pkg/dra/resource_claims_test.go
+++ b/pkg/dra/resource_claims_test.go
@@ -30,6 +30,8 @@ import (
 )
 
 var _ = Describe("ResourceClaims", func() {
+	const directClaimName = "direct-claim"
+	const templateClaimName = "template-claim"
 	DescribeTable("should convert VMI resourceClaims to Pod resourceClaims",
 		func(resourceClaims []v1.VirtualMachineInstanceResourceClaim, expected []k8sv1.PodResourceClaim) {
 			Expect(ToPodResourceClaims(resourceClaims)).To(Equal(expected))
@@ -45,21 +47,21 @@ var _ = Describe("ResourceClaims", func() {
 		Entry("direct and template resourceClaims",
 			[]v1.VirtualMachineInstanceResourceClaim{
 				{
-					Name:              "direct-claim",
+					Name:              directClaimName,
 					ResourceClaimName: ptr.To("resource-claim"),
 				},
 				{
-					Name:                      "template-claim",
+					Name:                      templateClaimName,
 					ResourceClaimTemplateName: ptr.To("resource-claim-template"),
 				},
 			},
 			[]k8sv1.PodResourceClaim{
 				{
-					Name:              "direct-claim",
+					Name:              directClaimName,
 					ResourceClaimName: ptr.To("resource-claim"),
 				},
 				{
-					Name:                      "template-claim",
+					Name:                      templateClaimName,
 					ResourceClaimTemplateName: ptr.To("resource-claim-template"),
 				},
 			},

--- a/pkg/dra/utils_test.go
+++ b/pkg/dra/utils_test.go
@@ -38,11 +38,24 @@ import (
 )
 
 const (
-	pciAddr0300 = "0000:03:00.0"
-	pciAddr0400 = "0000:04:00.0"
+	claim1Name         = "claim1"
+	deviceMetadataKind = "DeviceMetadata"
+	gpuRequestName     = "gpu-req"
+	pciAddr0300        = "0000:03:00.0"
+	pciAddr0400        = "0000:04:00.0"
+	request1Name       = "req1"
+	testClaimName      = "my-claim"
+	vgpuRequestName    = "vgpu-req"
 )
 
 var _ = Describe("DownwardAPIAttributes", func() {
+	const (
+		gpuDriver        = "gpu.example.com"
+		gpuPool          = "default"
+		gpuDeviceName    = "gpu-0"
+		multiDriverClaim = "multi-driver-claim"
+		worker0Pool      = "worker-0"
+	)
 	var tempDir string
 
 	BeforeEach(func() {
@@ -60,7 +73,7 @@ var _ = Describe("DownwardAPIAttributes", func() {
 	writeMetadataJSON := func(dir, driverName string, md *metadata.DeviceMetadata) {
 		Expect(os.MkdirAll(dir, 0o755)).To(Succeed())
 		md.APIVersion = metadata.APIVersionV1Alpha1
-		md.Kind = "DeviceMetadata"
+		md.Kind = deviceMetadataKind
 		data, err := json.Marshal(md)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(os.WriteFile(filepath.Join(dir, driverName+metadataFileSuffix), data, 0o600)).To(Succeed())
@@ -127,9 +140,9 @@ var _ = Describe("DownwardAPIAttributes", func() {
 				Requests: []metadata.DeviceMetadataRequest{{
 					Name: "gpu-request",
 					Devices: []metadata.Device{{
-						Driver: "gpu.example.com",
-						Pool:   "default",
-						Name:   "gpu-0",
+						Driver: gpuDriver,
+						Pool:   gpuPool,
+						Name:   gpuDeviceName,
 						Attributes: map[resourcev1.QualifiedName]resourcev1.DeviceAttribute{
 							metadata.PCIBusIDAttribute: {StringValue: &pciAddr},
 						},
@@ -155,8 +168,8 @@ var _ = Describe("DownwardAPIAttributes", func() {
 				Requests: []metadata.DeviceMetadataRequest{{
 					Name: "vgpu-request",
 					Devices: []metadata.Device{{
-						Driver: "gpu.example.com",
-						Pool:   "default",
+						Driver: gpuDriver,
+						Pool:   gpuPool,
 						Name:   "vgpu-0",
 						Attributes: map[resourcev1.QualifiedName]resourcev1.DeviceAttribute{
 							metadata.MDevUUIDAttribute: {StringValue: &mdevUUID},
@@ -181,7 +194,7 @@ var _ = Describe("DownwardAPIAttributes", func() {
 				ResourceClaimName: ptr.To("nonexistent"),
 			}}
 
-			_, err := GetPCIAddressForClaim(tempDir, resourceClaims, "missing-claim", "req1")
+			_, err := GetPCIAddressForClaim(tempDir, resourceClaims, "missing-claim", request1Name)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("failed to read metadata"))
 		})
@@ -190,10 +203,10 @@ var _ = Describe("DownwardAPIAttributes", func() {
 	Context("GetPCIAddressForClaim", func() {
 		It("should return the PCI address when present", func() {
 			pciAddr := pciAddr0300
-			createMetadataFile("pci-claim", "req1", &metadata.DeviceMetadata{
+			createMetadataFile("pci-claim", request1Name, &metadata.DeviceMetadata{
 				ObjectMeta: metav1.ObjectMeta{Name: "pci-claim"},
 				Requests: []metadata.DeviceMetadataRequest{{
-					Name: "req1",
+					Name: request1Name,
 					Devices: []metadata.Device{{
 						Attributes: map[resourcev1.QualifiedName]resourcev1.DeviceAttribute{
 							metadata.PCIBusIDAttribute: {StringValue: &pciAddr},
@@ -203,43 +216,43 @@ var _ = Describe("DownwardAPIAttributes", func() {
 			})
 
 			resourceClaims := []v1.VirtualMachineInstanceResourceClaim{{
-				Name:              "my-claim",
+				Name:              testClaimName,
 				ResourceClaimName: ptr.To("pci-claim"),
 			}}
 
-			addr, err := GetPCIAddressForClaim(tempDir, resourceClaims, "my-claim", "req1")
+			addr, err := GetPCIAddressForClaim(tempDir, resourceClaims, testClaimName, request1Name)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(addr).To(Equal(pciAddr))
 		})
 
 		It("should return error when claim ref not found", func() {
-			_, err := GetPCIAddressForClaim(tempDir, nil, "nonexistent", "req1")
+			_, err := GetPCIAddressForClaim(tempDir, nil, "nonexistent", request1Name)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("metadata not found"))
 		})
 
 		It("should return error when request not found in metadata file", func() {
-			createMetadataFile("claim1", "other-req", metadataWithoutAttributes("claim1", "other-req"))
+			createMetadataFile(claim1Name, "other-req", metadataWithoutAttributes(claim1Name, "other-req"))
 
 			resourceClaims := []v1.VirtualMachineInstanceResourceClaim{{
-				Name:              "my-claim",
-				ResourceClaimName: ptr.To("claim1"),
+				Name:              testClaimName,
+				ResourceClaimName: ptr.To(claim1Name),
 			}}
 
-			_, err := GetPCIAddressForClaim(tempDir, resourceClaims, "my-claim", "missing-req")
+			_, err := GetPCIAddressForClaim(tempDir, resourceClaims, testClaimName, "missing-req")
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("failed to read metadata for claim"))
 		})
 
 		It("should return error when pciBusID attribute not present", func() {
-			createMetadataFile("claim1", "req1", metadataWithoutAttributes("claim1", "req1"))
+			createMetadataFile(claim1Name, request1Name, metadataWithoutAttributes(claim1Name, request1Name))
 
 			resourceClaims := []v1.VirtualMachineInstanceResourceClaim{{
-				Name:              "my-claim",
-				ResourceClaimName: ptr.To("claim1"),
+				Name:              testClaimName,
+				ResourceClaimName: ptr.To(claim1Name),
 			}}
 
-			_, err := GetPCIAddressForClaim(tempDir, resourceClaims, "my-claim", "req1")
+			_, err := GetPCIAddressForClaim(tempDir, resourceClaims, testClaimName, request1Name)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("pciBusID not found"))
 		})
@@ -247,10 +260,10 @@ var _ = Describe("DownwardAPIAttributes", func() {
 		It("should return error when request has multiple devices (count > 1)", func() {
 			pciAddr1 := pciAddr0300
 			pciAddr2 := pciAddr0400
-			createMetadataFile("claim1", "req1", &metadata.DeviceMetadata{
-				ObjectMeta: metav1.ObjectMeta{Name: "claim1"},
+			createMetadataFile(claim1Name, request1Name, &metadata.DeviceMetadata{
+				ObjectMeta: metav1.ObjectMeta{Name: claim1Name},
 				Requests: []metadata.DeviceMetadataRequest{{
-					Name: "req1",
+					Name: request1Name,
 					Devices: []metadata.Device{
 						{Attributes: map[resourcev1.QualifiedName]resourcev1.DeviceAttribute{
 							metadata.PCIBusIDAttribute: {StringValue: &pciAddr1},
@@ -263,11 +276,11 @@ var _ = Describe("DownwardAPIAttributes", func() {
 			})
 
 			resourceClaims := []v1.VirtualMachineInstanceResourceClaim{{
-				Name:              "my-claim",
-				ResourceClaimName: ptr.To("claim1"),
+				Name:              testClaimName,
+				ResourceClaimName: ptr.To(claim1Name),
 			}}
 
-			_, err := GetPCIAddressForClaim(tempDir, resourceClaims, "my-claim", "req1")
+			_, err := GetPCIAddressForClaim(tempDir, resourceClaims, testClaimName, request1Name)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("count > 1 is not supported"))
 		})
@@ -276,10 +289,10 @@ var _ = Describe("DownwardAPIAttributes", func() {
 	Context("GetMDevUUIDForClaim", func() {
 		It("should return the mdev UUID when present", func() {
 			uuid := "abcd1234-5678-90ab-cdef-1234567890ab"
-			createMetadataFile("mdev-claim", "vgpu-req", &metadata.DeviceMetadata{
+			createMetadataFile("mdev-claim", vgpuRequestName, &metadata.DeviceMetadata{
 				ObjectMeta: metav1.ObjectMeta{Name: "mdev-claim"},
 				Requests: []metadata.DeviceMetadataRequest{{
-					Name: "vgpu-req",
+					Name: vgpuRequestName,
 					Devices: []metadata.Device{{
 						Attributes: map[resourcev1.QualifiedName]resourcev1.DeviceAttribute{
 							metadata.MDevUUIDAttribute: {StringValue: &uuid},
@@ -293,23 +306,23 @@ var _ = Describe("DownwardAPIAttributes", func() {
 				ResourceClaimName: ptr.To("mdev-claim"),
 			}}
 
-			result, err := GetMDevUUIDForClaim(tempDir, resourceClaims, "my-vgpu", "vgpu-req")
+			result, err := GetMDevUUIDForClaim(tempDir, resourceClaims, "my-vgpu", vgpuRequestName)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result).To(Equal(uuid))
 		})
 
 		It("should return error when claim ref not found", func() {
-			_, err := GetMDevUUIDForClaim(tempDir, nil, "nonexistent", "req1")
+			_, err := GetMDevUUIDForClaim(tempDir, nil, "nonexistent", request1Name)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("metadata not found"))
 		})
 
 		It("should return error when mdevUUID attribute not present", func() {
 			pciAddr := "0000:01:00.0"
-			createMetadataFile("pci-only", "req1", &metadata.DeviceMetadata{
+			createMetadataFile("pci-only", request1Name, &metadata.DeviceMetadata{
 				ObjectMeta: metav1.ObjectMeta{Name: "pci-only"},
 				Requests: []metadata.DeviceMetadataRequest{{
-					Name: "req1",
+					Name: request1Name,
 					Devices: []metadata.Device{{
 						Attributes: map[resourcev1.QualifiedName]resourcev1.DeviceAttribute{
 							metadata.PCIBusIDAttribute: {StringValue: &pciAddr},
@@ -319,11 +332,11 @@ var _ = Describe("DownwardAPIAttributes", func() {
 			})
 
 			resourceClaims := []v1.VirtualMachineInstanceResourceClaim{{
-				Name:              "my-claim",
+				Name:              testClaimName,
 				ResourceClaimName: ptr.To("pci-only"),
 			}}
 
-			_, err := GetMDevUUIDForClaim(tempDir, resourceClaims, "my-claim", "req1")
+			_, err := GetMDevUUIDForClaim(tempDir, resourceClaims, testClaimName, request1Name)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("mdevUUID not found"))
 		})
@@ -334,10 +347,10 @@ var _ = Describe("DownwardAPIAttributes", func() {
 			pciAddr := pciAddr0400
 			mdevUUID := "11111111-2222-3333-4444-555555555555"
 
-			createMetadataFile("gpu-claim", "gpu-req", &metadata.DeviceMetadata{
+			createMetadataFile("gpu-claim", gpuRequestName, &metadata.DeviceMetadata{
 				ObjectMeta: metav1.ObjectMeta{Name: "gpu-claim"},
 				Requests: []metadata.DeviceMetadataRequest{{
-					Name: "gpu-req",
+					Name: gpuRequestName,
 					Devices: []metadata.Device{{
 						Attributes: map[resourcev1.QualifiedName]resourcev1.DeviceAttribute{
 							metadata.PCIBusIDAttribute: {StringValue: &pciAddr},
@@ -346,10 +359,10 @@ var _ = Describe("DownwardAPIAttributes", func() {
 				}},
 			})
 
-			createMetadataFile("vgpu-claim", "vgpu-req", &metadata.DeviceMetadata{
+			createMetadataFile("vgpu-claim", vgpuRequestName, &metadata.DeviceMetadata{
 				ObjectMeta: metav1.ObjectMeta{Name: "vgpu-claim"},
 				Requests: []metadata.DeviceMetadataRequest{{
-					Name: "vgpu-req",
+					Name: vgpuRequestName,
 					Devices: []metadata.Device{{
 						Attributes: map[resourcev1.QualifiedName]resourcev1.DeviceAttribute{
 							metadata.MDevUUIDAttribute: {StringValue: &mdevUUID},
@@ -363,11 +376,11 @@ var _ = Describe("DownwardAPIAttributes", func() {
 				{Name: "claim-vgpu", ResourceClaimName: ptr.To("vgpu-claim")},
 			}
 
-			addr, err := GetPCIAddressForClaim(tempDir, resourceClaims, "claim-gpu", "gpu-req")
+			addr, err := GetPCIAddressForClaim(tempDir, resourceClaims, "claim-gpu", gpuRequestName)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(addr).To(Equal(pciAddr))
 
-			uuid, err := GetMDevUUIDForClaim(tempDir, resourceClaims, "claim-vgpu", "vgpu-req")
+			uuid, err := GetMDevUUIDForClaim(tempDir, resourceClaims, "claim-vgpu", vgpuRequestName)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(uuid).To(Equal(mdevUUID))
 		})
@@ -402,11 +415,11 @@ var _ = Describe("DownwardAPIAttributes", func() {
 			mdevUUID := "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
 			createTemplateMetadataFile(
 				"template-vgpu-claim",
-				"vgpu-req",
+				vgpuRequestName,
 				templateMetadataWithStringAttribute(
 					"generated-vgpu-claim-abc",
 					"template-vgpu-claim",
-					"vgpu-req",
+					vgpuRequestName,
 					metadata.MDevUUIDAttribute,
 					mdevUUID,
 				),
@@ -417,7 +430,7 @@ var _ = Describe("DownwardAPIAttributes", func() {
 				ResourceClaimTemplateName: ptr.To("vgpu-template"),
 			}}
 
-			uuid, err := GetMDevUUIDForClaim(tempDir, resourceClaims, "template-vgpu-claim", "vgpu-req")
+			uuid, err := GetMDevUUIDForClaim(tempDir, resourceClaims, "template-vgpu-claim", vgpuRequestName)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(uuid).To(Equal(mdevUUID))
 		})
@@ -438,11 +451,11 @@ var _ = Describe("DownwardAPIAttributes", func() {
 				}},
 			})
 
-			createTemplateMetadataFile("my-template-claim", "vgpu-req", &metadata.DeviceMetadata{
+			createTemplateMetadataFile("my-template-claim", vgpuRequestName, &metadata.DeviceMetadata{
 				ObjectMeta:   metav1.ObjectMeta{Name: "generated-claim-def456"},
 				PodClaimName: ptr.To("my-template-claim"),
 				Requests: []metadata.DeviceMetadataRequest{{
-					Name: "vgpu-req",
+					Name: vgpuRequestName,
 					Devices: []metadata.Device{{
 						Attributes: map[resourcev1.QualifiedName]resourcev1.DeviceAttribute{
 							metadata.MDevUUIDAttribute: {StringValue: &mdevUUID},
@@ -460,7 +473,7 @@ var _ = Describe("DownwardAPIAttributes", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(addr).To(Equal(pciAddr))
 
-			uuid, err := GetMDevUUIDForClaim(tempDir, resourceClaims, "my-template-claim", "vgpu-req")
+			uuid, err := GetMDevUUIDForClaim(tempDir, resourceClaims, "my-template-claim", vgpuRequestName)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(uuid).To(Equal(mdevUUID))
 		})
@@ -471,7 +484,7 @@ var _ = Describe("DownwardAPIAttributes", func() {
 				ResourceClaimTemplateName: ptr.To("nonexistent-template"),
 			}}
 
-			_, err := GetPCIAddressForClaim(tempDir, resourceClaims, "missing-template-claim", "req1")
+			_, err := GetPCIAddressForClaim(tempDir, resourceClaims, "missing-template-claim", request1Name)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("failed to read metadata"))
 		})
@@ -479,8 +492,8 @@ var _ = Describe("DownwardAPIAttributes", func() {
 
 	Context("request name mismatch in metadata content", func() {
 		It("should return error with available requests when request not found in metadata JSON", func() {
-			createMetadataFile("claim1", "req1", &metadata.DeviceMetadata{
-				ObjectMeta: metav1.ObjectMeta{Name: "claim1"},
+			createMetadataFile(claim1Name, request1Name, &metadata.DeviceMetadata{
+				ObjectMeta: metav1.ObjectMeta{Name: claim1Name},
 				Requests: []metadata.DeviceMetadataRequest{{
 					Name: "actual-req",
 					Devices: []metadata.Device{{
@@ -490,14 +503,14 @@ var _ = Describe("DownwardAPIAttributes", func() {
 			})
 
 			resourceClaims := []v1.VirtualMachineInstanceResourceClaim{{
-				Name:              "my-claim",
-				ResourceClaimName: ptr.To("claim1"),
+				Name:              testClaimName,
+				ResourceClaimName: ptr.To(claim1Name),
 			}}
 
-			_, err := GetPCIAddressForClaim(tempDir, resourceClaims, "my-claim", "req1")
+			_, err := GetPCIAddressForClaim(tempDir, resourceClaims, testClaimName, request1Name)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("not found in metadata for claim"))
-			Expect(err.Error()).To(ContainSubstring("claim1"))
+			Expect(err.Error()).To(ContainSubstring(claim1Name))
 			Expect(err.Error()).To(ContainSubstring("available requests: [actual-req]"))
 		})
 	})
@@ -507,15 +520,15 @@ var _ = Describe("DownwardAPIAttributes", func() {
 			pciAddr1 := "0000:08:00.0"
 			pciAddr2 := "0000:09:00.0"
 
-			dir := filepath.Join(tempDir, resourceClaimsSubdir, "multi-driver-claim", "gpu-req")
+			dir := filepath.Join(tempDir, resourceClaimsSubdir, "multi-driver-claim", gpuRequestName)
 			writeMetadataJSON(dir, "gpu-a.example.com", &metadata.DeviceMetadata{
-				ObjectMeta: metav1.ObjectMeta{Name: "multi-driver-claim"},
+				ObjectMeta: metav1.ObjectMeta{Name: multiDriverClaim},
 				Requests: []metadata.DeviceMetadataRequest{{
-					Name: "gpu-req",
+					Name: gpuRequestName,
 					Devices: []metadata.Device{{
 						Driver: "gpu-a.example.com",
-						Pool:   "worker-0",
-						Name:   "gpu-0",
+						Pool:   worker0Pool,
+						Name:   gpuDeviceName,
 						Attributes: map[resourcev1.QualifiedName]resourcev1.DeviceAttribute{
 							metadata.PCIBusIDAttribute: {StringValue: &pciAddr1},
 						},
@@ -523,12 +536,12 @@ var _ = Describe("DownwardAPIAttributes", func() {
 				}},
 			})
 			writeMetadataJSON(dir, "gpu-b.example.com", &metadata.DeviceMetadata{
-				ObjectMeta: metav1.ObjectMeta{Name: "multi-driver-claim"},
+				ObjectMeta: metav1.ObjectMeta{Name: multiDriverClaim},
 				Requests: []metadata.DeviceMetadataRequest{{
-					Name: "gpu-req",
+					Name: gpuRequestName,
 					Devices: []metadata.Device{{
 						Driver: "gpu-b.example.com",
-						Pool:   "worker-0",
+						Pool:   worker0Pool,
 						Name:   "gpu-1",
 						Attributes: map[resourcev1.QualifiedName]resourcev1.DeviceAttribute{
 							metadata.PCIBusIDAttribute: {StringValue: &pciAddr2},
@@ -538,11 +551,11 @@ var _ = Describe("DownwardAPIAttributes", func() {
 			})
 
 			resourceClaims := []v1.VirtualMachineInstanceResourceClaim{{
-				Name:              "my-claim",
+				Name:              testClaimName,
 				ResourceClaimName: ptr.To("multi-driver-claim"),
 			}}
 
-			_, err := GetPCIAddressForClaim(tempDir, resourceClaims, "my-claim", "gpu-req")
+			_, err := GetPCIAddressForClaim(tempDir, resourceClaims, testClaimName, gpuRequestName)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("only supports exactly one driver per request"))
 		})
@@ -561,12 +574,14 @@ var _ = Describe("DownwardAPIAttributes", func() {
 
 		It("should skip unknown apiVersion and decode v1alpha1 from stream", func() {
 			pciAddr := "0000:07:00.0"
-			v2Obj := `{"apiVersion":"metadata.resource.k8s.io/v2beta1","kind":"DeviceMetadata","metadata":{"name":"claim1"},"newField":"ignored"}`
+			v2Obj := fmt.Sprintf(
+				`{"apiVersion":"metadata.resource.k8s.io/v2beta1","kind":%q,"metadata":{"name":%q},"newField":"ignored"}`,
+				deviceMetadataKind, claim1Name)
 			v1Obj, err := json.Marshal(&metadata.DeviceMetadata{
-				TypeMeta:   metav1.TypeMeta{APIVersion: metadata.APIVersionV1Alpha1, Kind: "DeviceMetadata"},
-				ObjectMeta: metav1.ObjectMeta{Name: "claim1"},
+				TypeMeta:   metav1.TypeMeta{APIVersion: metadata.APIVersionV1Alpha1, Kind: deviceMetadataKind},
+				ObjectMeta: metav1.ObjectMeta{Name: claim1Name},
 				Requests: []metadata.DeviceMetadataRequest{{
-					Name: "req1",
+					Name: request1Name,
 					Devices: []metadata.Device{{
 						Attributes: map[resourcev1.QualifiedName]resourcev1.DeviceAttribute{
 							metadata.PCIBusIDAttribute: {StringValue: &pciAddr},
@@ -576,27 +591,27 @@ var _ = Describe("DownwardAPIAttributes", func() {
 			})
 			Expect(err).ToNot(HaveOccurred())
 
-			writeRawStreamFile("claim1", "req1", "gpu.example.com", v2Obj, string(v1Obj))
+			writeRawStreamFile(claim1Name, request1Name, "gpu.example.com", v2Obj, string(v1Obj))
 
 			resourceClaims := []v1.VirtualMachineInstanceResourceClaim{{
-				Name:              "my-claim",
-				ResourceClaimName: ptr.To("claim1"),
+				Name:              testClaimName,
+				ResourceClaimName: ptr.To(claim1Name),
 			}}
-			addr, err := GetPCIAddressForClaim(tempDir, resourceClaims, "my-claim", "req1")
+			addr, err := GetPCIAddressForClaim(tempDir, resourceClaims, testClaimName, request1Name)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(addr).To(Equal(pciAddr))
 		})
 
 		It("should return error when stream contains only unsupported versions", func() {
-			writeRawStreamFile("claim2", "req1", "gpu.example.com",
-				`{"apiVersion":"metadata.resource.k8s.io/v99","kind":"DeviceMetadata"}`,
+			writeRawStreamFile("claim2", request1Name, "gpu.example.com",
+				fmt.Sprintf(`{"apiVersion":"metadata.resource.k8s.io/v99","kind":%q}`, deviceMetadataKind),
 			)
 
 			resourceClaims := []v1.VirtualMachineInstanceResourceClaim{{
-				Name:              "my-claim",
+				Name:              testClaimName,
 				ResourceClaimName: ptr.To("claim2"),
 			}}
-			_, err := GetPCIAddressForClaim(tempDir, resourceClaims, "my-claim", "req1")
+			_, err := GetPCIAddressForClaim(tempDir, resourceClaims, testClaimName, request1Name)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring(
 				"no compatible metadata version found in stream (unknown versions: metadata.resource.k8s.io/v99)",
@@ -604,13 +619,13 @@ var _ = Describe("DownwardAPIAttributes", func() {
 		})
 
 		It("should return error on empty stream", func() {
-			writeRawStreamFile("claim3", "req1", "gpu.example.com")
+			writeRawStreamFile("claim3", request1Name, "gpu.example.com")
 
 			resourceClaims := []v1.VirtualMachineInstanceResourceClaim{{
-				Name:              "my-claim",
+				Name:              testClaimName,
 				ResourceClaimName: ptr.To("claim3"),
 			}}
-			_, err := GetPCIAddressForClaim(tempDir, resourceClaims, "my-claim", "req1")
+			_, err := GetPCIAddressForClaim(tempDir, resourceClaims, testClaimName, request1Name)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("no metadata objects"))
 		})
@@ -618,10 +633,10 @@ var _ = Describe("DownwardAPIAttributes", func() {
 		It("should fail if an entry's apiVersion cannot be peeked even when a later entry is valid", func() {
 			pciAddr := "0000:0a:00.0"
 			v1Obj, err := json.Marshal(&metadata.DeviceMetadata{
-				TypeMeta:   metav1.TypeMeta{APIVersion: metadata.APIVersionV1Alpha1, Kind: "DeviceMetadata"},
+				TypeMeta:   metav1.TypeMeta{APIVersion: metadata.APIVersionV1Alpha1, Kind: deviceMetadataKind},
 				ObjectMeta: metav1.ObjectMeta{Name: "claim4"},
 				Requests: []metadata.DeviceMetadataRequest{{
-					Name: "req1",
+					Name: request1Name,
 					Devices: []metadata.Device{{
 						Attributes: map[resourcev1.QualifiedName]resourcev1.DeviceAttribute{
 							metadata.PCIBusIDAttribute: {StringValue: &pciAddr},
@@ -630,16 +645,16 @@ var _ = Describe("DownwardAPIAttributes", func() {
 				}},
 			})
 			Expect(err).ToNot(HaveOccurred())
-			writeRawStreamFile("claim4", "req1", "gpu.example.com",
+			writeRawStreamFile("claim4", request1Name, "gpu.example.com",
 				`"not-an-object"`,
 				string(v1Obj),
 			)
 
 			resourceClaims := []v1.VirtualMachineInstanceResourceClaim{{
-				Name:              "my-claim",
+				Name:              testClaimName,
 				ResourceClaimName: ptr.To("claim4"),
 			}}
-			_, err = GetPCIAddressForClaim(tempDir, resourceClaims, "my-claim", "req1")
+			_, err = GetPCIAddressForClaim(tempDir, resourceClaims, testClaimName, request1Name)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("decode metadata object"))
 		})
@@ -647,14 +662,15 @@ var _ = Describe("DownwardAPIAttributes", func() {
 		It("should fail if a supported-version entry fails to unmarshal even when a later entry is valid", func() {
 			pciAddr := "0000:0b:00.0"
 			badV1 := fmt.Sprintf(
-				`{"apiVersion":%q,"kind":"DeviceMetadata","metadata":{"name":"claim5"},"requests":"this-should-be-an-array"}`,
+				`{"apiVersion":%q,"kind":%q,"metadata":{"name":"claim5"},"requests":"this-should-be-an-array"}`,
 				metadata.APIVersionV1Alpha1,
+				deviceMetadataKind,
 			)
 			goodV1, err := json.Marshal(&metadata.DeviceMetadata{
-				TypeMeta:   metav1.TypeMeta{APIVersion: metadata.APIVersionV1Alpha1, Kind: "DeviceMetadata"},
+				TypeMeta:   metav1.TypeMeta{APIVersion: metadata.APIVersionV1Alpha1, Kind: deviceMetadataKind},
 				ObjectMeta: metav1.ObjectMeta{Name: "claim5"},
 				Requests: []metadata.DeviceMetadataRequest{{
-					Name: "req1",
+					Name: request1Name,
 					Devices: []metadata.Device{{
 						Attributes: map[resourcev1.QualifiedName]resourcev1.DeviceAttribute{
 							metadata.PCIBusIDAttribute: {StringValue: &pciAddr},
@@ -663,13 +679,13 @@ var _ = Describe("DownwardAPIAttributes", func() {
 				}},
 			})
 			Expect(err).ToNot(HaveOccurred())
-			writeRawStreamFile("claim5", "req1", "gpu.example.com", badV1, string(goodV1))
+			writeRawStreamFile("claim5", request1Name, "gpu.example.com", badV1, string(goodV1))
 
 			resourceClaims := []v1.VirtualMachineInstanceResourceClaim{{
-				Name:              "my-claim",
+				Name:              testClaimName,
 				ResourceClaimName: ptr.To("claim5"),
 			}}
-			_, err = GetPCIAddressForClaim(tempDir, resourceClaims, "my-claim", "req1")
+			_, err = GetPCIAddressForClaim(tempDir, resourceClaims, testClaimName, request1Name)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring(fmt.Sprintf("decode %s", metadata.APIVersionV1Alpha1)))
 		})

--- a/pkg/instancetype/apply/annotations_test.go
+++ b/pkg/instancetype/apply/annotations_test.go
@@ -30,6 +30,8 @@ import (
 	"kubevirt.io/kubevirt/pkg/libvmi"
 )
 
+const testAnnotationKey1 = "annotation-1"
+
 var _ = Describe("Instancetype.Spec.Annotations", func() {
 	var (
 		vmi              *virtv1.VirtualMachineInstance
@@ -44,8 +46,8 @@ var _ = Describe("Instancetype.Spec.Annotations", func() {
 
 		instancetypeSpec = &instancetypev1beta1.VirtualMachineInstancetypeSpec{
 			Annotations: map[string]string{
-				"annotation-1": "1",
-				"annotation-2": "2",
+				testAnnotationKey1: "1",
+				"annotation-2":     "2",
 			},
 		}
 	})
@@ -65,7 +67,7 @@ var _ = Describe("Instancetype.Spec.Annotations", func() {
 
 		It("should detect conflict when annotation with different value already exists", func() {
 			vmi.Annotations = map[string]string{
-				"annotation-1": "conflict",
+				testAnnotationKey1: "conflict",
 			}
 
 			conflicts := vmiApplier.ApplyToVMI(field, instancetypeSpec, nil, &vmi.Spec, &vmi.ObjectMeta)

--- a/pkg/instancetype/apply/cpu_test.go
+++ b/pkg/instancetype/apply/cpu_test.go
@@ -36,6 +36,13 @@ import (
 )
 
 var _ = Describe("instancetype.spec.CPU and preference.spec.CPU", func() {
+	const (
+		barFeatureName           = "bar"
+		fooFeatureName           = "foo"
+		cpuFeaturePolicyRequire  = "require"
+		cpuFeaturePolicyOptional = "optional"
+	)
+
 	var (
 		vmi              *virtv1.VirtualMachineInstance
 		instancetypeSpec *v1beta1.VirtualMachineInstancetypeSpec
@@ -514,11 +521,11 @@ var _ = Describe("instancetype.spec.CPU and preference.spec.CPU", func() {
 			CPU: &v1beta1.CPUPreferences{
 				PreferredCPUFeatures: []virtv1.CPUFeature{
 					{
-						Name:   "foo",
-						Policy: "require",
+						Name:   fooFeatureName,
+						Policy: cpuFeaturePolicyRequire,
 					},
 					{
-						Name:   "bar",
+						Name:   barFeatureName,
 						Policy: "force",
 					},
 				},
@@ -527,8 +534,8 @@ var _ = Describe("instancetype.spec.CPU and preference.spec.CPU", func() {
 		vmi.Spec.Domain.CPU = &virtv1.CPU{
 			Features: []virtv1.CPUFeature{
 				{
-					Name:   "bar",
-					Policy: "optional",
+					Name:   barFeatureName,
+					Policy: cpuFeaturePolicyOptional,
 				},
 			},
 		}
@@ -536,12 +543,12 @@ var _ = Describe("instancetype.spec.CPU and preference.spec.CPU", func() {
 		Expect(vmi.Spec.Domain.CPU.Features).To(HaveLen(2))
 		Expect(vmi.Spec.Domain.CPU.Features).To(ContainElements([]virtv1.CPUFeature{
 			{
-				Name:   "foo",
-				Policy: "require",
+				Name:   fooFeatureName,
+				Policy: cpuFeaturePolicyRequire,
 			},
 			{
-				Name:   "bar",
-				Policy: "optional",
+				Name:   barFeatureName,
+				Policy: cpuFeaturePolicyOptional,
 			},
 		}))
 	})

--- a/pkg/instancetype/apply/gpu_test.go
+++ b/pkg/instancetype/apply/gpu_test.go
@@ -16,7 +16,6 @@
  * Copyright The KubeVirt Authors.
  */
 
-//nolint:dupl
 package apply_test
 
 import (
@@ -33,6 +32,11 @@ import (
 )
 
 var _ = Describe("instancetype.Spec.GPUs", func() {
+	const (
+		gpuConflictName = "foobar"
+		gpuDeviceName   = "vendor.com/gpu_name"
+	)
+
 	var (
 		vmi            *virtv1.VirtualMachineInstance
 		preferenceSpec *v1beta1.VirtualMachinePreferenceSpec
@@ -43,7 +47,7 @@ var _ = Describe("instancetype.Spec.GPUs", func() {
 			GPUs: []virtv1.GPU{
 				{
 					Name:       "barfoo",
-					DeviceName: "vendor.com/gpu_name",
+					DeviceName: gpuDeviceName,
 				},
 			},
 		}
@@ -62,8 +66,8 @@ var _ = Describe("instancetype.Spec.GPUs", func() {
 	It("should detect GPU conflict", func() {
 		vmi.Spec.Domain.Devices.GPUs = []virtv1.GPU{
 			{
-				Name:       "foobar",
-				DeviceName: "vendor.com/gpu_name",
+				Name:       gpuConflictName,
+				DeviceName: gpuDeviceName,
 			},
 		}
 

--- a/pkg/instancetype/apply/hostdevices_test.go
+++ b/pkg/instancetype/apply/hostdevices_test.go
@@ -16,7 +16,6 @@
  * Copyright The KubeVirt Authors.
  */
 
-//nolint:dupl
 package apply_test
 
 import (
@@ -33,6 +32,11 @@ import (
 )
 
 var _ = Describe("instancetype.Spec.HostDevices", func() {
+	const (
+		hostDeviceName       = "foobar"
+		hostDeviceDeviceName = "vendor.com/device_name"
+	)
+
 	var (
 		vmi            *virtv1.VirtualMachineInstance
 		preferenceSpec *v1beta1.VirtualMachinePreferenceSpec
@@ -42,8 +46,8 @@ var _ = Describe("instancetype.Spec.HostDevices", func() {
 		instancetypeSpec = &v1beta1.VirtualMachineInstancetypeSpec{
 			HostDevices: []virtv1.HostDevice{
 				{
-					Name:       "foobar",
-					DeviceName: "vendor.com/device_name",
+					Name:       hostDeviceName,
+					DeviceName: hostDeviceDeviceName,
 				},
 			},
 		}
@@ -62,8 +66,8 @@ var _ = Describe("instancetype.Spec.HostDevices", func() {
 	It("should detect HostDevice conflict", func() {
 		vmi.Spec.Domain.Devices.HostDevices = []virtv1.HostDevice{
 			{
-				Name:       "foobar",
-				DeviceName: "vendor.com/device_name",
+				Name:       hostDeviceName,
+				DeviceName: hostDeviceDeviceName,
 			},
 		}
 

--- a/pkg/instancetype/apply/memory_test.go
+++ b/pkg/instancetype/apply/memory_test.go
@@ -34,6 +34,8 @@ import (
 )
 
 var _ = Describe("instancetype.Spec.Memory", func() {
+	const hugepagesPageSize = "1Gi"
+
 	var (
 		vmi              *virtv1.VirtualMachineInstance
 		instancetypeSpec *v1beta1.VirtualMachineInstancetypeSpec
@@ -50,7 +52,7 @@ var _ = Describe("instancetype.Spec.Memory", func() {
 			Memory: v1beta1.MemoryInstancetype{
 				Guest: resource.MustParse("512M"),
 				Hugepages: &virtv1.Hugepages{
-					PageSize: "1Gi",
+					PageSize: hugepagesPageSize,
 				},
 				MaxGuest: &maxGuest,
 			},
@@ -98,7 +100,7 @@ var _ = Describe("instancetype.Spec.Memory", func() {
 		func() {
 			vmi.Spec.Domain.Memory = &virtv1.Memory{
 				Hugepages: &virtv1.Hugepages{
-					PageSize: "1Gi",
+					PageSize: hugepagesPageSize,
 				},
 			}
 
@@ -112,7 +114,7 @@ var _ = Describe("instancetype.Spec.Memory", func() {
 			instancetypeSpec.Memory.Hugepages = nil
 			vmi.Spec.Domain.Memory = &virtv1.Memory{
 				Hugepages: &virtv1.Hugepages{
-					PageSize: "1Gi",
+					PageSize: hugepagesPageSize,
 				},
 			}
 

--- a/pkg/instancetype/apply/nodeselector_test.go
+++ b/pkg/instancetype/apply/nodeselector_test.go
@@ -32,6 +32,9 @@ import (
 )
 
 var _ = Describe("instancetype.spec.NodeSelector", func() {
+	const nodeSelectorKey = "key"
+	const nodeSelectorValue = "value"
+
 	var (
 		vmi              *virtv1.VirtualMachineInstance
 		instancetypeSpec *v1beta1.VirtualMachineInstancetypeSpec
@@ -47,7 +50,7 @@ var _ = Describe("instancetype.spec.NodeSelector", func() {
 
 	It("should apply to VMI", func() {
 		instancetypeSpec = &v1beta1.VirtualMachineInstancetypeSpec{
-			NodeSelector: map[string]string{"key": "value"},
+			NodeSelector: map[string]string{nodeSelectorKey: nodeSelectorValue},
 		}
 
 		Expect(vmiApplier.ApplyToVMI(field, instancetypeSpec, preferenceSpec, &vmi.Spec, &vmi.ObjectMeta)).To(Succeed())
@@ -57,18 +60,18 @@ var _ = Describe("instancetype.spec.NodeSelector", func() {
 
 	It("should be no-op if vmi.Spec.NodeSelector is already set but instancetype.NodeSelector is empty", func() {
 		instancetypeSpec = &v1beta1.VirtualMachineInstancetypeSpec{}
-		vmi.Spec.NodeSelector = map[string]string{"key": "value"}
+		vmi.Spec.NodeSelector = map[string]string{nodeSelectorKey: nodeSelectorValue}
 
 		Expect(vmiApplier.ApplyToVMI(field, instancetypeSpec, preferenceSpec, &vmi.Spec, &vmi.ObjectMeta)).To(Succeed())
 
-		Expect(vmi.Spec.NodeSelector).To(Equal(map[string]string{"key": "value"}))
+		Expect(vmi.Spec.NodeSelector).To(Equal(map[string]string{nodeSelectorKey: nodeSelectorValue}))
 	})
 
 	It("should return a conflict if vmi.Spec.NodeSelector is already set and instancetype.NodeSelector is defined", func() {
 		instancetypeSpec = &v1beta1.VirtualMachineInstancetypeSpec{
-			NodeSelector: map[string]string{"key": "value"},
+			NodeSelector: map[string]string{nodeSelectorKey: nodeSelectorValue},
 		}
-		vmi.Spec.NodeSelector = map[string]string{"key": "value"}
+		vmi.Spec.NodeSelector = map[string]string{nodeSelectorKey: nodeSelectorValue}
 
 		conflicts := vmiApplier.ApplyToVMI(field, instancetypeSpec, preferenceSpec, &vmi.Spec, &vmi.ObjectMeta)
 		Expect(conflicts).To(HaveLen(1))

--- a/pkg/instancetype/compatibility/compatibility_test.go
+++ b/pkg/instancetype/compatibility/compatibility_test.go
@@ -35,7 +35,16 @@ import (
 	"kubevirt.io/kubevirt/pkg/pointer"
 )
 
+const (
+	controllerRevisionName = "crName"
+	clusterPreferenceKind  = "VirtualMachineClusterPreference"
+)
+
 var _ = Describe("compatibility", func() {
+	const (
+		vmInstancetypeKind        = "VirtualMachineInstancetype"
+		vmClusterInstancetypeKind = "VirtualMachineClusterInstancetype"
+	)
 	generateUnknownObjectControllerRevision := func() *appsv1.ControllerRevision {
 		unknownObject := snapshotv1beta1.VirtualMachineSnapshot{
 			TypeMeta: metav1.TypeMeta{
@@ -47,7 +56,7 @@ var _ = Describe("compatibility", func() {
 		Expect(err).ToNot(HaveOccurred())
 		return &appsv1.ControllerRevision{
 			ObjectMeta: metav1.ObjectMeta{
-				Name: "crName",
+				Name: controllerRevisionName,
 			},
 			Data: runtime.RawExtension{
 				Raw: unknownObjectBytes,
@@ -87,7 +96,7 @@ var _ = Describe("compatibility", func() {
 		DescribeTable("decode ControllerRevision containing ", func(getRevisionData func() []byte) {
 			revision := &appsv1.ControllerRevision{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "crName",
+					Name: controllerRevisionName,
 				},
 				Data: runtime.RawExtension{
 					Raw: getRevisionData(),
@@ -107,7 +116,7 @@ var _ = Describe("compatibility", func() {
 				instancetype := v1beta1.VirtualMachineInstancetype{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: v1beta1.SchemeGroupVersion.String(),
-						Kind:       "VirtualMachineInstancetype",
+						Kind:       vmInstancetypeKind,
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "VirtualMachineInstancetype",
@@ -128,7 +137,7 @@ var _ = Describe("compatibility", func() {
 				instancetype := v1beta1.VirtualMachineClusterInstancetype{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: v1beta1.SchemeGroupVersion.String(),
-						Kind:       "VirtualMachineClusterInstancetype",
+						Kind:       vmClusterInstancetypeKind,
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "VirtualMachineClusterInstancetype",
@@ -172,7 +181,7 @@ var _ = Describe("compatibility", func() {
 		DescribeTable("decode ControllerRevision containing ", func(getRevisionData func() []byte) {
 			revision := &appsv1.ControllerRevision{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "crName",
+					Name: controllerRevisionName,
 				},
 				Data: runtime.RawExtension{
 					Raw: getRevisionData(),
@@ -187,10 +196,10 @@ var _ = Describe("compatibility", func() {
 				preference := v1beta1.VirtualMachinePreference{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: v1beta1.SchemeGroupVersion.String(),
-						Kind:       "VirtualMachineClusterPreference",
+						Kind:       clusterPreferenceKind,
 					},
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "VirtualMachineClusterPreference",
+						Name: clusterPreferenceKind,
 					},
 					Spec: generatev1beta1PreferenceSpec(),
 				}
@@ -203,10 +212,10 @@ var _ = Describe("compatibility", func() {
 				preference := v1beta1.VirtualMachineClusterPreference{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: v1beta1.SchemeGroupVersion.String(),
-						Kind:       "VirtualMachineClusterPreference",
+						Kind:       clusterPreferenceKind,
 					},
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "VirtualMachineClusterPreference",
+						Name: clusterPreferenceKind,
 					},
 					Spec: generatev1beta1PreferenceSpec(),
 				}

--- a/pkg/instancetype/controller/vm/controller_test.go
+++ b/pkg/instancetype/controller/vm/controller_test.go
@@ -56,13 +56,16 @@ import (
 
 var _ = Describe("Instance type and Preference VirtualMachine Controller", func() {
 	const (
+		missingObjectName            = "foobar"
 		resourceUID        types.UID = "9160e5de-2540-476a-86d9-af0081aee68a"
 		resourceGeneration int64     = 1
 	)
 
 	const (
-		instancetypeName = "instancetype"
-		preferenceName   = "preference"
+		instancetypeName     = "instancetype"
+		preferenceName       = "preference"
+		preferredModelVirtio = "virtio"
+		crName               = "crName"
 	)
 
 	type instancetypeVMController interface {
@@ -196,7 +199,7 @@ var _ = Describe("Instance type and Preference VirtualMachine Controller", func(
 				},
 				Devices: &v1beta1.DevicePreferences{
 					PreferredDiskBus:        virtv1.DiskBusVirtio,
-					PreferredInterfaceModel: "virtio",
+					PreferredInterfaceModel: preferredModelVirtio,
 					PreferredInputBus:       virtv1.InputBusUSB,
 					PreferredInputType:      virtv1.InputTypeTablet,
 				},
@@ -300,7 +303,7 @@ var _ = Describe("Instance type and Preference VirtualMachine Controller", func(
 			func(getRevisionData func() []byte) {
 				instancetypeRevision := &appsv1.ControllerRevision{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "crName",
+						Name: crName,
 					},
 					Data: runtime.RawExtension{
 						Raw: getRevisionData(),
@@ -432,18 +435,18 @@ var _ = Describe("Instance type and Preference VirtualMachine Controller", func(
 			Entry("if an invalid InstancetypeMatcher Kind is provided",
 				&virtv1.InstancetypeMatcher{
 					Name: instancetypeName,
-					Kind: "foobar",
+					Kind: missingObjectName,
 				},
 			),
 			Entry("if a VirtualMachineInstancetype cannot be found",
 				&virtv1.InstancetypeMatcher{
-					Name: "foobar",
+					Name: missingObjectName,
 					Kind: instancetypeapi.SingularResourceName,
 				},
 			),
 			Entry("if a VirtualMachineClusterInstancetype cannot be found",
 				&virtv1.InstancetypeMatcher{
-					Name: "foobar",
+					Name: missingObjectName,
 					Kind: instancetypeapi.ClusterSingularResourceName,
 				},
 			),
@@ -508,7 +511,7 @@ var _ = Describe("Instance type and Preference VirtualMachine Controller", func(
 					},
 					Devices: &v1beta1.DevicePreferences{
 						PreferredDiskBus:        virtv1.DiskBusVirtio,
-						PreferredInterfaceModel: "virtio",
+						PreferredInterfaceModel: preferredModelVirtio,
 						PreferredInputBus:       virtv1.InputBusUSB,
 						PreferredInputType:      virtv1.InputTypeTablet,
 					},
@@ -555,7 +558,7 @@ var _ = Describe("Instance type and Preference VirtualMachine Controller", func(
 			func(getRevisionData func() []byte) {
 				preferenceRevision := &appsv1.ControllerRevision{
 					ObjectMeta: metav1.ObjectMeta{
-						Name: "crName",
+						Name: crName,
 					},
 					Data: runtime.RawExtension{
 						Raw: getRevisionData(),
@@ -682,18 +685,18 @@ var _ = Describe("Instance type and Preference VirtualMachine Controller", func(
 			Entry("if an invalid InstancetypeMatcher Kind is provided",
 				&virtv1.PreferenceMatcher{
 					Name: preferenceName,
-					Kind: "foobar",
+					Kind: missingObjectName,
 				},
 			),
 			Entry("if a VirtualMachinePreference cannot be found",
 				&virtv1.PreferenceMatcher{
-					Name: "foobar",
+					Name: missingObjectName,
 					Kind: instancetypeapi.SingularPreferenceResourceName,
 				},
 			),
 			Entry("if a VirtualMachineClusterPreference cannot be found",
 				&virtv1.PreferenceMatcher{
-					Name: "foobar",
+					Name: missingObjectName,
 					Kind: instancetypeapi.ClusterSingularPreferenceResourceName,
 				},
 			),

--- a/pkg/instancetype/find/spec_test.go
+++ b/pkg/instancetype/find/spec_test.go
@@ -51,6 +51,7 @@ var _ = Describe("Instance Type SpecFinder", func() {
 	const (
 		nonExistingResourceName = "non-existing-resource"
 		storedName              = "stored"
+		foobarKind              = "foobar"
 	)
 
 	type instancetypeSpecFinder interface {
@@ -209,7 +210,7 @@ var _ = Describe("Instance Type SpecFinder", func() {
 				func(vm *v1.VirtualMachine, crName string) {
 					vm.Status.InstancetypeRef = &v1.InstancetypeStatusRef{
 						ControllerRevisionRef: &v1.ControllerRevisionRef{
-							Name: "foobar",
+							Name: foobarKind,
 						},
 					}
 					vm.Spec.Instancetype = &v1.InstancetypeMatcher{
@@ -386,7 +387,7 @@ var _ = Describe("Instance Type SpecFinder", func() {
 				func(vm *v1.VirtualMachine, crName string) {
 					vm.Status.InstancetypeRef = &v1.InstancetypeStatusRef{
 						ControllerRevisionRef: &v1.ControllerRevisionRef{
-							Name: "foobar",
+							Name: foobarKind,
 						},
 					}
 					vm.Spec.Instancetype = &v1.InstancetypeMatcher{

--- a/pkg/instancetype/infer/handler_test.go
+++ b/pkg/instancetype/infer/handler_test.go
@@ -65,6 +65,8 @@ var _ = Describe("InferFromVolume", func() {
 	)
 
 	const (
+		dataVolumeName                 = "dataVolume"
+		dataVolumeWithSourceRef        = "dvWithSourceRef"
 		inferVolumeName                = "inferVolumeName"
 		defaultInferedNameFromPVC      = "defaultInferedNameFromPVC"
 		defaultInferedKindFromPVC      = "defaultInferedKindFromPVC"
@@ -83,12 +85,14 @@ var _ = Describe("InferFromVolume", func() {
 		dsWithLabelsName               = "dsWithLabelsName"
 		unknownPVCName                 = "unknownPVCName"
 		unknownDVName                  = "unknownDVName"
+		testLabel                      = "test"
+		dataSourceKind                 = "DataSource"
 	)
 
 	BeforeEach(func() {
 		vm = &v1.VirtualMachine{
 			ObjectMeta: k8smetav1.ObjectMeta{
-				Labels: map[string]string{"test": "test"},
+				Labels: map[string]string{testLabel: testLabel},
 			},
 		}
 		vm.Namespace = k8sv1.NamespaceDefault
@@ -356,13 +360,13 @@ var _ = Describe("InferFromVolume", func() {
 				Name: inferVolumeName,
 				VolumeSource: v1.VolumeSource{
 					DataVolume: &v1.DataVolumeSource{
-						Name: "dataVolume",
+						Name: dataVolumeName,
 					},
 				},
 			}}
 			vm.Spec.DataVolumeTemplates = []v1.DataVolumeTemplateSpec{{
 				ObjectMeta: k8smetav1.ObjectMeta{
-					Name: "dataVolume",
+					Name: dataVolumeName,
 				},
 				Spec: cdiv1.DataVolumeSpec{
 					Source: dvSource,
@@ -453,7 +457,7 @@ var _ = Describe("InferFromVolume", func() {
 				Spec: cdiv1.DataVolumeSpec{
 					SourceRef: &cdiv1.DataVolumeSourceRef{
 						Name:      dsWithSourceSnapshotName,
-						Kind:      "DataSource",
+						Kind:      dataSourceKind,
 						Namespace: &dsWithSourceSnapshot.Namespace,
 					},
 				},
@@ -575,7 +579,7 @@ var _ = Describe("InferFromVolume", func() {
 			}
 			dvWithSourceRef := &cdiv1.DataVolume{
 				ObjectMeta: k8smetav1.ObjectMeta{
-					Name:      "dvWithSourceRef",
+					Name:      dataVolumeWithSourceRef,
 					Namespace: vm.Namespace,
 				},
 				Spec: cdiv1.DataVolumeSpec{
@@ -699,12 +703,12 @@ var _ = Describe("InferFromVolume", func() {
 			vm.Spec.Preference = preferenceMatcher
 			vm.Spec.DataVolumeTemplates = []v1.DataVolumeTemplateSpec{{
 				ObjectMeta: k8smetav1.ObjectMeta{
-					Name: "dataVolume",
+					Name: dataVolumeName,
 				},
 				Spec: cdiv1.DataVolumeSpec{
 					SourceRef: &cdiv1.DataVolumeSourceRef{
 						Name:      sourceRefName,
-						Kind:      "DataSource",
+						Kind:      dataSourceKind,
 						Namespace: &sourceRefNamespace,
 					},
 				},
@@ -713,7 +717,7 @@ var _ = Describe("InferFromVolume", func() {
 				Name: inferVolumeName,
 				VolumeSource: v1.VolumeSource{
 					DataVolume: &v1.DataVolumeSource{
-						Name: "dataVolume",
+						Name: dataVolumeName,
 					},
 				},
 			}}
@@ -1057,7 +1061,7 @@ var _ = Describe("InferFromVolume", func() {
 			vm.Spec.Preference = preferenceMatcher
 			dvWithUnsupportedSource := &cdiv1.DataVolume{
 				ObjectMeta: k8smetav1.ObjectMeta{
-					Name:      "dvWithSourceRef",
+					Name:      dataVolumeWithSourceRef,
 					Namespace: vm.Namespace,
 				},
 				Spec: cdiv1.DataVolumeSpec{
@@ -1134,7 +1138,7 @@ var _ = Describe("InferFromVolume", func() {
 			vm.Spec.Preference = preferenceMatcher
 			dvWithUnknownSourceRefKind := &cdiv1.DataVolume{
 				ObjectMeta: k8smetav1.ObjectMeta{
-					Name:      "dvWithSourceRef",
+					Name:      dataVolumeWithSourceRef,
 					Namespace: vm.Namespace,
 				},
 				Spec: cdiv1.DataVolumeSpec{
@@ -1224,11 +1228,11 @@ var _ = Describe("InferFromVolume", func() {
 
 			vm.Spec.DataVolumeTemplates = []v1.DataVolumeTemplateSpec{{
 				ObjectMeta: k8smetav1.ObjectMeta{
-					Name: "dataVolume",
+					Name: dataVolumeName,
 				},
 				Spec: cdiv1.DataVolumeSpec{
 					SourceRef: &cdiv1.DataVolumeSourceRef{
-						Kind:      "DataSource",
+						Kind:      dataSourceKind,
 						Name:      dsWithoutSourcePVC.Name,
 						Namespace: &dsWithoutSourcePVC.Namespace,
 					},
@@ -1238,7 +1242,7 @@ var _ = Describe("InferFromVolume", func() {
 				Name: inferVolumeName,
 				VolumeSource: v1.VolumeSource{
 					DataVolume: &v1.DataVolumeSource{
-						Name: "dataVolume",
+						Name: dataVolumeName,
 					},
 				},
 			}}

--- a/pkg/instancetype/preference/annotations/annotations_test.go
+++ b/pkg/instancetype/preference/annotations/annotations_test.go
@@ -34,6 +34,12 @@ import (
 )
 
 var _ = Describe("Preferences - annotations", func() {
+	const (
+		dontOverwriteAnnotationValue = "dont-overwrite"
+		annotationKey1               = "annotation-1"
+		annotationKey2               = "annotation-2"
+	)
+
 	Context("set annotations", func() {
 		const preferenceName = "preference-name"
 
@@ -90,8 +96,8 @@ var _ = Describe("Preferences - annotations", func() {
 
 			preferenceSpec = &instancetypev1beta1.VirtualMachinePreferenceSpec{
 				Annotations: map[string]string{
-					"annotation-1": "1",
-					"annotation-2": "2",
+					annotationKey1: "1",
+					annotationKey2: "2",
 				},
 			}
 		})
@@ -103,9 +109,9 @@ var _ = Describe("Preferences - annotations", func() {
 
 		It("should not overwrite already existing values", func() {
 			vmiAnnotations := map[string]string{
-				"annotation-1": "dont-overwrite",
-				"annotation-2": "dont-overwrite",
-				"annotation-3": "dont-overwrite",
+				annotationKey1: dontOverwriteAnnotationValue,
+				annotationKey2: dontOverwriteAnnotationValue,
+				"annotation-3": dontOverwriteAnnotationValue,
 			}
 			vmi.Annotations = vmiAnnotations
 

--- a/pkg/instancetype/preference/apply/device_test.go
+++ b/pkg/instancetype/preference/apply/device_test.go
@@ -35,6 +35,11 @@ import (
 	"kubevirt.io/kubevirt/pkg/pointer"
 )
 
+const (
+	preferredVideoTypeVirtio = "virtio"
+	preferredVideoTypeVga    = "vga"
+)
+
 var _ = Describe("Preference.Devices", func() {
 	var (
 		vmi                  *virtv1.VirtualMachineInstance
@@ -329,19 +334,19 @@ var _ = Describe("Preference.Devices", func() {
 				Expect(vmi.Spec.Domain.Devices.Video).To(Equal(expectedVideo))
 			},
 			Entry("only apply when video device type is empty within VMI spec",
-				pointer.P("virtio"),
+				pointer.P(preferredVideoTypeVirtio),
 				&virtv1.VideoDevice{},
-				&virtv1.VideoDevice{Type: "virtio"},
+				&virtv1.VideoDevice{Type: preferredVideoTypeVirtio},
 			),
 			Entry("not apply when video device type is already set within VMI spec",
-				pointer.P("virtio"),
-				&virtv1.VideoDevice{Type: "vga"},
-				&virtv1.VideoDevice{Type: "vga"},
+				pointer.P(preferredVideoTypeVirtio),
+				&virtv1.VideoDevice{Type: preferredVideoTypeVga},
+				&virtv1.VideoDevice{Type: preferredVideoTypeVga},
 			),
 			Entry("create video device and apply when video device is not provided in the VMI spec",
-				pointer.P("virtio"),
+				pointer.P(preferredVideoTypeVirtio),
 				nil,
-				&virtv1.VideoDevice{Type: "virtio"},
+				&virtv1.VideoDevice{Type: preferredVideoTypeVirtio},
 			),
 			Entry("not apply when preferredVideoType is nil",
 				nil,

--- a/pkg/instancetype/preference/find/spec_test.go
+++ b/pkg/instancetype/preference/find/spec_test.go
@@ -47,6 +47,8 @@ import (
 	"kubevirt.io/kubevirt/pkg/testutils"
 )
 
+const foobarName = "foobar"
+
 var _ = Describe("Preference SpecFinder", func() {
 	const (
 		nonExistingResourceName = "non-existing-resource"
@@ -199,7 +201,7 @@ var _ = Describe("Preference SpecFinder", func() {
 				func(vm *v1.VirtualMachine, crName string) {
 					vm.Status.PreferenceRef = &v1.InstancetypeStatusRef{
 						ControllerRevisionRef: &v1.ControllerRevisionRef{
-							Name: "foobar",
+							Name: foobarName,
 						},
 					}
 					vm.Spec.Preference = &v1.PreferenceMatcher{
@@ -370,7 +372,7 @@ var _ = Describe("Preference SpecFinder", func() {
 				func(vm *v1.VirtualMachine, crName string) {
 					vm.Status.PreferenceRef = &v1.InstancetypeStatusRef{
 						ControllerRevisionRef: &v1.ControllerRevisionRef{
-							Name: "foobar",
+							Name: foobarName,
 						},
 					}
 					vm.Spec.Preference = &v1.PreferenceMatcher{

--- a/pkg/instancetype/preference/requirements/arch_test.go
+++ b/pkg/instancetype/preference/requirements/arch_test.go
@@ -32,6 +32,11 @@ import (
 )
 
 var _ = Describe("Architecture requirements", func() {
+	const (
+		amd64Architecture = "amd64"
+		arm64Architecture = "arm64"
+	)
+
 	requirementsChecker := requirements.New()
 
 	DescribeTable("should pass when architecture requirement is met",
@@ -43,21 +48,21 @@ var _ = Describe("Architecture requirements", func() {
 		Entry("when preference requires amd64 and vmi uses amd64",
 			&v1beta1.VirtualMachinePreferenceSpec{
 				Requirements: &v1beta1.PreferenceRequirements{
-					Architecture: pointer.P("amd64"),
+					Architecture: pointer.P(amd64Architecture),
 				},
 			},
 			&v1.VirtualMachineInstanceSpec{
-				Architecture: "amd64",
+				Architecture: amd64Architecture,
 			},
 		),
 		Entry("when preference requires arm64 and vmi uses arm64",
 			&v1beta1.VirtualMachinePreferenceSpec{
 				Requirements: &v1beta1.PreferenceRequirements{
-					Architecture: pointer.P("arm64"),
+					Architecture: pointer.P(arm64Architecture),
 				},
 			},
 			&v1.VirtualMachineInstanceSpec{
-				Architecture: "arm64",
+				Architecture: arm64Architecture,
 			},
 		),
 		Entry("when preference requires s390x and vmi uses s390x",
@@ -75,13 +80,13 @@ var _ = Describe("Architecture requirements", func() {
 				Requirements: &v1beta1.PreferenceRequirements{},
 			},
 			&v1.VirtualMachineInstanceSpec{
-				Architecture: "amd64",
+				Architecture: amd64Architecture,
 			},
 		),
 		Entry("when preference has no requirements at all",
 			&v1beta1.VirtualMachinePreferenceSpec{},
 			&v1.VirtualMachineInstanceSpec{
-				Architecture: "amd64",
+				Architecture: amd64Architecture,
 			},
 		),
 	)
@@ -101,26 +106,26 @@ var _ = Describe("Architecture requirements", func() {
 		Entry("when preference requires amd64 but vmi uses arm64",
 			&v1beta1.VirtualMachinePreferenceSpec{
 				Requirements: &v1beta1.PreferenceRequirements{
-					Architecture: pointer.P("amd64"),
+					Architecture: pointer.P(amd64Architecture),
 				},
 			},
 			&v1.VirtualMachineInstanceSpec{
-				Architecture: "arm64",
+				Architecture: arm64Architecture,
 			},
 			conflict.Conflicts{conflict.New("spec", "template", "spec", "architecture")},
-			fmt.Sprintf("preference requires architecture %s but %s is being requested", "amd64", "arm64"),
+			fmt.Sprintf("preference requires architecture %s but %s is being requested", amd64Architecture, arm64Architecture),
 		),
 		Entry("when preference requires arm64 but vmi uses amd64",
 			&v1beta1.VirtualMachinePreferenceSpec{
 				Requirements: &v1beta1.PreferenceRequirements{
-					Architecture: pointer.P("arm64"),
+					Architecture: pointer.P(arm64Architecture),
 				},
 			},
 			&v1.VirtualMachineInstanceSpec{
-				Architecture: "amd64",
+				Architecture: amd64Architecture,
 			},
 			conflict.Conflicts{conflict.New("spec", "template", "spec", "architecture")},
-			fmt.Sprintf("preference requires architecture %s but %s is being requested", "arm64", "amd64"),
+			fmt.Sprintf("preference requires architecture %s but %s is being requested", arm64Architecture, amd64Architecture),
 		),
 		Entry("when preference requires s390x but vmi uses amd64",
 			&v1beta1.VirtualMachinePreferenceSpec{
@@ -129,22 +134,22 @@ var _ = Describe("Architecture requirements", func() {
 				},
 			},
 			&v1.VirtualMachineInstanceSpec{
-				Architecture: "amd64",
+				Architecture: amd64Architecture,
 			},
 			conflict.Conflicts{conflict.New("spec", "template", "spec", "architecture")},
-			fmt.Sprintf("preference requires architecture %s but %s is being requested", "s390x", "amd64"),
+			fmt.Sprintf("preference requires architecture %s but %s is being requested", "s390x", amd64Architecture),
 		),
 		Entry("when preference requires amd64 but vmi uses empty architecture",
 			&v1beta1.VirtualMachinePreferenceSpec{
 				Requirements: &v1beta1.PreferenceRequirements{
-					Architecture: pointer.P("amd64"),
+					Architecture: pointer.P(amd64Architecture),
 				},
 			},
 			&v1.VirtualMachineInstanceSpec{
 				Architecture: "",
 			},
 			conflict.Conflicts{conflict.New("spec", "template", "spec", "architecture")},
-			fmt.Sprintf("preference requires architecture %s but %s is being requested", "amd64", ""),
+			fmt.Sprintf("preference requires architecture %s but %s is being requested", amd64Architecture, ""),
 		),
 	)
 })

--- a/pkg/instancetype/preference/webhooks/admitter_test.go
+++ b/pkg/instancetype/preference/webhooks/admitter_test.go
@@ -40,6 +40,10 @@ import (
 )
 
 var _ = Describe("Validating Preference Admitter", func() {
+	const (
+		testPreferenceName      = "test-name"
+		testPreferenceNamespace = "test-namespace"
+	)
 	var (
 		admitter      *webhooks.PreferenceAdmitter
 		preferenceObj *instancetypev1beta1.VirtualMachinePreference
@@ -50,8 +54,8 @@ var _ = Describe("Validating Preference Admitter", func() {
 
 		preferenceObj = &instancetypev1beta1.VirtualMachinePreference{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-name",
-				Namespace: "test-namespace",
+				Name:      testPreferenceName,
+				Namespace: testPreferenceNamespace,
 			},
 		}
 	})
@@ -215,6 +219,10 @@ var _ = Describe("Validating Preference Admitter", func() {
 })
 
 var _ = Describe("Validating ClusterPreference Admitter", func() {
+	const (
+		testPreferenceName      = "test-name"
+		testPreferenceNamespace = "test-namespace"
+	)
 	var (
 		admitter             *webhooks.ClusterPreferenceAdmitter
 		clusterPreferenceObj *instancetypev1beta1.VirtualMachineClusterPreference
@@ -225,8 +233,8 @@ var _ = Describe("Validating ClusterPreference Admitter", func() {
 
 		clusterPreferenceObj = &instancetypev1beta1.VirtualMachineClusterPreference{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-name",
-				Namespace: "test-namespace",
+				Name:      testPreferenceName,
+				Namespace: testPreferenceNamespace,
 			},
 		}
 	})

--- a/pkg/instancetype/revision/store_test.go
+++ b/pkg/instancetype/revision/store_test.go
@@ -50,6 +50,7 @@ const (
 	nonExistingResourceName           = "non-existing-resource"
 	resourceUID             types.UID = "9160e5de-2540-476a-86d9-af0081aee68a"
 	resourceGeneration      int64     = 1
+	foobarKind                        = "foobar"
 )
 
 type handler interface {
@@ -124,7 +125,7 @@ var _ = Describe("Instancetype and Preferences revision handler", func() {
 	Context("store instancetype", func() {
 		It("store returns error when instancetypeMatcher kind is invalid", func() {
 			vm.Spec.Instancetype = &virtv1.InstancetypeMatcher{
-				Kind: "foobar",
+				Kind: foobarKind,
 			}
 			Expect(storeHandler.Store(vm)).To(MatchError(ContainSubstring("got unexpected kind in InstancetypeMatcher")))
 		})
@@ -429,7 +430,7 @@ var _ = Describe("Instancetype and Preferences revision handler", func() {
 	Context("store preference", func() {
 		It("store returns error when preferenceMatcher kind is invalid", func() {
 			vm.Spec.Preference = &virtv1.PreferenceMatcher{
-				Kind: "foobar",
+				Kind: foobarKind,
 			}
 			Expect(storeHandler.Store(vm)).To(MatchError(ContainSubstring("got unexpected kind in PreferenceMatcher")))
 		})

--- a/pkg/instancetype/upgrade/upgrade_test.go
+++ b/pkg/instancetype/upgrade/upgrade_test.go
@@ -59,6 +59,11 @@ func deepCopyList(objects []interface{}) []interface{} {
 }
 
 var _ = Describe("ControllerRevision upgrades", func() {
+	const (
+		instancetypeObjectName = "instancetype"
+		preferenceObjectName   = "preference"
+	)
+
 	type upgrader interface {
 		Upgrade(vm *virtv1.VirtualMachine) error
 	}
@@ -187,7 +192,7 @@ var _ = Describe("ControllerRevision upgrades", func() {
 				cr := createControllerRevisionFromObject(
 					&instancetypev1beta1.VirtualMachineClusterInstancetype{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "instancetype",
+							Name:      instancetypeObjectName,
 							Namespace: vm.Namespace,
 						},
 						Spec: instancetypev1beta1.VirtualMachineInstancetypeSpec{
@@ -208,7 +213,7 @@ var _ = Describe("ControllerRevision upgrades", func() {
 				cr := createControllerRevisionFromObject(
 					&instancetypev1beta1.VirtualMachineClusterPreference{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "preference",
+							Name:      preferenceObjectName,
 							Namespace: vm.Namespace,
 						},
 						Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{
@@ -228,7 +233,7 @@ var _ = Describe("ControllerRevision upgrades", func() {
 				cr := createControllerRevisionFromObject(
 					&instancetypev1beta1.VirtualMachineInstancetype{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "instancetype",
+							Name:      instancetypeObjectName,
 							Namespace: vm.Namespace,
 						},
 						Spec: instancetypev1beta1.VirtualMachineInstancetypeSpec{
@@ -249,7 +254,7 @@ var _ = Describe("ControllerRevision upgrades", func() {
 				cr := createControllerRevisionFromObject(
 					&instancetypev1beta1.VirtualMachinePreference{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "preference",
+							Name:      preferenceObjectName,
 							Namespace: vm.Namespace,
 						},
 						Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{
@@ -308,7 +313,7 @@ var _ = Describe("ControllerRevision upgrades", func() {
 				return createControllerRevisionFromObject(
 					&instancetypev1beta1.VirtualMachineClusterInstancetype{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "instancetype",
+							Name:      instancetypeObjectName,
 							Namespace: vm.Namespace,
 						},
 						Spec: instancetypev1beta1.VirtualMachineInstancetypeSpec{
@@ -326,7 +331,7 @@ var _ = Describe("ControllerRevision upgrades", func() {
 				return createControllerRevisionFromObject(
 					&instancetypev1beta1.VirtualMachineClusterPreference{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "preference",
+							Name:      preferenceObjectName,
 							Namespace: vm.Namespace,
 						},
 						Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{
@@ -343,7 +348,7 @@ var _ = Describe("ControllerRevision upgrades", func() {
 				return createControllerRevisionFromObject(
 					&instancetypev1beta1.VirtualMachineInstancetype{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "instancetype",
+							Name:      instancetypeObjectName,
 							Namespace: vm.Namespace,
 						},
 						Spec: instancetypev1beta1.VirtualMachineInstancetypeSpec{
@@ -361,7 +366,7 @@ var _ = Describe("ControllerRevision upgrades", func() {
 				return createControllerRevisionFromObject(
 					&instancetypev1beta1.VirtualMachinePreference{
 						ObjectMeta: metav1.ObjectMeta{
-							Name:      "preference",
+							Name:      preferenceObjectName,
 							Namespace: vm.Namespace,
 						},
 						Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{

--- a/pkg/instancetype/webhooks/admitter_test.go
+++ b/pkg/instancetype/webhooks/admitter_test.go
@@ -38,6 +38,12 @@ import (
 	"kubevirt.io/kubevirt/pkg/instancetype/webhooks"
 )
 
+const (
+	testName      = "test-name"
+	testNamespace = "test-namespace"
+	testPageSize  = "1Gi"
+)
+
 var _ = Describe("Validating Instancetype Admitter", func() {
 	var (
 		admitter        *webhooks.InstancetypeAdmitter
@@ -49,8 +55,8 @@ var _ = Describe("Validating Instancetype Admitter", func() {
 
 		instancetypeObj = &instancetypev1beta1.VirtualMachineInstancetype{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-name",
-				Namespace: "test-namespace",
+				Name:      testName,
+				Namespace: testNamespace,
 			},
 		}
 	})
@@ -94,7 +100,7 @@ var _ = Describe("Validating Instancetype Admitter", func() {
 				Guest:             resource.MustParse("128M"),
 				OvercommitPercent: 15,
 				Hugepages: &v1.Hugepages{
-					PageSize: "1Gi",
+					PageSize: testPageSize,
 				},
 			},
 		}
@@ -130,8 +136,8 @@ var _ = Describe("Validating ClusterInstancetype Admitter", func() {
 
 		clusterInstancetypeObj = &instancetypev1beta1.VirtualMachineClusterInstancetype{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-name",
-				Namespace: "test-namespace",
+				Name:      testName,
+				Namespace: testNamespace,
 			},
 		}
 	})
@@ -155,7 +161,7 @@ var _ = Describe("Validating ClusterInstancetype Admitter", func() {
 				Guest:             resource.MustParse("128M"),
 				OvercommitPercent: 15,
 				Hugepages: &v1.Hugepages{
-					PageSize: "1Gi",
+					PageSize: testPageSize,
 				},
 			},
 		}

--- a/pkg/instancetype/webhooks/vm/admitter_test.go
+++ b/pkg/instancetype/webhooks/vm/admitter_test.go
@@ -63,9 +63,10 @@ var _ = Describe("Instance type and Preference VirtualMachine Admitter", func() 
 		)
 
 		const (
-			instancetypeName = "instancetypeName"
-			preferenceName   = "preferenceName"
-			unknownResource  = "unknown"
+			instancetypeName    = "instancetypeName"
+			preferenceName      = "preferenceName"
+			unknownResource     = "unknown"
+			cpuSocketsFieldPath = "spec.template.spec.domain.cpu.sockets"
 		)
 
 		BeforeEach(func() {
@@ -155,8 +156,8 @@ var _ = Describe("Instance type and Preference VirtualMachine Admitter", func() 
 				[]metav1.StatusCause{
 					{
 						Type:    metav1.CauseTypeFieldValueInvalid,
-						Message: "VM field(s) spec.template.spec.domain.cpu.sockets conflicts with selected instance type",
-						Field:   "spec.template.spec.domain.cpu.sockets",
+						Message: fmt.Sprintf("VM field(s) %s conflicts with selected instance type", cpuSocketsFieldPath),
+						Field:   cpuSocketsFieldPath,
 					},
 					{
 						Type:    metav1.CauseTypeFieldValueInvalid,
@@ -176,8 +177,8 @@ var _ = Describe("Instance type and Preference VirtualMachine Admitter", func() 
 			Expect(causes).To(ConsistOf(
 				metav1.StatusCause{
 					Type:    metav1.CauseTypeFieldValueInvalid,
-					Message: "VM field(s) spec.template.spec.domain.cpu.sockets conflicts with selected instance type",
-					Field:   "spec.template.spec.domain.cpu.sockets",
+					Message: fmt.Sprintf("VM field(s) %s conflicts with selected instance type", cpuSocketsFieldPath),
+					Field:   cpuSocketsFieldPath,
 				},
 				metav1.StatusCause{
 					Type:    metav1.CauseTypeFieldValueInvalid,

--- a/pkg/instancetype/webhooks/vm/mutator.go
+++ b/pkg/instancetype/webhooks/vm/mutator.go
@@ -39,6 +39,10 @@ import (
 	webhookutils "kubevirt.io/kubevirt/pkg/util/webhooks"
 )
 
+const inferFromVolumeNameSetMsg = "Name already set, should be cleared before setting inferFromVolume"
+
+const inferFromVolumeKindSetMsg = "Kind already set, should be cleared before setting inferFromVolume"
+
 type inferHandler interface {
 	Instancetype(vm *virtv1.VirtualMachine) error
 	Preference(vm *virtv1.VirtualMachine) error
@@ -204,14 +208,14 @@ func validateInstancetypeMatcher(vm *virtv1.VirtualMachine) []metav1.StatusCause
 		if vm.Spec.Instancetype.Name != "" {
 			causes = append(causes, metav1.StatusCause{
 				Type:    metav1.CauseTypeFieldValueNotSupported,
-				Message: "Name already set, should be cleared before setting inferFromVolume",
+				Message: inferFromVolumeNameSetMsg,
 				Field:   k8sfield.NewPath("spec", "instancetype", "name").String(),
 			})
 		}
 		if vm.Spec.Instancetype.Kind != "" {
 			causes = append(causes, metav1.StatusCause{
 				Type:    metav1.CauseTypeFieldValueNotSupported,
-				Message: "Kind already set, should be cleared before setting inferFromVolume",
+				Message: inferFromVolumeKindSetMsg,
 				Field:   k8sfield.NewPath("spec", "instancetype", "kind").String(),
 			})
 		}
@@ -246,14 +250,14 @@ func validatePreferenceMatcher(vm *virtv1.VirtualMachine) []metav1.StatusCause {
 		if vm.Spec.Preference.Name != "" {
 			causes = append(causes, metav1.StatusCause{
 				Type:    metav1.CauseTypeFieldValueNotSupported,
-				Message: "Name already set, should be cleared before setting inferFromVolume",
+				Message: inferFromVolumeNameSetMsg,
 				Field:   k8sfield.NewPath("spec", "preference", "name").String(),
 			})
 		}
 		if vm.Spec.Preference.Kind != "" {
 			causes = append(causes, metav1.StatusCause{
 				Type:    metav1.CauseTypeFieldValueNotSupported,
-				Message: "Kind already set, should be cleared before setting inferFromVolume",
+				Message: inferFromVolumeKindSetMsg,
 				Field:   k8sfield.NewPath("spec", "preference", "kind").String(),
 			})
 		}

--- a/pkg/libvmi/replicaset/replicaset.go
+++ b/pkg/libvmi/replicaset/replicaset.go
@@ -26,19 +26,21 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 )
 
+const rsSelectorLabel = "rsslector"
+
 func New(vmi *v1.VirtualMachineInstance, replicas int32) *v1.VirtualMachineInstanceReplicaSet {
 	const taillength = 5
-	rsselector := "rsselector" + rand.String(taillength)
+	rsselector := rsSelectorLabel + rand.String(taillength)
 	return &v1.VirtualMachineInstanceReplicaSet{
 		ObjectMeta: metav1.ObjectMeta{Name: "replicaset" + rand.String(taillength)},
 		Spec: v1.VirtualMachineInstanceReplicaSetSpec{
 			Replicas: &replicas,
 			Selector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{"rsslector": rsselector},
+				MatchLabels: map[string]string{rsSelectorLabel: rsselector},
 			},
 			Template: &v1.VirtualMachineInstanceTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{"rsslector": rsselector},
+					Labels: map[string]string{rsSelectorLabel: rsselector},
 					Name:   vmi.ObjectMeta.Name,
 				},
 				Spec: vmi.Spec,

--- a/pkg/libvmi/vm.go
+++ b/pkg/libvmi/vm.go
@@ -28,6 +28,8 @@ import (
 	"kubevirt.io/kubevirt/pkg/pointer"
 )
 
+const unused = "unused"
+
 type VMOption func(vm *v1.VirtualMachine)
 
 func NewVirtualMachine(vmi *v1.VirtualMachineInstance, opts ...VMOption) *v1.VirtualMachine {
@@ -182,7 +184,7 @@ func WithInstancetypeRevision(revisionName string) VMOption {
 	return func(vm *v1.VirtualMachine) {
 		resourcesRemovedFromVMI(&vm.Spec.Template.Spec)
 		vm.Spec.Instancetype = &v1.InstancetypeMatcher{
-			Name:         "unused",
+			Name:         unused,
 			RevisionName: revisionName,
 		}
 	}
@@ -192,7 +194,7 @@ func WithPreferenceRevision(revisionName string) VMOption {
 	return func(vm *v1.VirtualMachine) {
 		preferencesRemovedFromVMI(&vm.Spec.Template.Spec)
 		vm.Spec.Preference = &v1.PreferenceMatcher{
-			Name:         "unused",
+			Name:         unused,
 			RevisionName: revisionName,
 		}
 	}

--- a/pkg/monitoring/metrics/common/client/rest_metrics.go
+++ b/pkg/monitoring/metrics/common/client/rest_metrics.go
@@ -27,6 +27,9 @@ const (
 	rateLimiterBucketStart  = 0.001
 	rateLimiterBucketFactor = 2
 	rateLimiterBucketCount  = 10
+
+	metricLabelVerb = "verb"
+	metricLabelURL  = "url"
 )
 
 var (
@@ -51,7 +54,7 @@ var (
 				4, 5, 6, 8, 10, 15, 20, 30, 45, 60,
 			},
 		},
-		[]string{"verb", "url"},
+		[]string{metricLabelVerb, metricLabelURL},
 	)
 
 	rateLimiterLatency = operatormetrics.NewHistogramVec(
@@ -62,7 +65,7 @@ var (
 		prometheus.HistogramOpts{
 			Buckets: prometheus.ExponentialBuckets(rateLimiterBucketStart, rateLimiterBucketFactor, rateLimiterBucketCount),
 		},
-		[]string{"verb", "url"},
+		[]string{metricLabelVerb, metricLabelURL},
 	)
 
 	requestResult = operatormetrics.NewCounterVec(
@@ -70,6 +73,6 @@ var (
 			Name: "kubevirt_rest_client_requests_total",
 			Help: "Number of HTTP requests, partitioned by status code, method, and host.",
 		},
-		[]string{"code", "method", "host", "resource", "verb"},
+		[]string{"code", "method", "host", "resource", metricLabelVerb},
 	)
 )

--- a/pkg/monitoring/metrics/common/labels/labels_config_test.go
+++ b/pkg/monitoring/metrics/common/labels/labels_config_test.go
@@ -26,6 +26,11 @@ import (
 	k8sv1 "k8s.io/api/core/v1"
 )
 
+const (
+	configMapAllowlistKey  = "allowlist"
+	configMapIgnorelistKey = "ignorelist"
+)
+
 var _ = Describe("labels config", func() {
 	var cfg *configImpl
 
@@ -50,8 +55,8 @@ var _ = Describe("labels config", func() {
 	Context("ConfigMap updates", func() {
 		It("should prioritize ignorelist over allowlist when overlapping", func() {
 			cm := &k8sv1.ConfigMap{Data: map[string]string{
-				"allowlist":  "*",
-				"ignorelist": "vm.kubevirt.io/template",
+				configMapAllowlistKey:  "*",
+				configMapIgnorelistKey: "vm.kubevirt.io/template",
 			}}
 			cfg.updateFromConfigMap(cm)
 
@@ -61,8 +66,8 @@ var _ = Describe("labels config", func() {
 
 		It("should not report when allowlist is empty", func() {
 			cm := &k8sv1.ConfigMap{Data: map[string]string{
-				"allowlist":  "",
-				"ignorelist": "",
+				configMapAllowlistKey:  "",
+				configMapIgnorelistKey: "",
 			}}
 			cfg.updateFromConfigMap(cm)
 			Expect(cfg.ShouldReport("a")).To(BeFalse())
@@ -70,8 +75,8 @@ var _ = Describe("labels config", func() {
 
 		It("should not treat '*' in ignorelist as wildcard", func() {
 			cm := &k8sv1.ConfigMap{Data: map[string]string{
-				"allowlist":  "*",
-				"ignorelist": "*",
+				configMapAllowlistKey:  "*",
+				configMapIgnorelistKey: "*",
 			}}
 			cfg.updateFromConfigMap(cm)
 			Expect(cfg.ShouldReport("environment")).To(BeTrue())

--- a/pkg/monitoring/metrics/common/workqueue/metrics.go
+++ b/pkg/monitoring/metrics/common/workqueue/metrics.go
@@ -28,6 +28,8 @@ const (
 	workqueueBucketStart  = 10e-9
 	workqueueBucketFactor = 10
 	workqueueBucketCount  = 10
+
+	metricLabelName = "name"
 )
 
 var (
@@ -46,7 +48,7 @@ var (
 			Name: "kubevirt_workqueue_depth",
 			Help: "Current depth of workqueue",
 		},
-		[]string{"name"},
+		[]string{metricLabelName},
 	)
 
 	adds = operatormetrics.NewCounterVec(
@@ -54,7 +56,7 @@ var (
 			Name: "kubevirt_workqueue_adds_total",
 			Help: "Total number of adds handled by workqueue",
 		},
-		[]string{"name"},
+		[]string{metricLabelName},
 	)
 
 	latency = operatormetrics.NewHistogramVec(
@@ -65,7 +67,7 @@ var (
 		prometheus.HistogramOpts{
 			Buckets: prometheus.ExponentialBuckets(workqueueBucketStart, workqueueBucketFactor, workqueueBucketCount),
 		},
-		[]string{"name"},
+		[]string{metricLabelName},
 	)
 
 	workDuration = operatormetrics.NewHistogramVec(
@@ -76,7 +78,7 @@ var (
 		prometheus.HistogramOpts{
 			Buckets: prometheus.ExponentialBuckets(workqueueBucketStart, workqueueBucketFactor, workqueueBucketCount),
 		},
-		[]string{"name"},
+		[]string{metricLabelName},
 	)
 
 	retries = operatormetrics.NewCounterVec(
@@ -84,7 +86,7 @@ var (
 			Name: "kubevirt_workqueue_retries_total",
 			Help: "Total number of retries handled by workqueue",
 		},
-		[]string{"name"},
+		[]string{metricLabelName},
 	)
 
 	longestRunningProcessor = operatormetrics.NewGaugeVec(
@@ -92,7 +94,7 @@ var (
 			Name: "kubevirt_workqueue_longest_running_processor_seconds",
 			Help: "How many seconds has the longest running processor for workqueue been running.",
 		},
-		[]string{"name"},
+		[]string{metricLabelName},
 	)
 
 	unfinishedWork = operatormetrics.NewGaugeVec(
@@ -103,7 +105,7 @@ var (
 				"threads. The number of stuck threads can be deduced by observing " +
 				"the rate at which this value increases.",
 		},
-		[]string{"name"},
+		[]string{metricLabelName},
 	)
 )
 

--- a/pkg/monitoring/metrics/virt-api/connection_metrics.go
+++ b/pkg/monitoring/metrics/virt-api/connection_metrics.go
@@ -24,6 +24,11 @@ import (
 	"github.com/rhobs/operator-observability-toolkit/pkg/operatormetrics"
 )
 
+const (
+	namespaceLabel = "namespace"
+	vmiLabel       = "vmi"
+)
+
 var (
 	connectionMetrics = []operatormetrics.Metric{
 		activePortForwardTunnels,
@@ -33,7 +38,7 @@ var (
 		vmiLastConnectionTimestamp,
 	}
 
-	namespaceAndVMILabels = []string{"namespace", "vmi"}
+	namespaceAndVMILabels = []string{namespaceLabel, vmiLabel}
 
 	activePortForwardTunnels = operatormetrics.NewGaugeVec(
 		operatormetrics.MetricOpts{

--- a/pkg/monitoring/metrics/virt-controller/BUILD.bazel
+++ b/pkg/monitoring/metrics/virt-controller/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "component_metrics.go",
+        "constants.go",
         "leader_metrics.go",
         "metrics.go",
         "migration_metrics.go",
@@ -53,6 +54,7 @@ go_test(
         "migration_metrics_test.go",
         "migrationstats_collector_test.go",
         "perfscale_metrics_test.go",
+        "test_constants_test.go",
         "virt_controller_suite_test.go",
         "vmistats_collector_test.go",
         "vmsnapshot_test.go",

--- a/pkg/monitoring/metrics/virt-controller/constants.go
+++ b/pkg/monitoring/metrics/virt-controller/constants.go
@@ -1,0 +1,62 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package virtcontroller
+
+const (
+	metricLabelNode          = "node"
+	metricLabelName          = "name"
+	metricLabelNamespace     = "namespace"
+	metricLabelPhase         = "phase"
+	metricLabelVNICName      = "vnic_name"
+	metricLabelFlavor        = "flavor"
+	metricLabelInstanceType  = "instance_type"
+	metricLabelMigrationName = "migration_name"
+	metricLabelStatus        = "status"
+	metricLabelBindingName   = "binding_name"
+	metricLabelResource      = "resource"
+
+	resourceNameCPU    = "cpu"
+	resourceNameMemory = "memory"
+
+	resourceUnitBytes   = "bytes"
+	resourceUnitCores   = "cores"
+	resourceUnitThreads = "threads"
+	resourceUnitSockets = "sockets"
+
+	resourceSourceDefault        = "default"
+	resourceSourceDomain         = "domain"
+	resourceSourceGuest          = "guest"
+	resourceSourceGuestEffective = "guest_effective"
+	resourceSourceHugepages      = "hugepages"
+	resourceSourceRequests       = "requests"
+
+	bindingNameBridge     = "bridge"
+	bindingNameMasquerade = "masquerade"
+	bindingNameSRIOV      = "sriov"
+	networkNamePod        = "pod networking"
+
+	vmiInterfaceTypeExternal = "ExternalInterface"
+	vmiInterfaceTypeSystem   = "SystemInterface"
+
+	vmStatusGroupRunning        = "running"
+	migrationStatusSucceeded    = "succeeded"
+	metricVMResourceLimits      = "kubevirt_vm_resource_limits"
+	metricLabelMigrationVMIName = "vmi"
+)

--- a/pkg/monitoring/metrics/virt-controller/migration_metrics.go
+++ b/pkg/monitoring/metrics/virt-controller/migration_metrics.go
@@ -48,7 +48,7 @@ var (
 		},
 		[]string{
 			// phase of the vmi migration
-			"phase",
+			metricLabelPhase,
 		},
 	)
 )

--- a/pkg/monitoring/metrics/virt-controller/migration_metrics_test.go
+++ b/pkg/monitoring/metrics/virt-controller/migration_metrics_test.go
@@ -63,8 +63,8 @@ func createVMIMigrationSForPhaseTransitionTime(
 
 	migration := &v1.VirtualMachineInstanceMigration{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace:         "test-ns",
-			Name:              "testvmimigration",
+			Namespace:         testNamespace,
+			Name:              testVMIMName,
 			CreationTimestamp: creation,
 		},
 		Status: v1.VirtualMachineInstanceMigrationStatus{

--- a/pkg/monitoring/metrics/virt-controller/migrationstats_collector.go
+++ b/pkg/monitoring/metrics/virt-controller/migrationstats_collector.go
@@ -24,6 +24,8 @@ import (
 	k6tv1 "kubevirt.io/api/core/v1"
 )
 
+const labelVMIM = "vmim"
+
 var (
 	migrationStatsCollector = operatormetrics.Collector{
 		Metrics: []operatormetrics.Metric{
@@ -70,7 +72,7 @@ var (
 			Name: "kubevirt_vmi_migration_succeeded",
 			Help: "Indicates if the VMI migration succeeded.",
 		},
-		[]string{"vmi", "vmim", "namespace"},
+		[]string{metricLabelMigrationVMIName, labelVMIM, metricLabelNamespace},
 	)
 
 	failedMigration = operatormetrics.NewGaugeVec(
@@ -78,7 +80,7 @@ var (
 			Name: "kubevirt_vmi_migration_failed",
 			Help: "Indicates if the VMI migration failed.",
 		},
-		[]string{"vmi", "vmim", "namespace"},
+		[]string{metricLabelMigrationVMIName, labelVMIM, metricLabelNamespace},
 	)
 )
 

--- a/pkg/monitoring/metrics/virt-controller/perfscale_metrics.go
+++ b/pkg/monitoring/metrics/virt-controller/perfscale_metrics.go
@@ -52,7 +52,7 @@ var (
 		},
 		[]string{
 			// phase of the vmi
-			"phase",
+			metricLabelPhase,
 			// last phase of the vmi
 			"last_phase",
 		},
@@ -68,7 +68,7 @@ var (
 		},
 		[]string{
 			// phase of the vmi
-			"phase",
+			metricLabelPhase,
 		},
 	)
 
@@ -82,7 +82,7 @@ var (
 		},
 		[]string{
 			// phase of the vmi
-			"phase",
+			metricLabelPhase,
 		},
 	)
 )

--- a/pkg/monitoring/metrics/virt-controller/perfscale_metrics_test.go
+++ b/pkg/monitoring/metrics/virt-controller/perfscale_metrics_test.go
@@ -95,12 +95,12 @@ func createVMISForPhaseTransitionTime(
 
 	vmi := &v1.VirtualMachineInstance{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace:         "test-ns",
-			Name:              "testvmi",
+			Namespace:         testNamespace,
+			Name:              testVMIName,
 			CreationTimestamp: creation,
 		},
 		Status: v1.VirtualMachineInstanceStatus{
-			NodeName: "testNode",
+			NodeName: testNodeName,
 			Phase:    phase,
 		},
 	}

--- a/pkg/monitoring/metrics/virt-controller/test_constants_test.go
+++ b/pkg/monitoring/metrics/virt-controller/test_constants_test.go
@@ -1,0 +1,69 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package virtcontroller
+
+const (
+	testNamespace          = "test-ns"
+	testNodeName           = "testNode"
+	testVMIName            = "testvmi"
+	testVMINameDashed      = "test-vmi"
+	testVMName             = "testvm"
+	testVMNameDashed       = "test-vm"
+	testSecondVMNameDashed = "test-vm-2"
+	testVMIMName           = "testvmimigration"
+
+	testAnnotationOSCentos8      = "centos8"
+	testAnnotationOSCentos7      = "centos7"
+	testAnnotationWorkloadServer = "server"
+	testAnnotationFlavorTiny     = "tiny"
+	testAnnotationFlavorMedium   = "medium"
+	testAnnotationDummy          = "dummy"
+	testConditionAny             = "any"
+	testPhaseRunningLower        = "running"
+	testVMIPhaseRunning          = "Running"
+	testVMIPhaseScheduling       = "Scheduling"
+
+	testMigrationName = "test-migration"
+	testMigrationUID  = "test-migration-uid"
+	testDataVolumePVC = "test-dv-pvc"
+	testRootDiskName  = "rootdisk"
+	testVMLocalAlias  = "vm1"
+	testVNICIface1    = "iface1"
+	testVNICIface2    = "iface2"
+	testVNICIface3    = "iface3"
+	testVNICIface4    = "iface4"
+	testMultusNetwork = "multus-net"
+
+	testLabelEnvironment     = "environment"
+	testLabelTeam            = "team"
+	testLabelVersion         = "version"
+	testLabelValueProduction = "production"
+
+	testInfoSourceGuestAgent = "guest-agent"
+	testBridgeInterfaceName  = "br-int"
+	testVMIInterfaceName     = "net-0"
+	testVMIInterfaceBridge   = "br-ex"
+	testVMIInterfaceIP       = "10.11.126.126"
+	testOVSSystemInterface   = "ovs-system"
+	testModelE1000E          = "e1000e"
+	testModelVirtio          = "virtio"
+	testNetworkCustom        = "custom-net"
+	testCustomPluginName     = "custom-plugin"
+)

--- a/pkg/monitoring/metrics/virt-controller/vmistats_collector.go
+++ b/pkg/monitoring/metrics/virt-controller/vmistats_collector.go
@@ -47,6 +47,14 @@ const (
 
 	annotationPrefix        = "vm.kubevirt.io/"
 	instancetypeVendorLabel = "instancetype.kubevirt.io/vendor"
+
+	labelOS          = "os"
+	labelPreference  = "preference"
+	labelBindingType = "binding_type"
+	labelUnit        = "unit"
+	labelWorkload    = "workload"
+	labelModel       = "model"
+	labelNetwork     = "network"
 )
 
 var (
@@ -75,11 +83,11 @@ var (
 		},
 		[]string{
 			// Basic info
-			"node", "namespace", "name",
+			metricLabelNode, metricLabelNamespace, metricLabelName,
 			// Domain info
-			"phase", "os", "workload", "flavor",
+			metricLabelPhase, labelOS, labelWorkload, metricLabelFlavor,
 			// Instance type
-			"instance_type", "preference",
+			metricLabelInstanceType, labelPreference,
 			// Guest OS info
 			"guest_os_kernel_release", "guest_os_machine", "guest_os_arch", "guest_os_name", "guest_os_version_id",
 			// State info
@@ -94,7 +102,7 @@ var (
 			Name: "kubevirt_vmi_non_evictable",
 			Help: "Indication for a VirtualMachine that its eviction strategy is set to Live Migration but is not migratable.",
 		},
-		[]string{"node", "namespace", "name"},
+		[]string{metricLabelNode, metricLabelNamespace, metricLabelName},
 	)
 
 	vmiAddresses = operatormetrics.NewGaugeVec(
@@ -104,7 +112,7 @@ var (
 				"interface associated with the VMI in the 'address' label, and about the type of address, such as " +
 				"internal IP, in the 'type' label.",
 		},
-		[]string{"node", "namespace", "name", "vnic_name", "interface_name", "address", "type"},
+		[]string{metricLabelNode, metricLabelNamespace, metricLabelName, metricLabelVNICName, "interface_name", "address", "type"},
 	)
 
 	vmiMigrationStartTime = operatormetrics.NewGaugeVec(
@@ -112,7 +120,7 @@ var (
 			Name: "kubevirt_vmi_migration_start_time_seconds",
 			Help: "The time at which the migration started.",
 		},
-		[]string{"node", "namespace", "name", "migration_name"},
+		[]string{metricLabelNode, metricLabelNamespace, metricLabelName, metricLabelMigrationName},
 	)
 
 	vmiMigrationEndTime = operatormetrics.NewGaugeVec(
@@ -120,7 +128,7 @@ var (
 			Name: "kubevirt_vmi_migration_end_time_seconds",
 			Help: "The time at which the migration ended.",
 		},
-		[]string{"node", "namespace", "name", "migration_name", "status"},
+		[]string{metricLabelNode, metricLabelNamespace, metricLabelName, metricLabelMigrationName, metricLabelStatus},
 	)
 
 	vmiVnicInfo = operatormetrics.NewGaugeVec(
@@ -129,7 +137,7 @@ var (
 			Help: "Details of VirtualMachineInstance (VMI) vNIC interfaces, such as vNIC name, binding type, " +
 				"network name, and binding name for each vNIC of a running instance.",
 		},
-		[]string{"name", "namespace", "vnic_name", "binding_type", "network", "binding_name", "model"},
+		[]string{metricLabelName, metricLabelNamespace, metricLabelVNICName, labelBindingType, labelNetwork, metricLabelBindingName, labelModel},
 	)
 
 	vmiLauncherMemoryOverhead = operatormetrics.NewGaugeVec(
@@ -137,7 +145,7 @@ var (
 			Name: "kubevirt_vmi_launcher_memory_overhead_bytes",
 			Help: "Estimation of the memory amount required for virt-launcher's infrastructure components (e.g. libvirt, QEMU).",
 		},
-		[]string{"namespace", "name"},
+		[]string{metricLabelNamespace, metricLabelName},
 	)
 )
 
@@ -230,7 +238,7 @@ func getSystemInfoFromAnnotations(annotations map[string]string) (os, workload, 
 		os = val
 	}
 
-	if val, ok := annotations[annotationPrefix+"workload"]; ok {
+	if val, ok := annotations[annotationPrefix+labelWorkload]; ok {
 		workload = val
 	}
 
@@ -394,7 +402,7 @@ func collectVMIInterfaceInfo(
 	vmi *k6tv1.VirtualMachineInstance,
 	iface k6tv1.VirtualMachineInstanceNetworkInterface,
 ) *operatormetrics.CollectorResult {
-	interfaceType := "ExternalInterface"
+	interfaceType := vmiInterfaceTypeExternal
 
 	if iface.IP == "" {
 		if iface.Name == "" && iface.InterfaceName == "" {
@@ -402,7 +410,7 @@ func collectVMIInterfaceInfo(
 			return nil
 		}
 
-		interfaceType = "SystemInterface"
+		interfaceType = vmiInterfaceTypeSystem
 	}
 
 	return &operatormetrics.CollectorResult{
@@ -455,7 +463,7 @@ func calculateMigrationStatus(migrationState *k6tv1.VirtualMachineInstanceMigrat
 		return "failed"
 	}
 
-	return "succeeded"
+	return migrationStatusSucceeded
 }
 
 func getMigrationNameFromMigrationUID(migrationUID types.UID) string {

--- a/pkg/monitoring/metrics/virt-controller/vmistats_collector_test.go
+++ b/pkg/monitoring/metrics/virt-controller/vmistats_collector_test.go
@@ -60,26 +60,26 @@ var _ = Describe("VMI Stats Collector", func() {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "running#0",
 						Annotations: map[string]string{
-							annotationPrefix + "os":       "centos8",
-							annotationPrefix + "workload": "server",
-							annotationPrefix + "flavor":   "tiny",
+							annotationPrefix + "os":       testAnnotationOSCentos8,
+							annotationPrefix + "workload": testAnnotationWorkloadServer,
+							annotationPrefix + "flavor":   testAnnotationFlavorTiny,
 						},
 					},
 					Status: k6tv1.VirtualMachineInstanceStatus{
-						Phase: "Running",
+						Phase: testVMIPhaseRunning,
 					},
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "running#1",
 						Annotations: map[string]string{
-							annotationPrefix + "os":       "centos8",
-							annotationPrefix + "workload": "server",
-							annotationPrefix + "flavor":   "tiny",
+							annotationPrefix + "os":       testAnnotationOSCentos8,
+							annotationPrefix + "workload": testAnnotationWorkloadServer,
+							annotationPrefix + "flavor":   testAnnotationFlavorTiny,
 						},
 					},
 					Status: k6tv1.VirtualMachineInstanceStatus{
-						Phase: "Running",
+						Phase: testVMIPhaseRunning,
 					},
 				},
 				{
@@ -105,28 +105,28 @@ var _ = Describe("VMI Stats Collector", func() {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "scheduling#0",
 						Annotations: map[string]string{
-							annotationPrefix + "os":       "centos7",
-							annotationPrefix + "workload": "server",
-							annotationPrefix + "flavor":   "medium",
-							annotationPrefix + "dummy":    "dummy",
+							annotationPrefix + "os":       testAnnotationOSCentos7,
+							annotationPrefix + "workload": testAnnotationWorkloadServer,
+							annotationPrefix + "flavor":   testAnnotationFlavorMedium,
+							annotationPrefix + "dummy":    testAnnotationDummy,
 						},
 					},
 					Status: k6tv1.VirtualMachineInstanceStatus{
-						Phase: "Scheduling",
+						Phase: testVMIPhaseScheduling,
 					},
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "scheduling#1",
 						Annotations: map[string]string{
-							annotationPrefix + "os":       "centos7",
-							annotationPrefix + "workload": "server",
-							annotationPrefix + "flavor":   "medium",
+							annotationPrefix + "os":       testAnnotationOSCentos7,
+							annotationPrefix + "workload": testAnnotationWorkloadServer,
+							annotationPrefix + "flavor":   testAnnotationFlavorMedium,
 							annotationPrefix + "phase":    "dummy",
 						},
 					},
 					Status: k6tv1.VirtualMachineInstanceStatus{
-						Phase: "Scheduling",
+						Phase: testVMIPhaseScheduling,
 					},
 				},
 			}
@@ -188,8 +188,8 @@ var _ = Describe("VMI Stats Collector", func() {
 			vmis := []*k6tv1.VirtualMachineInstance{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:        "running",
-						Namespace:   "test-ns",
+						Name:        testPhaseRunningLower,
+						Namespace:   testNamespace,
 						Annotations: annotations,
 					},
 				},
@@ -225,8 +225,8 @@ var _ = Describe("VMI Stats Collector", func() {
 			vmis := []*k6tv1.VirtualMachineInstance{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:        "running",
-						Namespace:   "test-ns",
+						Name:        testPhaseRunningLower,
+						Namespace:   testNamespace,
 						Annotations: annotations,
 					},
 				},
@@ -285,11 +285,11 @@ var _ = Describe("VMI Stats Collector", func() {
 		DescribeTable("kubevirt_vmi_status_addresses metrics", func(ifaceValues [][]string) {
 			vmi := &k6tv1.VirtualMachineInstance{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "test-ns",
-					Name:      "testvmi",
+					Namespace: testNamespace,
+					Name:      testVMIName,
 				},
 				Status: k6tv1.VirtualMachineInstanceStatus{
-					NodeName:   "testNode",
+					NodeName:   testNodeName,
 					Interfaces: interfacesFor(ifaceValues),
 				},
 			}
@@ -298,35 +298,35 @@ var _ = Describe("VMI Stats Collector", func() {
 			Expect(metrics).To(HaveLen(len(ifaceValues)))
 
 			for i, labelValues := range ifaceValues {
-				values := append([]string{"testNode", "test-ns", "testvmi"}, labelValues...)
+				values := append([]string{testNodeName, testNamespace, testVMIName}, labelValues...)
 				Expect(metrics[i].Labels).To(Equal(values))
 			}
 		},
 			Entry("no interfaces", [][]string{}),
-			Entry("one interface", [][]string{{"default", "", "192.168.1.2", "ExternalInterface"}}),
+			Entry("one interface", [][]string{{testLabelDefault, "", "192.168.1.2", vmiInterfaceTypeExternal}}),
 			Entry("two interfaces", [][]string{
-				{"networkA", "", "170.170.170.170", "ExternalInterface"},
-				{"networkB", "", "180.180.180.180", "ExternalInterface"},
+				{"networkA", "", "170.170.170.170", vmiInterfaceTypeExternal},
+				{"networkB", "", "180.180.180.180", vmiInterfaceTypeExternal},
 			}),
 		)
 
 		It("should create metric for interfaces with empty name, but with interface name", func() {
 			vmi := &k6tv1.VirtualMachineInstance{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "test-ns",
-					Name:      "testvmi",
+					Namespace: testNamespace,
+					Name:      testVMIName,
 				},
 				Status: k6tv1.VirtualMachineInstanceStatus{
-					NodeName: "testNode",
+					NodeName: testNodeName,
 					Interfaces: []k6tv1.VirtualMachineInstanceNetworkInterface{
 						{
-							InfoSource:    "guest-agent",
-							InterfaceName: "br-int",
+							InfoSource:    testInfoSourceGuestAgent,
+							InterfaceName: testBridgeInterfaceName,
 							MAC:           "00:00:00:00:00:01",
 						},
 						{
-							InfoSource:    "guest-agent",
-							InterfaceName: "ovs-system",
+							InfoSource:    testInfoSourceGuestAgent,
+							InterfaceName: testOVSSystemInterface,
 							MAC:           "00:00:00:00:00:02",
 						},
 					},
@@ -335,35 +335,39 @@ var _ = Describe("VMI Stats Collector", func() {
 
 			metrics := collectVMIInterfacesInfo(vmi)
 			Expect(metrics).To(HaveLen(2))
-			Expect(metrics[0].Labels).To(Equal([]string{"testNode", "test-ns", "testvmi", "", "br-int", "", "SystemInterface"}))
-			Expect(metrics[1].Labels).To(Equal([]string{"testNode", "test-ns", "testvmi", "", "ovs-system", "", "SystemInterface"}))
+			Expect(metrics[0].Labels).To(Equal([]string{
+				testNodeName, testNamespace, testVMIName, "", testBridgeInterfaceName, "", vmiInterfaceTypeSystem,
+			}))
+			Expect(metrics[1].Labels).To(Equal([]string{
+				testNodeName, testNamespace, testVMIName, "", testOVSSystemInterface, "", vmiInterfaceTypeSystem,
+			}))
 		})
 
 		It("should not create metric for an interface with empty IP address, name and interface name", func() {
 			vmi := &k6tv1.VirtualMachineInstance{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "test-ns",
-					Name:      "testvmi",
+					Namespace: testNamespace,
+					Name:      testVMIName,
 				},
 				Status: k6tv1.VirtualMachineInstanceStatus{
-					NodeName: "testNode",
+					NodeName: testNodeName,
 					Interfaces: []k6tv1.VirtualMachineInstanceNetworkInterface{
 						{
 							InfoSource:    "domain, guest-agent, multus-status",
-							Name:          "net-0",
-							InterfaceName: "br-ex",
-							IP:            "10.11.126.126",
+							Name:          testVMIInterfaceName,
+							InterfaceName: testVMIInterfaceBridge,
+							IP:            testVMIInterfaceIP,
 						},
 						{
-							InfoSource:    "guest-agent",
-							InterfaceName: "ovs-system",
+							InfoSource:    testInfoSourceGuestAgent,
+							InterfaceName: testOVSSystemInterface,
 						},
 						{
-							InfoSource:    "guest-agent",
-							InterfaceName: "br-int",
+							InfoSource:    testInfoSourceGuestAgent,
+							InterfaceName: testBridgeInterfaceName,
 						},
 						{
-							InfoSource: "guest-agent",
+							InfoSource: testInfoSourceGuestAgent,
 						},
 					},
 				},
@@ -371,9 +375,15 @@ var _ = Describe("VMI Stats Collector", func() {
 
 			metrics := collectVMIInterfacesInfo(vmi)
 			Expect(metrics).To(HaveLen(3))
-			Expect(metrics[0].Labels).To(Equal([]string{"testNode", "test-ns", "testvmi", "net-0", "br-ex", "10.11.126.126", "ExternalInterface"}))
-			Expect(metrics[1].Labels).To(Equal([]string{"testNode", "test-ns", "testvmi", "", "ovs-system", "", "SystemInterface"}))
-			Expect(metrics[2].Labels).To(Equal([]string{"testNode", "test-ns", "testvmi", "", "br-int", "", "SystemInterface"}))
+			Expect(metrics[0].Labels).To(Equal([]string{
+				testNodeName, testNamespace, testVMIName, testVMIInterfaceName, testVMIInterfaceBridge, testVMIInterfaceIP, vmiInterfaceTypeExternal,
+			}))
+			Expect(metrics[1].Labels).To(Equal([]string{
+				testNodeName, testNamespace, testVMIName, "", testOVSSystemInterface, "", vmiInterfaceTypeSystem,
+			}))
+			Expect(metrics[2].Labels).To(Equal([]string{
+				testNodeName, testNamespace, testVMIName, "", testBridgeInterfaceName, "", vmiInterfaceTypeSystem,
+			}))
 		})
 	})
 
@@ -385,11 +395,11 @@ var _ = Describe("VMI Stats Collector", func() {
 			It("should not create migration metrics for a VMI with no migration state", func() {
 				vmi := &k6tv1.VirtualMachineInstance{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "test-ns",
-						Name:      "testvmi",
+						Namespace: testNamespace,
+						Name:      testVMIName,
 					},
 					Status: k6tv1.VirtualMachineInstanceStatus{
-						NodeName: "testNode",
+						NodeName: testNodeName,
 					},
 				}
 
@@ -400,13 +410,13 @@ var _ = Describe("VMI Stats Collector", func() {
 			It("should create kubevirt_vmi_migration_start_time metric for a migration in progress", func() {
 				vmi := &k6tv1.VirtualMachineInstance{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "test-ns",
-						Name:      "testvmi",
+						Namespace: testNamespace,
+						Name:      testVMIName,
 					},
 					Status: k6tv1.VirtualMachineInstanceStatus{
-						NodeName: "testNode",
+						NodeName: testNodeName,
 						MigrationState: &k6tv1.VirtualMachineInstanceMigrationState{
-							MigrationUID:   "test-migration-uid",
+							MigrationUID:   testMigrationUID,
 							StartTimestamp: &now,
 						},
 					},
@@ -417,19 +427,19 @@ var _ = Describe("VMI Stats Collector", func() {
 
 				Expect(metrics[0].Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vmi_migration_start_time"))
 				Expect(metrics[0].Value).To(BeEquivalentTo(nowFloatValue))
-				Expect(metrics[0].Labels).To(Equal([]string{"testNode", "test-ns", "testvmi", "test-migration"}))
+				Expect(metrics[0].Labels).To(Equal([]string{testNodeName, testNamespace, testVMIName, testMigrationName}))
 			})
 
 			It("should create kubevirt_vmi_migration_end_time metric for a completedmigration", func() {
 				vmi := &k6tv1.VirtualMachineInstance{
 					ObjectMeta: metav1.ObjectMeta{
-						Namespace: "test-ns",
-						Name:      "testvmi",
+						Namespace: testNamespace,
+						Name:      testVMIName,
 					},
 					Status: k6tv1.VirtualMachineInstanceStatus{
-						NodeName: "testNode",
+						NodeName: testNodeName,
 						MigrationState: &k6tv1.VirtualMachineInstanceMigrationState{
-							MigrationUID:   "test-migration-uid",
+							MigrationUID:   testMigrationUID,
 							StartTimestamp: &now,
 							EndTimestamp:   &now,
 							Completed:      true,
@@ -443,11 +453,11 @@ var _ = Describe("VMI Stats Collector", func() {
 
 				Expect(metrics[0].Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vmi_migration_start_time"))
 				Expect(metrics[0].Value).To(BeEquivalentTo(nowFloatValue))
-				Expect(metrics[0].Labels).To(Equal([]string{"testNode", "test-ns", "testvmi", "test-migration"}))
+				Expect(metrics[0].Labels).To(Equal([]string{testNodeName, testNamespace, testVMIName, testMigrationName}))
 
 				Expect(metrics[1].Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vmi_migration_end_time"))
 				Expect(metrics[1].Value).To(BeEquivalentTo(nowFloatValue))
-				Expect(metrics[1].Labels).To(Equal([]string{"testNode", "test-ns", "testvmi", "test-migration", "succeeded"}))
+				Expect(metrics[1].Labels).To(Equal([]string{testNodeName, testNamespace, testVMIName, testMigrationName, migrationStatusSucceeded}))
 			})
 		})
 	})
@@ -457,8 +467,8 @@ var _ = Describe("VMI Stats Collector", func() {
 			ifaces, nets := newVNICTestInterfaces()
 			vmi := &k6tv1.VirtualMachineInstance{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "test-ns",
-					Name:      "test-vmi",
+					Namespace: testNamespace,
+					Name:      testVMINameDashed,
 				},
 				Spec: k6tv1.VirtualMachineInstanceSpec{
 					Domain:   k6tv1.DomainSpec{Devices: k6tv1.Devices{Interfaces: ifaces}},
@@ -469,23 +479,31 @@ var _ = Describe("VMI Stats Collector", func() {
 			metrics := CollectVmisVnicInfo(vmi)
 			Expect(metrics).To(HaveLen(4))
 
-			Expect(metrics[0].Labels).To(Equal([]string{"test-vmi", "test-ns", "iface1", "core", "pod networking", "bridge", "virtio"}))
-			Expect(metrics[1].Labels).To(Equal([]string{"test-vmi", "test-ns", "iface2", "core", "pod networking", "masquerade", "e1000e"}))
-			Expect(metrics[2].Labels).To(Equal([]string{"test-vmi", "test-ns", "iface3", "core", "multus-net", "sriov", "<none>"}))
-			Expect(metrics[3].Labels).To(Equal([]string{"test-vmi", "test-ns", "iface4", "plugin", "custom-net", "custom-plugin", "<none>"}))
+			Expect(metrics[0].Labels).To(Equal([]string{
+				testVMINameDashed, testNamespace, testVNICIface1, bindingTypeCore, networkNamePod, bindingNameBridge, testModelVirtio,
+			}))
+			Expect(metrics[1].Labels).To(Equal([]string{
+				testVMINameDashed, testNamespace, testVNICIface2, bindingTypeCore, networkNamePod, bindingNameMasquerade, testModelE1000E,
+			}))
+			Expect(metrics[2].Labels).To(Equal([]string{
+				testVMINameDashed, testNamespace, testVNICIface3, bindingTypeCore, testMultusNetwork, bindingNameSRIOV, modelNone,
+			}))
+			Expect(metrics[3].Labels).To(Equal([]string{
+				testVMINameDashed, testNamespace, testVNICIface4, bindingTypePlugin, testNetworkCustom, testCustomPluginName, modelNone,
+			}))
 		})
 		It("should not collect kubevirt_vmi_vnic_info metric when interface name is not matching network name", func() {
 			vmi := &k6tv1.VirtualMachineInstance{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "test-ns",
-					Name:      "test-vmi",
+					Namespace: testNamespace,
+					Name:      testVMINameDashed,
 				},
 				Spec: k6tv1.VirtualMachineInstanceSpec{
 					Domain: k6tv1.DomainSpec{
 						Devices: k6tv1.Devices{
 							Interfaces: []k6tv1.Interface{
 								{
-									Name: "iface1",
+									Name: testVNICIface1,
 									InterfaceBindingMethod: k6tv1.InterfaceBindingMethod{
 										Bridge: &k6tv1.InterfaceBridge{},
 									},
@@ -495,7 +513,7 @@ var _ = Describe("VMI Stats Collector", func() {
 					},
 					Networks: []k6tv1.Network{
 						{
-							Name:          "iface2",
+							Name:          testVNICIface2,
 							NetworkSource: k6tv1.NetworkSource{Pod: &k6tv1.PodNetwork{}},
 						},
 					},
@@ -511,8 +529,8 @@ var _ = Describe("VMI Stats Collector", func() {
 		It("should collect kubevirt_vmi_launcher_memory_overhead_bytes metric for a VMI", func() {
 			vmi := &k6tv1.VirtualMachineInstance{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "test-ns",
-					Name:      "test-vmi",
+					Namespace: testNamespace,
+					Name:      testVMINameDashed,
 				},
 				Spec: k6tv1.VirtualMachineInstanceSpec{
 					Domain: k6tv1.DomainSpec{
@@ -529,14 +547,14 @@ var _ = Describe("VMI Stats Collector", func() {
 
 			Expect(metric).ToNot(BeNil())
 			Expect(metric.Metric.GetOpts().Name).To(Equal("kubevirt_vmi_launcher_memory_overhead_bytes"))
-			Expect(metric.Labels).To(Equal([]string{"test-ns", "test-vmi"}))
+			Expect(metric.Labels).To(Equal([]string{testNamespace, testVMINameDashed}))
 			Expect(metric.Value).To(BeNumerically(">", 0))
 		})
 
 		It("should calculate different overhead for different VMI configurations", func() {
 			vmi1 := &k6tv1.VirtualMachineInstance{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "test-ns",
+					Namespace: testNamespace,
 					Name:      "test-vmi-1",
 				},
 				Spec: k6tv1.VirtualMachineInstanceSpec{
@@ -552,7 +570,7 @@ var _ = Describe("VMI Stats Collector", func() {
 
 			vmi2 := &k6tv1.VirtualMachineInstance{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "test-ns",
+					Namespace: testNamespace,
 					Name:      "test-vmi-2",
 				},
 				Spec: k6tv1.VirtualMachineInstanceSpec{
@@ -581,7 +599,7 @@ var _ = Describe("VMI Stats Collector", func() {
 
 func setupMigrationPods() {
 	originalPod := &k8sv1.Pod{
-		ObjectMeta: newPodMetaForInformer("virt-launcher-originalpod", "test-ns", "test-vmi-uid"),
+		ObjectMeta: newPodMetaForInformer("virt-launcher-originalpod", testNamespace, "test-vmi-uid"),
 		Spec: k8sv1.PodSpec{
 			NodeName: "initial-node",
 		},
@@ -590,7 +608,7 @@ func setupMigrationPods() {
 		},
 	}
 	targetPod := &k8sv1.Pod{
-		ObjectMeta: newPodMetaForInformer("virt-launcher-targetpod", "test-ns", "test-vmi-uid"),
+		ObjectMeta: newPodMetaForInformer("virt-launcher-targetpod", testNamespace, "test-vmi-uid"),
 		Spec: k8sv1.PodSpec{
 			NodeName: "target-node",
 		},
@@ -606,8 +624,8 @@ func setupMigrationPods() {
 func createMigrationVMI(nodeName, targetPod string, completed, failed bool) *k6tv1.VirtualMachineInstance {
 	return &k6tv1.VirtualMachineInstance{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-vmi",
-			Namespace: "test-ns",
+			Name:      testVMINameDashed,
+			Namespace: testNamespace,
 			UID:       "test-vmi-uid",
 		},
 		Status: k6tv1.VirtualMachineInstanceStatus{
@@ -625,27 +643,27 @@ func createMigrationVMI(nodeName, targetPod string, completed, failed bool) *k6t
 func newVNICTestInterfaces() ([]k6tv1.Interface, []k6tv1.Network) {
 	return []k6tv1.Interface{
 			{
-				Name: "iface1",
+				Name: testVNICIface1,
 				InterfaceBindingMethod: k6tv1.InterfaceBindingMethod{
 					Bridge: &k6tv1.InterfaceBridge{},
 				},
-				Model: "virtio",
+				Model: testModelVirtio,
 			},
 			{
-				Name: "iface2",
+				Name: testVNICIface2,
 				InterfaceBindingMethod: k6tv1.InterfaceBindingMethod{
 					Masquerade: &k6tv1.InterfaceMasquerade{},
 				},
 				Model: "e1000e",
 			},
 			{
-				Name: "iface3",
+				Name: testVNICIface3,
 				InterfaceBindingMethod: k6tv1.InterfaceBindingMethod{
 					SRIOV: &k6tv1.InterfaceSRIOV{},
 				},
 			},
 			{
-				Name:    "iface4",
+				Name:    testVNICIface4,
 				Binding: &k6tv1.PluginBinding{Name: "custom-plugin"},
 			},
 		}, []k6tv1.Network{
@@ -654,17 +672,17 @@ func newVNICTestInterfaces() ([]k6tv1.Interface, []k6tv1.Network) {
 				NetworkSource: k6tv1.NetworkSource{Pod: &k6tv1.PodNetwork{}},
 			},
 			{
-				Name:          "iface2",
+				Name:          testVNICIface2,
 				NetworkSource: k6tv1.NetworkSource{Pod: &k6tv1.PodNetwork{}},
 			},
 			{
-				Name: "iface3",
+				Name: testVNICIface3,
 				NetworkSource: k6tv1.NetworkSource{
 					Multus: &k6tv1.MultusNetwork{NetworkName: "multus-net"},
 				},
 			},
 			{
-				Name: "iface4",
+				Name: testVNICIface4,
 				NetworkSource: k6tv1.NetworkSource{
 					Multus: &k6tv1.MultusNetwork{NetworkName: "custom-net"},
 				},
@@ -689,8 +707,8 @@ func createVMIForEviction(
 ) *k6tv1.VirtualMachineInstance {
 	vmi := &k6tv1.VirtualMachineInstance{
 		ObjectMeta: metav1.ObjectMeta{
-			Namespace: "test-ns",
-			Name:      "testvmi",
+			Namespace: testNamespace,
+			Name:      testVMIName,
 		},
 		Status: k6tv1.VirtualMachineInstanceStatus{
 			NodeName: "testNode",
@@ -719,10 +737,10 @@ func setupTestCollector() {
 	controllerRevisionInformer, _ := testutils.NewFakeInformerFor(&appsv1.ControllerRevision{})
 
 	_ = instanceTypeInformer.GetStore().Add(&instancetypev1beta1.VirtualMachineInstancetype{
-		ObjectMeta: newObjectMetaForInstancetypes("i-managed", "test-ns", "kubevirt.io"),
+		ObjectMeta: newObjectMetaForInstancetypes("i-managed", testNamespace, "kubevirt.io"),
 	})
 	_ = instanceTypeInformer.GetStore().Add(&instancetypev1beta1.VirtualMachineInstancetype{
-		ObjectMeta: newObjectMetaForInstancetypes("i-unmanaged", "test-ns", "some-user"),
+		ObjectMeta: newObjectMetaForInstancetypes("i-unmanaged", testNamespace, "some-user"),
 	})
 
 	_ = clusterInstanceTypeInformer.GetStore().Add(&instancetypev1beta1.VirtualMachineClusterInstancetype{
@@ -741,10 +759,10 @@ func setupTestCollector() {
 	})
 
 	_ = preferenceInformer.GetStore().Add(&instancetypev1beta1.VirtualMachinePreference{
-		ObjectMeta: newObjectMetaForInstancetypes("p-managed", "test-ns", "kubevirt.io"),
+		ObjectMeta: newObjectMetaForInstancetypes("p-managed", testNamespace, "kubevirt.io"),
 	})
 	_ = preferenceInformer.GetStore().Add(&instancetypev1beta1.VirtualMachinePreference{
-		ObjectMeta: newObjectMetaForInstancetypes("p-unmanaged", "test-ns", "some-vendor.com"),
+		ObjectMeta: newObjectMetaForInstancetypes("p-unmanaged", testNamespace, "some-vendor.com"),
 	})
 
 	_ = clusterPreferenceInformer.GetStore().Add(&instancetypev1beta1.VirtualMachineClusterPreference{
@@ -781,7 +799,7 @@ func setupTestCollector() {
 	indexers.KVPod = kvPodInformer.GetIndexer()
 
 	_ = indexers.KVPod.Add(&k8sv1.Pod{
-		ObjectMeta: newPodMetaForInformer("virt-launcher-testpod", "test-ns", "test-vmi-uid"),
+		ObjectMeta: newPodMetaForInformer("virt-launcher-testpod", testNamespace, "test-vmi-uid"),
 	})
 
 	// VMI Migration informer
@@ -793,8 +811,8 @@ func setupTestCollector() {
 
 	_ = indexers.VMIMigration.Add(&k6tv1.VirtualMachineInstanceMigration{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-migration",
-			Namespace: "test-ns",
+			Name:      testMigrationName,
+			Namespace: testNamespace,
 			UID:       "test-migration-uid",
 		},
 	})

--- a/pkg/monitoring/metrics/virt-controller/vmsnapshot.go
+++ b/pkg/monitoring/metrics/virt-controller/vmsnapshot.go
@@ -36,7 +36,7 @@ var (
 			Name: "kubevirt_vmsnapshot_succeeded_timestamp_seconds",
 			Help: "Returns the timestamp of successful virtual machine snapshot.",
 		},
-		[]string{"name", "snapshot_name", "namespace"},
+		[]string{metricLabelName, "snapshot_name", metricLabelNamespace},
 	)
 )
 

--- a/pkg/monitoring/metrics/virt-controller/vmstats_collector.go
+++ b/pkg/monitoring/metrics/virt-controller/vmstats_collector.go
@@ -100,7 +100,7 @@ var (
 		labels,
 	)
 
-	labels = []string{"name", "namespace"}
+	labels = []string{metricLabelName, metricLabelNamespace}
 
 	startingStatuses = []k6tv1.VirtualMachinePrintableStatus{
 		k6tv1.VirtualMachineStatusProvisioning,
@@ -138,15 +138,15 @@ var (
 			Name: "kubevirt_vm_resource_requests",
 			Help: "Resources requested by Virtual Machine. Reports memory and CPU requests.",
 		},
-		[]string{"name", "namespace", "resource", "unit", "source"},
+		[]string{metricLabelName, metricLabelNamespace, metricLabelResource, labelUnit, "source"},
 	)
 
 	vmResourceLimits = operatormetrics.NewGaugeVec(
 		operatormetrics.MetricOpts{
-			Name: "kubevirt_vm_resource_limits",
+			Name: metricVMResourceLimits,
 			Help: "Resource limits set for a Virtual Machine. Reports CPU and memory limits only when they are defined.",
 		},
-		[]string{"name", "namespace", "resource", "unit"},
+		[]string{metricLabelName, metricLabelNamespace, metricLabelResource, labelUnit},
 	)
 
 	vmInfo = operatormetrics.NewGaugeVec(
@@ -156,19 +156,19 @@ var (
 		},
 		[]string{
 			// Basic info
-			"name", "namespace",
+			metricLabelName, metricLabelNamespace,
 
 			// VM annotations
-			"os", "workload", "flavor",
+			labelOS, labelWorkload, metricLabelFlavor,
 
 			// VM Machine Type
 			"machine_type",
 
 			// Instance type
-			"instance_type", "preference",
+			metricLabelInstanceType, labelPreference,
 
 			// Status
-			"status", "status_group",
+			metricLabelStatus, "status_group",
 		},
 	)
 
@@ -179,7 +179,7 @@ var (
 				"Includes persistentvolumeclaim (PVC name), volume_mode (disk presentation mode: Filesystem or Block), " +
 				"and device (disk name).",
 		},
-		[]string{"name", "namespace", "persistentvolumeclaim", "volume_mode", "device"},
+		[]string{metricLabelName, metricLabelNamespace, "persistentvolumeclaim", "volume_mode", "device"},
 	)
 
 	vmCreationTimestamp = operatormetrics.NewGaugeVec(
@@ -187,7 +187,7 @@ var (
 			Name: "kubevirt_vm_create_date_timestamp_seconds",
 			Help: "Virtual Machine creation timestamp.",
 		},
-		[]string{"name", "namespace"},
+		[]string{metricLabelName, metricLabelNamespace},
 	)
 
 	vmVnicInfo = operatormetrics.NewGaugeVec(
@@ -196,7 +196,7 @@ var (
 			Help: "Details of Virtual Machine (VM) vNIC interfaces, such as vNIC name, binding type, network name, " +
 				"and binding name for each vNIC defined in the VM's configuration.",
 		},
-		[]string{"name", "namespace", "vnic_name", "binding_type", "network", "binding_name", "model"},
+		[]string{metricLabelName, metricLabelNamespace, metricLabelVNICName, labelBindingType, labelNetwork, metricLabelBindingName, labelModel},
 	)
 
 	vmLabels = operatormetrics.NewGaugeVec(
@@ -313,7 +313,7 @@ func getVMStatusGroup(status k6tv1.VirtualMachinePrintableStatus) string {
 	case containsStatus(status, startingStatuses):
 		return "starting"
 	case containsStatus(status, runningStatuses):
-		return "running"
+		return vmStatusGroupRunning
 	case containsStatus(status, migratingStatuses):
 		return "migrating"
 	case containsStatus(status, nonRunningStatuses):
@@ -446,7 +446,7 @@ func collectMemoryResourceRequestsFromDomainResources(vm *k6tv1.VirtualMachine) 
 		cr = append(cr, operatormetrics.CollectorResult{
 			Metric: vmResourceRequests,
 			Value:  float64(memoryRequested.Value()),
-			Labels: []string{vm.Name, vm.Namespace, "memory", "bytes", "domain"},
+			Labels: []string{vm.Name, vm.Namespace, resourceNameMemory, resourceUnitBytes, resourceSourceDomain},
 		})
 	}
 
@@ -459,7 +459,7 @@ func collectMemoryResourceRequestsFromDomainResources(vm *k6tv1.VirtualMachine) 
 		cr = append(cr, operatormetrics.CollectorResult{
 			Metric: vmResourceRequests,
 			Value:  float64(guestMemory.Value()),
-			Labels: []string{vm.Name, vm.Namespace, "memory", "bytes", "guest"},
+			Labels: []string{vm.Name, vm.Namespace, resourceNameMemory, resourceUnitBytes, resourceSourceGuest},
 		})
 	}
 
@@ -470,7 +470,7 @@ func collectMemoryResourceRequestsFromDomainResources(vm *k6tv1.VirtualMachine) 
 			cr = append(cr, operatormetrics.CollectorResult{
 				Metric: vmResourceRequests,
 				Value:  float64(quantity.Value()),
-				Labels: []string{vm.Name, vm.Namespace, "memory", "bytes", "hugepages"},
+				Labels: []string{vm.Name, vm.Namespace, resourceNameMemory, resourceUnitBytes, resourceSourceHugepages},
 			})
 		}
 	}
@@ -491,7 +491,7 @@ func collectMemoryResourceLimitsFromDomainResources(vm *k6tv1.VirtualMachine) []
 	return []operatormetrics.CollectorResult{{
 		Metric: vmResourceLimits,
 		Value:  float64(memoryLimit.Value()),
-		Labels: []string{vm.Name, vm.Namespace, "memory", "bytes"},
+		Labels: []string{vm.Name, vm.Namespace, resourceNameMemory, resourceUnitBytes},
 	}}
 }
 
@@ -509,7 +509,7 @@ func collectAllocatedMemoryValues(vm *k6tv1.VirtualMachine) []operatormetrics.Co
 		cr = append(cr, operatormetrics.CollectorResult{
 			Metric: vmResourceRequests,
 			Value:  float64(allocatedMemory.Value()),
-			Labels: []string{vm.Name, vm.Namespace, "memory", "bytes", "guest_effective"},
+			Labels: []string{vm.Name, vm.Namespace, resourceNameMemory, resourceUnitBytes, resourceSourceGuestEffective},
 		})
 	}
 	return cr
@@ -526,21 +526,21 @@ func collectCPUResourceRequestsFromDomainCPU(vm *k6tv1.VirtualMachine) []operato
 		cr = append(cr, operatormetrics.CollectorResult{
 			Metric: vmResourceRequests,
 			Value:  float64(vm.Spec.Template.Spec.Domain.CPU.Cores),
-			Labels: []string{vm.Name, vm.Namespace, "cpu", "cores", "domain"},
+			Labels: []string{vm.Name, vm.Namespace, resourceNameCPU, resourceUnitCores, resourceSourceDomain},
 		})
 	}
 	if vm.Spec.Template.Spec.Domain.CPU.Threads != 0 {
 		cr = append(cr, operatormetrics.CollectorResult{
 			Metric: vmResourceRequests,
 			Value:  float64(vm.Spec.Template.Spec.Domain.CPU.Threads),
-			Labels: []string{vm.Name, vm.Namespace, "cpu", "threads", "domain"},
+			Labels: []string{vm.Name, vm.Namespace, resourceNameCPU, resourceUnitThreads, resourceSourceDomain},
 		})
 	}
 	if vm.Spec.Template.Spec.Domain.CPU.Sockets != 0 {
 		cr = append(cr, operatormetrics.CollectorResult{
 			Metric: vmResourceRequests,
 			Value:  float64(vm.Spec.Template.Spec.Domain.CPU.Sockets),
-			Labels: []string{vm.Name, vm.Namespace, "cpu", "sockets", "domain"},
+			Labels: []string{vm.Name, vm.Namespace, resourceNameCPU, resourceUnitSockets, resourceSourceDomain},
 		})
 	}
 	return cr
@@ -560,15 +560,15 @@ func collectCPUResourceRequestsFromDomainResources(vm *k6tv1.VirtualMachine) []o
 			return append(cr,
 				operatormetrics.CollectorResult{
 					Metric: vmResourceRequests, Value: 1.0,
-					Labels: []string{vm.Name, vm.Namespace, "cpu", "cores", "default"},
+					Labels: []string{vm.Name, vm.Namespace, resourceNameCPU, resourceUnitCores, resourceSourceDefault},
 				},
 				operatormetrics.CollectorResult{
 					Metric: vmResourceRequests, Value: 1.0,
-					Labels: []string{vm.Name, vm.Namespace, "cpu", "threads", "default"},
+					Labels: []string{vm.Name, vm.Namespace, resourceNameCPU, resourceUnitThreads, resourceSourceDefault},
 				},
 				operatormetrics.CollectorResult{
 					Metric: vmResourceRequests, Value: 1.0,
-					Labels: []string{vm.Name, vm.Namespace, "cpu", "sockets", "default"},
+					Labels: []string{vm.Name, vm.Namespace, resourceNameCPU, resourceUnitSockets, resourceSourceDefault},
 				},
 			)
 		}
@@ -578,7 +578,7 @@ func collectCPUResourceRequestsFromDomainResources(vm *k6tv1.VirtualMachine) []o
 	cr = append(cr, operatormetrics.CollectorResult{
 		Metric: vmResourceRequests,
 		Value:  float64(cpuRequests.ScaledValue(resource.Milli)) / 1000,
-		Labels: []string{vm.Name, vm.Namespace, "cpu", "cores", "requests"},
+		Labels: []string{vm.Name, vm.Namespace, resourceNameCPU, resourceUnitCores, resourceSourceRequests},
 	})
 	return cr
 }
@@ -598,7 +598,7 @@ func collectCPUResourceLimitsFromDomainResources(vm *k6tv1.VirtualMachine) []ope
 	cr = append(cr, operatormetrics.CollectorResult{
 		Metric: vmResourceLimits,
 		Value:  float64(cpuLimits.ScaledValue(resource.Milli)) / 1000,
-		Labels: []string{vm.Name, vm.Namespace, "cpu", "cores"},
+		Labels: []string{vm.Name, vm.Namespace, resourceNameCPU, resourceUnitCores},
 	})
 	return cr
 }
@@ -616,13 +616,13 @@ func collectAllocatedCPUValues(vm *k6tv1.VirtualMachine) []operatormetrics.Colle
 		cr = append(cr, operatormetrics.CollectorResult{
 			Metric: vmResourceRequests,
 			Value:  float64(allocatedVCPUs),
-			Labels: []string{vm.Name, vm.Namespace, "cpu", "cores", "guest_effective"},
+			Labels: []string{vm.Name, vm.Namespace, resourceNameCPU, resourceUnitCores, resourceSourceGuestEffective},
 		})
 	} else {
 		cr = append(cr, operatormetrics.CollectorResult{
 			Metric: vmResourceRequests,
 			Value:  1.0,
-			Labels: []string{vm.Name, vm.Namespace, "cpu", "cores", "guest_effective"},
+			Labels: []string{vm.Name, vm.Namespace, resourceNameCPU, resourceUnitCores, resourceSourceGuestEffective},
 		})
 	}
 	return cr
@@ -800,13 +800,13 @@ func getBinding(iface k6tv1.Interface) (bindingType, bindingName string) {
 	switch {
 	case iface.Masquerade != nil:
 		bindingType = bindingTypeCore
-		bindingName = "masquerade"
+		bindingName = bindingNameMasquerade
 	case iface.Bridge != nil:
 		bindingType = bindingTypeCore
-		bindingName = "bridge"
+		bindingName = bindingNameBridge
 	case iface.SRIOV != nil:
 		bindingType = bindingTypeCore
-		bindingName = "sriov"
+		bindingName = bindingNameSRIOV
 	case iface.Binding != nil:
 		bindingType = bindingTypePlugin
 		bindingName = iface.Binding.Name
@@ -818,7 +818,7 @@ func getBinding(iface k6tv1.Interface) (bindingType, bindingName string) {
 func getNetworkName(ifaceName string, networks []k6tv1.Network) (string, bool) {
 	if net := LookupNetworkByName(networks, ifaceName); net != nil {
 		if net.Pod != nil {
-			return "pod networking", true
+			return networkNamePod, true
 		} else if net.Multus != nil {
 			return net.Multus.NetworkName, true
 		}

--- a/pkg/monitoring/metrics/virt-controller/vmstats_collector_test.go
+++ b/pkg/monitoring/metrics/virt-controller/vmstats_collector_test.go
@@ -51,6 +51,15 @@ const (
 	testLabelGuestEffective      = "guest_effective"
 	testLabelMemory              = "memory"
 	testLabelGuest               = "guest"
+	testMetricVMResourceLimits   = "kubevirt_vm_resource_limits"
+	testPVCName                  = "test-vm-pvc"
+	testPVCNilMode               = "test-vm-pvc-nil-mode"
+	testDataVolumeDiskName       = "datavolumedisk"
+	testLabelValueBackend        = "backend"
+	testSecondVMName             = "vm2"
+	testLabelTemplate            = "vm.kubevirt.io/template"
+	testLabelSecret              = "secret"
+	testLabelOther               = "other"
 )
 
 // Minimal stub for label config used by vmstats tests
@@ -62,26 +71,26 @@ var _ = Describe("VM Stats Collector", func() {
 	Context("VM status collector", func() {
 		createVM := func(status k6tv1.VirtualMachinePrintableStatus, vmLastTransitionsTime time.Time) *k6tv1.VirtualMachine {
 			return &k6tv1.VirtualMachine{
-				ObjectMeta: metav1.ObjectMeta{Namespace: "test-ns", Name: "test-vm"},
+				ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: testVMNameDashed},
 				Status: k6tv1.VirtualMachineStatus{
 					PrintableStatus: status,
 					Conditions: []k6tv1.VirtualMachineCondition{
 						{
 							Type:               k6tv1.VirtualMachineFailure,
-							Status:             "any",
-							Reason:             "any",
+							Status:             testConditionAny,
+							Reason:             testConditionAny,
 							LastTransitionTime: metav1.NewTime(vmLastTransitionsTime.Add(-20 * time.Second)),
 						},
 						{
 							Type:               k6tv1.VirtualMachineReady,
-							Status:             "any",
-							Reason:             "any",
+							Status:             testConditionAny,
+							Reason:             testConditionAny,
 							LastTransitionTime: metav1.NewTime(vmLastTransitionsTime),
 						},
 						{
 							Type:               k6tv1.VirtualMachinePaused,
-							Status:             "any",
-							Reason:             "any",
+							Status:             testConditionAny,
+							Reason:             testConditionAny,
 							LastTransitionTime: metav1.NewTime(vmLastTransitionsTime.Add(-40 * time.Second)),
 						},
 					},
@@ -130,10 +139,10 @@ var _ = Describe("VM Stats Collector", func() {
 					Template: &k6tv1.VirtualMachineInstanceTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Annotations: map[string]string{
-								annotationPrefix + "os":       "centos8",
-								annotationPrefix + "workload": "server",
-								annotationPrefix + "flavor":   "tiny",
-								"other":                       "other",
+								annotationPrefix + "os":       testAnnotationOSCentos8,
+								annotationPrefix + "workload": testAnnotationWorkloadServer,
+								annotationPrefix + "flavor":   testAnnotationFlavorTiny,
+								"other":                       testLabelOther,
 							},
 						},
 						Spec: k6tv1.VirtualMachineInstanceSpec{
@@ -145,7 +154,7 @@ var _ = Describe("VM Stats Collector", func() {
 				},
 				Status: k6tv1.VirtualMachineStatus{PrintableStatus: k6tv1.VirtualMachineStatusCrashLoopBackOff},
 			})
-			vms[1].Spec.Template.ObjectMeta.Annotations[annotationPrefix+"phase"] = "dummy"
+			vms[1].Spec.Template.ObjectMeta.Annotations[annotationPrefix+"phase"] = testAnnotationDummy
 
 			crs := CollectVMsInfo(vms)
 			Expect(crs).To(HaveLen(2), "Expected 2 metrics")
@@ -181,7 +190,7 @@ var _ = Describe("VM Stats Collector", func() {
 			}
 
 			vm := &k6tv1.VirtualMachine{
-				ObjectMeta: metav1.ObjectMeta{Namespace: "test-ns"},
+				ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace},
 				Spec:       k6tv1.VirtualMachineSpec{Instancetype: instanceType},
 			}
 			crs := CollectVMsInfo(cloneVM(vm))
@@ -217,7 +226,7 @@ var _ = Describe("VM Stats Collector", func() {
 			}
 
 			vm := &k6tv1.VirtualMachine{
-				ObjectMeta: metav1.ObjectMeta{Namespace: "test-ns"},
+				ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace},
 				Spec:       k6tv1.VirtualMachineSpec{Preference: preference},
 			}
 			crs := CollectVMsInfo(cloneVM(vm))
@@ -247,8 +256,8 @@ var _ = Describe("VM Stats Collector", func() {
 		It("should report default CPU when no CPU topology is set", func() {
 			vm := &k6tv1.VirtualMachine{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "test-ns",
-					Name:      "testvm",
+					Namespace: testNamespace,
+					Name:      testVMName,
 				},
 				Spec: k6tv1.VirtualMachineSpec{
 					Template: &k6tv1.VirtualMachineInstanceTemplateSpec{
@@ -260,7 +269,7 @@ var _ = Describe("VM Stats Collector", func() {
 			}
 
 			crs := CollectResourceRequestsAndLimits(cloneVM(vm))
-			expectVMs(crs, "testvm", "test-ns", func(crs []operatormetrics.CollectorResult, name, ns string) {
+			expectVMs(crs, testVMName, testNamespace, func(crs []operatormetrics.CollectorResult, name, ns string) {
 				Expect(crs).ToNot(BeEmpty())
 				var defaults []operatormetrics.CollectorResult
 				for _, cr := range crs {
@@ -295,8 +304,8 @@ var _ = Describe("VM Stats Collector", func() {
 		It("should collect effective memory and effective CPU metrics", func() {
 			vm := &k6tv1.VirtualMachine{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "test-ns",
-					Name:      "testvm",
+					Namespace: testNamespace,
+					Name:      testVMName,
 				},
 				Spec: k6tv1.VirtualMachineSpec{
 					Template: &k6tv1.VirtualMachineInstanceTemplateSpec{
@@ -351,14 +360,14 @@ var _ = Describe("VM Stats Collector", func() {
 				Expect(ge).To(BeTrue())
 			}
 
-			expectVMs(crs, "testvm", "test-ns", expectVM)
+			expectVMs(crs, "testvm", testNamespace, expectVM)
 		})
 
 		It("should collect CPU requests/limits and guest_effective when resources are set", func() {
 			vm := &k6tv1.VirtualMachine{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "test-ns",
-					Name:      "testvm",
+					Namespace: testNamespace,
+					Name:      testVMName,
 				},
 				Spec: k6tv1.VirtualMachineSpec{
 					Template: &k6tv1.VirtualMachineInstanceTemplateSpec{
@@ -379,7 +388,7 @@ var _ = Describe("VM Stats Collector", func() {
 			}
 
 			crs := CollectResourceRequestsAndLimits(cloneVM(vm))
-			expectVMs(crs, "testvm", "test-ns", func(filtered []operatormetrics.CollectorResult, name, ns string) {
+			expectVMs(crs, "testvm", testNamespace, func(filtered []operatormetrics.CollectorResult, name, ns string) {
 				var reqFound, limFound, geFound bool
 				for _, r := range filtered {
 					if r.Metric.GetOpts().Name == testMetricVMResourceRequests &&
@@ -388,7 +397,7 @@ var _ = Describe("VM Stats Collector", func() {
 						Expect(r.Value).To(BeEquivalentTo(0.5))
 						reqFound = true
 					}
-					if r.Metric.GetOpts().Name == "kubevirt_vm_resource_limits" &&
+					if r.Metric.GetOpts().Name == testMetricVMResourceLimits &&
 						len(r.Labels) == 4 && r.Labels[2] == testLabelCPU && r.Labels[3] == testLabelCores {
 						Expect(r.Value).To(BeEquivalentTo(1))
 						limFound = true
@@ -407,8 +416,8 @@ var _ = Describe("VM Stats Collector", func() {
 		It("should collect domain CPU metrics and guest_effective from topology", func() {
 			vm := &k6tv1.VirtualMachine{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "test-ns",
-					Name:      "testvm",
+					Namespace: testNamespace,
+					Name:      testVMName,
 				},
 				Spec: k6tv1.VirtualMachineSpec{
 					Template: &k6tv1.VirtualMachineInstanceTemplateSpec{
@@ -426,14 +435,14 @@ var _ = Describe("VM Stats Collector", func() {
 			}
 
 			crs := CollectResourceRequestsAndLimits(cloneVM(vm))
-			expectDomainCPUMetrics(crs, "testvm", "test-ns", 2, 4, 1, 8)
+			expectDomainCPUMetrics(crs, "testvm", testNamespace, 2, 4, 1, 8)
 		})
 
 		It("should collect VM CPU metrics from Instance Type (guest_effective present)", func() {
 			vm := &k6tv1.VirtualMachine{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "test-ns",
-					Name:      "testvm",
+					Namespace: testNamespace,
+					Name:      testVMName,
 				},
 				Spec: k6tv1.VirtualMachineSpec{
 					Instancetype: &k6tv1.InstancetypeMatcher{
@@ -462,14 +471,14 @@ var _ = Describe("VM Stats Collector", func() {
 				Expect(ge).To(BeTrue())
 			}
 
-			expectVMs(crs, "testvm", "test-ns", expectVM)
+			expectVMs(crs, "testvm", testNamespace, expectVM)
 		})
 
 		It("should report domain CPU metrics and guest_effective vCPUs", func() {
 			vm := &k6tv1.VirtualMachine{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "test-ns",
-					Name:      "testvm",
+					Namespace: testNamespace,
+					Name:      testVMName,
 				},
 				Spec: k6tv1.VirtualMachineSpec{
 					Template: &k6tv1.VirtualMachineInstanceTemplateSpec{
@@ -488,15 +497,15 @@ var _ = Describe("VM Stats Collector", func() {
 			}
 
 			crs := CollectResourceRequestsAndLimits(cloneVM(vm))
-			expectDomainCPUMetrics(crs, "testvm", "test-ns", 2, 2, 1, 4)
+			expectDomainCPUMetrics(crs, testVMName, testNamespace, 2, 2, 1, 4)
 		})
 
 		It("should emit default memory bytes equal to effective memory", func() {
 			guestMemory := resource.MustParse("2Gi")
 			vm := &k6tv1.VirtualMachine{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "test-ns",
-					Name:      "testvm",
+					Namespace: testNamespace,
+					Name:      testVMName,
 				},
 				Spec: k6tv1.VirtualMachineSpec{
 					Template: &k6tv1.VirtualMachineInstanceTemplateSpec{
@@ -513,14 +522,14 @@ var _ = Describe("VM Stats Collector", func() {
 			}
 
 			crs := CollectResourceRequestsAndLimits(cloneVM(vm))
-			expectMemoryGuestMetrics(crs, "testvm", "test-ns", float64(guestMemory.Value()), float64(guestMemory.Value()))
+			expectMemoryGuestMetrics(crs, testVMName, testNamespace, float64(guestMemory.Value()), float64(guestMemory.Value()))
 		})
 
 		It("should handle VM with only CPU topology but no limits (domain + guest_effective)", func() {
 			vm := &k6tv1.VirtualMachine{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "test-ns",
-					Name:      "testvm",
+					Namespace: testNamespace,
+					Name:      testVMName,
 				},
 				Spec: k6tv1.VirtualMachineSpec{
 					Template: &k6tv1.VirtualMachineInstanceTemplateSpec{
@@ -538,15 +547,15 @@ var _ = Describe("VM Stats Collector", func() {
 			}
 
 			crs := CollectResourceRequestsAndLimits(cloneVM(vm))
-			expectDomainCPUMetrics(crs, "testvm", "test-ns", 1, 1, 2, 2)
+			expectDomainCPUMetrics(crs, testVMName, testNamespace, 1, 1, 2, 2)
 		})
 
 		It("should handle VM with only memory guest but no limits", func() {
 			guestMemory := resource.MustParse("1Gi")
 			vm := &k6tv1.VirtualMachine{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "test-ns",
-					Name:      "testvm",
+					Namespace: testNamespace,
+					Name:      testVMName,
 				},
 				Spec: k6tv1.VirtualMachineSpec{
 					Template: &k6tv1.VirtualMachineInstanceTemplateSpec{
@@ -562,14 +571,14 @@ var _ = Describe("VM Stats Collector", func() {
 			}
 
 			crs := CollectResourceRequestsAndLimits(cloneVM(vm))
-			expectMemoryGuestMetrics(crs, "testvm", "test-ns", float64(guestMemory.Value()), float64(guestMemory.Value()))
+			expectMemoryGuestMetrics(crs, testVMName, testNamespace, float64(guestMemory.Value()), float64(guestMemory.Value()))
 		})
 
 		It("should return default CPU cores=1 for VM with no CPU topology or memory", func() {
 			vm := &k6tv1.VirtualMachine{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "test-ns",
-					Name:      "testvm",
+					Namespace: testNamespace,
+					Name:      testVMName,
 				},
 				Spec: k6tv1.VirtualMachineSpec{
 					Template: &k6tv1.VirtualMachineInstanceTemplateSpec{
@@ -582,7 +591,7 @@ var _ = Describe("VM Stats Collector", func() {
 
 			crs := CollectResourceRequestsAndLimits(cloneVM(vm))
 			var cpuFound bool
-			for _, r := range filterResultsByVM(crs, "testvm", "test-ns") {
+			for _, r := range filterResultsByVM(crs, "testvm", testNamespace) {
 				if r.Metric.GetOpts().Name == testMetricVMResourceRequests &&
 					len(r.Labels) == 5 && r.Labels[2] == testLabelCPU &&
 					r.Labels[3] == testLabelCores && r.Labels[4] == testLabelDefault {
@@ -592,7 +601,7 @@ var _ = Describe("VM Stats Collector", func() {
 			}
 			Expect(cpuFound).To(BeTrue())
 			// No memory guest/guest_effective when memory not specified
-			for _, r := range filterResultsByVM(crs, "testvm", "test-ns") {
+			for _, r := range filterResultsByVM(crs, "testvm", testNamespace) {
 				isMemoryRequest := r.Metric.GetOpts().Name == testMetricVMResourceRequests &&
 					len(r.Labels) == 5 && r.Labels[2] == testLabelMemory
 				Expect(isMemoryRequest).To(BeFalse())
@@ -625,25 +634,25 @@ var _ = Describe("VM Stats Collector", func() {
 		}
 
 		It("should collect PVC size metrics correctly", func() {
-			pvc := createPVC("default", "test-vm-pvc", resource.MustParse("5Gi"), pointer.P(k8sv1.PersistentVolumeFilesystem))
+			pvc := createPVC(testLabelDefault, testPVCName, resource.MustParse("5Gi"), pointer.P(k8sv1.PersistentVolumeFilesystem))
 			err := stores.PersistentVolumeClaim.Add(pvc)
 			Expect(err).ToNot(HaveOccurred())
 
 			vm := &k6tv1.VirtualMachine{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "default",
-					Name:      "test-vm",
+					Namespace: testLabelDefault,
+					Name:      testVMNameDashed,
 				},
 				Spec: k6tv1.VirtualMachineSpec{
 					Template: &k6tv1.VirtualMachineInstanceTemplateSpec{
 						Spec: k6tv1.VirtualMachineInstanceSpec{
 							Volumes: []k6tv1.Volume{
 								{
-									Name: "rootdisk",
+									Name: testRootDiskName,
 									VolumeSource: k6tv1.VolumeSource{
 										PersistentVolumeClaim: &k6tv1.PersistentVolumeClaimVolumeSource{
 											PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
-												ClaimName: "test-vm-pvc",
+												ClaimName: testPVCName,
 											},
 										},
 									},
@@ -661,19 +670,19 @@ var _ = Describe("VM Stats Collector", func() {
 				Expect(crs).To(HaveLen(1))
 				Expect(crs[0].Metric.GetOpts().Name).To(Equal("kubevirt_vm_disk_allocated_size_bytes"))
 				Expect(crs[0].Value).To(Equal(float64(5 * 1024 * 1024 * 1024)))
-				Expect(crs[0].Labels).To(Equal([]string{name, ns, "test-vm-pvc", "Filesystem", "rootdisk"}))
+				Expect(crs[0].Labels).To(Equal([]string{name, ns, testPVCName, string(k8sv1.PersistentVolumeFilesystem), testRootDiskName}))
 			}
-			expectVMs(results, "test-vm", "default", expectVM)
+			expectVMs(results, testVMNameDashed, testLabelDefault, expectVM)
 		})
 
 		It("should handle PVC with nil volume mode", func() {
-			pvc := createPVC("default", "test-vm-pvc-nil-mode", resource.MustParse("3Gi"), nil)
+			pvc := createPVC(testLabelDefault, testPVCNilMode, resource.MustParse("3Gi"), nil)
 			err := stores.PersistentVolumeClaim.Add(pvc)
 			Expect(err).ToNot(HaveOccurred())
 
 			vm := &k6tv1.VirtualMachine{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "default",
+					Namespace: testLabelDefault,
 					Name:      "test-vm-nil-mode",
 				},
 				Spec: k6tv1.VirtualMachineSpec{
@@ -681,11 +690,11 @@ var _ = Describe("VM Stats Collector", func() {
 						Spec: k6tv1.VirtualMachineInstanceSpec{
 							Volumes: []k6tv1.Volume{
 								{
-									Name: "rootdisk",
+									Name: testRootDiskName,
 									VolumeSource: k6tv1.VolumeSource{
 										PersistentVolumeClaim: &k6tv1.PersistentVolumeClaimVolumeSource{
 											PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
-												ClaimName: "test-vm-pvc-nil-mode",
+												ClaimName: testPVCNilMode,
 											},
 										},
 									},
@@ -703,26 +712,26 @@ var _ = Describe("VM Stats Collector", func() {
 				Expect(crs).To(HaveLen(1))
 				Expect(crs[0].Metric.GetOpts().Name).To(Equal("kubevirt_vm_disk_allocated_size_bytes"))
 				Expect(crs[0].Value).To(Equal(float64(3 * 1024 * 1024 * 1024)))
-				Expect(crs[0].Labels).To(Equal([]string{name, ns, "test-vm-pvc-nil-mode", "", "rootdisk"}))
+				Expect(crs[0].Labels).To(Equal([]string{name, ns, testPVCNilMode, "", "rootdisk"}))
 			}
-			expectVMs(results, "test-vm-nil-mode", "default", expectVM)
+			expectVMs(results, "test-vm-nil-mode", testLabelDefault, expectVM)
 		})
 
 		It("should prioritize DataVolume template size over PVC size", func() {
-			pvc := createPVC("default", "test-dv-pvc", resource.MustParse("5Gi"), pointer.P(k8sv1.PersistentVolumeFilesystem))
+			pvc := createPVC(testLabelDefault, testDataVolumePVC, resource.MustParse("5Gi"), pointer.P(k8sv1.PersistentVolumeFilesystem))
 			err := stores.PersistentVolumeClaim.Add(pvc)
 			Expect(err).ToNot(HaveOccurred())
 
 			vm := &k6tv1.VirtualMachine{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "default",
+					Namespace: testLabelDefault,
 					Name:      "test-vm-dv",
 				},
 				Spec: k6tv1.VirtualMachineSpec{
 					DataVolumeTemplates: []k6tv1.DataVolumeTemplateSpec{
 						{
 							ObjectMeta: metav1.ObjectMeta{
-								Name: "test-dv-pvc",
+								Name: testDataVolumePVC,
 							},
 							Spec: cdiv1.DataVolumeSpec{
 								PVC: &k8sv1.PersistentVolumeClaimSpec{
@@ -739,10 +748,10 @@ var _ = Describe("VM Stats Collector", func() {
 						Spec: k6tv1.VirtualMachineInstanceSpec{
 							Volumes: []k6tv1.Volume{
 								{
-									Name: "datavolumedisk",
+									Name: testDataVolumeDiskName,
 									VolumeSource: k6tv1.VolumeSource{
 										DataVolume: &k6tv1.DataVolumeSource{
-											Name: "test-dv-pvc",
+											Name: testDataVolumePVC,
 										},
 									},
 								},
@@ -759,9 +768,9 @@ var _ = Describe("VM Stats Collector", func() {
 				Expect(crs).To(HaveLen(1))
 				Expect(crs[0].Metric.GetOpts().Name).To(Equal("kubevirt_vm_disk_allocated_size_bytes"))
 				Expect(crs[0].Value).To(Equal(float64(2 * 1024 * 1024 * 1024)))
-				Expect(crs[0].Labels).To(Equal([]string{name, ns, "test-dv-pvc", "Filesystem", "datavolumedisk"}))
+				Expect(crs[0].Labels).To(Equal([]string{name, ns, testDataVolumePVC, string(k8sv1.PersistentVolumeFilesystem), testDataVolumeDiskName}))
 			}
-			expectVMs(results, "test-vm-dv", "default", expectVM)
+			expectVMs(results, "test-vm-dv", testLabelDefault, expectVM)
 		})
 	})
 
@@ -771,8 +780,8 @@ var _ = Describe("VM Stats Collector", func() {
 
 			vm := &k6tv1.VirtualMachine{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace:         "test-ns",
-					Name:              "test-vm",
+					Namespace:         testNamespace,
+					Name:              testVMNameDashed,
 					CreationTimestamp: metav1.NewTime(testTime),
 				},
 				Spec: k6tv1.VirtualMachineSpec{
@@ -789,13 +798,13 @@ var _ = Describe("VM Stats Collector", func() {
 				Expect(crs[0].Value).To(Equal(float64(testTime.Unix())))
 				Expect(crs[0].Labels).To(Equal([]string{name, ns}))
 			}
-			expectVMs(results, "test-vm", "test-ns", expectVM)
+			expectVMs(results, "test-vm", testNamespace, expectVM)
 		})
 
 		It("should collect correct creation times for multiple VMs", func() {
 			vm1 := &k6tv1.VirtualMachine{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace:         "test-ns",
+					Namespace:         testNamespace,
 					Name:              "test-vm1",
 					CreationTimestamp: metav1.NewTime(time.Now().Add(-time.Hour)),
 				},
@@ -805,7 +814,7 @@ var _ = Describe("VM Stats Collector", func() {
 			}
 			vm2 := &k6tv1.VirtualMachine{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace:         "test-ns",
+					Namespace:         testNamespace,
 					Name:              "test-vm2",
 					CreationTimestamp: metav1.NewTime(time.Now().Add(-2 * time.Hour)),
 				},
@@ -825,7 +834,7 @@ var _ = Describe("VM Stats Collector", func() {
 		It("metric should not exists if the VM creation timestamp is zero", func() {
 			vm := &k6tv1.VirtualMachine{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace:         "test-ns",
+					Namespace:         testNamespace,
 					Name:              "test-vm-zero-time",
 					CreationTimestamp: metav1.Time{},
 				},
@@ -836,8 +845,8 @@ var _ = Describe("VM Stats Collector", func() {
 
 			results := collectVMCreationTimestamp(cloneVM(vm))
 
-			Expect(filterResultsByVM(results, "test-vm-zero-time", "test-ns")).To(BeEmpty())
-			Expect(filterResultsByVM(results, "test-vm-zero-time-2", "test-ns")).To(BeEmpty())
+			Expect(filterResultsByVM(results, "test-vm-zero-time", testNamespace)).To(BeEmpty())
+			Expect(filterResultsByVM(results, "test-vm-zero-time-2", testNamespace)).To(BeEmpty())
 		})
 	})
 
@@ -846,8 +855,8 @@ var _ = Describe("VM Stats Collector", func() {
 			ifaces, nets := newVNICTestInterfaces()
 			vm := &k6tv1.VirtualMachine{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "test-ns",
-					Name:      "test-vm",
+					Namespace: testNamespace,
+					Name:      testVMNameDashed,
 				},
 				Spec: k6tv1.VirtualMachineSpec{
 					Template: &k6tv1.VirtualMachineInstanceTemplateSpec{
@@ -862,25 +871,41 @@ var _ = Describe("VM Stats Collector", func() {
 			metrics := CollectVmsVnicInfo(cloneVM(vm))
 			Expect(metrics).To(HaveLen(8), "Expected metrics for all vNICs in both VMs")
 
-			vm1 := filterResultsByVM(metrics, "test-vm", "test-ns")
+			vm1 := filterResultsByVM(metrics, testVMNameDashed, testNamespace)
 			Expect(vm1).To(HaveLen(4))
-			Expect(vm1[0].Labels).To(Equal([]string{"test-vm", "test-ns", "iface1", "core", "pod networking", "bridge", "virtio"}))
-			Expect(vm1[1].Labels).To(Equal([]string{"test-vm", "test-ns", "iface2", "core", "pod networking", "masquerade", "e1000e"}))
-			Expect(vm1[2].Labels).To(Equal([]string{"test-vm", "test-ns", "iface3", "core", "multus-net", "sriov", "<none>"}))
-			Expect(vm1[3].Labels).To(Equal([]string{"test-vm", "test-ns", "iface4", "plugin", "custom-net", "custom-plugin", "<none>"}))
+			Expect(vm1[0].Labels).To(Equal([]string{
+				testVMNameDashed, testNamespace, testVNICIface1, bindingTypeCore, networkNamePod, bindingNameBridge, testModelVirtio,
+			}))
+			Expect(vm1[1].Labels).To(Equal([]string{
+				testVMNameDashed, testNamespace, testVNICIface2, bindingTypeCore, networkNamePod, bindingNameMasquerade, testModelE1000E,
+			}))
+			Expect(vm1[2].Labels).To(Equal([]string{
+				testVMNameDashed, testNamespace, testVNICIface3, bindingTypeCore, testMultusNetwork, bindingNameSRIOV, modelNone,
+			}))
+			Expect(vm1[3].Labels).To(Equal([]string{
+				testVMNameDashed, testNamespace, testVNICIface4, bindingTypePlugin, testNetworkCustom, testCustomPluginName, modelNone,
+			}))
 
-			vm2 := filterResultsByVM(metrics, "test-vm-2", "test-ns")
+			vm2 := filterResultsByVM(metrics, testSecondVMNameDashed, testNamespace)
 			Expect(vm2).To(HaveLen(4))
-			Expect(vm2[0].Labels).To(Equal([]string{"test-vm-2", "test-ns", "iface1", "core", "pod networking", "bridge", "virtio"}))
-			Expect(vm2[1].Labels).To(Equal([]string{"test-vm-2", "test-ns", "iface2", "core", "pod networking", "masquerade", "e1000e"}))
-			Expect(vm2[2].Labels).To(Equal([]string{"test-vm-2", "test-ns", "iface3", "core", "multus-net", "sriov", "<none>"}))
-			Expect(vm2[3].Labels).To(Equal([]string{"test-vm-2", "test-ns", "iface4", "plugin", "custom-net", "custom-plugin", "<none>"}))
+			Expect(vm2[0].Labels).To(Equal([]string{
+				testSecondVMNameDashed, testNamespace, testVNICIface1, bindingTypeCore, networkNamePod, bindingNameBridge, testModelVirtio,
+			}))
+			Expect(vm2[1].Labels).To(Equal([]string{
+				testSecondVMNameDashed, testNamespace, testVNICIface2, bindingTypeCore, networkNamePod, bindingNameMasquerade, testModelE1000E,
+			}))
+			Expect(vm2[2].Labels).To(Equal([]string{
+				testSecondVMNameDashed, testNamespace, testVNICIface3, bindingTypeCore, testMultusNetwork, bindingNameSRIOV, modelNone,
+			}))
+			Expect(vm2[3].Labels).To(Equal([]string{
+				testSecondVMNameDashed, testNamespace, testVNICIface4, bindingTypePlugin, testNetworkCustom, testCustomPluginName, modelNone,
+			}))
 		})
 		It("should not collect kubevirt_vm_vnic_info metric if no network defined", func() {
 			vm := &k6tv1.VirtualMachine{
 				ObjectMeta: metav1.ObjectMeta{
-					Namespace: "test-ns",
-					Name:      "test-vm",
+					Namespace: testNamespace,
+					Name:      testVMNameDashed,
 				},
 				Spec: k6tv1.VirtualMachineSpec{
 					Template: &k6tv1.VirtualMachineInstanceTemplateSpec{
@@ -889,7 +914,7 @@ var _ = Describe("VM Stats Collector", func() {
 								Devices: k6tv1.Devices{
 									Interfaces: []k6tv1.Interface{
 										{
-											Name: "iface1",
+											Name: testVNICIface1,
 											InterfaceBindingMethod: k6tv1.InterfaceBindingMethod{
 												Bridge: &k6tv1.InterfaceBridge{},
 											},
@@ -903,8 +928,8 @@ var _ = Describe("VM Stats Collector", func() {
 			}
 
 			metrics := CollectVmsVnicInfo(cloneVM(vm))
-			Expect(filterResultsByVM(metrics, "test-vm", "test-ns")).To(BeEmpty())
-			Expect(filterResultsByVM(metrics, "test-vm-2", "test-ns")).To(BeEmpty())
+			Expect(filterResultsByVM(metrics, testVMNameDashed, testNamespace)).To(BeEmpty())
+			Expect(filterResultsByVM(metrics, testSecondVMNameDashed, testNamespace)).To(BeEmpty())
 		})
 	})
 
@@ -919,21 +944,21 @@ var _ = Describe("VM Stats Collector", func() {
 			vms := []*k6tv1.VirtualMachine{
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "vm1",
-						Namespace: "default",
+						Name:      testVMLocalAlias,
+						Namespace: testLabelDefault,
 						Labels: map[string]string{
-							"environment": "production",
-							"team":        "backend",
+							testLabelEnvironment: testLabelValueProduction,
+							testLabelTeam:        testLabelValueBackend,
 						},
 					},
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "vm2",
-						Namespace: "default",
+						Name:      testSecondVMName,
+						Namespace: testLabelDefault,
 						Labels: map[string]string{
-							"environment": "staging",
-							"version":     "2.0",
+							testLabelEnvironment: "staging",
+							testLabelVersion:     "2.0",
 						},
 					},
 				},
@@ -949,32 +974,32 @@ var _ = Describe("VM Stats Collector", func() {
 			Expect(labelResults).To(HaveLen(2))
 
 			var r1, r2 operatormetrics.CollectorResult
-			if labelResults[0].Labels[0] == "vm1" {
+			if labelResults[0].Labels[0] == testVMLocalAlias {
 				r1, r2 = labelResults[0], labelResults[1]
 			} else {
 				r1, r2 = labelResults[1], labelResults[0]
 			}
-			Expect(r1.Labels).To(Equal([]string{"vm1", "default"}))
-			Expect(r1.ConstLabels).To(HaveKeyWithValue("label_environment", "production"))
-			Expect(r1.ConstLabels).To(HaveKeyWithValue("label_team", "backend"))
+			Expect(r1.Labels).To(Equal([]string{testVMLocalAlias, testLabelDefault}))
+			Expect(r1.ConstLabels).To(HaveKeyWithValue("label_environment", testLabelValueProduction))
+			Expect(r1.ConstLabels).To(HaveKeyWithValue("label_team", testLabelValueBackend))
 
-			Expect(r2.Labels).To(Equal([]string{"vm2", "default"}))
+			Expect(r2.Labels).To(Equal([]string{testSecondVMName, testLabelDefault}))
 			Expect(r2.ConstLabels).To(HaveKeyWithValue("label_environment", "staging"))
 			Expect(r2.ConstLabels).To(HaveKeyWithValue("label_version", "2.0"))
 		})
 
 		It("should prioritize ignorelist over allowlist when overlapping", func() {
 			vmLabelsCfg = funcLabelsConfig(func(l string) bool {
-				return l != "vm.kubevirt.io/template"
+				return l != testLabelTemplate
 			})
 
 			vm := &k6tv1.VirtualMachine{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-vm",
-					Namespace: "default",
+					Name:      testVMNameDashed,
+					Namespace: testLabelDefault,
 					Labels: map[string]string{
-						"environment":             "production",
-						"vm.kubevirt.io/template": "tmpl",
+						testLabelEnvironment: testLabelValueProduction,
+						testLabelTemplate:    "tmpl",
 					},
 				},
 			}
@@ -989,20 +1014,20 @@ var _ = Describe("VM Stats Collector", func() {
 		It("should change metric output when configuration changes dynamically", func() {
 			// Restrict to specific labels and ignore secret
 			vmLabelsCfg = funcLabelsConfig(func(l string) bool {
-				if l == "secret" {
+				if l == testLabelSecret {
 					return false
 				}
-				return l == "environment" || l == "team" || l == "version"
+				return l == testLabelEnvironment || l == testLabelTeam || l == testLabelVersion
 			})
 			vm := &k6tv1.VirtualMachine{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-vm",
-					Namespace: "default",
+					Name:      testVMNameDashed,
+					Namespace: testLabelDefault,
 					Labels: map[string]string{
-						"environment": "production",
-						"team":        "backend",
-						"secret":      "sensitive",
-						"version":     "1.0",
+						testLabelEnvironment: "production",
+						testLabelTeam:        testLabelValueBackend,
+						testLabelSecret:      "sensitive",
+						"version":            "1.0",
 					},
 				},
 			}
@@ -1011,7 +1036,7 @@ var _ = Describe("VM Stats Collector", func() {
 			Expect(afterRestrict).To(HaveLen(1))
 			Expect(afterRestrict[0].ConstLabels).To(HaveLen(3))
 			Expect(afterRestrict[0].ConstLabels).To(HaveKeyWithValue("label_environment", "production"))
-			Expect(afterRestrict[0].ConstLabels).To(HaveKeyWithValue("label_team", "backend"))
+			Expect(afterRestrict[0].ConstLabels).To(HaveKeyWithValue("label_team", testLabelValueBackend))
 			Expect(afterRestrict[0].ConstLabels).To(HaveKeyWithValue("label_version", "1.0"))
 			Expect(afterRestrict[0].ConstLabels).ToNot(HaveKey("label_secret"))
 		})
@@ -1022,7 +1047,7 @@ var _ = Describe("VM Stats Collector", func() {
 			vm := &k6tv1.VirtualMachine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "vm-no-metric",
-					Namespace: "default",
+					Namespace: testLabelDefault,
 					Labels: map[string]string{
 						"a": "1",
 					},
@@ -1041,10 +1066,10 @@ var _ = Describe("VM Stats Collector", func() {
 			vm := &k6tv1.VirtualMachine{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "vm-wildcard-ignore",
-					Namespace: "default",
+					Namespace: testLabelDefault,
 					Labels: map[string]string{
-						"environment": "prod",
-						"team":        "be",
+						testLabelEnvironment: "prod",
+						testLabelTeam:        "be",
 					},
 				},
 			}

--- a/pkg/monitoring/metrics/virt-handler/domainstats/BUILD.bazel
+++ b/pkg/monitoring/metrics/virt-handler/domainstats/BUILD.bazel
@@ -44,6 +44,7 @@ go_test(
         "memory_metrics_test.go",
         "network_metrics_test.go",
         "node_cpu_affinity_metrics_test.go",
+        "test_constants_test.go",
         "vcpu_metrics_test.go",
     ],
     embed = [":go_default_library"],

--- a/pkg/monitoring/metrics/virt-handler/domainstats/block_metrics_test.go
+++ b/pkg/monitoring/metrics/virt-handler/domainstats/block_metrics_test.go
@@ -35,8 +35,8 @@ var _ = Describe("block metrics", func() {
 	Context("on Collect", func() {
 		vmi := &k6tv1.VirtualMachineInstance{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-vmi-1",
-				Namespace: "test-ns-1",
+				Name:      testDomainstatsVMIName,
+				Namespace: testDomainstatsNamespace,
 			},
 		}
 

--- a/pkg/monitoring/metrics/virt-handler/domainstats/collector_test.go
+++ b/pkg/monitoring/metrics/virt-handler/domainstats/collector_test.go
@@ -39,14 +39,14 @@ var _ = Describe("domain stats collector", func() {
 		vmis := []*k6tv1.VirtualMachineInstance{
 			{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-vmi-1",
-					Namespace: "test-ns-1",
+					Name:      testDomainstatsVMIName,
+					Namespace: testDomainstatsNamespace,
 				},
 			},
 			{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-vmi-1",
-					Namespace: "test-ns-1",
+					Name:      testDomainstatsVMIName,
+					Namespace: testDomainstatsNamespace,
 				},
 			},
 		}

--- a/pkg/monitoring/metrics/virt-handler/domainstats/cpu_metrics_test.go
+++ b/pkg/monitoring/metrics/virt-handler/domainstats/cpu_metrics_test.go
@@ -35,8 +35,8 @@ var _ = Describe("CPU Metrics", func() {
 	Context("CPU time stats", func() {
 		vmi := &k6tv1.VirtualMachineInstance{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-vmi-1",
-				Namespace: "test-ns-1",
+				Name:      testDomainstatsVMIName,
+				Namespace: testDomainstatsNamespace,
 			},
 		}
 

--- a/pkg/monitoring/metrics/virt-handler/domainstats/domainstats_test.go
+++ b/pkg/monitoring/metrics/virt-handler/domainstats/domainstats_test.go
@@ -41,8 +41,8 @@ var _ = Describe("domainstats", func() {
 			vmiReport = &VirtualMachineInstanceReport{
 				vmi: &k6tv1.VirtualMachineInstance{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-vmi-1",
-						Namespace: "test-ns-1",
+						Name:      testDomainstatsVMIName,
+						Namespace: testDomainstatsNamespace,
 					},
 					Status: k6tv1.VirtualMachineInstanceStatus{
 						NodeName: "test-node-1",
@@ -59,8 +59,8 @@ var _ = Describe("domainstats", func() {
 			Expect(cr.Value).To(Equal(5.0))
 
 			Expect(cr.ConstLabels).To(HaveKeyWithValue("node", "test-node-1"))
-			Expect(cr.ConstLabels).To(HaveKeyWithValue("namespace", "test-ns-1"))
-			Expect(cr.ConstLabels).To(HaveKeyWithValue("name", "test-vmi-1"))
+			Expect(cr.ConstLabels).To(HaveKeyWithValue("namespace", testDomainstatsNamespace))
+			Expect(cr.ConstLabels).To(HaveKeyWithValue("name", testDomainstatsVMIName))
 
 			Expect(cr.ConstLabels).To(HaveKeyWithValue("test-label-1", "test-value-1"))
 		})
@@ -73,8 +73,8 @@ var _ = Describe("domainstats", func() {
 			Expect(cr.Value).To(Equal(5.0))
 
 			Expect(cr.ConstLabels).To(HaveKeyWithValue("node", "test-node-1"))
-			Expect(cr.ConstLabels).To(HaveKeyWithValue("namespace", "test-ns-1"))
-			Expect(cr.ConstLabels).To(HaveKeyWithValue("name", "test-vmi-1"))
+			Expect(cr.ConstLabels).To(HaveKeyWithValue("namespace", testDomainstatsNamespace))
+			Expect(cr.ConstLabels).To(HaveKeyWithValue("name", testDomainstatsVMIName))
 		})
 	})
 })

--- a/pkg/monitoring/metrics/virt-handler/domainstats/filesystem_metrics_test.go
+++ b/pkg/monitoring/metrics/virt-handler/domainstats/filesystem_metrics_test.go
@@ -34,8 +34,8 @@ var _ = Describe("filesystem metrics", func() {
 	Context("on Collect", func() {
 		vmi := &k6tv1.VirtualMachineInstance{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-vmi-1",
-				Namespace: "test-ns-1",
+				Name:      testDomainstatsVMIName,
+				Namespace: testDomainstatsNamespace,
 			},
 		}
 

--- a/pkg/monitoring/metrics/virt-handler/domainstats/memory_metrics_test.go
+++ b/pkg/monitoring/metrics/virt-handler/domainstats/memory_metrics_test.go
@@ -35,8 +35,8 @@ var _ = Describe("memory metrics", func() {
 	Context("on Collect", func() {
 		vmi := &k6tv1.VirtualMachineInstance{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-vmi-1",
-				Namespace: "test-ns-1",
+				Name:      testDomainstatsVMIName,
+				Namespace: testDomainstatsNamespace,
 			},
 		}
 

--- a/pkg/monitoring/metrics/virt-handler/domainstats/network_metrics.go
+++ b/pkg/monitoring/metrics/virt-handler/domainstats/network_metrics.go
@@ -21,6 +21,11 @@ package domainstats
 
 import "github.com/rhobs/operator-observability-toolkit/pkg/operatormetrics"
 
+const (
+	networkInterfaceLabel = "interface"
+	networkTypeLabel      = "type"
+)
+
 var (
 	networkTrafficBytesDeprecated = operatormetrics.NewCounter(
 		operatormetrics.MetricOpts{
@@ -118,10 +123,10 @@ func (networkMetrics) Collect(vmiReport *VirtualMachineInstanceReport) []operato
 		if net.AliasSet {
 			iface = net.Alias
 		}
-		netLabels := map[string]string{"interface": iface}
+		netLabels := map[string]string{networkInterfaceLabel: iface}
 
 		if net.RxBytesSet {
-			deprecatedLabels := map[string]string{"interface": iface, "type": "rx"}
+			deprecatedLabels := map[string]string{networkInterfaceLabel: iface, networkTypeLabel: "rx"}
 			crs = append(crs,
 				vmiReport.newCollectorResultWithLabels(networkTrafficBytesDeprecated, float64(net.RxBytes), deprecatedLabels),
 				vmiReport.newCollectorResultWithLabels(networkReceiveBytes, float64(net.RxBytes), netLabels),
@@ -129,7 +134,7 @@ func (networkMetrics) Collect(vmiReport *VirtualMachineInstanceReport) []operato
 		}
 
 		if net.TxBytesSet {
-			deprecatedLabels := map[string]string{"interface": iface, "type": "tx"}
+			deprecatedLabels := map[string]string{networkInterfaceLabel: iface, networkTypeLabel: "tx"}
 			crs = append(crs,
 				vmiReport.newCollectorResultWithLabels(networkTrafficBytesDeprecated, float64(net.TxBytes), deprecatedLabels),
 				vmiReport.newCollectorResultWithLabels(networkTransmitBytes, float64(net.TxBytes), netLabels),

--- a/pkg/monitoring/metrics/virt-handler/domainstats/network_metrics_test.go
+++ b/pkg/monitoring/metrics/virt-handler/domainstats/network_metrics_test.go
@@ -35,8 +35,8 @@ var _ = Describe("network metrics", func() {
 	Context("on Collect", func() {
 		vmi := &k6tv1.VirtualMachineInstance{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-vmi-1",
-				Namespace: "test-ns-1",
+				Name:      testDomainstatsVMIName,
+				Namespace: testDomainstatsNamespace,
 			},
 		}
 

--- a/pkg/monitoring/metrics/virt-handler/domainstats/node_cpu_affinity_metrics_test.go
+++ b/pkg/monitoring/metrics/virt-handler/domainstats/node_cpu_affinity_metrics_test.go
@@ -35,8 +35,8 @@ var _ = Describe("node cpu affinity metrics", func() {
 	Context("on Collect", func() {
 		vmi := &k6tv1.VirtualMachineInstance{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-vmi-1",
-				Namespace: "test-ns-1",
+				Name:      testDomainstatsVMIName,
+				Namespace: testDomainstatsNamespace,
 			},
 		}
 

--- a/pkg/monitoring/metrics/virt-handler/domainstats/test_constants_test.go
+++ b/pkg/monitoring/metrics/virt-handler/domainstats/test_constants_test.go
@@ -17,27 +17,9 @@
  *
  */
 
-package virtapi
+package domainstats
 
-import (
-	"github.com/rhobs/operator-observability-toolkit/pkg/operatormetrics"
-	v1 "kubevirt.io/api/core/v1"
+const (
+	testDomainstatsVMIName   = "test-vmi-1"
+	testDomainstatsNamespace = "test-ns-1"
 )
-
-var (
-	vmMetrics = []operatormetrics.Metric{
-		vmsCreatedCounter,
-	}
-
-	vmsCreatedCounter = operatormetrics.NewCounterVec(
-		operatormetrics.MetricOpts{
-			Name: "kubevirt_vm_created_by_pod_total",
-			Help: "[Deprecated] The total number of VMs created by namespace and virt-api pod, since install.",
-		},
-		[]string{namespaceLabel},
-	)
-)
-
-func NewVMCreated(vm *v1.VirtualMachine) {
-	vmsCreatedCounter.WithLabelValues(vm.Namespace).Inc()
-}

--- a/pkg/monitoring/metrics/virt-handler/domainstats/vcpu_metrics.go
+++ b/pkg/monitoring/metrics/virt-handler/domainstats/vcpu_metrics.go
@@ -27,6 +27,8 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/stats"
 )
 
+const vcpuIDLabel = "id"
+
 var (
 	vcpuSeconds = operatormetrics.NewCounter(
 		operatormetrics.MetricOpts{
@@ -74,22 +76,22 @@ func (vcpuMetrics) Collect(vmiReport *VirtualMachineInstanceReport) []operatorme
 
 		if vcpu.TimeSet {
 			additionalLabels := map[string]string{
-				"id":    stringVcpuIdx,
-				"state": humanReadableState(vcpu.State),
+				vcpuIDLabel: stringVcpuIdx,
+				"state":     humanReadableState(vcpu.State),
 			}
 			crs = append(crs, vmiReport.newCollectorResultWithLabels(vcpuSeconds, nanosecondsToSeconds(vcpu.Time), additionalLabels))
 		}
 
 		if vcpu.WaitSet {
 			additionalLabels := map[string]string{
-				"id": stringVcpuIdx,
+				vcpuIDLabel: stringVcpuIdx,
 			}
 			crs = append(crs, vmiReport.newCollectorResultWithLabels(vcpuWaitSeconds, nanosecondsToSeconds(vcpu.Wait), additionalLabels))
 		}
 
 		if vcpu.DelaySet {
 			additionalLabels := map[string]string{
-				"id": stringVcpuIdx,
+				vcpuIDLabel: stringVcpuIdx,
 			}
 			crs = append(crs, vmiReport.newCollectorResultWithLabels(vcpuDelaySeconds, nanosecondsToSeconds(vcpu.Delay), additionalLabels))
 		}

--- a/pkg/monitoring/metrics/virt-handler/domainstats/vcpu_metrics_test.go
+++ b/pkg/monitoring/metrics/virt-handler/domainstats/vcpu_metrics_test.go
@@ -35,8 +35,8 @@ var _ = Describe("vcpu metrics", func() {
 	Context("on Collect", func() {
 		vmi := &k6tv1.VirtualMachineInstance{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-vmi-1",
-				Namespace: "test-ns-1",
+				Name:      testDomainstatsVMIName,
+				Namespace: testDomainstatsNamespace,
 			},
 		}
 

--- a/pkg/monitoring/metrics/virt-handler/gpuinfo/collector_test.go
+++ b/pkg/monitoring/metrics/virt-handler/gpuinfo/collector_test.go
@@ -26,6 +26,12 @@ import (
 )
 
 var _ = Describe("GPU Info Collector", func() {
+	const (
+		testNodeWorker1 = "worker-1"
+		testNamespace   = "test-ns"
+		testPodName     = "virt-launcher-test-vmi-abc123"
+		testGPUResource = "nvidia.com/NVIDIA_A2-2Q"
+	)
 	Context("collectCallback", func() {
 		It("should return nil when cache is not initialized", func() {
 			gpuCache = nil
@@ -35,19 +41,19 @@ var _ = Describe("GPU Info Collector", func() {
 
 		It("should return correct collector results from cache", func() {
 			gpuCache = &gpuInfoCache{
-				nodeName:    "worker-1",
+				nodeName:    testNodeWorker1,
 				lastRefresh: time.Now(),
 				allocations: []GPUAllocation{
 					{
-						Namespace: "test-ns",
-						PodName:   "virt-launcher-test-vmi-abc123",
-						Resource:  "nvidia.com/NVIDIA_A2-2Q",
+						Namespace: testNamespace,
+						PodName:   testPodName,
+						Resource:  testGPUResource,
 						UUID:      "gpu-uuid-123",
 					},
 					{
-						Namespace: "test-ns",
-						PodName:   "virt-launcher-test-vmi-abc123",
-						Resource:  "nvidia.com/NVIDIA_A2-2Q",
+						Namespace: testNamespace,
+						PodName:   testPodName,
+						Resource:  testGPUResource,
 						UUID:      "gpu-uuid-456",
 					},
 				},
@@ -57,10 +63,10 @@ var _ = Describe("GPU Info Collector", func() {
 			Expect(results).To(HaveLen(2))
 
 			Expect(results[0].Value).To(Equal(float64(1)))
-			Expect(results[0].ConstLabels["node"]).To(Equal("worker-1"))
-			Expect(results[0].ConstLabels["namespace"]).To(Equal("test-ns"))
-			Expect(results[0].ConstLabels["pod"]).To(Equal("virt-launcher-test-vmi-abc123"))
-			Expect(results[0].ConstLabels["resource"]).To(Equal("nvidia.com/NVIDIA_A2-2Q"))
+			Expect(results[0].ConstLabels["node"]).To(Equal(testNodeWorker1))
+			Expect(results[0].ConstLabels["namespace"]).To(Equal(testNamespace))
+			Expect(results[0].ConstLabels["pod"]).To(Equal(testPodName))
+			Expect(results[0].ConstLabels["resource"]).To(Equal(testGPUResource))
 			Expect(results[0].ConstLabels["uuid"]).To(Equal("gpu-uuid-123"))
 
 			Expect(results[1].ConstLabels["uuid"]).To(Equal("gpu-uuid-456"))
@@ -68,7 +74,7 @@ var _ = Describe("GPU Info Collector", func() {
 
 		It("should return empty results when cache has no allocations", func() {
 			gpuCache = &gpuInfoCache{
-				nodeName:    "worker-1",
+				nodeName:    testNodeWorker1,
 				lastRefresh: time.Now(),
 			}
 

--- a/pkg/monitoring/metrics/virt-handler/machine_type.go
+++ b/pkg/monitoring/metrics/virt-handler/machine_type.go
@@ -24,6 +24,11 @@ import (
 	"libvirt.org/go/libvirtxml"
 )
 
+const (
+	machineTypeLabel = "machine_type"
+	nodeLabel        = "node"
+)
+
 var (
 	machineTypeMetrics = []operatormetrics.Metric{
 		deprecatedMachineTypeMetric,
@@ -34,7 +39,7 @@ var (
 			Name: "kubevirt_node_deprecated_machine_types",
 			Help: "List of deprecated machine types based on the capabilities of individual nodes, as detected by virt-handler.",
 		},
-		[]string{"machine_type", "node"},
+		[]string{machineTypeLabel, nodeLabel},
 	)
 )
 

--- a/pkg/monitoring/metrics/virt-handler/machine_type_test.go
+++ b/pkg/monitoring/metrics/virt-handler/machine_type_test.go
@@ -27,6 +27,8 @@ import (
 	"libvirt.org/go/libvirtxml"
 )
 
+const testNodeName = "test-node"
+
 var _ = Describe("deprecated machine types metric", func() {
 	Context("ReportDeprecatedMachineTypes", func() {
 		BeforeEach(func() {
@@ -40,7 +42,7 @@ var _ = Describe("deprecated machine types metric", func() {
 				{Name: "machine2", Deprecated: "true"},
 			}
 
-			ReportDeprecatedMachineTypes(machineTypes, "test-node")
+			ReportDeprecatedMachineTypes(machineTypes, testNodeName)
 
 			Expect(machineTypeMetrics).ToNot(BeEmpty())
 			Expect(deprecatedMachineTypeMetric).ToNot(BeNil(), "deprecatedMachineTypeMetric should be initialized")
@@ -48,7 +50,7 @@ var _ = Describe("deprecated machine types metric", func() {
 			for _, machine := range machineTypes {
 				labels := map[string]string{
 					"machine_type": machine.Name,
-					"node":         "test-node",
+					"node":         testNodeName,
 				}
 				_, err := deprecatedMachineTypeMetric.GetMetricWith(labels)
 				Expect(err).ToNot(HaveOccurred(), "should initialize metric with labels %v", labels)

--- a/pkg/monitoring/rules/alerts/alerts.go
+++ b/pkg/monitoring/rules/alerts/alerts.go
@@ -44,6 +44,12 @@ const (
 
 	eightyPercent = 80
 	fiveMinutes   = 5
+
+	alertSeverityCritical = "critical"
+	alertSeverityInfo     = "info"
+	alertSeverityWarning  = "warning"
+
+	operatorHealthImpactNone = "none"
 )
 
 func Register(registry *operatorrules.Registry, namespace string) error {

--- a/pkg/monitoring/rules/alerts/system.go
+++ b/pkg/monitoring/rules/alerts/system.go
@@ -36,8 +36,8 @@ func systemAlerts(namespace string) []promv1.Rule {
 				summaryAnnotationKey:     "At least two nodes with kvm resource required for VM live migration.",
 			},
 			Labels: map[string]string{
-				severityAlertLabelKey:        "warning",
-				operatorHealthImpactLabelKey: "warning",
+				severityAlertLabelKey:        alertSeverityWarning,
+				operatorHealthImpactLabelKey: alertSeverityWarning,
 			},
 		},
 		{
@@ -52,8 +52,8 @@ func systemAlerts(namespace string) []promv1.Rule {
 				summaryAnnotationKey: "There are no available nodes in the cluster to run VMs.",
 			},
 			Labels: map[string]string{
-				severityAlertLabelKey:        "warning",
-				operatorHealthImpactLabelKey: "critical",
+				severityAlertLabelKey:        alertSeverityWarning,
+				operatorHealthImpactLabelKey: alertSeverityCritical,
 			},
 		},
 	}

--- a/pkg/monitoring/rules/alerts/virt-api.go
+++ b/pkg/monitoring/rules/alerts/virt-api.go
@@ -36,8 +36,8 @@ func virtAPIAlerts(namespace string) []promv1.Rule {
 				summaryAnnotationKey: "No running virt-api pods were detected for the last 10 min.",
 			},
 			Labels: map[string]string{
-				severityAlertLabelKey:        "critical",
-				operatorHealthImpactLabelKey: "critical",
+				severityAlertLabelKey:        alertSeverityCritical,
+				operatorHealthImpactLabelKey: alertSeverityCritical,
 			},
 		},
 		{
@@ -51,8 +51,8 @@ func virtAPIAlerts(namespace string) []promv1.Rule {
 				summaryAnnotationKey: "Some virt-api pods are running but not ready.",
 			},
 			Labels: map[string]string{
-				severityAlertLabelKey:        "warning",
-				operatorHealthImpactLabelKey: "warning",
+				severityAlertLabelKey:        alertSeverityWarning,
+				operatorHealthImpactLabelKey: alertSeverityWarning,
 			},
 		},
 		{
@@ -63,8 +63,8 @@ func virtAPIAlerts(namespace string) []promv1.Rule {
 				summaryAnnotationKey: "No ready virt-api was detected for the last 10 min.",
 			},
 			Labels: map[string]string{
-				severityAlertLabelKey:        "critical",
-				operatorHealthImpactLabelKey: "critical",
+				severityAlertLabelKey:        alertSeverityCritical,
+				operatorHealthImpactLabelKey: alertSeverityCritical,
 			},
 		},
 		{
@@ -79,8 +79,8 @@ func virtAPIAlerts(namespace string) []promv1.Rule {
 				summaryAnnotationKey: "Less than 75% of desired virt-api pods are running.",
 			},
 			Labels: map[string]string{
-				severityAlertLabelKey:        "warning",
-				operatorHealthImpactLabelKey: "warning",
+				severityAlertLabelKey:        alertSeverityWarning,
+				operatorHealthImpactLabelKey: alertSeverityWarning,
 			},
 		},
 		{
@@ -91,8 +91,8 @@ func virtAPIAlerts(namespace string) []promv1.Rule {
 				summaryAnnotationKey: getRestCallsFailedWarning(eightyPercent, "virt-api", fiveMinutes),
 			},
 			Labels: map[string]string{
-				severityAlertLabelKey:        "critical",
-				operatorHealthImpactLabelKey: "critical",
+				severityAlertLabelKey:        alertSeverityCritical,
+				operatorHealthImpactLabelKey: alertSeverityCritical,
 			},
 		},
 		{
@@ -109,8 +109,8 @@ func virtAPIAlerts(namespace string) []promv1.Rule {
 				summaryAnnotationKey:     "Detected {{ $value }} requests in the last 10 minutes.",
 			},
 			Labels: map[string]string{
-				severityAlertLabelKey:        "info",
-				operatorHealthImpactLabelKey: "none",
+				severityAlertLabelKey:        alertSeverityInfo,
+				operatorHealthImpactLabelKey: operatorHealthImpactNone,
 			},
 		},
 	}

--- a/pkg/monitoring/rules/alerts/virt-controller.go
+++ b/pkg/monitoring/rules/alerts/virt-controller.go
@@ -39,8 +39,8 @@ func virtControllerAlerts(namespace string) []promv1.Rule {
 				summaryAnnotationKey: "Some virt controllers are running but not ready.",
 			},
 			Labels: map[string]string{
-				severityAlertLabelKey:        "warning",
-				operatorHealthImpactLabelKey: "warning",
+				severityAlertLabelKey:        alertSeverityWarning,
+				operatorHealthImpactLabelKey: alertSeverityWarning,
 			},
 		},
 		{
@@ -51,8 +51,8 @@ func virtControllerAlerts(namespace string) []promv1.Rule {
 				summaryAnnotationKey: "No ready virt-controller was detected for the last 10 min.",
 			},
 			Labels: map[string]string{
-				severityAlertLabelKey:        "critical",
-				operatorHealthImpactLabelKey: "critical",
+				severityAlertLabelKey:        alertSeverityCritical,
+				operatorHealthImpactLabelKey: alertSeverityCritical,
 			},
 		},
 		{
@@ -63,8 +63,8 @@ func virtControllerAlerts(namespace string) []promv1.Rule {
 				summaryAnnotationKey: "No leading virt-controller was detected for the last 10 min.",
 			},
 			Labels: map[string]string{
-				severityAlertLabelKey:        "critical",
-				operatorHealthImpactLabelKey: "critical",
+				severityAlertLabelKey:        alertSeverityCritical,
+				operatorHealthImpactLabelKey: alertSeverityCritical,
 			},
 		},
 		{
@@ -75,8 +75,8 @@ func virtControllerAlerts(namespace string) []promv1.Rule {
 				summaryAnnotationKey: "No running virt-controller was detected for the last 10 min.",
 			},
 			Labels: map[string]string{
-				severityAlertLabelKey:        "critical",
-				operatorHealthImpactLabelKey: "critical",
+				severityAlertLabelKey:        alertSeverityCritical,
+				operatorHealthImpactLabelKey: alertSeverityCritical,
 			},
 		},
 		{
@@ -91,8 +91,8 @@ func virtControllerAlerts(namespace string) []promv1.Rule {
 				summaryAnnotationKey: "Less than 75% of desired virt-controller pods are running.",
 			},
 			Labels: map[string]string{
-				severityAlertLabelKey:        "warning",
-				operatorHealthImpactLabelKey: "warning",
+				severityAlertLabelKey:        alertSeverityWarning,
+				operatorHealthImpactLabelKey: alertSeverityWarning,
 			},
 		},
 		{
@@ -103,8 +103,8 @@ func virtControllerAlerts(namespace string) []promv1.Rule {
 				summaryAnnotationKey: getRestCallsFailedWarning(eightyPercent, "virt-controller", fiveMinutes),
 			},
 			Labels: map[string]string{
-				severityAlertLabelKey:        "critical",
-				operatorHealthImpactLabelKey: "critical",
+				severityAlertLabelKey:        alertSeverityCritical,
+				operatorHealthImpactLabelKey: alertSeverityCritical,
 			},
 		},
 	}

--- a/pkg/monitoring/rules/alerts/virt-handler.go
+++ b/pkg/monitoring/rules/alerts/virt-handler.go
@@ -36,8 +36,8 @@ func virtHandlerAlerts(namespace string) []promv1.Rule {
 				summaryAnnotationKey: "No running virt-handler pods were detected for the last 10 min.",
 			},
 			Labels: map[string]string{
-				severityAlertLabelKey:        "critical",
-				operatorHealthImpactLabelKey: "critical",
+				severityAlertLabelKey:        alertSeverityCritical,
+				operatorHealthImpactLabelKey: alertSeverityCritical,
 			},
 		},
 		{
@@ -51,8 +51,8 @@ func virtHandlerAlerts(namespace string) []promv1.Rule {
 				summaryAnnotationKey: "Some virt-handlers are running but not ready.",
 			},
 			Labels: map[string]string{
-				severityAlertLabelKey:        "warning",
-				operatorHealthImpactLabelKey: "warning",
+				severityAlertLabelKey:        alertSeverityWarning,
+				operatorHealthImpactLabelKey: alertSeverityWarning,
 			},
 		},
 		{
@@ -63,8 +63,8 @@ func virtHandlerAlerts(namespace string) []promv1.Rule {
 				summaryAnnotationKey: "No ready virt-handler was detected for the last 10 min.",
 			},
 			Labels: map[string]string{
-				severityAlertLabelKey:        "critical",
-				operatorHealthImpactLabelKey: "critical",
+				severityAlertLabelKey:        alertSeverityCritical,
+				operatorHealthImpactLabelKey: alertSeverityCritical,
 			},
 		},
 		{
@@ -78,8 +78,8 @@ func virtHandlerAlerts(namespace string) []promv1.Rule {
 				summaryAnnotationKey: "Some virt-handlers failed to roll out",
 			},
 			Labels: map[string]string{
-				severityAlertLabelKey:        "warning",
-				operatorHealthImpactLabelKey: "warning",
+				severityAlertLabelKey:        alertSeverityWarning,
+				operatorHealthImpactLabelKey: alertSeverityWarning,
 			},
 		},
 		{
@@ -90,8 +90,8 @@ func virtHandlerAlerts(namespace string) []promv1.Rule {
 				summaryAnnotationKey: getRestCallsFailedWarning(eightyPercent, "virt-handler", fiveMinutes),
 			},
 			Labels: map[string]string{
-				severityAlertLabelKey:        "critical",
-				operatorHealthImpactLabelKey: "critical",
+				severityAlertLabelKey:        alertSeverityCritical,
+				operatorHealthImpactLabelKey: alertSeverityCritical,
 			},
 		},
 	}

--- a/pkg/monitoring/rules/alerts/virt-operator.go
+++ b/pkg/monitoring/rules/alerts/virt-operator.go
@@ -36,8 +36,8 @@ func virtOperatorAlerts(namespace string) []promv1.Rule {
 				summaryAnnotationKey: "No running virt-operator pods were detected for the last 10 min.",
 			},
 			Labels: map[string]string{
-				severityAlertLabelKey:        "critical",
-				operatorHealthImpactLabelKey: "critical",
+				severityAlertLabelKey:        alertSeverityCritical,
+				operatorHealthImpactLabelKey: alertSeverityCritical,
 			},
 		},
 		{
@@ -52,8 +52,8 @@ func virtOperatorAlerts(namespace string) []promv1.Rule {
 				summaryAnnotationKey: "Less than 75% of desired virt-operator pods are running.",
 			},
 			Labels: map[string]string{
-				severityAlertLabelKey:        "warning",
-				operatorHealthImpactLabelKey: "warning",
+				severityAlertLabelKey:        alertSeverityWarning,
+				operatorHealthImpactLabelKey: alertSeverityWarning,
 			},
 		},
 		{
@@ -64,8 +64,8 @@ func virtOperatorAlerts(namespace string) []promv1.Rule {
 				summaryAnnotationKey: getRestCallsFailedWarning(eightyPercent, "virt-operator", fiveMinutes),
 			},
 			Labels: map[string]string{
-				severityAlertLabelKey:        "critical",
-				operatorHealthImpactLabelKey: "critical",
+				severityAlertLabelKey:        alertSeverityCritical,
+				operatorHealthImpactLabelKey: alertSeverityCritical,
 			},
 		},
 		{
@@ -79,8 +79,8 @@ func virtOperatorAlerts(namespace string) []promv1.Rule {
 				summaryAnnotationKey: "Some virt-operators are running but not ready.",
 			},
 			Labels: map[string]string{
-				severityAlertLabelKey:        "warning",
-				operatorHealthImpactLabelKey: "warning",
+				severityAlertLabelKey:        alertSeverityWarning,
+				operatorHealthImpactLabelKey: alertSeverityWarning,
 			},
 		},
 		{
@@ -91,8 +91,8 @@ func virtOperatorAlerts(namespace string) []promv1.Rule {
 				summaryAnnotationKey: "No ready virt-operator was detected for the last 10 min.",
 			},
 			Labels: map[string]string{
-				severityAlertLabelKey:        "critical",
-				operatorHealthImpactLabelKey: "critical",
+				severityAlertLabelKey:        alertSeverityCritical,
+				operatorHealthImpactLabelKey: alertSeverityCritical,
 			},
 		},
 		{
@@ -103,8 +103,8 @@ func virtOperatorAlerts(namespace string) []promv1.Rule {
 				summaryAnnotationKey: "No leading virt-operator was detected for the last 10 min.",
 			},
 			Labels: map[string]string{
-				severityAlertLabelKey:        "critical",
-				operatorHealthImpactLabelKey: "critical",
+				severityAlertLabelKey:        alertSeverityCritical,
+				operatorHealthImpactLabelKey: alertSeverityCritical,
 			},
 		},
 	}

--- a/pkg/monitoring/rules/alerts/vms.go
+++ b/pkg/monitoring/rules/alerts/vms.go
@@ -35,6 +35,8 @@ import (
 const excludedFilesystemTypesRegex = "CDFS|iso9660|udf|squashfs|cramfs|tmpfs|devtmpfs|proc|sysfs|selinuxfs|securityfs|pstore|debugfs|" +
 	"tracefs|configfs|binfmt_misc|bpf|devpts|mqueue|nsfs|rpc_pipefs|ramfs|rootfs|overlay|cgroup.*|fuse\\\\..*|fusectl"
 
+const alertGuestFilesystemAlmostOutOfSpace = "GuestFilesystemAlmostOutOfSpace"
+
 var vmsAlerts = []promv1.Rule{
 	{
 		Alert: "VirtLauncherPodsStuckFailed",
@@ -44,8 +46,8 @@ var vmsAlerts = []promv1.Rule{
 			summaryAnnotationKey: "At least 200 virt-launcher pods are stuck in Failed state and not deleted for 10 minutes.",
 		},
 		Labels: map[string]string{
-			severityAlertLabelKey:        "critical",
-			operatorHealthImpactLabelKey: "critical",
+			severityAlertLabelKey:        alertSeverityCritical,
+			operatorHealthImpactLabelKey: alertSeverityCritical,
 		},
 	},
 	{
@@ -60,8 +62,8 @@ var vmsAlerts = []promv1.Rule{
 			summaryAnnotationKey: "No ready virt-handler pod detected on node {{ $labels.node }} with running vmis for more than 10 minutes",
 		},
 		Labels: map[string]string{
-			severityAlertLabelKey:        "warning",
-			operatorHealthImpactLabelKey: "warning",
+			severityAlertLabelKey:        alertSeverityWarning,
+			operatorHealthImpactLabelKey: alertSeverityWarning,
 		},
 	},
 	{
@@ -77,8 +79,8 @@ var vmsAlerts = []promv1.Rule{
 			summaryAnnotationKey: "The VM's eviction strategy is set to Live Migration but the VM is not migratable",
 		},
 		Labels: map[string]string{
-			severityAlertLabelKey:        "warning",
-			operatorHealthImpactLabelKey: "none",
+			severityAlertLabelKey:        alertSeverityWarning,
+			operatorHealthImpactLabelKey: operatorHealthImpactNone,
 		},
 	},
 	{
@@ -92,8 +94,8 @@ var vmsAlerts = []promv1.Rule{
 			summaryAnnotationKey: "An excessive amount of migrations have been detected on a VirtualMachineInstance in the last 24 hours.",
 		},
 		Labels: map[string]string{
-			severityAlertLabelKey:        "warning",
-			operatorHealthImpactLabelKey: "none",
+			severityAlertLabelKey:        alertSeverityWarning,
+			operatorHealthImpactLabelKey: operatorHealthImpactNone,
 		},
 	},
 	{
@@ -104,8 +106,8 @@ var vmsAlerts = []promv1.Rule{
 			summaryAnnotationKey: "Some running VMIs are still active in outdated pods after KubeVirt control plane update has completed.",
 		},
 		Labels: map[string]string{
-			severityAlertLabelKey:        "warning",
-			operatorHealthImpactLabelKey: "none",
+			severityAlertLabelKey:        alertSeverityWarning,
+			operatorHealthImpactLabelKey: operatorHealthImpactNone,
 		},
 	},
 	{
@@ -116,8 +118,8 @@ var vmsAlerts = []promv1.Rule{
 			summaryAnnotationKey:     "Guest vCPU Queue within collection cycle > 10",
 		},
 		Labels: map[string]string{
-			severityAlertLabelKey:        "warning",
-			operatorHealthImpactLabelKey: "none",
+			severityAlertLabelKey:        alertSeverityWarning,
+			operatorHealthImpactLabelKey: operatorHealthImpactNone,
 		},
 	},
 	{
@@ -128,8 +130,8 @@ var vmsAlerts = []promv1.Rule{
 			summaryAnnotationKey:     "Guest vCPU Queue within collection cycle > 20",
 		},
 		Labels: map[string]string{
-			severityAlertLabelKey:        "critical",
-			operatorHealthImpactLabelKey: "none",
+			severityAlertLabelKey:        alertSeverityCritical,
+			operatorHealthImpactLabelKey: operatorHealthImpactNone,
 		},
 	},
 	{
@@ -146,8 +148,8 @@ var vmsAlerts = []promv1.Rule{
 				"{{ $labels.status }} state for more than 10 minutes.",
 		},
 		Labels: map[string]string{
-			severityAlertLabelKey:        "warning",
-			operatorHealthImpactLabelKey: "none",
+			severityAlertLabelKey:        alertSeverityWarning,
+			operatorHealthImpactLabelKey: operatorHealthImpactNone,
 		},
 	},
 	{
@@ -167,8 +169,8 @@ var vmsAlerts = []promv1.Rule{
 				"node.",
 		},
 		Labels: map[string]string{
-			severityAlertLabelKey:        "warning",
-			operatorHealthImpactLabelKey: "none",
+			severityAlertLabelKey:        alertSeverityWarning,
+			operatorHealthImpactLabelKey: operatorHealthImpactNone,
 		},
 	},
 	{
@@ -188,12 +190,12 @@ var vmsAlerts = []promv1.Rule{
 			summaryAnnotationKey: "The VirtualMachine is under memory pressure (possible thrashing)",
 		},
 		Labels: map[string]string{
-			severityAlertLabelKey:        "warning",
-			operatorHealthImpactLabelKey: "none",
+			severityAlertLabelKey:        alertSeverityWarning,
+			operatorHealthImpactLabelKey: operatorHealthImpactNone,
 		},
 	},
 	{
-		Alert: "GuestFilesystemAlmostOutOfSpace",
+		Alert: alertGuestFilesystemAlmostOutOfSpace,
 		Expr: intstr.FromString(fmt.Sprintf(
 			"(kubevirt_vmi_filesystem_used_bytes{namespace!='',file_system_type!~'%s',mount_point!='System Reserved'} / "+
 				"kubevirt_vmi_filesystem_capacity_bytes{namespace!='',file_system_type!~'%s',mount_point!='System Reserved'})*100 >= 85 < 95",
@@ -207,11 +209,11 @@ var vmsAlerts = []promv1.Rule{
 		},
 		Labels: map[string]string{
 			severityAlertLabelKey:        "warning",
-			operatorHealthImpactLabelKey: "none",
+			operatorHealthImpactLabelKey: operatorHealthImpactNone,
 		},
 	},
 	{
-		Alert: "GuestFilesystemAlmostOutOfSpace",
+		Alert: alertGuestFilesystemAlmostOutOfSpace,
 		Expr: intstr.FromString(fmt.Sprintf(
 			"(kubevirt_vmi_filesystem_used_bytes{namespace!='',file_system_type!~'%s',mount_point!='System Reserved'} / "+
 				"kubevirt_vmi_filesystem_capacity_bytes{namespace!='',file_system_type!~'%s',mount_point!='System Reserved'})*100 >= 95",
@@ -223,8 +225,8 @@ var vmsAlerts = []promv1.Rule{
 				"filesystem {{ $labels.disk_name }} ({{ $labels.mount_point }}) usage above 95% (current: {{ $value }}%).",
 		},
 		Labels: map[string]string{
-			severityAlertLabelKey:        "critical",
-			operatorHealthImpactLabelKey: "none",
+			severityAlertLabelKey:        alertSeverityCritical,
+			operatorHealthImpactLabelKey: operatorHealthImpactNone,
 		},
 	},
 	{
@@ -246,7 +248,7 @@ var vmsAlerts = []promv1.Rule{
 		},
 		Labels: map[string]string{
 			severityAlertLabelKey:        "info",
-			operatorHealthImpactLabelKey: "none",
+			operatorHealthImpactLabelKey: operatorHealthImpactNone,
 		},
 	},
 	{
@@ -259,7 +261,7 @@ var vmsAlerts = []promv1.Rule{
 		},
 		Labels: map[string]string{
 			severityAlertLabelKey:        "critical",
-			operatorHealthImpactLabelKey: "none",
+			operatorHealthImpactLabelKey: operatorHealthImpactNone,
 		},
 	},
 }

--- a/pkg/monitoring/rules/recordingrules/operator.go
+++ b/pkg/monitoring/rules/recordingrules/operator.go
@@ -24,14 +24,21 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
+const (
+	memoryDeltaMetricName = "container:kubevirt_memory_delta_from_requested_bytes:max"
+	reasonLabel           = "reason"
+	reasonWorkingSetDelta = "memory_working_set_delta_from_request"
+	reasonRSSDelta        = "memory_rss_delta_from_request"
+)
+
 var operatorRecordingRules = []operatorrules.RecordingRule{
 	{
 		MetricsOpts: operatormetrics.MetricOpts{
-			Name: "container:kubevirt_memory_delta_from_requested_bytes:max",
+			Name: memoryDeltaMetricName,
 			Help: "The delta between the pod with highest memory working set or rss and its requested memory for each container, " +
 				"virt-controller, virt-handler, virt-api, virt-operator and compute(virt-launcher).",
 			ConstLabels: map[string]string{
-				"reason": "memory_working_set_delta_from_request",
+				reasonLabel: reasonWorkingSetDelta,
 			},
 		},
 		MetricType: operatormetrics.GaugeType,
@@ -46,11 +53,11 @@ var operatorRecordingRules = []operatorrules.RecordingRule{
 	},
 	{
 		MetricsOpts: operatormetrics.MetricOpts{
-			Name: "container:kubevirt_memory_delta_from_requested_bytes:max",
+			Name: memoryDeltaMetricName,
 			Help: "The delta between the pod with highest memory working set or rss and its requested memory for each container, " +
 				"virt-controller, virt-handler, virt-api, virt-operator and compute(virt-launcher).",
 			ConstLabels: map[string]string{
-				"reason": "memory_rss_delta_from_request",
+				reasonLabel: reasonRSSDelta,
 			},
 		},
 		MetricType: operatormetrics.GaugeType,

--- a/pkg/network/admitter/admit_test.go
+++ b/pkg/network/admitter/admit_test.go
@@ -34,17 +34,35 @@ import (
 	"kubevirt.io/kubevirt/pkg/network/admitter"
 )
 
+const (
+	fooIfaceName              = "foo"
+	net1Name                  = "default"
+	testPortName              = "test"
+	fieldValueInvalidType     = "FieldValueInvalid"
+	fieldValueDuplicateType   = "FieldValueDuplicate"
+	fakePrimaryIfaceNameField = "fake.domain.devices.interfaces[0].name"
+	draClaimName              = "claim1"
+	draNetworkName            = "dra-net"
+	multusNet1Name            = "multus-net1"
+	tcpProtocol               = "TCP"
+	udpProtocol               = "UDP"
+	extraOptionsDomain        = "extra.options.kubevirt.io"
+	secondaryIfaceName        = "multus1"
+	netNetworkName            = "net"
+	fakeDomainState           = "fake.domain.devices.interfaces[0].state"
+)
+
 var _ = Describe("Validating VMI network spec", func() {
 	DescribeTable("network interface state valid value", func(value v1.InterfaceState) {
 		vm := libvmi.New(
 			libvmi.WithInterface(v1.Interface{
-				Name:                   "foo",
+				Name:                   fooIfaceName,
 				State:                  value,
 				InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}},
 			}),
 			libvmi.WithNetwork(&v1.Network{
-				Name:          "foo",
-				NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{NetworkName: "net"}},
+				Name:          fooIfaceName,
+				NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{NetworkName: netNetworkName}},
 			}),
 		)
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vm.Spec, stubClusterConfigChecker{})
@@ -59,41 +77,41 @@ var _ = Describe("Validating VMI network spec", func() {
 	It("network interface state value is invalid", func() {
 		vm := libvmi.New(
 			libvmi.WithNetwork(&v1.Network{
-				Name:          "foo",
+				Name:          fooIfaceName,
 				NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}},
 			}),
 			libvmi.WithInterface(v1.Interface{
-				Name:                   "foo",
-				State:                  v1.InterfaceState("foo"),
+				Name:                   fooIfaceName,
+				State:                  v1.InterfaceState(fooIfaceName),
 				InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}},
 			}),
 		)
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vm.Spec, stubClusterConfigChecker{})
 		Expect(validator.Validate()).To(
 			ConsistOf(metav1.StatusCause{
-				Type:    "FieldValueInvalid",
+				Type:    fieldValueInvalidType,
 				Message: "logical foo interface state value is unsupported: foo",
-				Field:   "fake.domain.devices.interfaces[0].state",
+				Field:   fakeDomainState,
 			}))
 	})
 
 	DescribeTable("network interface state ", func(state v1.InterfaceState, messageRegex types.GomegaMatcher) {
 		vm := libvmi.New(
 			libvmi.WithInterface(v1.Interface{
-				Name:                   "foo",
+				Name:                   fooIfaceName,
 				State:                  state,
 				InterfaceBindingMethod: v1.InterfaceBindingMethod{SRIOV: &v1.InterfaceSRIOV{}},
 			}),
 			libvmi.WithNetwork(&v1.Network{
-				Name:          "foo",
-				NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{NetworkName: "net"}},
+				Name:          fooIfaceName,
+				NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{NetworkName: netNetworkName}},
 			}),
 		)
 		statusCause := admitter.NewValidator(k8sfield.NewPath("fake"), &vm.Spec, stubClusterConfigChecker{}).Validate()
 		Expect(statusCause).To(HaveLen(1))
 		Expect(statusCause[0]).To(MatchAllFields(Fields{
-			"Type":    Equal(metav1.CauseType("FieldValueInvalid")),
-			"Field":   Equal("fake.domain.devices.interfaces[0].state"),
+			"Type":    Equal(metav1.CauseType(fieldValueInvalidType)),
+			"Field":   Equal(fakeDomainState),
 			"Message": messageRegex,
 		}))
 	},
@@ -105,11 +123,11 @@ var _ = Describe("Validating VMI network spec", func() {
 	It("network interface state value of absent is not supported on the default network", func() {
 		vm := libvmi.New(
 			libvmi.WithNetwork(&v1.Network{
-				Name:          "foo",
+				Name:          fooIfaceName,
 				NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}},
 			}),
 			libvmi.WithInterface(v1.Interface{
-				Name:                   "foo",
+				Name:                   fooIfaceName,
 				State:                  v1.InterfaceStateAbsent,
 				InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}},
 			}),
@@ -119,9 +137,9 @@ var _ = Describe("Validating VMI network spec", func() {
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vm.Spec, clusterConfig)
 		Expect(validator.Validate()).To(
 			ConsistOf(metav1.StatusCause{
-				Type:    "FieldValueInvalid",
+				Type:    fieldValueInvalidType,
 				Message: "\"foo\" interface's state \"absent\" is not supported on default networks",
-				Field:   "fake.domain.devices.interfaces[0].state",
+				Field:   fakeDomainState,
 			}))
 	})
 })

--- a/pkg/network/admitter/binding_test.go
+++ b/pkg/network/admitter/binding_test.go
@@ -33,8 +33,10 @@ import (
 )
 
 const (
-	booBindingName     = "boo"
-	fakeDomainMACField = "fake.domain.devices.interfaces[0].macAddress"
+	booBindingName           = "boo"
+	fakeDomainMACField       = "fake.domain.devices.interfaces[0].macAddress"
+	bindingErrMsg            = "logical foo interface must have exactly one binding method or binding plugin"
+	fakeDomainInterfaceField = "fake.domain.devices.interfaces[0]"
 )
 
 var _ = Describe("Validating network binding combinations", func() {
@@ -55,8 +57,8 @@ var _ = Describe("Validating network binding combinations", func() {
 		Expect(validator.Validate()).To(
 			ConsistOf(metav1.StatusCause{
 				Type:    fieldValueInvalidType,
-				Message: "logical foo interface must have exactly one binding method or binding plugin",
-				Field:   "fake.domain.devices.interfaces[0]",
+				Message: bindingErrMsg,
+				Field:   fakeDomainInterfaceField,
 			}))
 	})
 
@@ -79,10 +81,10 @@ var _ = Describe("Validating network binding combinations", func() {
 	It("network interface has neither binding plugin nor interface binding method", func() {
 		vm := libvmi.New(
 			libvmi.WithInterface(v1.Interface{
-				Name: "foo",
+				Name: fooIfaceName,
 			}),
 			libvmi.WithNetwork(&v1.Network{
-				Name:          "foo",
+				Name:          fooIfaceName,
 				NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}},
 			}),
 		)
@@ -90,23 +92,23 @@ var _ = Describe("Validating network binding combinations", func() {
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vm.Spec, clusterConfig)
 		Expect(validator.Validate()).To(
 			ConsistOf(metav1.StatusCause{
-				Type:    "FieldValueInvalid",
-				Message: "logical foo interface must have exactly one binding method or binding plugin",
-				Field:   "fake.domain.devices.interfaces[0]",
+				Type:    fieldValueInvalidType,
+				Message: bindingErrMsg,
+				Field:   fakeDomainInterfaceField,
 			}))
 	})
 
 	It("network interface has more than one binding method", func() {
 		vm := libvmi.New(
 			libvmi.WithInterface(v1.Interface{
-				Name: "foo",
+				Name: fooIfaceName,
 				InterfaceBindingMethod: v1.InterfaceBindingMethod{
 					Bridge:     &v1.InterfaceBridge{},
 					Masquerade: &v1.InterfaceMasquerade{},
 				},
 			}),
 			libvmi.WithNetwork(&v1.Network{
-				Name:          "foo",
+				Name:          fooIfaceName,
 				NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}},
 			}),
 		)
@@ -114,9 +116,9 @@ var _ = Describe("Validating network binding combinations", func() {
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vm.Spec, clusterConfig)
 		Expect(validator.Validate()).To(
 			ConsistOf(metav1.StatusCause{
-				Type:    "FieldValueInvalid",
-				Message: "logical foo interface must have exactly one binding method or binding plugin",
-				Field:   "fake.domain.devices.interfaces[0]",
+				Type:    fieldValueInvalidType,
+				Message: bindingErrMsg,
+				Field:   fakeDomainInterfaceField,
 			}))
 	})
 

--- a/pkg/network/admitter/binding_test.go
+++ b/pkg/network/admitter/binding_test.go
@@ -32,16 +32,21 @@ import (
 	"kubevirt.io/kubevirt/pkg/network/admitter"
 )
 
+const (
+	booBindingName     = "boo"
+	fakeDomainMACField = "fake.domain.devices.interfaces[0].macAddress"
+)
+
 var _ = Describe("Validating network binding combinations", func() {
 	It("network interface has both binding plugin and interface binding method", func() {
 		vm := libvmi.New(
 			libvmi.WithInterface(v1.Interface{
-				Name:                   "foo",
+				Name:                   fooIfaceName,
 				InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}},
-				Binding:                &v1.PluginBinding{Name: "boo"},
+				Binding:                &v1.PluginBinding{Name: booBindingName},
 			}),
 			libvmi.WithNetwork(&v1.Network{
-				Name:          "foo",
+				Name:          fooIfaceName,
 				NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}},
 			}),
 		)
@@ -49,7 +54,7 @@ var _ = Describe("Validating network binding combinations", func() {
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vm.Spec, clusterConfig)
 		Expect(validator.Validate()).To(
 			ConsistOf(metav1.StatusCause{
-				Type:    "FieldValueInvalid",
+				Type:    fieldValueInvalidType,
 				Message: "logical foo interface must have exactly one binding method or binding plugin",
 				Field:   "fake.domain.devices.interfaces[0]",
 			}))
@@ -58,11 +63,11 @@ var _ = Describe("Validating network binding combinations", func() {
 	It("network interface has only plugin binding", func() {
 		vm := libvmi.New(
 			libvmi.WithInterface(v1.Interface{
-				Name:    "foo",
-				Binding: &v1.PluginBinding{Name: "boo"},
+				Name:    fooIfaceName,
+				Binding: &v1.PluginBinding{Name: booBindingName},
 			}),
 			libvmi.WithNetwork(&v1.Network{
-				Name:          "foo",
+				Name:          fooIfaceName,
 				NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}},
 			}),
 		)
@@ -118,11 +123,11 @@ var _ = Describe("Validating network binding combinations", func() {
 	It("network interface has only binding method", func() {
 		vm := libvmi.New(
 			libvmi.WithNetwork(&v1.Network{
-				Name:          "foo",
+				Name:          fooIfaceName,
 				NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}},
 			}),
 			libvmi.WithInterface(v1.Interface{
-				Name:                   "foo",
+				Name:                   fooIfaceName,
 				InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}},
 			}),
 		)
@@ -136,13 +141,13 @@ var _ = Describe("Validating core binding", func() {
 	It("should reject a masquerade interface on a network different than pod", func() {
 		vmi := libvmi.New(
 			libvmi.WithInterface(v1.Interface{
-				Name:                   "default",
+				Name:                   net1Name,
 				InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}},
-				Ports:                  []v1.Port{{Name: "test"}},
+				Ports:                  []v1.Port{{Name: testPortName}},
 			}),
 			libvmi.WithNetwork(&v1.Network{
-				Name:          "default",
-				NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{NetworkName: "test"}},
+				Name:          net1Name,
+				NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{NetworkName: testPortName}},
 			}),
 		)
 
@@ -150,9 +155,9 @@ var _ = Describe("Validating core binding", func() {
 		causes := validator.Validate()
 
 		Expect(causes).To(ConsistOf(metav1.StatusCause{
-			Type:    "FieldValueInvalid",
+			Type:    fieldValueInvalidType,
 			Message: "Masquerade interface only implemented with pod network",
-			Field:   "fake.domain.devices.interfaces[0].name",
+			Field:   fakePrimaryIfaceNameField,
 		}))
 	})
 
@@ -160,7 +165,7 @@ var _ = Describe("Validating core binding", func() {
 		vmi := libvmi.New(
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
 			libvmi.WithInterface(v1.Interface{
-				Name:                   "default",
+				Name:                   net1Name,
 				InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}},
 				MacAddress:             "02:00:00:00:00:00",
 			}),
@@ -170,9 +175,9 @@ var _ = Describe("Validating core binding", func() {
 		causes := validator.Validate()
 
 		Expect(causes).To(ConsistOf(metav1.StatusCause{
-			Type:    "FieldValueInvalid",
+			Type:    fieldValueInvalidType,
 			Message: "The requested MAC address is reserved for the in-pod bridge. Please choose another one.",
-			Field:   "fake.domain.devices.interfaces[0].macAddress",
+			Field:   fakeDomainMACField,
 		}))
 	})
 
@@ -186,9 +191,9 @@ var _ = Describe("Validating core binding", func() {
 		causes := validator.Validate()
 
 		Expect(causes).To(ConsistOf(metav1.StatusCause{
-			Type:    "FieldValueInvalid",
+			Type:    fieldValueInvalidType,
 			Message: "Bridge on pod network configuration is not enabled under kubevirt-config",
-			Field:   "fake.domain.devices.interfaces[0].name",
+			Field:   fakePrimaryIfaceNameField,
 		}))
 	})
 })

--- a/pkg/network/admitter/discontinued_test.go
+++ b/pkg/network/admitter/discontinued_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Validate discontinued bindings", func() {
 		func(interfaceBindingMethod v1.InterfaceBindingMethod, expectedMessage, expectedField string) {
 			vmi := libvmi.New(
 				libvmi.WithInterface(v1.Interface{
-					Name:                   "default",
+					Name:                   net1Name,
 					InterfaceBindingMethod: interfaceBindingMethod,
 				}),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
@@ -47,7 +47,7 @@ var _ = Describe("Validate discontinued bindings", func() {
 			causes := validator.ValidateCreation()
 			Expect(causes).To(
 				ConsistOf(metav1.StatusCause{
-					Type:    "FieldValueInvalid",
+					Type:    fieldValueInvalidType,
 					Message: expectedMessage,
 					Field:   expectedField,
 				}),

--- a/pkg/network/admitter/dra_test.go
+++ b/pkg/network/admitter/dra_test.go
@@ -20,6 +20,8 @@
 package admitter_test
 
 import (
+	"fmt"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -29,6 +31,13 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 
 	"kubevirt.io/kubevirt/pkg/network/admitter"
+)
+
+const (
+	draNet1Name   = "dra-net-1"
+	draNet2Name   = "dra-net-2"
+	vfRequest     = "vf"
+	multusNetName = "multus-net"
 )
 
 var _ = Describe("Validate network DRA", func() {
@@ -82,13 +91,13 @@ var _ = Describe("Validate network DRA", func() {
 		spec := newDRASpec()
 		spec.Domain.Devices.Interfaces = []v1.Interface{
 			{
-				Name: "dra-net-1",
+				Name: draNet1Name,
 				InterfaceBindingMethod: v1.InterfaceBindingMethod{
 					SRIOV: &v1.InterfaceSRIOV{},
 				},
 			},
 			{
-				Name: "dra-net-2",
+				Name: draNet2Name,
 				InterfaceBindingMethod: v1.InterfaceBindingMethod{
 					SRIOV: &v1.InterfaceSRIOV{},
 				},
@@ -96,20 +105,20 @@ var _ = Describe("Validate network DRA", func() {
 		}
 		spec.Networks = []v1.Network{
 			{
-				Name: "dra-net-1",
+				Name: draNet1Name,
 				NetworkSource: v1.NetworkSource{
 					ResourceClaim: &v1.ClaimRequest{
-						ClaimName:   "claim1",
-						RequestName: "vf",
+						ClaimName:   draClaimName,
+						RequestName: vfRequest,
 					},
 				},
 			},
 			{
-				Name: "dra-net-2",
+				Name: draNet2Name,
 				NetworkSource: v1.NetworkSource{
 					ResourceClaim: &v1.ClaimRequest{
-						ClaimName:   "claim1",
-						RequestName: "vf",
+						ClaimName:   draClaimName,
+						RequestName: vfRequest,
 					},
 				},
 			},
@@ -125,13 +134,13 @@ var _ = Describe("Validate network DRA", func() {
 		spec := newDRASpec()
 		spec.Domain.Devices.Interfaces = []v1.Interface{
 			{
-				Name: "multus-net",
+				Name: multusNetName,
 				InterfaceBindingMethod: v1.InterfaceBindingMethod{
 					SRIOV: &v1.InterfaceSRIOV{},
 				},
 			},
 			{
-				Name: "dra-net",
+				Name: draNetworkName,
 				InterfaceBindingMethod: v1.InterfaceBindingMethod{
 					SRIOV: &v1.InterfaceSRIOV{},
 				},
@@ -139,7 +148,7 @@ var _ = Describe("Validate network DRA", func() {
 		}
 		spec.Networks = []v1.Network{
 			{
-				Name:          "multus-net",
+				Name:          multusNetName,
 				NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{NetworkName: "nad1"}},
 			},
 			spec.Networks[0],
@@ -154,11 +163,11 @@ var _ = Describe("Validate network DRA", func() {
 	It("should reject DRA network with non-SRIOV interface binding", func() {
 		spec := newDRASpec()
 		spec.Domain.Devices.Interfaces[0] = *v1.DefaultBridgeNetworkInterface()
-		spec.Domain.Devices.Interfaces[0].Name = "dra-net"
+		spec.Domain.Devices.Interfaces[0].Name = draNetworkName
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{networkDRAEnabled: true})
 		causes := validator.Validate()
 		Expect(causes).To(HaveLen(1))
-		Expect(causes[0].Message).To(Equal(`DRA network "dra-net" requires an SR-IOV or binding plugin interface`))
+		Expect(causes[0].Message).To(Equal(fmt.Sprintf(`DRA network %q requires an SR-IOV or binding plugin interface`, draNetworkName)))
 		Expect(causes[0].Field).To(Equal("fake.domain.devices.interfaces"))
 	})
 
@@ -166,20 +175,20 @@ var _ = Describe("Validate network DRA", func() {
 		spec := newDRASpec()
 		spec.Domain.Devices.Interfaces = []v1.Interface{
 			{
-				Name: "default",
+				Name: net1Name,
 				InterfaceBindingMethod: v1.InterfaceBindingMethod{
 					Masquerade: &v1.InterfaceMasquerade{},
 				},
 			},
 			{
-				Name: "dra-net",
+				Name: draNetworkName,
 				Binding: &v1.PluginBinding{
 					Name: "vhostuser",
 				},
 			},
 		}
 		spec.Networks = append(spec.Networks, v1.Network{
-			Name:          "default",
+			Name:          net1Name,
 			NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}},
 		})
 
@@ -194,7 +203,7 @@ var _ = Describe("Validate network DRA", func() {
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{networkDRAEnabled: true})
 		causes := validator.Validate()
 		Expect(causes).To(HaveLen(1))
-		Expect(causes[0].Message).To(Equal("fake.networks[0].name 'dra-net' not found."))
+		Expect(causes[0].Message).To(Equal(fmt.Sprintf("fake.networks[0].name '%s' not found.", draNetworkName)))
 		Expect(causes[0].Field).To(Equal("fake.networks[0].name"))
 	})
 })
@@ -205,7 +214,7 @@ func newDRASpec() *v1.VirtualMachineInstanceSpec {
 			Devices: v1.Devices{
 				Interfaces: []v1.Interface{
 					{
-						Name: "dra-net",
+						Name: draNetworkName,
 						InterfaceBindingMethod: v1.InterfaceBindingMethod{
 							SRIOV: &v1.InterfaceSRIOV{},
 						},
@@ -215,17 +224,17 @@ func newDRASpec() *v1.VirtualMachineInstanceSpec {
 		},
 		Networks: []v1.Network{
 			{
-				Name: "dra-net",
+				Name: draNetworkName,
 				NetworkSource: v1.NetworkSource{
 					ResourceClaim: &v1.ClaimRequest{
-						ClaimName:   "claim1",
-						RequestName: "vf",
+						ClaimName:   draClaimName,
+						RequestName: vfRequest,
 					},
 				},
 			},
 		},
 		ResourceClaims: []v1.VirtualMachineInstanceResourceClaim{
-			{Name: "claim1", ResourceClaimName: ptr.To("claim1")},
+			{Name: draClaimName, ResourceClaimName: ptr.To(draClaimName)},
 		},
 	}
 }

--- a/pkg/network/admitter/netiface.go
+++ b/pkg/network/admitter/netiface.go
@@ -236,11 +236,17 @@ func validateForwardPortsName(field *k8sfield.Path, idx int, ports []v1.Port) []
 	return causes
 }
 
+const (
+	tcpProtocol        = "TCP"
+	udpProtocol        = "UDP"
+	unknownProtocolMsg = "Unknown protocol, only TCP or UDP allowed"
+)
+
 func validateForwardPortProtocol(field *k8sfield.Path, idx int, forwardPort v1.Port, portIdx int) []metav1.StatusCause {
-	if forwardPort.Protocol != "" && forwardPort.Protocol != "TCP" && forwardPort.Protocol != "UDP" {
+	if forwardPort.Protocol != "" && forwardPort.Protocol != tcpProtocol && forwardPort.Protocol != udpProtocol {
 		return []metav1.StatusCause{{
 			Type:    metav1.CauseTypeFieldValueInvalid,
-			Message: "Unknown protocol, only TCP or UDP allowed",
+			Message: unknownProtocolMsg,
 			Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("ports").Index(portIdx).Child("protocol").String(),
 		}}
 	}
@@ -341,7 +347,7 @@ func validateForwardPortRanges(field *k8sfield.Path, idx int, portRanges []v1.Po
 		case portRange.Protocol != "TCP" && portRange.Protocol != "UDP":
 			causes = append(causes, metav1.StatusCause{
 				Type:    metav1.CauseTypeFieldValueInvalid,
-				Message: "Unknown protocol, only TCP or UDP allowed",
+				Message: unknownProtocolMsg,
 				Field:   field.Child("domain", "devices", "interfaces").Index(idx).Child("portRanges").Index(portRangeIdx).Child("protocol").String(),
 			})
 		case portRange.Start <= 0 || portRange.Start >= 65536:

--- a/pkg/network/admitter/netiface_test.go
+++ b/pkg/network/admitter/netiface_test.go
@@ -33,6 +33,17 @@ import (
 	"kubevirt.io/kubevirt/pkg/network/admitter"
 )
 
+const (
+	fieldValueRequired       = "FieldValueRequired"
+	badInterfaceName         = "bad.name"
+	fakeDomainPortField      = "fake.domain.devices.interfaces[0].ports[0].port"
+	unknownProtocolMsg       = "Unknown protocol, only TCP or UDP allowed"
+	testportName             = "testport"
+	fakeDomainPortRangeField = "fake.domain.devices.interfaces[0].portRanges[0].start"
+	fakeDomainField          = "fake"
+	ntpServersMsg            = "NTP servers must be a list of valid IPv4 addresses."
+)
+
 var _ = Describe("Validating VMI network spec", func() {
 	It("should reject network with missing interface", func() {
 		spec := &v1.VirtualMachineInstanceSpec{}
@@ -46,7 +57,7 @@ var _ = Describe("Validating VMI network spec", func() {
 		causes := validator.Validate()
 
 		Expect(causes).To(ConsistOf(metav1.StatusCause{
-			Type:    "FieldValueRequired",
+			Type:    fieldValueRequired,
 			Message: "fake.networks[0].name 'not-the-default' not found.",
 			Field:   "fake.networks[0].name",
 		}))
@@ -61,9 +72,9 @@ var _ = Describe("Validating VMI network spec", func() {
 		causes := validator.Validate()
 
 		Expect(causes).To(ConsistOf(metav1.StatusCause{
-			Type:    "FieldValueInvalid",
+			Type:    fieldValueInvalidType,
 			Message: "fake.domain.devices.interfaces[0].name 'default' not found.",
-			Field:   "fake.domain.devices.interfaces[0].name",
+			Field:   fakePrimaryIfaceNameField,
 		}))
 	})
 
@@ -72,15 +83,15 @@ var _ = Describe("Validating VMI network spec", func() {
 		spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultBridgeNetworkInterface()}
 		spec.Networks = []v1.Network{
 			{
-				Name: "default",
+				Name: net1Name,
 				NetworkSource: v1.NetworkSource{
 					Pod: &v1.PodNetwork{},
 				},
 			},
 			{
-				Name: "default",
+				Name: net1Name,
 				NetworkSource: v1.NetworkSource{
-					Multus: &v1.MultusNetwork{NetworkName: "test"},
+					Multus: &v1.MultusNetwork{NetworkName: testPortName},
 				},
 			},
 		}
@@ -89,7 +100,7 @@ var _ = Describe("Validating VMI network spec", func() {
 		causes := validator.Validate()
 
 		Expect(causes).To(ConsistOf(metav1.StatusCause{
-			Type:    "FieldValueDuplicate",
+			Type:    fieldValueDuplicateType,
 			Message: "Network with name \"default\" already exists, every network must have a unique name",
 			Field:   "fake.networks[1].name",
 		}))
@@ -102,15 +113,15 @@ var _ = Describe("Validating VMI network spec", func() {
 			*v1.DefaultBridgeNetworkInterface(),
 		}
 		spec.Networks = []v1.Network{
-			{Name: "default", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}},
-			{Name: "default", NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{NetworkName: "test"}}},
+			{Name: net1Name, NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}},
+			{Name: net1Name, NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{NetworkName: testPortName}}},
 		}
 
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{})
 		causes := validator.Validate()
 
 		Expect(causes).To(ContainElements(metav1.StatusCause{
-			Type:    "FieldValueDuplicate",
+			Type:    fieldValueDuplicateType,
 			Message: "Only one interface can be connected to one specific network",
 			Field:   "fake.domain.devices.interfaces[1].name",
 		}))
@@ -119,16 +130,16 @@ var _ = Describe("Validating VMI network spec", func() {
 	It("should reject interface named with unsupported characters", func() {
 		spec := &v1.VirtualMachineInstanceSpec{}
 		spec.Domain.Devices.Interfaces = []v1.Interface{{
-			Name:                   "bad.name",
+			Name:                   badInterfaceName,
 			InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}},
 		}}
-		spec.Networks = []v1.Network{{Name: "bad.name", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}}}
+		spec.Networks = []v1.Network{{Name: badInterfaceName, NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}}}
 
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{})
 		Expect(validator.Validate()).To(ConsistOf(metav1.StatusCause{
-			Type:    "FieldValueInvalid",
+			Type:    fieldValueInvalidType,
 			Message: "Network interface name can only contain alphabetical characters, numbers, dashes (-) or underscores (_)",
-			Field:   "fake.domain.devices.interfaces[0].name",
+			Field:   fakePrimaryIfaceNameField,
 		}))
 	})
 
@@ -164,9 +175,9 @@ var _ = Describe("Validating VMI network spec", func() {
 
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{})
 		Expect(validator.Validate()).To(ConsistOf(metav1.StatusCause{
-			Type:    "FieldValueInvalid",
+			Type:    fieldValueInvalidType,
 			Message: expectedMessage,
-			Field:   "fake.domain.devices.interfaces[0].macAddress",
+			Field:   fakeDomainMACField,
 		}))
 	},
 		Entry(
@@ -209,7 +220,7 @@ var _ = Describe("Validating VMI network spec", func() {
 
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{})
 		Expect(validator.Validate()).To(ConsistOf(metav1.StatusCause{
-			Type:    "FieldValueInvalid",
+			Type:    fieldValueInvalidType,
 			Message: fmt.Sprintf("interface fake.domain.devices.interfaces[0].name has malformed PCI address (%s).", pciAddress),
 			Field:   "fake.domain.devices.interfaces[0].pciAddress",
 		}))
@@ -236,30 +247,30 @@ var _ = Describe("Validating VMI network spec", func() {
 		DescribeTable("should reject interface port with", func(ports []v1.Port, expectedCauses []metav1.StatusCause) {
 			spec := &v1.VirtualMachineInstanceSpec{}
 			spec.Domain.Devices.Interfaces = []v1.Interface{{
-				Name:                   "default",
+				Name:                   net1Name,
 				InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}},
 				Ports:                  ports,
 			}}
-			spec.Networks = []v1.Network{{Name: "default", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}}}
+			spec.Networks = []v1.Network{{Name: net1Name, NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}}}
 
 			validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{})
 			Expect(validator.Validate()).To(ConsistOf(expectedCauses))
 		},
 			Entry(
 				"only the port name",
-				[]v1.Port{{Name: "test"}},
+				[]v1.Port{{Name: testPortName}},
 				[]metav1.StatusCause{{
-					Type:    "FieldValueRequired",
+					Type:    fieldValueRequired,
 					Message: "Port field is mandatory.",
-					Field:   "fake.domain.devices.interfaces[0].ports[0].port",
+					Field:   fakeDomainPortField,
 				}},
 			),
 			Entry(
 				"bad protocol type",
 				[]v1.Port{{Protocol: "bad", Port: 80}},
 				[]metav1.StatusCause{{
-					Type:    "FieldValueInvalid",
-					Message: "Unknown protocol, only TCP or UDP allowed",
+					Type:    fieldValueInvalidType,
+					Message: unknownProtocolMsg,
 					Field:   "fake.domain.devices.interfaces[0].ports[0].protocol",
 				}},
 			),
@@ -267,16 +278,16 @@ var _ = Describe("Validating VMI network spec", func() {
 				"port out of range",
 				[]v1.Port{{Port: 80000}},
 				[]metav1.StatusCause{{
-					Type:    "FieldValueInvalid",
+					Type:    fieldValueInvalidType,
 					Message: "Port field must be in range 0 < x < 65536.",
-					Field:   "fake.domain.devices.interfaces[0].ports[0].port",
+					Field:   fakeDomainPortField,
 				}},
 			),
 			Entry(
 				"two ports that have the same name",
-				[]v1.Port{{Name: "testport", Port: 80}, {Name: "testport", Protocol: "UDP", Port: 80}},
+				[]v1.Port{{Name: testportName, Port: 80}, {Name: testportName, Protocol: udpProtocol, Port: 80}},
 				[]metav1.StatusCause{{
-					Type:    "FieldValueDuplicate",
+					Type:    fieldValueDuplicateType,
 					Message: "Duplicate name of the port: testport",
 					Field:   "fake.domain.devices.interfaces[0].ports[1].name",
 				}},
@@ -285,7 +296,7 @@ var _ = Describe("Validating VMI network spec", func() {
 				"bad port name",
 				[]v1.Port{{Name: "Test", Port: 80}},
 				[]metav1.StatusCause{{
-					Type:    "FieldValueInvalid",
+					Type:    fieldValueInvalidType,
 					Message: "Invalid name of the port: Test",
 					Field:   "fake.domain.devices.interfaces[0].ports[0].name",
 				}},
@@ -295,20 +306,20 @@ var _ = Describe("Validating VMI network spec", func() {
 		DescribeTable("should accept interface with", func(ports []v1.Port) {
 			spec := &v1.VirtualMachineInstanceSpec{}
 			spec.Domain.Devices.Interfaces = []v1.Interface{{
-				Name:                   "default",
+				Name:                   net1Name,
 				InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}},
 				Ports:                  ports,
 			}}
-			spec.Networks = []v1.Network{{Name: "default", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}}}
+			spec.Networks = []v1.Network{{Name: net1Name, NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}}}
 
 			validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{})
 			Expect(validator.Validate()).To(BeEmpty())
 		},
 			Entry("single minimal port", []v1.Port{{Port: 80}}),
-			Entry("multiple ports, same number, with protocol and without", []v1.Port{{Port: 80}, {Protocol: "UDP", Port: 80}}),
+			Entry("multiple ports, same number, with protocol and without", []v1.Port{{Port: 80}, {Protocol: udpProtocol, Port: 80}}),
 			Entry(
 				"multiple ports, same number, different protocols",
-				[]v1.Port{{Port: 80}, {Protocol: "UDP", Port: 80}, {Protocol: "TCP", Port: 80}},
+				[]v1.Port{{Port: 80}, {Protocol: udpProtocol, Port: 80}, {Protocol: tcpProtocol, Port: 80}},
 			),
 		)
 	})
@@ -316,65 +327,65 @@ var _ = Describe("Validating VMI network spec", func() {
 		It("should reject portRanges when feature gate is disabled", func() {
 			spec := &v1.VirtualMachineInstanceSpec{}
 			spec.Domain.Devices.Interfaces = []v1.Interface{{
-				Name:                   "default",
+				Name:                   net1Name,
 				InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}},
 				PortRanges:             []v1.PortRange{{Start: 80, End: 90}},
 			}}
-			spec.Networks = []v1.Network{{Name: "default", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}}}
+			spec.Networks = []v1.Network{{Name: net1Name, NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}}}
 
 			validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{portRangesSpecGateEnabled: false})
 			Expect(validator.Validate()).To(ConsistOf(metav1.StatusCause{
-				Type:    "FieldValueInvalid",
+				Type:    fieldValueInvalidType,
 				Message: "portRanges is specified on interface but the PortRangesSpec feature gate is not enabled",
-				Field:   "fake.domain.devices.interfaces[0].name",
+				Field:   fakePrimaryIfaceNameField,
 			}))
 		})
 		It("should reject when binding method is not masquerade", func() {
 			spec := &v1.VirtualMachineInstanceSpec{}
 			spec.Domain.Devices.Interfaces = []v1.Interface{{
-				Name:                   "default",
+				Name:                   net1Name,
 				InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}},
-				PortRanges:             []v1.PortRange{{Protocol: "TCP", Start: 80, End: 90}},
+				PortRanges:             []v1.PortRange{{Protocol: tcpProtocol, Start: 80, End: 90}},
 			}}
-			spec.Networks = []v1.Network{{Name: "default", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}}}
+			spec.Networks = []v1.Network{{Name: net1Name, NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}}}
 
 			validator := admitter.NewValidator(
 				k8sfield.NewPath("fake"), spec,
 				stubClusterConfigChecker{portRangesSpecGateEnabled: true, bridgeBindingOnPodNetEnabled: true},
 			)
 			Expect(validator.Validate()).To(ConsistOf(metav1.StatusCause{
-				Type:    "FieldValueInvalid",
+				Type:    fieldValueInvalidType,
 				Message: "portRanges are only supported on masquerade interfaces",
-				Field:   "fake.domain.devices.interfaces[0].name",
+				Field:   fakePrimaryIfaceNameField,
 			}))
 		})
 
 		It("should reject when portRanges and ports are both set", func() {
 			spec := &v1.VirtualMachineInstanceSpec{}
 			spec.Domain.Devices.Interfaces = []v1.Interface{{
-				Name:                   "default",
+				Name:                   net1Name,
 				InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}},
 				Ports:                  []v1.Port{{Port: 22}},
-				PortRanges:             []v1.PortRange{{Protocol: "TCP", Start: 80, End: 90}},
+				PortRanges:             []v1.PortRange{{Protocol: tcpProtocol, Start: 80, End: 90}},
 			}}
-			spec.Networks = []v1.Network{{Name: "default", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}}}
+			spec.Networks = []v1.Network{{Name: net1Name, NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}}}
 
 			validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{portRangesSpecGateEnabled: true})
 			Expect(validator.Validate()).To(ConsistOf(metav1.StatusCause{
-				Type:    "FieldValueInvalid",
+				Type:    fieldValueInvalidType,
 				Message: "Cannot define both ports and portRanges on interface",
-				Field:   "fake.domain.devices.interfaces[0].name",
+				Field:   fakePrimaryIfaceNameField,
 			}))
 		})
 
 		DescribeTable("should reject portRanges with", func(portRanges []v1.PortRange, expectedCauses []metav1.StatusCause) {
 			spec := &v1.VirtualMachineInstanceSpec{}
 			spec.Domain.Devices.Interfaces = []v1.Interface{{
-				Name:                   "default",
+				Name:                   net1Name,
 				InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}},
 				PortRanges:             portRanges,
 			}}
-			spec.Networks = []v1.Network{{Name: "default", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}}}
+			spec.Networks = []v1.Network{{Name: net1Name, NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}}}
 
 			validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{portRangesSpecGateEnabled: true})
 			Expect(validator.Validate()).To(ConsistOf(expectedCauses))
@@ -383,43 +394,43 @@ var _ = Describe("Validating VMI network spec", func() {
 				"bad protocol",
 				[]v1.PortRange{{Protocol: "SCTP", Start: 80, End: 90}},
 				[]metav1.StatusCause{{
-					Type:    "FieldValueInvalid",
-					Message: "Unknown protocol, only TCP or UDP allowed",
+					Type:    fieldValueInvalidType,
+					Message: unknownProtocolMsg,
 					Field:   "fake.domain.devices.interfaces[0].portRanges[0].protocol",
 				}},
 			),
 			Entry(
 				"start port out of range",
-				[]v1.PortRange{{Protocol: "TCP", Start: 0, End: 100}},
+				[]v1.PortRange{{Protocol: tcpProtocol, Start: 0, End: 100}},
 				[]metav1.StatusCause{{
-					Type:    "FieldValueInvalid",
+					Type:    fieldValueInvalidType,
 					Message: "Start must be a valid port number, 0 < x < 65536",
-					Field:   "fake.domain.devices.interfaces[0].portRanges[0].start",
+					Field:   fakeDomainPortRangeField,
 				}},
 			),
 			Entry(
 				"end port out of range",
-				[]v1.PortRange{{Protocol: "TCP", Start: 80, End: 70000}},
+				[]v1.PortRange{{Protocol: tcpProtocol, Start: 80, End: 70000}},
 				[]metav1.StatusCause{{
-					Type:    "FieldValueInvalid",
+					Type:    fieldValueInvalidType,
 					Message: "End must be a valid port number, 0 < x < 65536",
 					Field:   "fake.domain.devices.interfaces[0].portRanges[0].end",
 				}},
 			),
 			Entry(
 				"start greater than end",
-				[]v1.PortRange{{Protocol: "TCP", Start: 100, End: 80}},
+				[]v1.PortRange{{Protocol: tcpProtocol, Start: 100, End: 80}},
 				[]metav1.StatusCause{{
-					Type:    "FieldValueInvalid",
+					Type:    fieldValueInvalidType,
 					Message: "Start must be less than or equal to end",
-					Field:   "fake.domain.devices.interfaces[0].portRanges[0].start",
+					Field:   fakeDomainPortRangeField,
 				}},
 			),
 			Entry(
 				"two TCP ranges overlapping",
-				[]v1.PortRange{{Protocol: "TCP", Start: 80, End: 200}, {Protocol: "TCP", Start: 150, End: 300}},
+				[]v1.PortRange{{Protocol: tcpProtocol, Start: 80, End: 200}, {Protocol: tcpProtocol, Start: 150, End: 300}},
 				[]metav1.StatusCause{{
-					Type:    "FieldValueInvalid",
+					Type:    fieldValueInvalidType,
 					Message: "TCP portRanges [80-200] and [150-300] overlap",
 					Field:   "fake.domain.devices.interfaces[0].portRanges",
 				}},
@@ -429,21 +440,24 @@ var _ = Describe("Validating VMI network spec", func() {
 		DescribeTable("should accept portRanges with", func(portRanges []v1.PortRange) {
 			spec := &v1.VirtualMachineInstanceSpec{}
 			spec.Domain.Devices.Interfaces = []v1.Interface{{
-				Name:                   "default",
+				Name:                   net1Name,
 				InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}},
 				PortRanges:             portRanges,
 			}}
-			spec.Networks = []v1.Network{{Name: "default", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}}}
+			spec.Networks = []v1.Network{{Name: net1Name, NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}}}
 
 			validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{portRangesSpecGateEnabled: true})
 			Expect(validator.Validate()).To(BeEmpty())
 		},
-			Entry("single range", []v1.PortRange{{Protocol: "TCP", Start: 80, End: 90}}),
-			Entry("single port (start == end)", []v1.PortRange{{Protocol: "TCP", Start: 22, End: 22}}),
-			Entry("two non-overlapping TCP ranges", []v1.PortRange{{Protocol: "TCP", Start: 80, End: 100}, {Protocol: "TCP", Start: 200, End: 300}}),
+			Entry("single range", []v1.PortRange{{Protocol: tcpProtocol, Start: 80, End: 90}}),
+			Entry("single port (start == end)", []v1.PortRange{{Protocol: tcpProtocol, Start: 22, End: 22}}),
+			Entry(
+				"two non-overlapping TCP ranges",
+				[]v1.PortRange{{Protocol: tcpProtocol, Start: 80, End: 100}, {Protocol: tcpProtocol, Start: 200, End: 300}},
+			),
 			Entry(
 				"TCP and UDP ranges that overlap (allowed)",
-				[]v1.PortRange{{Protocol: "TCP", Start: 80, End: 200}, {Protocol: "UDP", Start: 150, End: 300}},
+				[]v1.PortRange{{Protocol: tcpProtocol, Start: 80, End: 200}, {Protocol: udpProtocol, Start: 150, End: 300}},
 			),
 		)
 	})
@@ -452,48 +466,48 @@ var _ = Describe("Validating VMI network spec", func() {
 		DescribeTable("should reject interface DHCP options with", func(dhcpOpts v1.DHCPOptions, expectedCauses []metav1.StatusCause) {
 			spec := &v1.VirtualMachineInstanceSpec{}
 			spec.Domain.Devices.Interfaces = []v1.Interface{{
-				Name:                   "default",
+				Name:                   net1Name,
 				InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}},
 				DHCPOptions:            &dhcpOpts,
 			}}
-			spec.Networks = []v1.Network{{Name: "default", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}}}
+			spec.Networks = []v1.Network{{Name: net1Name, NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}}}
 
 			validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{})
 			Expect(validator.Validate()).To(ConsistOf(expectedCauses))
 		},
 			Entry(
 				"invalid DHCPPrivateOptions",
-				v1.DHCPOptions{PrivateOptions: []v1.DHCPPrivateOptions{{Option: 223, Value: "extra.options.kubevirt.io"}}},
+				v1.DHCPOptions{PrivateOptions: []v1.DHCPPrivateOptions{{Option: 223, Value: extraOptionsDomain}}},
 				[]metav1.StatusCause{{
-					Type:    "FieldValueInvalid",
+					Type:    fieldValueInvalidType,
 					Message: "provided DHCPPrivateOptions are out of range, must be in range 224 to 254",
-					Field:   "fake",
+					Field:   fakeDomainField,
 				}},
 			),
 			Entry(
 				"duplicate DHCPPrivateOptions",
 				v1.DHCPOptions{
 					PrivateOptions: []v1.DHCPPrivateOptions{
-						{Option: 240, Value: "extra.options.kubevirt.io"},
+						{Option: 240, Value: extraOptionsDomain},
 						{Option: 240, Value: "sameextra.options.kubevirt.io"},
 					},
 				},
 				[]metav1.StatusCause{{
-					Type:    "FieldValueInvalid",
+					Type:    fieldValueInvalidType,
 					Message: "Found Duplicates: you have provided duplicate DHCPPrivateOptions",
-					Field:   "fake",
+					Field:   fakeDomainField,
 				}},
 			),
 			Entry(
 				"non-IPv4 NTP servers",
 				v1.DHCPOptions{NTPServers: []string{"::1", "hostname"}},
 				[]metav1.StatusCause{{
-					Type:    "FieldValueInvalid",
-					Message: "NTP servers must be a list of valid IPv4 addresses.",
+					Type:    fieldValueInvalidType,
+					Message: ntpServersMsg,
 					Field:   "fake.domain.devices.interfaces[0].dhcpOptions.ntpServers[0]",
 				}, {
-					Type:    "FieldValueInvalid",
-					Message: "NTP servers must be a list of valid IPv4 addresses.",
+					Type:    fieldValueInvalidType,
+					Message: ntpServersMsg,
 					Field:   "fake.domain.devices.interfaces[0].dhcpOptions.ntpServers[1]",
 				}},
 			),
@@ -502,25 +516,25 @@ var _ = Describe("Validating VMI network spec", func() {
 		DescribeTable("should accept interface DHCP options with", func(dhcpOpts v1.DHCPOptions) {
 			spec := &v1.VirtualMachineInstanceSpec{}
 			spec.Domain.Devices.Interfaces = []v1.Interface{{
-				Name:                   "default",
+				Name:                   net1Name,
 				InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}},
 				DHCPOptions:            &dhcpOpts,
 			}}
-			spec.Networks = []v1.Network{{Name: "default", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}}}
+			spec.Networks = []v1.Network{{Name: net1Name, NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}}}
 
 			validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{})
 			Expect(validator.Validate()).To(BeEmpty())
 		},
 			Entry("  valid DHCPPrivateOptions", v1.DHCPOptions{
-				PrivateOptions: []v1.DHCPPrivateOptions{{Option: 240, Value: "extra.options.kubevirt.io"}},
+				PrivateOptions: []v1.DHCPPrivateOptions{{Option: 240, Value: extraOptionsDomain}},
 			}),
 			Entry(" valid NTP servers", v1.DHCPOptions{NTPServers: []string{"127.0.0.1", "127.0.0.2"}}),
 			Entry(
 				"unique DHCPPrivateOptions",
 				v1.DHCPOptions{
 					PrivateOptions: []v1.DHCPPrivateOptions{
-						{Option: 240, Value: "extra.options.kubevirt.io"},
-						{Option: 241, Value: "extra.options.kubevirt.io"},
+						{Option: 240, Value: extraOptionsDomain},
+						{Option: 241, Value: extraOptionsDomain},
 					},
 				},
 			),

--- a/pkg/network/admitter/netsource_test.go
+++ b/pkg/network/admitter/netsource_test.go
@@ -31,6 +31,13 @@ import (
 	"kubevirt.io/kubevirt/pkg/network/admitter"
 )
 
+const (
+	defaultNetworkName1 = "default1"
+	requestName1        = "request1"
+	multusNet2          = "multus-net2"
+	net2Name            = "multus2"
+)
+
 var _ = Describe("Validate network source", func() {
 	It("support only a single pod network", func() {
 		const net1Name = "default"
@@ -56,9 +63,9 @@ var _ = Describe("Validate network source", func() {
 		spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultBridgeNetworkInterface()}
 		spec.Networks = []v1.Network{
 			{
-				Name: "default",
+				Name: net1Name,
 				NetworkSource: v1.NetworkSource{
-					Multus: &v1.MultusNetwork{NetworkName: "default1"},
+					Multus: &v1.MultusNetwork{NetworkName: defaultNetworkName1},
 					Pod:    &v1.PodNetwork{},
 				},
 			},
@@ -92,14 +99,14 @@ var _ = Describe("Validate network source", func() {
 		spec.Domain.Devices.Interfaces = []v1.Interface{
 			{Name: draSRIOVNetName, InterfaceBindingMethod: v1.InterfaceBindingMethod{SRIOV: &v1.InterfaceSRIOV{}}},
 		}
-		spec.ResourceClaims = []v1.VirtualMachineInstanceResourceClaim{{Name: "claim1", ResourceClaimName: ptr.To("claim1")}}
+		spec.ResourceClaims = []v1.VirtualMachineInstanceResourceClaim{{Name: draClaimName, ResourceClaimName: ptr.To(draClaimName)}}
 		spec.Networks = []v1.Network{
 			{
 				Name: draSRIOVNetName,
 				NetworkSource: v1.NetworkSource{
 					ResourceClaim: &v1.ClaimRequest{
-						ClaimName:   "claim1",
-						RequestName: "request1",
+						ClaimName:   draClaimName,
+						RequestName: requestName1,
 					},
 				},
 			},
@@ -113,16 +120,16 @@ var _ = Describe("Validate network source", func() {
 		func(networkSource v1.NetworkSource) {
 			spec := &v1.VirtualMachineInstanceSpec{}
 			spec.Domain.Devices.Interfaces = []v1.Interface{
-				{Name: "default", InterfaceBindingMethod: v1.InterfaceBindingMethod{SRIOV: &v1.InterfaceSRIOV{}}},
+				{Name: net1Name, InterfaceBindingMethod: v1.InterfaceBindingMethod{SRIOV: &v1.InterfaceSRIOV{}}},
 			}
-			spec.ResourceClaims = []v1.VirtualMachineInstanceResourceClaim{{Name: "claim1", ResourceClaimName: ptr.To("claim1")}}
+			spec.ResourceClaims = []v1.VirtualMachineInstanceResourceClaim{{Name: draClaimName, ResourceClaimName: ptr.To(draClaimName)}}
 			spec.Networks = []v1.Network{
 				{
-					Name: "default",
+					Name: net1Name,
 					NetworkSource: v1.NetworkSource{
 						ResourceClaim: &v1.ClaimRequest{
-							ClaimName:   "claim1",
-							RequestName: "request1",
+							ClaimName:   draClaimName,
+							RequestName: requestName1,
 						},
 						Pod:    networkSource.Pod,
 						Multus: networkSource.Multus,
@@ -134,14 +141,14 @@ var _ = Describe("Validate network source", func() {
 			Expect(causes).To(ContainElement(HaveField("Message", "should have only one network type")))
 		},
 		Entry("pod network", v1.NetworkSource{Pod: &v1.PodNetwork{}}),
-		Entry("multus network", v1.NetworkSource{Multus: &v1.MultusNetwork{NetworkName: "default1"}}),
+		Entry("multus network", v1.NetworkSource{Multus: &v1.MultusNetwork{NetworkName: defaultNetworkName1}}),
 	)
 
 	It("should reject multus network source without networkName", func() {
 		spec := &v1.VirtualMachineInstanceSpec{}
 		spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultBridgeNetworkInterface()}
 		spec.Networks = []v1.Network{{
-			Name:          "default",
+			Name:          net1Name,
 			NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{}},
 		}}
 
@@ -165,13 +172,13 @@ var _ = Describe("Validate network source", func() {
 			{
 				Name: net1Name,
 				NetworkSource: v1.NetworkSource{
-					Multus: &v1.MultusNetwork{NetworkName: "multus-net1", Default: true},
+					Multus: &v1.MultusNetwork{NetworkName: multusNet1Name, Default: true},
 				},
 			},
 			{
 				Name: net2Name,
 				NetworkSource: v1.NetworkSource{
-					Multus: &v1.MultusNetwork{NetworkName: "multus-net2", Default: true},
+					Multus: &v1.MultusNetwork{NetworkName: multusNet2, Default: true},
 				},
 			},
 		}
@@ -179,7 +186,7 @@ var _ = Describe("Validate network source", func() {
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{})
 		causes := validator.Validate()
 		Expect(causes).To(HaveLen(1))
-		Expect(string(causes[0].Type)).To(Equal("FieldValueInvalid"))
+		Expect(string(causes[0].Type)).To(Equal(fieldValueInvalidType))
 		Expect(causes[0].Field).To(Equal("fake.networks"))
 		Expect(causes[0].Message).To(Equal("Multus CNI should only have one default network"))
 	})
@@ -199,7 +206,7 @@ var _ = Describe("Validate network source", func() {
 
 		spec.Networks = []v1.Network{
 			{
-				Name: "default",
+				Name: net1Name,
 				NetworkSource: v1.NetworkSource{
 					Pod: &v1.PodNetwork{},
 				},
@@ -207,7 +214,7 @@ var _ = Describe("Validate network source", func() {
 			{
 				Name: defaultMultusNetName,
 				NetworkSource: v1.NetworkSource{
-					Multus: &v1.MultusNetwork{NetworkName: "multus-net1", Default: true},
+					Multus: &v1.MultusNetwork{NetworkName: multusNet1Name, Default: true},
 				},
 			},
 		}
@@ -216,7 +223,7 @@ var _ = Describe("Validate network source", func() {
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, clusterConfig)
 		causes := validator.Validate()
 		Expect(causes).To(HaveLen(1))
-		Expect(string(causes[0].Type)).To(Equal("FieldValueInvalid"))
+		Expect(string(causes[0].Type)).To(Equal(fieldValueInvalidType))
 		Expect(causes[0].Field).To(Equal("fake.networks"))
 		Expect(causes[0].Message).To(Equal("Pod network cannot be defined when Multus default network is defined"))
 	})
@@ -226,12 +233,12 @@ var _ = Describe("Validate network source", func() {
 		spec.Domain.Devices.Interfaces = []v1.Interface{
 			*v1.DefaultBridgeNetworkInterface(),
 		}
-		spec.Domain.Devices.Interfaces[0].Name = "multus1"
+		spec.Domain.Devices.Interfaces[0].Name = net1Name
 		spec.Networks = []v1.Network{
 			{
-				Name: "multus1",
+				Name: net1Name,
 				NetworkSource: v1.NetworkSource{
-					Multus: &v1.MultusNetwork{NetworkName: "multus-net1", Default: true},
+					Multus: &v1.MultusNetwork{NetworkName: multusNet1Name, Default: true},
 				},
 			},
 		}
@@ -246,7 +253,7 @@ var _ = Describe("Validate network source", func() {
 		spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultBridgeNetworkInterface()}
 		spec.Networks = []v1.Network{
 			{
-				Name: "default",
+				Name: net1Name,
 				NetworkSource: v1.NetworkSource{
 					Multus: &v1.MultusNetwork{NetworkName: "default"},
 				},
@@ -262,19 +269,19 @@ var _ = Describe("Validate network source", func() {
 		spec := &v1.VirtualMachineInstanceSpec{}
 		spec.Domain.Devices.Interfaces = []v1.Interface{
 			{
-				Name: "default",
+				Name: net1Name,
 				InterfaceBindingMethod: v1.InterfaceBindingMethod{
 					Bridge: &v1.InterfaceBridge{},
 				},
 			},
 			{
-				Name: "multus1",
+				Name: secondaryIfaceName,
 				InterfaceBindingMethod: v1.InterfaceBindingMethod{
 					Bridge: &v1.InterfaceBridge{},
 				},
 			},
 			{
-				Name: "multus2",
+				Name: net2Name,
 				InterfaceBindingMethod: v1.InterfaceBindingMethod{
 					Bridge: &v1.InterfaceBridge{},
 				},
@@ -283,21 +290,21 @@ var _ = Describe("Validate network source", func() {
 
 		spec.Networks = []v1.Network{
 			{
-				Name: "default",
+				Name: net1Name,
 				NetworkSource: v1.NetworkSource{
 					Pod: &v1.PodNetwork{},
 				},
 			},
 			{
-				Name: "multus1",
+				Name: secondaryIfaceName,
 				NetworkSource: v1.NetworkSource{
-					Multus: &v1.MultusNetwork{NetworkName: "multus-net1"},
+					Multus: &v1.MultusNetwork{NetworkName: multusNet1Name},
 				},
 			},
 			{
-				Name: "multus2",
+				Name: net2Name,
 				NetworkSource: v1.NetworkSource{
-					Multus: &v1.MultusNetwork{NetworkName: "multus-net2"},
+					Multus: &v1.MultusNetwork{NetworkName: multusNet2},
 				},
 			},
 		}

--- a/pkg/network/admitter/passt_test.go
+++ b/pkg/network/admitter/passt_test.go
@@ -35,12 +35,12 @@ var _ = Describe("Validating passtBinding core binding", func() {
 	It("should reject networks with a multus network source and passtBinding interface", func() {
 		spec := &v1.VirtualMachineInstanceSpec{}
 		spec.Domain.Devices.Interfaces = []v1.Interface{{
-			Name:                   "default",
+			Name:                   net1Name,
 			InterfaceBindingMethod: v1.InterfaceBindingMethod{PasstBinding: &v1.InterfacePasstBinding{}},
 		}}
 		spec.Networks = []v1.Network{{
-			Name:          "default",
-			NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{NetworkName: "test"}},
+			Name:          net1Name,
+			NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{NetworkName: testPortName}},
 		}}
 
 		clusterConfig := stubClusterConfigChecker{passtBindingFeatureGateEnabled: true}
@@ -48,16 +48,16 @@ var _ = Describe("Validating passtBinding core binding", func() {
 		causes := validator.Validate()
 
 		Expect(causes).To(ConsistOf(metav1.StatusCause{
-			Type:    "FieldValueInvalid",
+			Type:    fieldValueInvalidType,
 			Message: "PasstBinding interface only implemented with pod network",
-			Field:   "fake.domain.devices.interfaces[0].name",
+			Field:   fakePrimaryIfaceNameField,
 		}))
 	})
 
 	It("should reject networks with a passtBinding interface and passtBinding feature gate disabled", func() {
 		spec := &v1.VirtualMachineInstanceSpec{}
 		spec.Domain.Devices.Interfaces = []v1.Interface{{
-			Name:                   "default",
+			Name:                   net1Name,
 			InterfaceBindingMethod: v1.InterfaceBindingMethod{PasstBinding: &v1.InterfacePasstBinding{}},
 		}}
 		spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
@@ -66,16 +66,16 @@ var _ = Describe("Validating passtBinding core binding", func() {
 		causes := validator.Validate()
 
 		Expect(causes).To(ConsistOf(metav1.StatusCause{
-			Type:    "FieldValueInvalid",
+			Type:    fieldValueInvalidType,
 			Message: "PasstBinding feature gate is not enabled",
-			Field:   "fake.domain.devices.interfaces[0].name",
+			Field:   fakePrimaryIfaceNameField,
 		}))
 	})
 
 	It("should accept networks with a pod network source and passtBinding interface", func() {
 		spec := &v1.VirtualMachineInstanceSpec{}
 		spec.Domain.Devices.Interfaces = []v1.Interface{{
-			Name:                   "default",
+			Name:                   net1Name,
 			InterfaceBindingMethod: v1.InterfaceBindingMethod{PasstBinding: &v1.InterfacePasstBinding{}},
 		}}
 		spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}

--- a/pkg/network/controllers/vm_test.go
+++ b/pkg/network/controllers/vm_test.go
@@ -53,6 +53,7 @@ var _ = Describe("VM Network Controller", func() {
 		nadName3          = "foonet-nad3"
 		updatedNADName1   = "new-nad1"
 		updatedNADName2   = "new-nad2"
+		net1PodIface      = "net1"
 	)
 	DescribeTable("sync does nothing when", func(vm *v1.VirtualMachine, vmi *v1.VirtualMachineInstance) {
 		c := controllers.NewVMController(fake.NewSimpleClientset())
@@ -518,7 +519,7 @@ var _ = Describe("VM Network Controller", func() {
 						v1.VirtualMachineInstanceNetworkInterface{Name: defaultNetName, PodInterfaceName: namescheme.PrimaryPodInterfaceName},
 					),
 					libvmistatus.WithInterfaceStatus(
-						v1.VirtualMachineInstanceNetworkInterface{Name: "foonet", PodInterfaceName: "net1"},
+						v1.VirtualMachineInstanceNetworkInterface{Name: "foonet", PodInterfaceName: net1PodIface},
 					),
 				),
 			),

--- a/pkg/network/controllers/vmi_test.go
+++ b/pkg/network/controllers/vmi_test.go
@@ -39,15 +39,18 @@ import (
 
 var _ = Describe("Status Update", func() {
 	const (
-		testNamespace = "default"
+		testNamespace              = "default"
+		defaultPrimaryPodIfaceName = "eth0"
+		secondaryPodIfaceName      = "pod7e0055a6880"
 
-		multusNetworksAnnotation        = `[{"name":"meganet","namespace":"default","interface":"pod7e0055a6880"}]`
+		multusNetworksAnnotation        = `[{"name":"meganet","namespace":"default","interface":"` + secondaryPodIfaceName + `"}]`
 		multusOrdinalNetworksAnnotation = `[{"name":"meganet","namespace":"default","interface":"net1"}]`
 
 		multusNetworkStatusWithPrimaryNet = `[{"name":"k8s-pod-network","ips":["10.244.196.146","fd10:244::c491"],"default":true,"dns":{}}]`
 
 		multusNetworkStatusWithPrimaryNetAndIfaceName = `[` +
-			`{"name":"k8s-pod-network","interface":"eth0","ips":["10.244.196.146","fd10:244::c491"],"default":true,"dns":{}}` +
+			`{"name":"k8s-pod-network","interface":"` + defaultPrimaryPodIfaceName +
+			`","ips":["10.244.196.146","fd10:244::c491"],"default":true,"dns":{}}` +
 			`]`
 
 		multusNetworkStatusWithAlternativePrimaryNet = `[` +
@@ -55,23 +58,26 @@ var _ = Describe("Status Update", func() {
 			`]`
 
 		multusNetworkStatusWithAlternativePrimaryNetAndIfaceName = `[` +
-			`{"name":"alternativeNAD", "interface":"eth0", "ips":["10.244.196.146", "fd10:244::c491"], "default":true,"dns":{}}` +
+			`{"name":"alternativeNAD", "interface":"` + defaultPrimaryPodIfaceName +
+			`", "ips":["10.244.196.146", "fd10:244::c491"], "default":true,"dns":{}}` +
 			`]`
 
 		multusNetworkStatusWithCustomPrimaryNet = `[` +
-			`{"name":"k8s-pod-network", "interface":"eth0", "ips":["10.244.196.146", "fd10:244::c491"], "default":false,"dns":{}}, ` +
+			`{"name":"k8s-pod-network", "interface":"` + defaultPrimaryPodIfaceName +
+			`", "ips":["10.244.196.146", "fd10:244::c491"], "default":false,"dns":{}}, ` +
 			`{"name":"cluster-network", "interface":"custom-iface", "ips":["10.128.0.4"], "mac":"0a:58:0a:80:00:04", "default":true, "dns":{}}` +
 			`]`
 
 		multusNetworkStatusWithCustomPrimaryAndSecondaryNets = `[` +
-			`{"name":"k8s-pod-network", "interface":"eth0", "ips":["10.244.196.146", "fd10:244::c491"], "default":false,"dns":{}}, ` +
+			`{"name":"k8s-pod-network", "interface":"` + defaultPrimaryPodIfaceName +
+			`", "ips":["10.244.196.146", "fd10:244::c491"], "default":false,"dns":{}}, ` +
 			`{"name":"cluster-network", "interface":"custom-iface", "ips":["10.128.0.4"], "mac":"0a:58:0a:80:00:04", "default":true, "dns":{}}, ` +
-			`{"name":"meganet", "interface":"pod7e0055a6880", "mac":"8a:37:d9:e7:0f:18", "dns":{}}` +
+			`{"name":"meganet", "interface":"` + secondaryPodIfaceName + `", "mac":"8a:37:d9:e7:0f:18", "dns":{}}` +
 			`]`
 
 		multusNetworkStatusWithPrimaryAndSecondaryNets = `[` +
 			`{"name":"k8s-pod-network","ips":["10.244.196.146","fd10:244::c491"],"default":true,"dns":{}},` +
-			`{"name":"meganet","interface":"pod7e0055a6880","mac":"8a:37:d9:e7:0f:18","dns":{}}` +
+			`{"name":"meganet","interface":"` + secondaryPodIfaceName + `","mac":"8a:37:d9:e7:0f:18","dns":{}}` +
 			`]`
 
 		multusNetworkStatusWithPrimaryAndOrdinalSecondaryNets = `[` +
@@ -88,6 +94,13 @@ var _ = Describe("Status Update", func() {
 		alternativeNetworkAttachmentDefinitionName = "alternativeNAD"
 
 		customIfaceName = "custom-iface"
+
+		net1PodIface  = "net1"
+		ip1921685010  = "192.168.50.10"
+		macDeadBeef   = "de:ad:00:00:be:ef"
+		macAABabe     = "aa:ad:ba:be:00:02"
+		eth1IfaceName = "eth1"
+		eth2IfaceName = "eth2"
 	)
 
 	DescribeTable("Shouldn't generate interface status for a VMI without interfaces", func(podAnnotations map[string]string) {
@@ -115,7 +128,7 @@ var _ = Describe("Status Update", func() {
 		Expect(controllers.UpdateVMIStatus(vmi, newPodFromVMI(vmi, podAnnotations))).To(Succeed())
 
 		expectedInterfacesStatus := []v1.VirtualMachineInstanceNetworkInterface{
-			{Name: defaultNetworkName, PodInterfaceName: "eth0"},
+			{Name: defaultNetworkName, PodInterfaceName: defaultPrimaryPodIfaceName},
 		}
 
 		Expect(vmi.Status.Interfaces).To(Equal(expectedInterfacesStatus))
@@ -144,7 +157,7 @@ var _ = Describe("Status Update", func() {
 		Expect(controllers.UpdateVMIStatus(vmi, newPodFromVMI(vmi, podAnnotations))).To(Succeed())
 
 		expectedInterfacesStatus := []v1.VirtualMachineInstanceNetworkInterface{
-			{Name: defaultNetworkName, PodInterfaceName: "eth0", InfoSource: vmispec.InfoSourceDomainAndGA},
+			{Name: defaultNetworkName, PodInterfaceName: defaultPrimaryPodIfaceName, InfoSource: vmispec.InfoSourceDomainAndGA},
 		}
 
 		Expect(vmi.Status.Interfaces).To(Equal(expectedInterfacesStatus))
@@ -194,7 +207,7 @@ var _ = Describe("Status Update", func() {
 			Expect(controllers.UpdateVMIStatus(vmi, newPodFromVMI(vmi, map[string]string{}))).To(Succeed())
 
 			expectedInterfacesStatus := []v1.VirtualMachineInstanceNetworkInterface{
-				{Name: alternativeNetworkName, PodInterfaceName: "eth0"},
+				{Name: alternativeNetworkName, PodInterfaceName: defaultPrimaryPodIfaceName},
 			}
 
 			Expect(vmi.Status.Interfaces).To(Equal(expectedInterfacesStatus))
@@ -239,7 +252,7 @@ var _ = Describe("Status Update", func() {
 		Expect(controllers.UpdateVMIStatus(vmi, newPodFromVMI(vmi, podAnnotations))).To(Succeed())
 
 		expectedInterfacesStatus := []v1.VirtualMachineInstanceNetworkInterface{
-			{Name: alternativeNetworkName, PodInterfaceName: "eth0", InfoSource: vmispec.InfoSourceDomainAndGA},
+			{Name: alternativeNetworkName, PodInterfaceName: defaultPrimaryPodIfaceName, InfoSource: vmispec.InfoSourceDomainAndGA},
 		}
 
 		Expect(vmi.Status.Interfaces).To(Equal(expectedInterfacesStatus))
@@ -295,7 +308,7 @@ var _ = Describe("Status Update", func() {
 				networkv1.NetworkStatusAnnot:     multusNetworkStatusWithPrimaryAndSecondaryNets,
 			},
 			[]v1.VirtualMachineInstanceNetworkInterface{
-				{Name: secondaryNetworkName, PodInterfaceName: "pod7e0055a6880", InfoSource: vmispec.InfoSourceMultusStatus},
+				{Name: secondaryNetworkName, PodInterfaceName: secondaryPodIfaceName, InfoSource: vmispec.InfoSourceMultusStatus},
 			},
 		),
 		Entry("When using ordinal naming scheme",
@@ -304,7 +317,7 @@ var _ = Describe("Status Update", func() {
 				networkv1.NetworkStatusAnnot:     multusNetworkStatusWithPrimaryAndOrdinalSecondaryNets,
 			},
 			[]v1.VirtualMachineInstanceNetworkInterface{
-				{Name: secondaryNetworkName, PodInterfaceName: "net1", InfoSource: vmispec.InfoSourceMultusStatus},
+				{Name: secondaryNetworkName, PodInterfaceName: net1PodIface, InfoSource: vmispec.InfoSourceMultusStatus},
 			},
 		),
 	)
@@ -323,7 +336,7 @@ var _ = Describe("Status Update", func() {
 
 			expectedInterfacesStatus := []v1.VirtualMachineInstanceNetworkInterface{
 				{Name: defaultNetworkName, PodInterfaceName: expectedPrimaryInterfaceName},
-				{Name: secondaryNetworkName, PodInterfaceName: "pod7e0055a6880", InfoSource: vmispec.InfoSourceMultusStatus},
+				{Name: secondaryNetworkName, PodInterfaceName: secondaryPodIfaceName, InfoSource: vmispec.InfoSourceMultusStatus},
 			}
 
 			Expect(vmi.Status.Interfaces).To(Equal(expectedInterfacesStatus))
@@ -333,7 +346,7 @@ var _ = Describe("Status Update", func() {
 				networkv1.NetworkAttachmentAnnot: multusNetworksAnnotation,
 				networkv1.NetworkStatusAnnot:     multusNetworkStatusWithPrimaryAndSecondaryNets,
 			},
-			"eth0",
+			defaultPrimaryPodIfaceName,
 		),
 		Entry("With custom primary pod interface name",
 			map[string]string{
@@ -365,8 +378,8 @@ var _ = Describe("Status Update", func() {
 		Expect(controllers.UpdateVMIStatus(vmi, newPodFromVMI(vmi, podAnnotations))).To(Succeed())
 
 		expectedInterfacesStatus := []v1.VirtualMachineInstanceNetworkInterface{
-			{Name: defaultNetworkName, PodInterfaceName: "eth0"},
-			{Name: secondaryNetworkName, PodInterfaceName: "pod7e0055a6880", InfoSource: vmispec.InfoSourceMultusStatus},
+			{Name: defaultNetworkName, PodInterfaceName: defaultPrimaryPodIfaceName},
+			{Name: secondaryNetworkName, PodInterfaceName: secondaryPodIfaceName, InfoSource: vmispec.InfoSourceMultusStatus},
 		}
 
 		Expect(vmi.Status.Interfaces).To(Equal(expectedInterfacesStatus))
@@ -392,7 +405,7 @@ var _ = Describe("Status Update", func() {
 		Expect(controllers.UpdateVMIStatus(vmi, newPodFromVMI(vmi, podAnnotations))).To(Succeed())
 
 		expectedInterfacesStatus := []v1.VirtualMachineInstanceNetworkInterface{
-			{Name: secondaryNetworkName, PodInterfaceName: "pod7e0055a6880", InfoSource: vmispec.InfoSourceMultusStatus},
+			{Name: secondaryNetworkName, PodInterfaceName: secondaryPodIfaceName, InfoSource: vmispec.InfoSourceMultusStatus},
 		}
 
 		Expect(vmi.Status.Interfaces).To(Equal(expectedInterfacesStatus))
@@ -400,7 +413,7 @@ var _ = Describe("Status Update", func() {
 
 	It("Should remove the Multus info source when VMI.status has an interface but it is not reported by Multus network-status", func() {
 		existingInterfacesStatus := []v1.VirtualMachineInstanceNetworkInterface{
-			{Name: secondaryNetworkName, PodInterfaceName: "pod7e0055a6880", InfoSource: vmispec.InfoSourceMultusStatus},
+			{Name: secondaryNetworkName, PodInterfaceName: secondaryPodIfaceName, InfoSource: vmispec.InfoSourceMultusStatus},
 		}
 
 		vmi := libvmi.New(
@@ -417,7 +430,7 @@ var _ = Describe("Status Update", func() {
 		Expect(controllers.UpdateVMIStatus(vmi, newPodFromVMI(vmi, podAnnotations))).To(Succeed())
 
 		expectedInterfacesStatus := []v1.VirtualMachineInstanceNetworkInterface{
-			{Name: secondaryNetworkName, PodInterfaceName: "pod7e0055a6880"},
+			{Name: secondaryNetworkName, PodInterfaceName: secondaryPodIfaceName},
 		}
 
 		Expect(vmi.Status.Interfaces).To(Equal(expectedInterfacesStatus))
@@ -442,7 +455,7 @@ var _ = Describe("Status Update", func() {
 		Expect(controllers.UpdateVMIStatus(vmi, newPodFromVMI(vmi, podAnnotations))).To(Succeed())
 
 		expectedInterfacesStatus := []v1.VirtualMachineInstanceNetworkInterface{
-			{Name: secondaryNetworkName, PodInterfaceName: "pod7e0055a6880", InfoSource: vmispec.InfoSourceGuestAgent},
+			{Name: secondaryNetworkName, PodInterfaceName: secondaryPodIfaceName, InfoSource: vmispec.InfoSourceGuestAgent},
 		}
 
 		Expect(vmi.Status.Interfaces).To(Equal(expectedInterfacesStatus))
@@ -450,7 +463,7 @@ var _ = Describe("Status Update", func() {
 
 	It("Should keep existing interface status for an interface created within the guest", func() {
 		existingInterfacesStatus := []v1.VirtualMachineInstanceNetworkInterface{
-			{Name: "", InfoSource: vmispec.InfoSourceGuestAgent, IP: "192.168.50.10"},
+			{Name: "", InfoSource: vmispec.InfoSourceGuestAgent, IP: ip1921685010},
 		}
 
 		vmi := libvmi.New(
@@ -468,8 +481,8 @@ var _ = Describe("Status Update", func() {
 		Expect(controllers.UpdateVMIStatus(vmi, newPodFromVMI(vmi, podAnnotations))).To(Succeed())
 
 		expectedInterfacesStatus := []v1.VirtualMachineInstanceNetworkInterface{
-			{Name: secondaryNetworkName, PodInterfaceName: "pod7e0055a6880", InfoSource: vmispec.InfoSourceMultusStatus},
-			{Name: "", InfoSource: vmispec.InfoSourceGuestAgent, IP: "192.168.50.10"},
+			{Name: secondaryNetworkName, PodInterfaceName: secondaryPodIfaceName, InfoSource: vmispec.InfoSourceMultusStatus},
+			{Name: "", InfoSource: vmispec.InfoSourceGuestAgent, IP: ip1921685010},
 		}
 
 		Expect(vmi.Status.Interfaces).To(Equal(expectedInterfacesStatus))
@@ -494,7 +507,7 @@ var _ = Describe("Status Update", func() {
 		Expect(controllers.UpdateVMIStatus(vmi, newPodFromVMI(vmi, podAnnotations))).To(Succeed())
 
 		expectedInterfacesStatus := []v1.VirtualMachineInstanceNetworkInterface{
-			{Name: secondaryNetworkName, PodInterfaceName: "pod7e0055a6880"},
+			{Name: secondaryNetworkName, PodInterfaceName: secondaryPodIfaceName},
 		}
 
 		Expect(vmi.Status.Interfaces).To(Equal(expectedInterfacesStatus))
@@ -511,8 +524,8 @@ var _ = Describe("Status Update", func() {
 
 		existingInterfacesStatus := []v1.VirtualMachineInstanceNetworkInterface{
 			{Name: defaultNetworkName, InfoSource: vmispec.InfoSourceDomainAndGA},
-			{Name: redIfaceName, MAC: "de:ad:00:00:be:ef", InterfaceName: "eth1", InfoSource: vmispec.InfoSourceDomainAndGA},
-			{Name: blueIfaceName, MAC: "aa:ad:ba:be:00:02", InterfaceName: "eth2", InfoSource: vmispec.InfoSourceDomainAndGA},
+			{Name: redIfaceName, MAC: macDeadBeef, InterfaceName: eth1IfaceName, InfoSource: vmispec.InfoSourceDomainAndGA},
+			{Name: blueIfaceName, MAC: macAABabe, InterfaceName: eth2IfaceName, InfoSource: vmispec.InfoSourceDomainAndGA},
 		}
 
 		vmi := libvmi.New(
@@ -529,9 +542,9 @@ var _ = Describe("Status Update", func() {
 		Expect(controllers.UpdateVMIStatus(vmi, newPodFromVMI(vmi, map[string]string{}))).To(Succeed())
 
 		expectedInterfacesStatus := []v1.VirtualMachineInstanceNetworkInterface{
-			{Name: defaultNetworkName, PodInterfaceName: "eth0", InfoSource: vmispec.InfoSourceDomainAndGA},
-			{Name: redIfaceName, MAC: "de:ad:00:00:be:ef", InterfaceName: "eth1", InfoSource: vmispec.InfoSourceDomainAndGA},
-			{Name: blueIfaceName, MAC: "aa:ad:ba:be:00:02", InterfaceName: "eth2", InfoSource: vmispec.InfoSourceDomainAndGA},
+			{Name: defaultNetworkName, PodInterfaceName: defaultPrimaryPodIfaceName, InfoSource: vmispec.InfoSourceDomainAndGA},
+			{Name: redIfaceName, MAC: macDeadBeef, InterfaceName: eth1IfaceName, InfoSource: vmispec.InfoSourceDomainAndGA},
+			{Name: blueIfaceName, MAC: macAABabe, InterfaceName: eth2IfaceName, InfoSource: vmispec.InfoSourceDomainAndGA},
 		}
 
 		Expect(vmi.Status.Interfaces).To(Equal(expectedInterfacesStatus))

--- a/pkg/network/dhcp/server/server_test.go
+++ b/pkg/network/dhcp/server/server_test.go
@@ -33,6 +33,12 @@ import (
 
 var _ = Describe("DHCP Server", func() {
 
+	const (
+		searchDomain1 = "pix3ob5ymm5jbsjessf0o4e84uvij588rz23iz0o.com"
+		searchDomain2 = "3wg5xngig6vzfqjww4kocnky3c9dqjpwkewzlwpf.com"
+		searchDomain3 = "t4lanpt7z4ix58nvxl4d.com"
+	)
+
 	Context("check routes", func() {
 		It("verify should form correctly", func() {
 			expected := []byte{4, 224, 0, 0, 0, 0, 24, 192, 168, 1, 192, 168, 2, 1}
@@ -119,12 +125,12 @@ var _ = Describe("DHCP Server", func() {
 		It("should reject search domains that exceed max length", func() {
 			// should result in 256 byte slice
 			searchDomains := []string{
-				"pix3ob5ymm5jbsjessf0o4e84uvij588rz23iz0o.com",
-				"3wg5xngig6vzfqjww4kocnky3c9dqjpwkewzlwpf.com",
+				searchDomain1,
+				searchDomain2,
 				"38rfuqbyvkjg4z1f3aogul55wtgxrd9dlwzewqo0.com",
 				"yza01ojnzi0tkyjeusmlg728nqdqvz3domymifvq.com",
 				"m130lhs7a8yjgpn6almqggkqc222otedms6vslcd.com",
-				"t4lanpt7z4ix58nvxl4d.com",
+				searchDomain3,
 			}
 
 			_, err := convertSearchDomainsToBytes(searchDomains)
@@ -170,9 +176,9 @@ var _ = Describe("DHCP Server", func() {
 	Context("Options returned by prepareDHCPOptions", func() {
 		It("should contain the domain name option", func() {
 			searchDomains := []string{
-				"pix3ob5ymm5jbsjessf0o4e84uvij588rz23iz0o.com",
-				"3wg5xngig6vzfqjww4kocnky3c9dqjpwkewzlwpf.com",
-				"t4lanpt7z4ix58nvxl4d.com",
+				searchDomain1,
+				searchDomain2,
+				searchDomain3,
 				"14wg5xngig6vzfqjww4kocnky3c9dqjpwkewzlwpf.com",
 				"4wg5xngig6vzfqjww4kocnky3c9dqjpwkewzlwpf.com",
 			}
@@ -184,9 +190,9 @@ var _ = Describe("DHCP Server", func() {
 
 		It("should contain custom options", func() {
 			searchDomains := []string{
-				"pix3ob5ymm5jbsjessf0o4e84uvij588rz23iz0o.com",
-				"3wg5xngig6vzfqjww4kocnky3c9dqjpwkewzlwpf.com",
-				"t4lanpt7z4ix58nvxl4d.com",
+				searchDomain1,
+				searchDomain2,
+				searchDomain3,
 				"14wg5xngig6vzfqjww4kocnky3c9dqjpwkewzlwpf.com",
 				"4wg5xngig6vzfqjww4kocnky3c9dqjpwkewzlwpf.com",
 			}

--- a/pkg/network/dns/resolveconf_test.go
+++ b/pkg/network/dns/resolveconf_test.go
@@ -26,7 +26,14 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+const (
+	defaultServiceSearchDomain = "default.svc.cluster.local"
+	serviceSearchDomain        = "svc.cluster.local"
+	exampleSearchDomain        = "example.com"
+)
+
 var _ = Describe("Resolveconf", func() {
+	const localSearchDomain = "local"
 	Context("Function ParseNameservers()", func() {
 		It("should return a byte array of nameservers", func() {
 			ns1, ns2 := []uint8{8, 8, 8, 8}, []uint8{8, 8, 4, 4}
@@ -79,21 +86,21 @@ var _ = Describe("Resolveconf", func() {
 		It("should return a string of search domains", func() {
 			resolvConf := "search cluster.local svc.cluster.local example.com\nnameserver 8.8.8.8\n"
 			searchDomains, err := ParseSearchDomains(resolvConf)
-			Expect(searchDomains).To(Equal([]string{"cluster.local", "svc.cluster.local", "example.com"}))
+			Expect(searchDomains).To(Equal([]string{defaultSearchDomain, serviceSearchDomain, exampleSearchDomain}))
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("should handle multi-line search domains", func() {
 			resolvConf := "search cluster.local\nsearch svc.cluster.local example.com\nnameserver 8.8.8.8\n"
 			searchDomains, err := ParseSearchDomains(resolvConf)
-			Expect(searchDomains).To(Equal([]string{"cluster.local", "svc.cluster.local", "example.com"}))
+			Expect(searchDomains).To(Equal([]string{defaultSearchDomain, serviceSearchDomain, exampleSearchDomain}))
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("should clean up extra whitespace between search domains", func() {
 			resolvConf := "search cluster.local\tsvc.cluster.local    example.com\nnameserver 8.8.8.8\n"
 			searchDomains, err := ParseSearchDomains(resolvConf)
-			Expect(searchDomains).To(Equal([]string{"cluster.local", "svc.cluster.local", "example.com"}))
+			Expect(searchDomains).To(Equal([]string{defaultSearchDomain, serviceSearchDomain, exampleSearchDomain}))
 			Expect(err).ToNot(HaveOccurred())
 		})
 
@@ -107,14 +114,14 @@ var _ = Describe("Resolveconf", func() {
 		It("should allow partial search domains", func() {
 			resolvConf := "search local\nnameserver 8.8.8.8\n"
 			searchDomains, err := ParseSearchDomains(resolvConf)
-			Expect(searchDomains).To(Equal([]string{"local"}))
+			Expect(searchDomains).To(Equal([]string{localSearchDomain}))
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("should normalize search domains to lower-case", func() {
 			resolvConf := "search LoCaL\nnameserver 8.8.8.8\n"
 			searchDomains, err := ParseSearchDomains(resolvConf)
-			Expect(searchDomains).To(Equal([]string{"local"}))
+			Expect(searchDomains).To(Equal([]string{localSearchDomain}))
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})
@@ -135,7 +142,7 @@ var _ = Describe("Resolveconf", func() {
 
 	Context("subdomain", func() {
 		It("should be added to the longest service domain", func() {
-			searchDomains := []string{"default.svc.cluster.local", "svc.cluster.local", "cluster.local"}
+			searchDomains := []string{defaultServiceSearchDomain, serviceSearchDomain, defaultSearchDomain}
 
 			const subdomain = "subdomain"
 			domain := DomainNameWithSubdomain(searchDomains, subdomain)
@@ -143,7 +150,7 @@ var _ = Describe("Resolveconf", func() {
 		})
 
 		It("should not be added if subdomain is empty", func() {
-			searchDomains := []string{"default.svc.cluster.local", "svc.cluster.local", "cluster.local"}
+			searchDomains := []string{defaultServiceSearchDomain, serviceSearchDomain, defaultSearchDomain}
 
 			const subdomain = ""
 			domain := DomainNameWithSubdomain(searchDomains, subdomain)
@@ -151,7 +158,7 @@ var _ = Describe("Resolveconf", func() {
 		})
 
 		It("should be added even if the longest existing service domain isn't the first", func() {
-			searchDomains := []string{"svc.cluster.local", "cluster.local", "default.svc.cluster.local"}
+			searchDomains := []string{serviceSearchDomain, defaultSearchDomain, defaultServiceSearchDomain}
 
 			const subdomain = "subdomain"
 			domain := DomainNameWithSubdomain(searchDomains, subdomain)
@@ -159,7 +166,7 @@ var _ = Describe("Resolveconf", func() {
 		})
 
 		It("should not be added if the longest existing service domain already has it", func() {
-			searchDomains := []string{"svc.cluster.local", "cluster.local", "subdomain.default.svc.cluster.local"}
+			searchDomains := []string{serviceSearchDomain, defaultSearchDomain, "subdomain.default.svc.cluster.local"}
 
 			const subdomain = "subdomain"
 			domain := DomainNameWithSubdomain(searchDomains, subdomain)
@@ -168,8 +175,8 @@ var _ = Describe("Resolveconf", func() {
 
 		It("should be added to the right entry if the longest entry is not a service entry", func() {
 			searchDomains := []string{
-				"default.svc.cluster.local", "svc.cluster.local",
-				"cluster.local", "this.is.a.very.very.very.long.entry",
+				defaultServiceSearchDomain, serviceSearchDomain,
+				defaultSearchDomain, "this.is.a.very.very.very.long.entry",
 			}
 
 			const subdomain = "subdomain"
@@ -178,7 +185,7 @@ var _ = Describe("Resolveconf", func() {
 		})
 
 		It("should not be added if there is no service entry", func() {
-			searchDomains := []string{"example.com"}
+			searchDomains := []string{exampleSearchDomain}
 
 			const subdomain = "subdomain"
 			domain := DomainNameWithSubdomain(searchDomains, subdomain)

--- a/pkg/network/domainspec/generators.go
+++ b/pkg/network/domainspec/generators.go
@@ -33,7 +33,10 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )
 
-const linkIfaceFailFmt = "failed to get a link for interface: %s"
+const (
+	linkIfaceFailFmt = "failed to get a link for interface: %s"
+	managedNo        = "no"
+)
 
 type LibvirtSpecGenerator interface {
 	Generate() error
@@ -103,7 +106,7 @@ func (b *TapLibvirtSpecGenerator) discoverDomainIfaceSpec() (*api.Interface, err
 		MTU: &api.MTU{Size: strconv.Itoa(podNicLink.Attrs().MTU)},
 		Target: &api.InterfaceTarget{
 			Device:  targetName,
-			Managed: "no",
+			Managed: managedNo,
 		},
 	}, nil
 }

--- a/pkg/network/domainspec/generators_test.go
+++ b/pkg/network/domainspec/generators_test.go
@@ -123,7 +123,7 @@ func verifyTapDomain(domainIfaces []api.Interface, expectedTargetName, expectedM
 		Equal(
 			&api.InterfaceTarget{
 				Device:  expectedTargetName,
-				Managed: "no",
+				Managed: managedNo,
 			}), "should have an unmanaged interface")
 	ExpectWithOffset(1, domainIfaces[0].MAC).To(Equal(&api.MAC{MAC: expectedMAC}), "should have the expected MAC address")
 	ExpectWithOffset(1, domainIfaces[0].MTU).To(Equal(&api.MTU{Size: expectedMTU}), "should have the expected MTU")

--- a/pkg/network/downwardapi/networkinfo_test.go
+++ b/pkg/network/downwardapi/networkinfo_test.go
@@ -30,18 +30,35 @@ import (
 	"kubevirt.io/kubevirt/pkg/network/downwardapi"
 )
 
+const (
+	netAMacAddress = "0c:42:a1:22:a3:52"
+	netBMacAddress = "0c:42:a1:22:a3:53"
+	netCMacAddress = "0c:42:a1:22:a3:54"
+	netAName       = "netA"
+	netBName       = "netB"
+	netCName       = "netC"
+	fooNetworkName = "foo"
+	booNetworkName = "boo"
+	deviceType1    = "type1"
+	deviceType2    = "type2"
+	deviceType3    = "type3"
+	podAInterface  = "pod33219a16a42"
+	podBInterface  = "pod034d3d19642"
+	podCInterface  = "pod01783857d47"
+)
+
 var _ = Describe("Network info", func() {
 	It("should create network info annotation value", func() {
 		deviceInfoFoo := &networkv1.DeviceInfo{Type: "fooType"}
 
 		networkStatusByNetworkName := map[string]networkv1.NetworkStatus{
-			"foo": {Interface: "pod2c26b46b68f", DeviceInfo: deviceInfoFoo, Mtu: 1500},
-			"boo": {Interface: "pod6446d58d6df"},
+			fooNetworkName: {Interface: "pod2c26b46b68f", DeviceInfo: deviceInfoFoo, Mtu: 1500},
+			booNetworkName: {Interface: "pod6446d58d6df"},
 		}
 
 		expectedInterfaces := []downwardapi.Interface{
-			{Network: "foo", DeviceInfo: deviceInfoFoo, Mtu: 1500},
-			{Network: "boo"},
+			{Network: fooNetworkName, DeviceInfo: deviceInfoFoo, Mtu: 1500},
+			{Network: booNetworkName},
 		}
 
 		annotation := downwardapi.CreateNetworkInfoAnnotationValue(networkStatusByNetworkName)
@@ -58,20 +75,20 @@ var _ = Describe("Network info", func() {
 	})
 
 	It("should produce a deterministic and output sorted by network name regardless of the map key order", func() {
-		deviceInfo1 := &networkv1.DeviceInfo{Type: "type1"}
-		deviceInfo2 := &networkv1.DeviceInfo{Type: "type2"}
-		deviceInfo3 := &networkv1.DeviceInfo{Type: "type3"}
+		deviceInfo1 := &networkv1.DeviceInfo{Type: deviceType1}
+		deviceInfo2 := &networkv1.DeviceInfo{Type: deviceType2}
+		deviceInfo3 := &networkv1.DeviceInfo{Type: deviceType3}
 
 		networkStatusByNetworkName1 := map[string]networkv1.NetworkStatus{
-			"netA": {Interface: "pod33219a16a42", Mac: "0c:42:a1:22:a3:52", DeviceInfo: deviceInfo1, Mtu: 1500},
-			"netB": {Interface: "pod034d3d19642", Mac: "0c:42:a1:22:a3:53", DeviceInfo: deviceInfo2, Mtu: 9000},
-			"netC": {Interface: "pod01783857d47", Mac: "0c:42:a1:22:a3:54", DeviceInfo: deviceInfo3},
+			netAName: {Interface: podAInterface, Mac: netAMacAddress, DeviceInfo: deviceInfo1, Mtu: 1500},
+			netBName: {Interface: podBInterface, Mac: netBMacAddress, DeviceInfo: deviceInfo2, Mtu: 9000},
+			netCName: {Interface: podCInterface, Mac: netCMacAddress, DeviceInfo: deviceInfo3},
 		}
 
 		networkStatusByNetworkName2 := map[string]networkv1.NetworkStatus{
-			"netC": {Interface: "pod01783857d47", Mac: "0c:42:a1:22:a3:54", DeviceInfo: deviceInfo3},
-			"netB": {Interface: "pod034d3d19642", Mac: "0c:42:a1:22:a3:53", DeviceInfo: deviceInfo2, Mtu: 9000},
-			"netA": {Interface: "pod33219a16a42", Mac: "0c:42:a1:22:a3:52", DeviceInfo: deviceInfo1, Mtu: 1500},
+			netCName: {Interface: podCInterface, Mac: netCMacAddress, DeviceInfo: deviceInfo3},
+			netBName: {Interface: podBInterface, Mac: netBMacAddress, DeviceInfo: deviceInfo2, Mtu: 9000},
+			netAName: {Interface: podAInterface, Mac: netAMacAddress, DeviceInfo: deviceInfo1, Mtu: 1500},
 		}
 
 		annotationValue1 := downwardapi.CreateNetworkInfoAnnotationValue(networkStatusByNetworkName1)
@@ -84,9 +101,9 @@ var _ = Describe("Network info", func() {
 
 		expectedNetworkInfo := downwardapi.NetworkInfo{
 			Interfaces: []downwardapi.Interface{
-				{Network: "netA", Mac: "0c:42:a1:22:a3:52", DeviceInfo: &networkv1.DeviceInfo{Type: "type1"}, Mtu: 1500},
-				{Network: "netB", Mac: "0c:42:a1:22:a3:53", DeviceInfo: &networkv1.DeviceInfo{Type: "type2"}, Mtu: 9000},
-				{Network: "netC", Mac: "0c:42:a1:22:a3:54", DeviceInfo: &networkv1.DeviceInfo{Type: "type3"}},
+				{Network: netAName, Mac: netAMacAddress, DeviceInfo: &networkv1.DeviceInfo{Type: deviceType1}, Mtu: 1500},
+				{Network: netBName, Mac: netBMacAddress, DeviceInfo: &networkv1.DeviceInfo{Type: deviceType2}, Mtu: 9000},
+				{Network: netCName, Mac: netCMacAddress, DeviceInfo: &networkv1.DeviceInfo{Type: deviceType3}},
 			},
 		}
 

--- a/pkg/network/driver/procsys/fake/fake.go
+++ b/pkg/network/driver/procsys/fake/fake.go
@@ -79,15 +79,17 @@ func (p *ProcSys) IPv4SetUnprivilegedPortStart(port int) error {
 	return nil
 }
 
+const allIface = "all"
+
 func (p *ProcSys) IPv4GetArpIgnore(ifaceName string) (procsys.ArpReplyMode, error) {
-	if ifaceName == "all" {
+	if ifaceName == allIface {
 		return p.linuxStackData.arpIgnoreMode, nil
 	}
 	return 0, nil
 }
 
 func (p *ProcSys) IPv4SetArpIgnore(ifaceName string, mode procsys.ArpReplyMode) error {
-	if ifaceName == "all" {
+	if ifaceName == allIface {
 		p.linuxStackData.arpIgnoreMode = mode
 	}
 	return nil

--- a/pkg/network/link/address_test.go
+++ b/pkg/network/link/address_test.go
@@ -31,6 +31,8 @@ import (
 	netdriver "kubevirt.io/kubevirt/pkg/network/driver"
 )
 
+const testIfaceName = "abcd"
+
 var _ = Describe("Common Methods", func() {
 	createNetwork := func(cidr string, ipv6Cidr string) *v1.Network {
 		return &v1.Network{
@@ -85,7 +87,7 @@ var _ = Describe("Common Methods", func() {
 		})
 		It("Should return an error if the spec contain MAC address with wrong format", func() {
 			iface := &v1.Interface{
-				MacAddress: "abcd",
+				MacAddress: testIfaceName,
 			}
 			mac, err := RetrieveMacAddressFromVMISpecIface(iface)
 			Expect(err).To(HaveOccurred())
@@ -109,15 +111,15 @@ var _ = Describe("Common Methods", func() {
 	})
 	Context("GetFakeBridgeIP function", func() {
 		It("Should return empty string when interface name is not in the interface list", func() {
-			ip := GetFakeBridgeIP([]v1.Interface{v1.Interface{Name: "aaaa"}}, &v1.Interface{Name: "abcd"})
+			ip := GetFakeBridgeIP([]v1.Interface{v1.Interface{Name: "aaaa"}}, &v1.Interface{Name: testIfaceName})
 			Expect(ip).To(Equal(""))
 		})
 		It("Should return the correct ip when the interface is the first in the list", func() {
-			ip := GetFakeBridgeIP([]v1.Interface{v1.Interface{Name: "abcd"}}, &v1.Interface{Name: "abcd"})
+			ip := GetFakeBridgeIP([]v1.Interface{v1.Interface{Name: testIfaceName}}, &v1.Interface{Name: testIfaceName})
 			Expect(ip).To(Equal(fmt.Sprintf(bridgeFakeIP, 0)))
 		})
 		It("Should return the correct ip when the interface is not the first in the list", func() {
-			ip := GetFakeBridgeIP([]v1.Interface{v1.Interface{Name: "aaaa"}, v1.Interface{Name: "abcd"}}, &v1.Interface{Name: "abcd"})
+			ip := GetFakeBridgeIP([]v1.Interface{v1.Interface{Name: "aaaa"}, v1.Interface{Name: testIfaceName}}, &v1.Interface{Name: testIfaceName})
 			Expect(ip).To(Equal(fmt.Sprintf(bridgeFakeIP, 1)))
 		})
 	})

--- a/pkg/network/migration/evaluator_test.go
+++ b/pkg/network/migration/evaluator_test.go
@@ -39,8 +39,10 @@ import (
 
 var _ = Describe("Evaluator", func() {
 	const (
+		defaultNetworkName   = "default"
 		secondaryNetworkName = "secondary-network"
 		nadName              = "my-nad"
+		networkStatusAnnot   = "k8s.v1.cni.cncf.io/network-status"
 	)
 
 	multusAndDomainInfoSource := vmispec.NewInfoSource(vmispec.InfoSourceMultusStatus, vmispec.InfoSourceDomain)
@@ -61,7 +63,7 @@ var _ = Describe("Evaluator", func() {
 				libvmistatus.WithStatus(
 					libvmistatus.New(
 						libvmistatus.WithInterfaceStatus(v1.VirtualMachineInstanceNetworkInterface{
-							Name:       "default",
+							Name:       defaultNetworkName,
 							InfoSource: vmispec.InfoSourceDomain,
 						}),
 						libvmistatus.WithInterfaceStatus(v1.VirtualMachineInstanceNetworkInterface{
@@ -87,7 +89,7 @@ var _ = Describe("Evaluator", func() {
 				libvmistatus.WithStatus(
 					libvmistatus.New(
 						libvmistatus.WithInterfaceStatus(v1.VirtualMachineInstanceNetworkInterface{
-							Name:       "default",
+							Name:       defaultNetworkName,
 							InfoSource: vmispec.InfoSourceDomain,
 						}),
 						libvmistatus.WithInterfaceStatus(v1.VirtualMachineInstanceNetworkInterface{
@@ -113,7 +115,7 @@ var _ = Describe("Evaluator", func() {
 				libvmistatus.WithStatus(
 					libvmistatus.New(
 						libvmistatus.WithInterfaceStatus(v1.VirtualMachineInstanceNetworkInterface{
-							Name:       "default",
+							Name:       defaultNetworkName,
 							InfoSource: vmispec.InfoSourceDomain,
 						}),
 					),
@@ -135,7 +137,7 @@ var _ = Describe("Evaluator", func() {
 				libvmistatus.WithStatus(
 					libvmistatus.New(
 						libvmistatus.WithInterfaceStatus(v1.VirtualMachineInstanceNetworkInterface{
-							Name:       "default",
+							Name:       defaultNetworkName,
 							InfoSource: vmispec.InfoSourceDomain,
 						}),
 						libvmistatus.WithInterfaceStatus(v1.VirtualMachineInstanceNetworkInterface{
@@ -157,7 +159,7 @@ var _ = Describe("Evaluator", func() {
 			libvmistatus.WithStatus(
 				libvmistatus.New(
 					libvmistatus.WithInterfaceStatus(v1.VirtualMachineInstanceNetworkInterface{
-						Name:       "default",
+						Name:       defaultNetworkName,
 						InfoSource: vmispec.InfoSourceDomain,
 					}),
 				),
@@ -186,7 +188,7 @@ var _ = Describe("Evaluator", func() {
 							Reason:             v1.VirtualMachineInstanceReasonAutoMigrationPending,
 						}),
 						libvmistatus.WithInterfaceStatus(v1.VirtualMachineInstanceNetworkInterface{
-							Name:       "default",
+							Name:       defaultNetworkName,
 							InfoSource: vmispec.InfoSourceDomain,
 						}),
 					),
@@ -213,7 +215,7 @@ var _ = Describe("Evaluator", func() {
 
 	Context("NAD name change", func() {
 		const (
-			testNamespace  = "default"
+			testNamespace  = defaultNetworkName
 			otherNamespace = "other-namespace"
 
 			secondaryNetworkName1 = "secondary-network"
@@ -245,7 +247,7 @@ var _ = Describe("Evaluator", func() {
 					)),
 				),
 				newPod(map[string]string{
-					"k8s.v1.cni.cncf.io/network-status": fmt.Sprintf(`[{"interface": %q, "name": "%s/%s"}]`,
+					networkStatusAnnot: fmt.Sprintf(`[{"interface": %q, "name": "%s/%s"}]`,
 						secondaryPodIfaceName1, testNamespace, nadName1),
 				}),
 				k8scorev1.ConditionUnknown,
@@ -264,7 +266,7 @@ var _ = Describe("Evaluator", func() {
 					)),
 				),
 				newPod(map[string]string{
-					"k8s.v1.cni.cncf.io/network-status": fmt.Sprintf(`[{"interface": %q, "name": "%s/%s"}]`,
+					networkStatusAnnot: fmt.Sprintf(`[{"interface": %q, "name": "%s/%s"}]`,
 						secondaryPodIfaceName1, testNamespace, nadName1),
 				}),
 				k8scorev1.ConditionTrue,
@@ -291,7 +293,7 @@ var _ = Describe("Evaluator", func() {
 					)),
 				),
 				newPod(map[string]string{
-					"k8s.v1.cni.cncf.io/network-status": fmt.Sprintf(
+					networkStatusAnnot: fmt.Sprintf(
 						`[{"interface": %q, "name": "%s/%s"}, {"interface": %q, "name": "%s/%s"}]`,
 						secondaryPodIfaceName1, testNamespace, nadName2,
 						secondaryPodIfaceName2, otherNamespace, nadName1,

--- a/pkg/network/multus/annotation_test.go
+++ b/pkg/network/multus/annotation_test.go
@@ -30,16 +30,24 @@ import (
 	"kubevirt.io/kubevirt/pkg/network/multus"
 )
 
+const (
+	defaultNetworkName = "default"
+	bindingPluginName  = "test-binding"
+	testVMIName        = "testvmi"
+	blueNetworkName    = "blue"
+	redNetworkName     = "red"
+)
+
 var _ = Describe("Multus annotations", func() {
 	Context("Generate Multus network selection annotation", func() {
 		When("NetworkBindingPlugins feature enabled", func() {
 			It("should fail if the specified network binding plugin is not registered (specified in Kubevirt config)", func() {
-				vmi := &v1.VirtualMachineInstance{ObjectMeta: metav1.ObjectMeta{Name: "testvmi", Namespace: "default"}}
+				vmi := &v1.VirtualMachineInstance{ObjectMeta: metav1.ObjectMeta{Name: testVMIName, Namespace: defaultNetworkName}}
 				vmi.Spec.Networks = []v1.Network{
-					{Name: "default", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}},
+					{Name: defaultNetworkName, NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}},
 				}
 				vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{
-					{Name: "default", Binding: &v1.PluginBinding{Name: "test-binding"}},
+					{Name: defaultNetworkName, Binding: &v1.PluginBinding{Name: bindingPluginName}},
 				}
 
 				registeredBindinPlugins := map[string]v1.InterfaceBindingPlugin{
@@ -52,20 +60,20 @@ var _ = Describe("Multus annotations", func() {
 			})
 
 			It("should add network binding plugin net-attach-def to multus annotation", func() {
-				vmi := &v1.VirtualMachineInstance{ObjectMeta: metav1.ObjectMeta{Name: "testvmi", Namespace: "default"}}
+				vmi := &v1.VirtualMachineInstance{ObjectMeta: metav1.ObjectMeta{Name: testVMIName, Namespace: defaultNetworkName}}
 				vmi.Spec.Networks = []v1.Network{
-					{Name: "default", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}},
-					{Name: "blue", NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{NetworkName: "test1"}}},
-					{Name: "red", NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{NetworkName: "other-namespace/test1"}}},
+					{Name: defaultNetworkName, NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}},
+					{Name: blueNetworkName, NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{NetworkName: "test1"}}},
+					{Name: redNetworkName, NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{NetworkName: "other-namespace/test1"}}},
 				}
 				vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{
-					{Name: "default", Binding: &v1.PluginBinding{Name: "test-binding"}},
-					{Name: "blue"},
-					{Name: "red"},
+					{Name: defaultNetworkName, Binding: &v1.PluginBinding{Name: bindingPluginName}},
+					{Name: blueNetworkName},
+					{Name: redNetworkName},
 				}
 
 				registeredBindinPlugins := map[string]v1.InterfaceBindingPlugin{
-					"test-binding": {NetworkAttachmentDefinition: "test-binding-net"},
+					bindingPluginName: {NetworkAttachmentDefinition: "test-binding-net"},
 				}
 
 				Expect(multus.GenerateCNIAnnotation(
@@ -83,14 +91,14 @@ var _ = Describe("Multus annotations", func() {
 
 			DescribeTable("should parse NetworkAttachmentDefinition name and namespace correctly, given",
 				func(netAttachDefRawName, expectedAnnot string) {
-					vmi := &v1.VirtualMachineInstance{ObjectMeta: metav1.ObjectMeta{Name: "testvmi", Namespace: "default"}}
+					vmi := &v1.VirtualMachineInstance{ObjectMeta: metav1.ObjectMeta{Name: testVMIName, Namespace: defaultNetworkName}}
 					vmi.Spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
 					vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{
-						{Name: "default", Binding: &v1.PluginBinding{Name: "test-binding"}},
+						{Name: defaultNetworkName, Binding: &v1.PluginBinding{Name: bindingPluginName}},
 					}
 
 					registeredBindinPlugins := map[string]v1.InterfaceBindingPlugin{
-						"test-binding": {NetworkAttachmentDefinition: netAttachDefRawName},
+						bindingPluginName: {NetworkAttachmentDefinition: netAttachDefRawName},
 					}
 
 					Expect(

--- a/pkg/network/multus/nad_test.go
+++ b/pkg/network/multus/nad_test.go
@@ -31,16 +31,21 @@ import (
 	"kubevirt.io/kubevirt/pkg/network/multus"
 )
 
+const (
+	testNamespace = "testns"
+	testNetName   = "testnet"
+)
+
 var _ = Describe("NetAttachDefNamespacedName", func() {
 	It("should return vmi namespace when namespace is implicit", func() {
-		vmi := &v1.VirtualMachineInstance{ObjectMeta: metav1.ObjectMeta{Name: "testvmi", Namespace: "testns"}}
-		nadNamespacedName := multus.NetAttachDefNamespacedName(vmi.Namespace, "testnet")
-		Expect(nadNamespacedName).To(Equal(types.NamespacedName{Namespace: "testns", Name: "testnet"}))
+		vmi := &v1.VirtualMachineInstance{ObjectMeta: metav1.ObjectMeta{Name: testVMIName, Namespace: testNamespace}}
+		nadNamespacedName := multus.NetAttachDefNamespacedName(vmi.Namespace, testNetName)
+		Expect(nadNamespacedName).To(Equal(types.NamespacedName{Namespace: testNamespace, Name: testNetName}))
 	})
 
 	It("should return namespace from networkName when namespace is explicit", func() {
-		vmi := &v1.VirtualMachineInstance{ObjectMeta: metav1.ObjectMeta{Name: "testvmi", Namespace: "testns"}}
-		nadNamespacedName := multus.NetAttachDefNamespacedName(vmi.Namespace, "otherns/testnet")
-		Expect(nadNamespacedName).To(Equal(types.NamespacedName{Namespace: "otherns", Name: "testnet"}))
+		vmi := &v1.VirtualMachineInstance{ObjectMeta: metav1.ObjectMeta{Name: testVMIName, Namespace: testNamespace}}
+		nadNamespacedName := multus.NetAttachDefNamespacedName(vmi.Namespace, "otherns/"+testNetName)
+		Expect(nadNamespacedName).To(Equal(types.NamespacedName{Namespace: "otherns", Name: testNetName}))
 	})
 })

--- a/pkg/network/multus/status_test.go
+++ b/pkg/network/multus/status_test.go
@@ -32,17 +32,27 @@ import (
 	"kubevirt.io/kubevirt/pkg/network/multus"
 )
 
+const (
+	defaultPrimaryPodIfaceName = "eth0"
+	secondaryNetworkName       = "meganet"
+	primaryPodNetworkName      = "k8s-pod-network"
+	secondaryPodIfaceName      = "pod7e0055a6880"
+	clusterDefaultNetworkName  = "cluster-default"
+	networkNameNet1            = "net1"
+	someNetName                = "some-net"
+)
+
 var _ = Describe("Network Status", func() {
 	Context("NetworkStatusesByPodIfaceName", func() {
 		It("Should map network statuses by pod interface name with multiple networks", func() {
 			networkStatuses := []networkv1.NetworkStatus{
-				{Name: "cluster-default", Interface: "eth0"},
-				{Name: "meganet", Interface: "pod7e0055a6880"},
+				{Name: clusterDefaultNetworkName, Interface: defaultPrimaryPodIfaceName},
+				{Name: secondaryNetworkName, Interface: secondaryPodIfaceName},
 			}
 
 			expected := map[string]networkv1.NetworkStatus{
-				"eth0":           {Name: "cluster-default", Interface: "eth0"},
-				"pod7e0055a6880": {Name: "meganet", Interface: "pod7e0055a6880"},
+				defaultPrimaryPodIfaceName: {Name: clusterDefaultNetworkName, Interface: defaultPrimaryPodIfaceName},
+				secondaryPodIfaceName:      {Name: secondaryNetworkName, Interface: secondaryPodIfaceName},
 			}
 
 			Expect(multus.NetworkStatusesByPodIfaceName(networkStatuses)).To(Equal(expected))
@@ -75,7 +85,7 @@ var _ = Describe("Network Status", func() {
 				},
 				{
 					Name:      "meganet",
-					Interface: "pod7e0055a6880",
+					Interface: secondaryPodIfaceName,
 					Mac:       "8a:37:d9:e7:0f:18",
 					Default:   false,
 					DNS:       networkv1.DNS{},
@@ -88,8 +98,7 @@ var _ = Describe("Network Status", func() {
 
 	Context("LookupPodPrimaryIfaceName", func() {
 		const (
-			defaultPrimaryPodIfaceName = "eth0"
-			customPrimaryPodIfaceName  = "custom-iface"
+			customPrimaryPodIfaceName = "custom-iface"
 		)
 
 		DescribeTable("should return empty string", func(networkStatuses []networkv1.NetworkStatus) {
@@ -99,12 +108,12 @@ var _ = Describe("Network Status", func() {
 			Entry("when network status is empty", []networkv1.NetworkStatus{}),
 			Entry("when network status does not report interface name",
 				[]networkv1.NetworkStatus{
-					{Name: "k8s-pod-network", Default: true},
+					{Name: primaryPodNetworkName, Default: true},
 				},
 			),
 			Entry("when network status does not report a default interface name",
 				[]networkv1.NetworkStatus{
-					{Name: "net1", Interface: "", Default: false},
+					{Name: networkNameNet1, Interface: "", Default: false},
 					{Name: "net2", Interface: "pod12345", Default: false},
 				},
 			),
@@ -115,16 +124,16 @@ var _ = Describe("Network Status", func() {
 		},
 			Entry("When the primary pod interface name is reported and its the default value",
 				[]networkv1.NetworkStatus{
-					{Name: "k8s-pod-network", Interface: defaultPrimaryPodIfaceName, Default: true},
-					{Name: "some-net", Interface: "pod123456", Default: false},
+					{Name: primaryPodNetworkName, Interface: defaultPrimaryPodIfaceName, Default: true},
+					{Name: someNetName, Interface: "pod123456", Default: false},
 				},
 				defaultPrimaryPodIfaceName,
 			),
 			Entry("When the primary pod interface name is reported and it has the custom value",
 				[]networkv1.NetworkStatus{
-					{Name: "k8s-pod-network", Interface: defaultPrimaryPodIfaceName, Default: false},
-					{Name: "k8s-pod-network", Interface: customPrimaryPodIfaceName, Default: true},
-					{Name: "some-net", Interface: "net1", Default: false},
+					{Name: primaryPodNetworkName, Interface: defaultPrimaryPodIfaceName, Default: false},
+					{Name: primaryPodNetworkName, Interface: customPrimaryPodIfaceName, Default: true},
+					{Name: someNetName, Interface: networkNameNet1, Default: false},
 				},
 				customPrimaryPodIfaceName,
 			),

--- a/pkg/network/namescheme/networknamescheme_test.go
+++ b/pkg/network/namescheme/networknamescheme_test.go
@@ -30,7 +30,26 @@ import (
 	"kubevirt.io/kubevirt/pkg/network/namescheme"
 )
 
+const (
+	defaultNetworkName    = "default"
+	secondaryNetwork1Name = "network1"
+	secondaryNetwork2Name = "network2"
+	podIface1OrdinalName  = "net1"
+	podIface2OrdinalName  = "net2"
+	network0Name          = "network0"
+	hashedPodIface1Name   = "poda7662f44d65"
+	hashedPodIface2Name   = "pod27f4a77f94e"
+	eth0IfaceName         = "eth0"
+	podIface1HashedName   = "podb1f51a511f1"
+	podIface3HashedName   = "pod16477688c0e"
+)
+
 var _ = Describe("Network Name Scheme", func() {
+	const (
+		net1Name = "net1"
+		net2Name = "net2"
+	)
+
 	DescribeTable("create pod interfaces name scheme",
 		func(nameSchemeFn func([]virtv1.Network) map[string]string, networkList []virtv1.Network, expectedNetworkNameScheme map[string]string) {
 			podIfacesNameScheme := nameSchemeFn(networkList)
@@ -44,31 +63,31 @@ var _ = Describe("Network Name Scheme", func() {
 				newPodNetwork(),
 			},
 			map[string]string{
-				"default": namescheme.PrimaryPodInterfaceName,
+				defaultNetworkName: namescheme.PrimaryPodInterfaceName,
 			}),
 		Entry("hashed, when default multus networks exist",
 			namescheme.CreateHashedNetworkNameScheme,
 			[]virtv1.Network{
 				createMultusDefaultNetwork("network0", "default/nad0"),
-				createMultusSecondaryNetwork("network1", "default/nad1"),
-				createMultusSecondaryNetwork("network2", "default/nad2"),
+				createMultusSecondaryNetwork(secondaryNetwork1Name, "default/nad1"),
+				createMultusSecondaryNetwork(secondaryNetwork2Name, "default/nad2"),
 			},
 			map[string]string{
-				"network0": namescheme.PrimaryPodInterfaceName,
-				"network1": "poda7662f44d65",
-				"network2": "pod27f4a77f94e",
+				network0Name:          namescheme.PrimaryPodInterfaceName,
+				secondaryNetwork1Name: hashedPodIface1Name,
+				secondaryNetwork2Name: hashedPodIface2Name,
 			}),
 		Entry("hashed, when default pod networks exist",
 			namescheme.CreateHashedNetworkNameScheme,
 			[]virtv1.Network{
 				newPodNetwork(),
-				createMultusSecondaryNetwork("network1", "default/nad1"),
-				createMultusSecondaryNetwork("network2", "default/nad2"),
+				createMultusSecondaryNetwork(secondaryNetwork1Name, "default/nad1"),
+				createMultusSecondaryNetwork(secondaryNetwork2Name, "default/nad2"),
 			},
 			map[string]string{
-				"default":  namescheme.PrimaryPodInterfaceName,
-				"network1": "poda7662f44d65",
-				"network2": "pod27f4a77f94e",
+				defaultNetworkName:    namescheme.PrimaryPodInterfaceName,
+				secondaryNetwork1Name: hashedPodIface1Name,
+				secondaryNetwork2Name: hashedPodIface2Name,
 			}),
 		Entry("ordinal, when network list is nil", namescheme.CreateOrdinalNetworkNameScheme, nil, map[string]string{}),
 		Entry("ordinal, when no multus networks exist",
@@ -77,31 +96,31 @@ var _ = Describe("Network Name Scheme", func() {
 				newPodNetwork(),
 			},
 			map[string]string{
-				"default": namescheme.PrimaryPodInterfaceName,
+				defaultNetworkName: namescheme.PrimaryPodInterfaceName,
 			}),
 		Entry("ordinal, when default multus networks exist",
 			namescheme.CreateOrdinalNetworkNameScheme,
 			[]virtv1.Network{
 				createMultusDefaultNetwork("network0", "default/nad0"),
-				createMultusSecondaryNetwork("network1", "default/nad1"),
-				createMultusSecondaryNetwork("network2", "default/nad2"),
+				createMultusSecondaryNetwork(secondaryNetwork1Name, "default/nad1"),
+				createMultusSecondaryNetwork(secondaryNetwork2Name, "default/nad2"),
 			},
 			map[string]string{
-				"network0": namescheme.PrimaryPodInterfaceName,
-				"network1": "net1",
-				"network2": "net2",
+				network0Name:          namescheme.PrimaryPodInterfaceName,
+				secondaryNetwork1Name: podIface1OrdinalName,
+				secondaryNetwork2Name: podIface2OrdinalName,
 			}),
 		Entry("ordinal, when default pod networks exist",
 			namescheme.CreateOrdinalNetworkNameScheme,
 			[]virtv1.Network{
 				newPodNetwork(),
-				createMultusSecondaryNetwork("network1", "default/nad1"),
-				createMultusSecondaryNetwork("network2", "default/nad2"),
+				createMultusSecondaryNetwork(secondaryNetwork1Name, "default/nad1"),
+				createMultusSecondaryNetwork(secondaryNetwork2Name, "default/nad2"),
 			},
 			map[string]string{
-				"default":  namescheme.PrimaryPodInterfaceName,
-				"network1": "net1",
-				"network2": "net2",
+				defaultNetworkName:    namescheme.PrimaryPodInterfaceName,
+				secondaryNetwork1Name: podIface1OrdinalName,
+				secondaryNetwork2Name: podIface2OrdinalName,
 			}),
 	)
 
@@ -109,11 +128,11 @@ var _ = Describe("Network Name Scheme", func() {
 		const (
 			network1Name         = "red"
 			podIface1HashedName  = "podb1f51a511f1"
-			podIface1OrdinalName = "net1"
+			podIface1OrdinalName = net1Name
 
 			network2Name         = "green"
 			podIface2HashedName  = "podba4788b226a"
-			podIface2OrdinalName = "net2"
+			podIface2OrdinalName = net2Name
 		)
 
 		DescribeTable("should map VMI network names to pod interfaces names",
@@ -128,7 +147,7 @@ var _ = Describe("Network Name Scheme", func() {
 			Entry("given only pod network",
 				[]virtv1.Network{newPodNetwork()},
 				[]networkv1.NetworkStatus{{Interface: namescheme.PrimaryPodInterfaceName}},
-				map[string]string{"default": namescheme.PrimaryPodInterfaceName},
+				map[string]string{defaultNetworkName: namescheme.PrimaryPodInterfaceName},
 			),
 			Entry("when the pod interfaces use a hashed naming scheme",
 				multusNetworks(network1Name, network2Name),
@@ -150,14 +169,14 @@ var _ = Describe("Network Name Scheme", func() {
 			},
 			Entry("with primary pod network interface",
 				[]networkv1.NetworkStatus{
-					{Interface: "eth0"},
-					{Interface: "net1"},
-					{Interface: "net2"},
+					{Interface: eth0IfaceName},
+					{Interface: podIface1OrdinalName},
+					{Interface: podIface2OrdinalName},
 				}),
 			Entry("without primary pod network interface",
 				[]networkv1.NetworkStatus{
-					{Interface: "net1"},
-					{Interface: "net2"},
+					{Interface: podIface1OrdinalName},
+					{Interface: podIface2OrdinalName},
 				}),
 		)
 
@@ -168,14 +187,14 @@ var _ = Describe("Network Name Scheme", func() {
 			Entry("When networks statutes is empty", []networkv1.NetworkStatus{}),
 			Entry("when networks statutes has primary pod and hashed secondary network interface",
 				[]networkv1.NetworkStatus{
-					{Interface: "eth0"},
-					{Interface: "podb1f51a511f1"},
-					{Interface: "pod16477688c0e"},
+					{Interface: eth0IfaceName},
+					{Interface: podIface1HashedName},
+					{Interface: podIface3HashedName},
 				}),
 			Entry("when networks statutes has hashed secondary network interface",
 				[]networkv1.NetworkStatus{
-					{Interface: "podb1f51a511f1"},
-					{Interface: "pod16477688c0e"},
+					{Interface: podIface1HashedName},
+					{Interface: podIface3HashedName},
 				}),
 		)
 	})
@@ -187,15 +206,15 @@ var _ = Describe("Network Name Scheme", func() {
 			},
 			Entry("given default network name when default is pod network",
 				newPodNetwork(),
-				"eth0",
+				eth0IfaceName,
 			),
 			Entry("given default network name when default is Multus default network",
 				createMultusDefaultNetwork("overlay-network", "pod-net-br"),
-				"eth0",
+				eth0IfaceName,
 			),
 			Entry("given secondary network name",
 				createMultusSecondaryNetwork("red", "test-br"),
-				"podb1f51a511f1",
+				podIface1HashedName,
 			),
 		)
 	})
@@ -222,13 +241,13 @@ var _ = Describe("Network Name Scheme", func() {
 				Expect(namescheme.OrdinalPodInterfaceName(networkName, networks)).To(Equal(expectedPodIfaceName))
 			},
 			Entry("given default network name and default is pod network",
-				"default",
+				defaultNetworkName,
 				[]virtv1.Network{
 					newPodNetwork(),
 					createMultusSecondaryNetwork("blue", "test-br"),
 					createMultusSecondaryNetwork("red", "test-br"),
 				},
-				"eth0",
+				eth0IfaceName,
 			),
 			Entry("given default network name and default is Multus default network",
 				"overlay",
@@ -237,7 +256,7 @@ var _ = Describe("Network Name Scheme", func() {
 					createMultusSecondaryNetwork("blue", "test-br"),
 					createMultusSecondaryNetwork("red", "test-br"),
 				},
-				"eth0",
+				eth0IfaceName,
 			),
 			Entry("given secondary network name",
 				"red",
@@ -246,7 +265,7 @@ var _ = Describe("Network Name Scheme", func() {
 					createMultusSecondaryNetwork("blue", "test-br"),
 					createMultusSecondaryNetwork("red", "test-br"),
 				},
-				"net2",
+				net2Name,
 			),
 			Entry("given secondary network name with different order",
 				"multus01",
@@ -255,14 +274,14 @@ var _ = Describe("Network Name Scheme", func() {
 					createMultusSecondaryNetwork("multus01", "test-br"),
 					newPodNetwork(),
 				},
-				"net2",
+				net2Name,
 			),
 			Entry("given secondary network name, only one secondary network",
 				"multus01",
 				[]virtv1.Network{
 					createMultusSecondaryNetwork("multus01", "test-br"),
 				},
-				"net1",
+				net1Name,
 			),
 		)
 	})
@@ -299,7 +318,7 @@ func createMultusNetwork(name, networkName string) virtv1.Network {
 
 func newPodNetwork() virtv1.Network {
 	return virtv1.Network{
-		Name: "default",
+		Name: defaultNetworkName,
 		NetworkSource: virtv1.NetworkSource{
 			Pod: &virtv1.PodNetwork{},
 		},

--- a/pkg/network/passt/repair_test.go
+++ b/pkg/network/passt/repair_test.go
@@ -34,12 +34,9 @@ import (
 	"kubevirt.io/kubevirt/pkg/network/passt"
 )
 
-var _ = Describe("Passt Repair Handler", func() {
-	const (
-		alternativeNetworkName = "alternative"
-		defaultNetworkName     = "default"
-	)
+const alternativeNetworkName = "alternative"
 
+var _ = Describe("Passt Repair Handler", func() {
 	Context("should not run passt repair", func() {
 		var vmi *v1.VirtualMachineInstance
 		BeforeEach(func() {
@@ -85,25 +82,15 @@ var _ = Describe("Passt Repair Handler", func() {
 	},
 		Entry("When an iface is connected to pod network using passt binding",
 			libvmi.New(
-<<<<<<< HEAD
 				libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithPasstBinding())),
-=======
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithPasstBinding(defaultNetworkName)),
->>>>>>> d0ba6682b7 (network: fix goconst linter issues)
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 			),
 		),
 		Entry("When an iface is connected to Multus default network using passt binding",
 			libvmi.New(
-<<<<<<< HEAD
 				libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithPasstBinding())),
 				libvmi.WithNetwork(&v1.Network{
 					Name: v1.DefaultPodNetwork().Name,
-=======
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithPasstBinding(defaultNetworkName)),
-				libvmi.WithNetwork(&v1.Network{
-					Name: defaultNetworkName,
->>>>>>> d0ba6682b7 (network: fix goconst linter issues)
 					NetworkSource: v1.NetworkSource{
 						Multus: &v1.MultusNetwork{
 							NetworkName: alternativeNetworkName,
@@ -132,25 +119,15 @@ var _ = Describe("Passt Repair Handler", func() {
 	},
 		Entry("When an iface is connected to pod network using passt binding",
 			libvmi.New(
-<<<<<<< HEAD
 				libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithPasstBinding())),
-=======
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithPasstBinding(defaultNetworkName)),
->>>>>>> d0ba6682b7 (network: fix goconst linter issues)
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 			),
 		),
 		Entry("When an iface is connected to Multus default network using passt binding",
 			libvmi.New(
-<<<<<<< HEAD
 				libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithPasstBinding())),
 				libvmi.WithNetwork(&v1.Network{
 					Name: v1.DefaultPodNetwork().Name,
-=======
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithPasstBinding(defaultNetworkName)),
-				libvmi.WithNetwork(&v1.Network{
-					Name: defaultNetworkName,
->>>>>>> d0ba6682b7 (network: fix goconst linter issues)
 					NetworkSource: v1.NetworkSource{
 						Multus: &v1.MultusNetwork{
 							NetworkName: alternativeNetworkName,
@@ -163,11 +140,7 @@ var _ = Describe("Passt Repair Handler", func() {
 	)
 
 	vmi := libvmi.New(
-<<<<<<< HEAD
 		libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithPasstBinding())),
-=======
-		libvmi.WithInterface(libvmi.InterfaceDeviceWithPasstBinding(defaultNetworkName)),
->>>>>>> d0ba6682b7 (network: fix goconst linter issues)
 		libvmi.WithNetwork(v1.DefaultPodNetwork()),
 	)
 
@@ -214,11 +187,7 @@ var _ = Describe("Passt Repair Handler", func() {
 
 	It("Should not run HandleMigrationSource because it is already running", func() {
 		vmi := libvmi.New(
-<<<<<<< HEAD
 			libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithPasstBinding())),
-=======
-			libvmi.WithInterface(libvmi.InterfaceDeviceWithPasstBinding(defaultNetworkName)),
->>>>>>> d0ba6682b7 (network: fix goconst linter issues)
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
 		)
 
@@ -247,11 +216,7 @@ var _ = Describe("Passt Repair Handler", func() {
 		}
 
 		vmi := libvmi.New(
-<<<<<<< HEAD
 			libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithPasstBinding())),
-=======
-			libvmi.WithInterface(libvmi.InterfaceDeviceWithPasstBinding(defaultNetworkName)),
->>>>>>> d0ba6682b7 (network: fix goconst linter issues)
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
 		)
 

--- a/pkg/network/passt/repair_test.go
+++ b/pkg/network/passt/repair_test.go
@@ -35,6 +35,11 @@ import (
 )
 
 var _ = Describe("Passt Repair Handler", func() {
+	const (
+		alternativeNetworkName = "alternative"
+		defaultNetworkName     = "default"
+	)
+
 	Context("should not run passt repair", func() {
 		var vmi *v1.VirtualMachineInstance
 		BeforeEach(func() {
@@ -80,18 +85,28 @@ var _ = Describe("Passt Repair Handler", func() {
 	},
 		Entry("When an iface is connected to pod network using passt binding",
 			libvmi.New(
+<<<<<<< HEAD
 				libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithPasstBinding())),
+=======
+				libvmi.WithInterface(libvmi.InterfaceDeviceWithPasstBinding(defaultNetworkName)),
+>>>>>>> d0ba6682b7 (network: fix goconst linter issues)
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 			),
 		),
 		Entry("When an iface is connected to Multus default network using passt binding",
 			libvmi.New(
+<<<<<<< HEAD
 				libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithPasstBinding())),
 				libvmi.WithNetwork(&v1.Network{
 					Name: v1.DefaultPodNetwork().Name,
+=======
+				libvmi.WithInterface(libvmi.InterfaceDeviceWithPasstBinding(defaultNetworkName)),
+				libvmi.WithNetwork(&v1.Network{
+					Name: defaultNetworkName,
+>>>>>>> d0ba6682b7 (network: fix goconst linter issues)
 					NetworkSource: v1.NetworkSource{
 						Multus: &v1.MultusNetwork{
-							NetworkName: "alternative",
+							NetworkName: alternativeNetworkName,
 							Default:     true,
 						},
 					},
@@ -117,18 +132,28 @@ var _ = Describe("Passt Repair Handler", func() {
 	},
 		Entry("When an iface is connected to pod network using passt binding",
 			libvmi.New(
+<<<<<<< HEAD
 				libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithPasstBinding())),
+=======
+				libvmi.WithInterface(libvmi.InterfaceDeviceWithPasstBinding(defaultNetworkName)),
+>>>>>>> d0ba6682b7 (network: fix goconst linter issues)
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 			),
 		),
 		Entry("When an iface is connected to Multus default network using passt binding",
 			libvmi.New(
+<<<<<<< HEAD
 				libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithPasstBinding())),
 				libvmi.WithNetwork(&v1.Network{
 					Name: v1.DefaultPodNetwork().Name,
+=======
+				libvmi.WithInterface(libvmi.InterfaceDeviceWithPasstBinding(defaultNetworkName)),
+				libvmi.WithNetwork(&v1.Network{
+					Name: defaultNetworkName,
+>>>>>>> d0ba6682b7 (network: fix goconst linter issues)
 					NetworkSource: v1.NetworkSource{
 						Multus: &v1.MultusNetwork{
-							NetworkName: "alternative",
+							NetworkName: alternativeNetworkName,
 							Default:     true,
 						},
 					},
@@ -138,7 +163,11 @@ var _ = Describe("Passt Repair Handler", func() {
 	)
 
 	vmi := libvmi.New(
+<<<<<<< HEAD
 		libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithPasstBinding())),
+=======
+		libvmi.WithInterface(libvmi.InterfaceDeviceWithPasstBinding(defaultNetworkName)),
+>>>>>>> d0ba6682b7 (network: fix goconst linter issues)
 		libvmi.WithNetwork(v1.DefaultPodNetwork()),
 	)
 
@@ -185,7 +214,11 @@ var _ = Describe("Passt Repair Handler", func() {
 
 	It("Should not run HandleMigrationSource because it is already running", func() {
 		vmi := libvmi.New(
+<<<<<<< HEAD
 			libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithPasstBinding())),
+=======
+			libvmi.WithInterface(libvmi.InterfaceDeviceWithPasstBinding(defaultNetworkName)),
+>>>>>>> d0ba6682b7 (network: fix goconst linter issues)
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
 		)
 
@@ -214,7 +247,11 @@ var _ = Describe("Passt Repair Handler", func() {
 		}
 
 		vmi := libvmi.New(
+<<<<<<< HEAD
 			libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithPasstBinding())),
+=======
+			libvmi.WithInterface(libvmi.InterfaceDeviceWithPasstBinding(defaultNetworkName)),
+>>>>>>> d0ba6682b7 (network: fix goconst linter issues)
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
 		)
 

--- a/pkg/network/pod/annotations/BUILD.bazel
+++ b/pkg/network/pod/annotations/BUILD.bazel
@@ -32,6 +32,7 @@ go_test(
         "//pkg/network/downwardapi:go_default_library",
         "//pkg/network/istio:go_default_library",
         "//pkg/network/multus:go_default_library",
+        "//pkg/network/namescheme:go_default_library",
         "//pkg/network/vmispec:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",

--- a/pkg/network/pod/annotations/generator_test.go
+++ b/pkg/network/pod/annotations/generator_test.go
@@ -38,6 +38,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/network/downwardapi"
 	"kubevirt.io/kubevirt/pkg/network/istio"
 	"kubevirt.io/kubevirt/pkg/network/multus"
+	"kubevirt.io/kubevirt/pkg/network/namescheme"
 	"kubevirt.io/kubevirt/pkg/network/pod/annotations"
 	"kubevirt.io/kubevirt/pkg/network/vmispec"
 )
@@ -248,6 +249,8 @@ var _ = Describe("Annotations Generator", func() {
 
 			deviceInfoPlugin    = "deviceinfo"
 			nonDeviceInfoPlugin = "non_deviceinfo"
+			deviceInfoTypePci   = "pci"
+			deviceInfoVersion   = "1.0.0"
 		)
 
 		const (
@@ -455,8 +458,8 @@ var _ = Describe("Annotations Generator", func() {
 				{
 					Network: networkName3,
 					DeviceInfo: &networkv1.DeviceInfo{
-						Type:    "pci",
-						Version: "1.0.0",
+						Type:    deviceInfoTypePci,
+						Version: deviceInfoVersion,
 						Pci: &networkv1.PciDevice{
 							PciAddress: "0000:65:00.3",
 						},
@@ -465,8 +468,8 @@ var _ = Describe("Annotations Generator", func() {
 				{
 					Network: networkName2,
 					DeviceInfo: &networkv1.DeviceInfo{
-						Type:    "pci",
-						Version: "1.0.0",
+						Type:    deviceInfoTypePci,
+						Version: deviceInfoVersion,
 						Pci: &networkv1.PciDevice{
 							PciAddress: "0000:65:00.2",
 						},
@@ -480,6 +483,7 @@ var _ = Describe("Annotations Generator", func() {
 
 	Context("NIC Hotplug / Hotunplug", func() {
 		const (
+			defaultPrimaryPodIfaceName       = "eth0"
 			network1Name                     = "red"
 			networkAttachmentDefinitionName1 = "some-net"
 
@@ -595,7 +599,10 @@ var _ = Describe("Annotations Generator", func() {
 				libvmi.WithNetwork(libvmi.MultusNetwork(network1Name, networkAttachmentDefinitionName1)),
 				libvmistatus.WithStatus(
 					libvmistatus.New(
-						libvmistatus.WithInterfaceStatus(v1.VirtualMachineInstanceNetworkInterface{Name: "default", PodInterfaceName: "eth0"}),
+						libvmistatus.WithInterfaceStatus(v1.VirtualMachineInstanceNetworkInterface{
+							Name:             testNamespace,
+							PodInterfaceName: namescheme.PrimaryPodInterfaceName,
+						}),
 						libvmistatus.WithInterfaceStatus(v1.VirtualMachineInstanceNetworkInterface{
 							Name:       network1Name,
 							InfoSource: vmispec.InfoSourceMultusStatus,
@@ -717,7 +724,10 @@ var _ = Describe("Annotations Generator", func() {
 				libvmi.WithNetwork(libvmi.MultusNetwork(network2Name, networkAttachmentDefinitionName2)),
 				libvmistatus.WithStatus(
 					libvmistatus.New(
-						libvmistatus.WithInterfaceStatus(v1.VirtualMachineInstanceNetworkInterface{Name: "default", PodInterfaceName: "eth0"}),
+						libvmistatus.WithInterfaceStatus(v1.VirtualMachineInstanceNetworkInterface{
+							Name:             testNamespace,
+							PodInterfaceName: defaultPrimaryPodIfaceName,
+						}),
 						libvmistatus.WithInterfaceStatus(v1.VirtualMachineInstanceNetworkInterface{
 							Name:       network1Name,
 							InfoSource: vmispec.InfoSourceMultusStatus,
@@ -753,7 +763,10 @@ var _ = Describe("Annotations Generator", func() {
 				libvmi.WithNetwork(libvmi.MultusNetwork(network1Name, networkAttachmentDefinitionName1)),
 				libvmistatus.WithStatus(
 					libvmistatus.New(
-						libvmistatus.WithInterfaceStatus(v1.VirtualMachineInstanceNetworkInterface{Name: "default", PodInterfaceName: "eth0"}),
+						libvmistatus.WithInterfaceStatus(v1.VirtualMachineInstanceNetworkInterface{
+							Name:             testNamespace,
+							PodInterfaceName: defaultPrimaryPodIfaceName,
+						}),
 						libvmistatus.WithInterfaceStatus(v1.VirtualMachineInstanceNetworkInterface{
 							Name:       network1Name,
 							InfoSource: vmispec.InfoSourceMultusStatus,

--- a/pkg/network/setup/filters_test.go
+++ b/pkg/network/setup/filters_test.go
@@ -32,6 +32,8 @@ import (
 	"kubevirt.io/kubevirt/pkg/network/vmispec"
 )
 
+const primaryNetworkName = "default"
+
 var _ = Describe("Network setup filters", func() {
 	Context("FilterNetsForVMStartup", func() {
 		It("Should return a list non-absent networks", func() {
@@ -87,7 +89,7 @@ var _ = Describe("Network setup filters", func() {
 				libvmistatus.WithStatus(
 					libvmistatus.New(
 						libvmistatus.WithInterfaceStatus(v1.VirtualMachineInstanceNetworkInterface{
-							Name:       "default",
+							Name:       primaryNetworkName,
 							InfoSource: vmispec.InfoSourceDomain,
 						}),
 						libvmistatus.WithInterfaceStatus(v1.VirtualMachineInstanceNetworkInterface{
@@ -117,7 +119,7 @@ var _ = Describe("Network setup filters", func() {
 				libvmistatus.WithStatus(
 					libvmistatus.New(
 						libvmistatus.WithInterfaceStatus(v1.VirtualMachineInstanceNetworkInterface{
-							Name:       "default",
+							Name:       primaryNetworkName,
 							InfoSource: vmispec.InfoSourceDomain,
 						}),
 						libvmistatus.WithInterfaceStatus(v1.VirtualMachineInstanceNetworkInterface{
@@ -152,7 +154,7 @@ var _ = Describe("Network setup filters", func() {
 				libvmistatus.WithStatus(
 					libvmistatus.New(
 						libvmistatus.WithInterfaceStatus(v1.VirtualMachineInstanceNetworkInterface{
-							Name:       "default",
+							Name:       primaryNetworkName,
 							InfoSource: vmispec.InfoSourceDomain,
 						}),
 						libvmistatus.WithInterfaceStatus(v1.VirtualMachineInstanceNetworkInterface{
@@ -184,7 +186,7 @@ var _ = Describe("Network setup filters", func() {
 				libvmistatus.WithStatus(
 					libvmistatus.New(
 						libvmistatus.WithInterfaceStatus(v1.VirtualMachineInstanceNetworkInterface{
-							Name:       "default",
+							Name:       primaryNetworkName,
 							InfoSource: vmispec.InfoSourceDomain,
 						}),
 						libvmistatus.WithInterfaceStatus(v1.VirtualMachineInstanceNetworkInterface{

--- a/pkg/network/setup/launcher/configurator_test.go
+++ b/pkg/network/setup/launcher/configurator_test.go
@@ -37,8 +37,12 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )
 
+const managedNo = "no"
+
 var _ = Describe("SetupPodNetworkPhase2", func() {
-	const podIfaceName = "eth0"
+	const (
+		podIfaceName = "eth0"
+	)
 
 	DescribeTable("should skip non-tap-based interfaces",
 		func(vmi *v1.VirtualMachineInstance, domain *api.Domain) {
@@ -83,7 +87,7 @@ var _ = Describe("SetupPodNetworkPhase2", func() {
 			expectedDomain := domainWithDefaultInterface()
 			expectedDomain.Spec.Devices.Interfaces[0].MTU = &api.MTU{Size: "1500"}
 			expectedDomain.Spec.Devices.Interfaces[0].MAC = &api.MAC{MAC: "aa:bb:cc:dd:ee:ff"}
-			expectedDomain.Spec.Devices.Interfaces[0].Target = &api.InterfaceTarget{Device: podIfaceName, Managed: "no"}
+			expectedDomain.Spec.Devices.Interfaces[0].Target = &api.InterfaceTarget{Device: podIfaceName, Managed: managedNo}
 			Expect(domain).To(Equal(expectedDomain))
 		},
 		Entry("bridge", libvmi.New(
@@ -158,7 +162,7 @@ func domainWithSRIOVHostDevice() *api.Domain {
 	domain := &api.Domain{}
 	domain.Spec.Devices.HostDevices = []api.HostDevice{{
 		Type:    "pci",
-		Managed: "no",
+		Managed: managedNo,
 		Alias:   api.NewUserDefinedAlias("sriov"),
 	}}
 	return domain

--- a/pkg/network/setup/netpod/masquerade/masquerade_test.go
+++ b/pkg/network/setup/netpod/masquerade/masquerade_test.go
@@ -34,6 +34,21 @@ import (
 	"kubevirt.io/kubevirt/pkg/pointer"
 )
 
+const (
+	defaultPodNetworkName       = "default"
+	defaultPodBridgeName        = "k6t-eth0"
+	masqueradeBridgeMACAddress  = "bb:bb:bb:bb:bb:bb"
+	defaultPodBridgeIPv4Address = "10.0.2.1"
+	defaultPodBridgeIPv6Address = "fd10:0:2::1"
+	defaultPrimaryPodIfaceName  = "eth0"
+	podInterfaceMACAddress      = "aa:aa:aa:aa:aa:aa"
+	primaryIPv4Address          = "10.222.222.1"
+	primaryIPv6Address          = "2001::1"
+	httpPortName                = "http"
+	tcpProtocol                 = "TCP"
+	tcpProtocolLower            = "tcp"
+)
+
 var _ = Describe("masquerade (NAT)", func() {
 	It("setup fails", func() {
 		testErr := errors.New("test error")
@@ -51,35 +66,35 @@ var _ = Describe("masquerade (NAT)", func() {
 
 		err := masqPod.Setup(
 			&nmstate.Interface{
-				Name:       "k6t-eth0",
+				Name:       defaultPodBridgeName,
 				Index:      1,
 				TypeName:   nmstate.TypeBridge,
 				State:      nmstate.IfaceStateUp,
-				MacAddress: "bb:bb:bb:bb:bb:bb",
+				MacAddress: masqueradeBridgeMACAddress,
 				IPv4: nmstate.IP{
 					Enabled: pointer.P(true),
-					Address: []nmstate.IPAddress{{IP: "10.0.2.1", PrefixLen: 24}},
+					Address: []nmstate.IPAddress{{IP: defaultPodBridgeIPv4Address, PrefixLen: 24}},
 				},
-				Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: "default"},
+				Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 			},
 			&nmstate.Interface{
-				Name:       "eth0",
+				Name:       defaultPrimaryPodIfaceName,
 				Index:      0,
 				TypeName:   nmstate.TypeVETH,
 				State:      nmstate.IfaceStateUp,
-				MacAddress: "aa:aa:aa:aa:aa:aa",
+				MacAddress: podInterfaceMACAddress,
 				MTU:        1500,
 				IPv4: nmstate.IP{
 					Enabled: pointer.P(true),
 					Address: []nmstate.IPAddress{{
-						IP:        "10.222.222.1",
+						IP:        primaryIPv4Address,
 						PrefixLen: 30,
 					}},
 				},
-				Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: "default"},
+				Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 			},
 			v1.Interface{
-				Name:                   "default",
+				Name:                   defaultPodNetworkName,
 				InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}},
 			},
 		)
@@ -110,35 +125,35 @@ family ip table nat chain output rulespec [ip daddr { 127.0.0.1 } counter dnat t
 
 		err := masqPod.Setup(
 			&nmstate.Interface{
-				Name:       "k6t-eth0",
+				Name:       defaultPodBridgeName,
 				Index:      1,
 				TypeName:   nmstate.TypeBridge,
 				State:      nmstate.IfaceStateUp,
-				MacAddress: "bb:bb:bb:bb:bb:bb",
+				MacAddress: masqueradeBridgeMACAddress,
 				IPv6: nmstate.IP{
 					Enabled: pointer.P(true),
-					Address: []nmstate.IPAddress{{IP: "fd10:0:2::1", PrefixLen: 120}},
+					Address: []nmstate.IPAddress{{IP: defaultPodBridgeIPv6Address, PrefixLen: 120}},
 				},
-				Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: "default"},
+				Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 			},
 			&nmstate.Interface{
-				Name:       "eth0",
+				Name:       defaultPrimaryPodIfaceName,
 				Index:      0,
 				TypeName:   nmstate.TypeVETH,
 				State:      nmstate.IfaceStateUp,
-				MacAddress: "aa:aa:aa:aa:aa:aa",
+				MacAddress: podInterfaceMACAddress,
 				MTU:        1500,
 				IPv6: nmstate.IP{
 					Enabled: pointer.P(true),
 					Address: []nmstate.IPAddress{{
-						IP:        "2001::1",
+						IP:        primaryIPv6Address,
 						PrefixLen: 64,
 					}},
 				},
-				Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: "default"},
+				Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 			},
 			v1.Interface{
-				Name:                   "default",
+				Name:                   defaultPodNetworkName,
 				InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}},
 			},
 		)
@@ -169,46 +184,46 @@ family ip6 table nat chain output rulespec [ip6 daddr { ::1 } counter dnat to fd
 
 		err := masqPod.Setup(
 			&nmstate.Interface{
-				Name:       "k6t-eth0",
+				Name:       defaultPodBridgeName,
 				Index:      1,
 				TypeName:   nmstate.TypeBridge,
 				State:      nmstate.IfaceStateUp,
-				MacAddress: "bb:bb:bb:bb:bb:bb",
+				MacAddress: masqueradeBridgeMACAddress,
 				IPv4: nmstate.IP{
 					Enabled: pointer.P(true),
-					Address: []nmstate.IPAddress{{IP: "10.0.2.1", PrefixLen: 24}},
+					Address: []nmstate.IPAddress{{IP: defaultPodBridgeIPv4Address, PrefixLen: 24}},
 				},
 				IPv6: nmstate.IP{
 					Enabled: pointer.P(true),
-					Address: []nmstate.IPAddress{{IP: "fd10:0:2::1", PrefixLen: 120}},
+					Address: []nmstate.IPAddress{{IP: defaultPodBridgeIPv6Address, PrefixLen: 120}},
 				},
-				Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: "default"},
+				Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 			},
 			&nmstate.Interface{
-				Name:       "eth0",
+				Name:       defaultPrimaryPodIfaceName,
 				Index:      0,
 				TypeName:   nmstate.TypeVETH,
 				State:      nmstate.IfaceStateUp,
-				MacAddress: "aa:aa:aa:aa:aa:aa",
+				MacAddress: podInterfaceMACAddress,
 				MTU:        1500,
 				IPv4: nmstate.IP{
 					Enabled: pointer.P(true),
 					Address: []nmstate.IPAddress{{
-						IP:        "10.222.222.1",
+						IP:        primaryIPv4Address,
 						PrefixLen: 30,
 					}},
 				},
 				IPv6: nmstate.IP{
 					Enabled: pointer.P(true),
 					Address: []nmstate.IPAddress{{
-						IP:        "2001::1",
+						IP:        primaryIPv6Address,
 						PrefixLen: 64,
 					}},
 				},
-				Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: "default"},
+				Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 			},
 			v1.Interface{
-				Name:                   "default",
+				Name:                   defaultPodNetworkName,
 				InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}},
 			},
 		)
@@ -252,50 +267,50 @@ family ip6 table nat chain output rulespec [ip6 daddr { ::1 } counter dnat to fd
 
 		err := masqPod.Setup(
 			&nmstate.Interface{
-				Name:       "k6t-eth0",
+				Name:       defaultPodBridgeName,
 				Index:      1,
 				TypeName:   nmstate.TypeBridge,
 				State:      nmstate.IfaceStateUp,
-				MacAddress: "bb:bb:bb:bb:bb:bb",
+				MacAddress: masqueradeBridgeMACAddress,
 				IPv4: nmstate.IP{
 					Enabled: pointer.P(true),
-					Address: []nmstate.IPAddress{{IP: "10.0.2.1", PrefixLen: 24}},
+					Address: []nmstate.IPAddress{{IP: defaultPodBridgeIPv4Address, PrefixLen: 24}},
 				},
 				IPv6: nmstate.IP{
 					Enabled: pointer.P(true),
-					Address: []nmstate.IPAddress{{IP: "fd10:0:2::1", PrefixLen: 120}},
+					Address: []nmstate.IPAddress{{IP: defaultPodBridgeIPv6Address, PrefixLen: 120}},
 				},
-				Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: "default"},
+				Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 			},
 			&nmstate.Interface{
-				Name:       "eth0",
+				Name:       defaultPrimaryPodIfaceName,
 				Index:      0,
 				TypeName:   nmstate.TypeVETH,
 				State:      nmstate.IfaceStateUp,
-				MacAddress: "aa:aa:aa:aa:aa:aa",
+				MacAddress: podInterfaceMACAddress,
 				MTU:        1500,
 				IPv4: nmstate.IP{
 					Enabled: pointer.P(true),
 					Address: []nmstate.IPAddress{{
-						IP:        "10.222.222.1",
+						IP:        primaryIPv4Address,
 						PrefixLen: 30,
 					}},
 				},
 				IPv6: nmstate.IP{
 					Enabled: pointer.P(true),
 					Address: []nmstate.IPAddress{{
-						IP:        "2001::1",
+						IP:        primaryIPv6Address,
 						PrefixLen: 64,
 					}},
 				},
-				Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: "default"},
+				Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 			},
 			v1.Interface{
-				Name:                   "default",
+				Name:                   defaultPodNetworkName,
 				InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}},
 				Ports: []v1.Port{
-					{Name: "http", Protocol: "tcp", Port: 80},
-					{Name: "http", Protocol: "tcp", Port: 8080},
+					{Name: httpPortName, Protocol: tcpProtocolLower, Port: 80},
+					{Name: httpPortName, Protocol: tcpProtocolLower, Port: 8080},
 				},
 			},
 		)
@@ -345,38 +360,38 @@ family ip6 table nat chain output rulespec [ip6 daddr { ::1 } tcp dport 8080 cou
 
 		err := masqPod.Setup(
 			&nmstate.Interface{
-				Name:       "k6t-eth0",
+				Name:       defaultPodBridgeName,
 				Index:      1,
 				TypeName:   nmstate.TypeBridge,
 				State:      nmstate.IfaceStateUp,
-				MacAddress: "bb:bb:bb:bb:bb:bb",
+				MacAddress: masqueradeBridgeMACAddress,
 				IPv4: nmstate.IP{
 					Enabled: pointer.P(true),
-					Address: []nmstate.IPAddress{{IP: "10.0.2.1", PrefixLen: 24}},
+					Address: []nmstate.IPAddress{{IP: defaultPodBridgeIPv4Address, PrefixLen: 24}},
 				},
-				Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: "default"},
+				Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 			},
 			&nmstate.Interface{
-				Name:       "eth0",
+				Name:       defaultPrimaryPodIfaceName,
 				Index:      0,
 				TypeName:   nmstate.TypeVETH,
 				State:      nmstate.IfaceStateUp,
-				MacAddress: "aa:aa:aa:aa:aa:aa",
+				MacAddress: podInterfaceMACAddress,
 				MTU:        1500,
 				IPv4: nmstate.IP{
 					Enabled: pointer.P(true),
 					Address: []nmstate.IPAddress{{
-						IP:        "10.222.222.1",
+						IP:        primaryIPv4Address,
 						PrefixLen: 30,
 					}},
 				},
-				Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: "default"},
+				Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 			},
 			v1.Interface{
-				Name:                   "default",
+				Name:                   defaultPodNetworkName,
 				InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}},
 				PortRanges: []v1.PortRange{
-					{Start: 80, End: 81, Protocol: "TCP"},
+					{Start: 80, End: 81, Protocol: tcpProtocol},
 				},
 			},
 		)
@@ -410,49 +425,49 @@ family ip table nat chain output rulespec [ip daddr { 127.0.0.1 } counter dnat t
 
 		err := masqPod.Setup(
 			&nmstate.Interface{
-				Name:       "k6t-eth0",
+				Name:       defaultPodBridgeName,
 				Index:      1,
 				TypeName:   nmstate.TypeBridge,
 				State:      nmstate.IfaceStateUp,
-				MacAddress: "bb:bb:bb:bb:bb:bb",
+				MacAddress: masqueradeBridgeMACAddress,
 				IPv4: nmstate.IP{
 					Enabled: pointer.P(true),
-					Address: []nmstate.IPAddress{{IP: "10.0.2.1", PrefixLen: 24}},
+					Address: []nmstate.IPAddress{{IP: defaultPodBridgeIPv4Address, PrefixLen: 24}},
 				},
 				IPv6: nmstate.IP{
 					Enabled: pointer.P(true),
-					Address: []nmstate.IPAddress{{IP: "fd10:0:2::1", PrefixLen: 120}},
+					Address: []nmstate.IPAddress{{IP: defaultPodBridgeIPv6Address, PrefixLen: 120}},
 				},
-				Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: "default"},
+				Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 			},
 			&nmstate.Interface{
-				Name:       "eth0",
+				Name:       defaultPrimaryPodIfaceName,
 				Index:      0,
 				TypeName:   nmstate.TypeVETH,
 				State:      nmstate.IfaceStateUp,
-				MacAddress: "aa:aa:aa:aa:aa:aa",
+				MacAddress: podInterfaceMACAddress,
 				MTU:        1500,
 				IPv4: nmstate.IP{
 					Enabled: pointer.P(true),
 					Address: []nmstate.IPAddress{{
-						IP:        "10.222.222.1",
+						IP:        primaryIPv4Address,
 						PrefixLen: 30,
 					}},
 				},
 				IPv6: nmstate.IP{
 					Enabled: pointer.P(true),
 					Address: []nmstate.IPAddress{{
-						IP:        "2001::1",
+						IP:        primaryIPv6Address,
 						PrefixLen: 64,
 					}},
 				},
 			},
 			v1.Interface{
-				Name:                   "default",
+				Name:                   defaultPodNetworkName,
 				InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}},
 				PortRanges: []v1.PortRange{
-					{Start: 80, End: 81, Protocol: "TCP"},
-					{Start: 443, End: 444, Protocol: "TCP"},
+					{Start: 80, End: 81, Protocol: tcpProtocol},
+					{Start: 443, End: 444, Protocol: tcpProtocol},
 				},
 			},
 		)
@@ -505,47 +520,47 @@ family ip6 table nat chain output rulespec [ip6 daddr { ::1 } tcp dport 443-444 
 
 		err := masqPod.Setup(
 			&nmstate.Interface{
-				Name:       "k6t-eth0",
+				Name:       defaultPodBridgeName,
 				Index:      1,
 				TypeName:   nmstate.TypeBridge,
 				State:      nmstate.IfaceStateUp,
-				MacAddress: "bb:bb:bb:bb:bb:bb",
+				MacAddress: masqueradeBridgeMACAddress,
 				IPv4: nmstate.IP{
 					Enabled: pointer.P(true),
-					Address: []nmstate.IPAddress{{IP: "10.0.2.1", PrefixLen: 24}},
+					Address: []nmstate.IPAddress{{IP: defaultPodBridgeIPv4Address, PrefixLen: 24}},
 				},
 				IPv6: nmstate.IP{
 					Enabled: pointer.P(true),
-					Address: []nmstate.IPAddress{{IP: "fd10:0:2::1", PrefixLen: 120}},
+					Address: []nmstate.IPAddress{{IP: defaultPodBridgeIPv6Address, PrefixLen: 120}},
 				},
 			},
 			&nmstate.Interface{
-				Name:       "eth0",
+				Name:       defaultPrimaryPodIfaceName,
 				Index:      0,
 				TypeName:   nmstate.TypeVETH,
 				State:      nmstate.IfaceStateUp,
-				MacAddress: "aa:aa:aa:aa:aa:aa",
+				MacAddress: podInterfaceMACAddress,
 				MTU:        1500,
 				IPv4: nmstate.IP{
 					Enabled: pointer.P(true),
 					Address: []nmstate.IPAddress{{
-						IP:        "10.222.222.1",
+						IP:        primaryIPv4Address,
 						PrefixLen: 30,
 					}},
 				},
 				IPv6: nmstate.IP{
 					Enabled: pointer.P(true),
 					Address: []nmstate.IPAddress{{
-						IP:        "2001::1",
+						IP:        primaryIPv6Address,
 						PrefixLen: 64,
 					}},
 				},
 			},
 			v1.Interface{
-				Name:                   "default",
+				Name:                   defaultPodNetworkName,
 				InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}},
 				PortRanges: []v1.PortRange{
-					{Start: 1000, End: 2000, Protocol: "TCP"},
+					{Start: 1000, End: 2000, Protocol: tcpProtocol},
 					{Start: 1500, End: 2500, Protocol: "UDP"}, // Overlaps with TCP range but different protocol - should be allowed
 				},
 			},
@@ -597,46 +612,46 @@ family ip6 table nat chain output rulespec [ip6 daddr { ::1 } udp dport 1500-250
 
 			err := masqPod.Setup(
 				&nmstate.Interface{
-					Name:       "k6t-eth0",
+					Name:       defaultPodBridgeName,
 					Index:      1,
 					TypeName:   nmstate.TypeBridge,
 					State:      nmstate.IfaceStateUp,
-					MacAddress: "bb:bb:bb:bb:bb:bb",
+					MacAddress: masqueradeBridgeMACAddress,
 					IPv4: nmstate.IP{
 						Enabled: pointer.P(true),
-						Address: []nmstate.IPAddress{{IP: "10.0.2.1", PrefixLen: 24}},
+						Address: []nmstate.IPAddress{{IP: defaultPodBridgeIPv4Address, PrefixLen: 24}},
 					},
 					IPv6: nmstate.IP{
 						Enabled: pointer.P(true),
-						Address: []nmstate.IPAddress{{IP: "fd10:0:2::1", PrefixLen: 120}},
+						Address: []nmstate.IPAddress{{IP: defaultPodBridgeIPv6Address, PrefixLen: 120}},
 					},
-					Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: "default"},
+					Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 				},
 				&nmstate.Interface{
-					Name:       "eth0",
+					Name:       defaultPrimaryPodIfaceName,
 					Index:      0,
 					TypeName:   nmstate.TypeVETH,
 					State:      nmstate.IfaceStateUp,
-					MacAddress: "aa:aa:aa:aa:aa:aa",
+					MacAddress: podInterfaceMACAddress,
 					MTU:        1500,
 					IPv4: nmstate.IP{
 						Enabled: pointer.P(true),
 						Address: []nmstate.IPAddress{{
-							IP:        "10.222.222.1",
+							IP:        primaryIPv4Address,
 							PrefixLen: 30,
 						}},
 					},
 					IPv6: nmstate.IP{
 						Enabled: pointer.P(true),
 						Address: []nmstate.IPAddress{{
-							IP:        "2001::1",
+							IP:        primaryIPv6Address,
 							PrefixLen: 64,
 						}},
 					},
-					Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: "default"},
+					Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 				},
 				v1.Interface{
-					Name:                   "default",
+					Name:                   defaultPodNetworkName,
 					InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}},
 				},
 			)
@@ -688,50 +703,50 @@ family ip6 table nat chain output rulespec [ip6 daddr { ::1 } counter dnat to fd
 
 			err := masqPod.Setup(
 				&nmstate.Interface{
-					Name:       "k6t-eth0",
+					Name:       defaultPodBridgeName,
 					Index:      1,
 					TypeName:   nmstate.TypeBridge,
 					State:      nmstate.IfaceStateUp,
-					MacAddress: "bb:bb:bb:bb:bb:bb",
+					MacAddress: masqueradeBridgeMACAddress,
 					IPv4: nmstate.IP{
 						Enabled: pointer.P(true),
-						Address: []nmstate.IPAddress{{IP: "10.0.2.1", PrefixLen: 24}},
+						Address: []nmstate.IPAddress{{IP: defaultPodBridgeIPv4Address, PrefixLen: 24}},
 					},
 					IPv6: nmstate.IP{
 						Enabled: pointer.P(true),
-						Address: []nmstate.IPAddress{{IP: "fd10:0:2::1", PrefixLen: 120}},
+						Address: []nmstate.IPAddress{{IP: defaultPodBridgeIPv6Address, PrefixLen: 120}},
 					},
-					Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: "default"},
+					Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 				},
 				&nmstate.Interface{
-					Name:       "eth0",
+					Name:       defaultPrimaryPodIfaceName,
 					Index:      0,
 					TypeName:   nmstate.TypeVETH,
 					State:      nmstate.IfaceStateUp,
-					MacAddress: "aa:aa:aa:aa:aa:aa",
+					MacAddress: podInterfaceMACAddress,
 					MTU:        1500,
 					IPv4: nmstate.IP{
 						Enabled: pointer.P(true),
 						Address: []nmstate.IPAddress{{
-							IP:        "10.222.222.1",
+							IP:        primaryIPv4Address,
 							PrefixLen: 30,
 						}},
 					},
 					IPv6: nmstate.IP{
 						Enabled: pointer.P(true),
 						Address: []nmstate.IPAddress{{
-							IP:        "2001::1",
+							IP:        primaryIPv6Address,
 							PrefixLen: 64,
 						}},
 					},
-					Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: "default"},
+					Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 				},
 				v1.Interface{
-					Name:                   "default",
+					Name:                   defaultPodNetworkName,
 					InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}},
 					Ports: []v1.Port{
-						{Name: "http", Protocol: "tcp", Port: 80},
-						{Name: "http", Protocol: "tcp", Port: 8080},
+						{Name: httpPortName, Protocol: tcpProtocolLower, Port: 80},
+						{Name: httpPortName, Protocol: tcpProtocolLower, Port: 8080},
 					},
 				},
 			)
@@ -784,50 +799,50 @@ family ip6 table nat chain output rulespec [ip6 daddr { ::1 } tcp dport 8080 cou
 
 			err := masqPod.Setup(
 				&nmstate.Interface{
-					Name:       "k6t-eth0",
+					Name:       defaultPodBridgeName,
 					Index:      1,
 					TypeName:   nmstate.TypeBridge,
 					State:      nmstate.IfaceStateUp,
-					MacAddress: "bb:bb:bb:bb:bb:bb",
+					MacAddress: masqueradeBridgeMACAddress,
 					IPv4: nmstate.IP{
 						Enabled: pointer.P(true),
-						Address: []nmstate.IPAddress{{IP: "10.0.2.1", PrefixLen: 24}},
+						Address: []nmstate.IPAddress{{IP: defaultPodBridgeIPv4Address, PrefixLen: 24}},
 					},
 					IPv6: nmstate.IP{
 						Enabled: pointer.P(true),
-						Address: []nmstate.IPAddress{{IP: "fd10:0:2::1", PrefixLen: 120}},
+						Address: []nmstate.IPAddress{{IP: defaultPodBridgeIPv6Address, PrefixLen: 120}},
 					},
-					Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: "default"},
+					Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 				},
 				&nmstate.Interface{
-					Name:       "eth0",
+					Name:       defaultPrimaryPodIfaceName,
 					Index:      0,
 					TypeName:   nmstate.TypeVETH,
 					State:      nmstate.IfaceStateUp,
-					MacAddress: "aa:aa:aa:aa:aa:aa",
+					MacAddress: podInterfaceMACAddress,
 					MTU:        1500,
 					IPv4: nmstate.IP{
 						Enabled: pointer.P(true),
 						Address: []nmstate.IPAddress{{
-							IP:        "10.222.222.1",
+							IP:        primaryIPv4Address,
 							PrefixLen: 30,
 						}},
 					},
 					IPv6: nmstate.IP{
 						Enabled: pointer.P(true),
 						Address: []nmstate.IPAddress{{
-							IP:        "2001::1",
+							IP:        primaryIPv6Address,
 							PrefixLen: 64,
 						}},
 					},
-					Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: "default"},
+					Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 				},
 				v1.Interface{
-					Name:                   "default",
+					Name:                   defaultPodNetworkName,
 					InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}},
 					Ports: []v1.Port{
-						{Name: "http", Protocol: "tcp", Port: 80},
-						{Name: "http", Protocol: "tcp", Port: 8080},
+						{Name: httpPortName, Protocol: tcpProtocolLower, Port: 80},
+						{Name: httpPortName, Protocol: tcpProtocolLower, Port: 8080},
 					},
 				},
 			)
@@ -876,50 +891,50 @@ family ip6 table nat chain output rulespec [ip6 daddr { ::1 } tcp dport 8080 cou
 
 			err := masqPod.Setup(
 				&nmstate.Interface{
-					Name:       "k6t-eth0",
+					Name:       defaultPodBridgeName,
 					Index:      1,
 					TypeName:   nmstate.TypeBridge,
 					State:      nmstate.IfaceStateUp,
-					MacAddress: "bb:bb:bb:bb:bb:bb",
+					MacAddress: masqueradeBridgeMACAddress,
 					IPv4: nmstate.IP{
 						Enabled: pointer.P(true),
-						Address: []nmstate.IPAddress{{IP: "10.0.2.1", PrefixLen: 24}},
+						Address: []nmstate.IPAddress{{IP: defaultPodBridgeIPv4Address, PrefixLen: 24}},
 					},
 					IPv6: nmstate.IP{
 						Enabled: pointer.P(true),
-						Address: []nmstate.IPAddress{{IP: "fd10:0:2::1", PrefixLen: 120}},
+						Address: []nmstate.IPAddress{{IP: defaultPodBridgeIPv6Address, PrefixLen: 120}},
 					},
-					Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: "default"},
+					Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 				},
 				&nmstate.Interface{
-					Name:       "eth0",
+					Name:       defaultPrimaryPodIfaceName,
 					Index:      0,
 					TypeName:   nmstate.TypeVETH,
 					State:      nmstate.IfaceStateUp,
-					MacAddress: "aa:aa:aa:aa:aa:aa",
+					MacAddress: podInterfaceMACAddress,
 					MTU:        1500,
 					IPv4: nmstate.IP{
 						Enabled: pointer.P(true),
 						Address: []nmstate.IPAddress{{
-							IP:        "10.222.222.1",
+							IP:        primaryIPv4Address,
 							PrefixLen: 30,
 						}},
 					},
 					IPv6: nmstate.IP{
 						Enabled: pointer.P(true),
 						Address: []nmstate.IPAddress{{
-							IP:        "2001::1",
+							IP:        primaryIPv6Address,
 							PrefixLen: 64,
 						}},
 					},
-					Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: "default"},
+					Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 				},
 				v1.Interface{
-					Name:                   "default",
+					Name:                   defaultPodNetworkName,
 					InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}},
 					Ports: []v1.Port{
-						{Name: "http", Protocol: "tcp", Port: 22},
-						{Name: "http", Protocol: "tcp", Port: 8080},
+						{Name: httpPortName, Protocol: tcpProtocolLower, Port: 22},
+						{Name: httpPortName, Protocol: tcpProtocolLower, Port: 8080},
 					},
 				},
 			)
@@ -970,49 +985,49 @@ family ip6 table nat chain output rulespec [ip6 daddr { ::1 } tcp dport 8080 cou
 
 			err := masqPod.Setup(
 				&nmstate.Interface{
-					Name:       "k6t-eth0",
+					Name:       defaultPodBridgeName,
 					Index:      1,
 					TypeName:   nmstate.TypeBridge,
 					State:      nmstate.IfaceStateUp,
-					MacAddress: "bb:bb:bb:bb:bb:bb",
+					MacAddress: masqueradeBridgeMACAddress,
 					IPv4: nmstate.IP{
 						Enabled: pointer.P(true),
-						Address: []nmstate.IPAddress{{IP: "10.0.2.1", PrefixLen: 24}},
+						Address: []nmstate.IPAddress{{IP: defaultPodBridgeIPv4Address, PrefixLen: 24}},
 					},
 					IPv6: nmstate.IP{
 						Enabled: pointer.P(true),
-						Address: []nmstate.IPAddress{{IP: "fd10:0:2::1", PrefixLen: 120}},
+						Address: []nmstate.IPAddress{{IP: defaultPodBridgeIPv6Address, PrefixLen: 120}},
 					},
-					Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: "default"},
+					Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 				},
 				&nmstate.Interface{
-					Name:       "eth0",
+					Name:       defaultPrimaryPodIfaceName,
 					Index:      0,
 					TypeName:   nmstate.TypeVETH,
 					State:      nmstate.IfaceStateUp,
-					MacAddress: "aa:aa:aa:aa:aa:aa",
+					MacAddress: podInterfaceMACAddress,
 					MTU:        1500,
 					IPv4: nmstate.IP{
 						Enabled: pointer.P(true),
 						Address: []nmstate.IPAddress{{
-							IP:        "10.222.222.1",
+							IP:        primaryIPv4Address,
 							PrefixLen: 30,
 						}},
 					},
 					IPv6: nmstate.IP{
 						Enabled: pointer.P(true),
 						Address: []nmstate.IPAddress{{
-							IP:        "2001::1",
+							IP:        primaryIPv6Address,
 							PrefixLen: 64,
 						}},
 					},
-					Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: "default"},
+					Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 				},
 				v1.Interface{
-					Name:                   "default",
+					Name:                   defaultPodNetworkName,
 					InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}},
 					Ports: []v1.Port{
-						{Name: "http", Protocol: "tcp", Port: 15000},
+						{Name: httpPortName, Protocol: tcpProtocolLower, Port: 15000},
 					},
 				},
 			)
@@ -1058,49 +1073,49 @@ family ip6 table nat chain output rulespec [ip6 daddr { ::1 } tcp dport 15000 co
 
 			err := masqPod.Setup(
 				&nmstate.Interface{
-					Name:       "k6t-eth0",
+					Name:       defaultPodBridgeName,
 					Index:      1,
 					TypeName:   nmstate.TypeBridge,
 					State:      nmstate.IfaceStateUp,
-					MacAddress: "bb:bb:bb:bb:bb:bb",
+					MacAddress: masqueradeBridgeMACAddress,
 					IPv4: nmstate.IP{
 						Enabled: pointer.P(true),
-						Address: []nmstate.IPAddress{{IP: "10.0.2.1", PrefixLen: 24}},
+						Address: []nmstate.IPAddress{{IP: defaultPodBridgeIPv4Address, PrefixLen: 24}},
 					},
 					IPv6: nmstate.IP{
 						Enabled: pointer.P(true),
-						Address: []nmstate.IPAddress{{IP: "fd10:0:2::1", PrefixLen: 120}},
+						Address: []nmstate.IPAddress{{IP: defaultPodBridgeIPv6Address, PrefixLen: 120}},
 					},
-					Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: "default"},
+					Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 				},
 				&nmstate.Interface{
-					Name:       "eth0",
+					Name:       defaultPrimaryPodIfaceName,
 					Index:      0,
 					TypeName:   nmstate.TypeVETH,
 					State:      nmstate.IfaceStateUp,
-					MacAddress: "aa:aa:aa:aa:aa:aa",
+					MacAddress: podInterfaceMACAddress,
 					MTU:        1500,
 					IPv4: nmstate.IP{
 						Enabled: pointer.P(true),
 						Address: []nmstate.IPAddress{{
-							IP:        "10.222.222.1",
+							IP:        primaryIPv4Address,
 							PrefixLen: 30,
 						}},
 					},
 					IPv6: nmstate.IP{
 						Enabled: pointer.P(true),
 						Address: []nmstate.IPAddress{{
-							IP:        "2001::1",
+							IP:        primaryIPv6Address,
 							PrefixLen: 64,
 						}},
 					},
-					Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: "default"},
+					Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 				},
 				v1.Interface{
-					Name:                   "default",
+					Name:                   defaultPodNetworkName,
 					InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}},
 					PortRanges: []v1.PortRange{
-						{Protocol: "TCP", Start: 1000, End: 1500},
+						{Protocol: tcpProtocol, Start: 1000, End: 1500},
 					},
 				},
 			)
@@ -1146,49 +1161,49 @@ family ip6 table nat chain output rulespec [ip6 daddr { ::1 } tcp dport 1000-150
 
 			err := masqPod.Setup(
 				&nmstate.Interface{
-					Name:       "k6t-eth0",
+					Name:       defaultPodBridgeName,
 					Index:      1,
 					TypeName:   nmstate.TypeBridge,
 					State:      nmstate.IfaceStateUp,
-					MacAddress: "bb:bb:bb:bb:bb:bb",
+					MacAddress: masqueradeBridgeMACAddress,
 					IPv4: nmstate.IP{
 						Enabled: pointer.P(true),
-						Address: []nmstate.IPAddress{{IP: "10.0.2.1", PrefixLen: 24}},
+						Address: []nmstate.IPAddress{{IP: defaultPodBridgeIPv4Address, PrefixLen: 24}},
 					},
 					IPv6: nmstate.IP{
 						Enabled: pointer.P(true),
-						Address: []nmstate.IPAddress{{IP: "fd10:0:2::1", PrefixLen: 120}},
+						Address: []nmstate.IPAddress{{IP: defaultPodBridgeIPv6Address, PrefixLen: 120}},
 					},
-					Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: "default"},
+					Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 				},
 				&nmstate.Interface{
-					Name:       "eth0",
+					Name:       defaultPrimaryPodIfaceName,
 					Index:      0,
 					TypeName:   nmstate.TypeVETH,
 					State:      nmstate.IfaceStateUp,
-					MacAddress: "aa:aa:aa:aa:aa:aa",
+					MacAddress: podInterfaceMACAddress,
 					MTU:        1500,
 					IPv4: nmstate.IP{
 						Enabled: pointer.P(true),
 						Address: []nmstate.IPAddress{{
-							IP:        "10.222.222.1",
+							IP:        primaryIPv4Address,
 							PrefixLen: 30,
 						}},
 					},
 					IPv6: nmstate.IP{
 						Enabled: pointer.P(true),
 						Address: []nmstate.IPAddress{{
-							IP:        "2001::1",
+							IP:        primaryIPv6Address,
 							PrefixLen: 64,
 						}},
 					},
-					Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: "default"},
+					Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 				},
 				v1.Interface{
-					Name:                   "default",
+					Name:                   defaultPodNetworkName,
 					InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}},
 					PortRanges: []v1.PortRange{
-						{Protocol: "TCP", Start: 20, End: 25},
+						{Protocol: tcpProtocol, Start: 20, End: 25},
 					},
 				},
 			)
@@ -1236,49 +1251,49 @@ family ip6 table nat chain output rulespec [ip6 daddr { ::1 } tcp dport 20-25 co
 
 			err := masqPod.Setup(
 				&nmstate.Interface{
-					Name:       "k6t-eth0",
+					Name:       defaultPodBridgeName,
 					Index:      1,
 					TypeName:   nmstate.TypeBridge,
 					State:      nmstate.IfaceStateUp,
-					MacAddress: "bb:bb:bb:bb:bb:bb",
+					MacAddress: masqueradeBridgeMACAddress,
 					IPv4: nmstate.IP{
 						Enabled: pointer.P(true),
-						Address: []nmstate.IPAddress{{IP: "10.0.2.1", PrefixLen: 24}},
+						Address: []nmstate.IPAddress{{IP: defaultPodBridgeIPv4Address, PrefixLen: 24}},
 					},
 					IPv6: nmstate.IP{
 						Enabled: pointer.P(true),
-						Address: []nmstate.IPAddress{{IP: "fd10:0:2::1", PrefixLen: 120}},
+						Address: []nmstate.IPAddress{{IP: defaultPodBridgeIPv6Address, PrefixLen: 120}},
 					},
-					Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: "default"},
+					Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 				},
 				&nmstate.Interface{
-					Name:       "eth0",
+					Name:       defaultPrimaryPodIfaceName,
 					Index:      0,
 					TypeName:   nmstate.TypeVETH,
 					State:      nmstate.IfaceStateUp,
-					MacAddress: "aa:aa:aa:aa:aa:aa",
+					MacAddress: podInterfaceMACAddress,
 					MTU:        1500,
 					IPv4: nmstate.IP{
 						Enabled: pointer.P(true),
 						Address: []nmstate.IPAddress{{
-							IP:        "10.222.222.1",
+							IP:        primaryIPv4Address,
 							PrefixLen: 30,
 						}},
 					},
 					IPv6: nmstate.IP{
 						Enabled: pointer.P(true),
 						Address: []nmstate.IPAddress{{
-							IP:        "2001::1",
+							IP:        primaryIPv6Address,
 							PrefixLen: 64,
 						}},
 					},
-					Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: "default"},
+					Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 				},
 				v1.Interface{
-					Name:                   "default",
+					Name:                   defaultPodNetworkName,
 					InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}},
 					PortRanges: []v1.PortRange{
-						{Protocol: "TCP", Start: 14000, End: 16000},
+						{Protocol: tcpProtocol, Start: 14000, End: 16000},
 					},
 				},
 			)

--- a/pkg/network/setup/netpod/netpod_test.go
+++ b/pkg/network/setup/netpod/netpod_test.go
@@ -46,7 +46,31 @@ import (
 )
 
 const (
-	defaultPodNetworkName = "default"
+	defaultPodNetworkName        = "default"
+	defaultPrimaryPodIfaceName   = "eth0"
+	defaultPodIfaceOriginalMAC   = "12:34:56:78:90:ab"
+	defaultPodBridgeName         = "k6t-eth0"
+	defaultPodBridgeMACAddress   = "02:00:00:00:00:00"
+	defaultPodBridgeIPv4Address  = "10.0.2.1"
+	defaultPodBridgeIPv6Address  = "fd10:0:2::1"
+	defaultTapDeviceName         = "tap0"
+	defaultRouteDestination      = "0.0.0.0/0"
+	defaultPodIfaceBridgeNICName = "eth0-nic"
+	customPrimaryBridgeName      = "k6t-cust-iface"
+	hashedSecondaryBridgeName    = "k6t-914f438d88d"
+	orderedSecondaryBridgeName   = "k6t-net1"
+	testNet1PodIfaceName         = "pod7087ef4cd1f"
+	testNet1PodIfaceMACAddress   = "22:34:56:78:90:ab"
+	testNet2PodIfaceName         = "podbc6cc93fa1e"
+	testNet2PodIfaceMACAddress   = "32:34:56:78:90:ab"
+	testNet1BridgeName           = "k6t-7087ef4cd1f"
+	testNet1TapName              = "tap7087ef4cd1f"
+	testNet2BridgeName           = "k6t-bc6cc93fa1e"
+	testNet2TapName              = "tapbc6cc93fa1e"
+	masqueradeBridgeMACAddress   = "bb:bb:bb:bb:bb:bb"
+	podInterfaceMACAddress       = "aa:aa:aa:aa:aa:aa"
+	httpPortName                 = "http"
+	tcpProtocol                  = "TCP"
 
 	vmiUID = "12345"
 
@@ -107,11 +131,11 @@ var _ = Describe("netpod", func() {
 				applyErr: errNMStateApply,
 				status: nmstate.Status{
 					Interfaces: []nmstate.Interface{{
-						Name:       "eth0",
+						Name:       defaultPrimaryPodIfaceName,
 						Index:      0,
 						TypeName:   nmstate.TypeVETH,
 						State:      nmstate.IfaceStateUp,
-						MacAddress: "12:34:56:78:90:ab",
+						MacAddress: defaultPodIfaceOriginalMAC,
 						MTU:        1500,
 					}},
 				},
@@ -132,11 +156,11 @@ var _ = Describe("netpod", func() {
 			vmiUID, 0, 0, 0, state,
 			netpod.WithNMStateAdapter(&nmstateStub{status: nmstate.Status{
 				Interfaces: []nmstate.Interface{{
-					Name:       "eth0",
+					Name:       defaultPrimaryPodIfaceName,
 					Index:      0,
 					TypeName:   nmstate.TypeVETH,
 					State:      nmstate.IfaceStateUp,
-					MacAddress: "12:34:56:78:90:ab",
+					MacAddress: defaultPodIfaceOriginalMAC,
 					MTU:        1500,
 				}},
 			}}),
@@ -156,11 +180,11 @@ var _ = Describe("netpod", func() {
 			vmiUID, 0, 0, 0, state,
 			netpod.WithNMStateAdapter(&nmstateStub{status: nmstate.Status{
 				Interfaces: []nmstate.Interface{{
-					Name:       "eth0",
+					Name:       defaultPrimaryPodIfaceName,
 					Index:      0,
 					TypeName:   nmstate.TypeVETH,
 					State:      nmstate.IfaceStateUp,
-					MacAddress: "12:34:56:78:90:ab",
+					MacAddress: defaultPodIfaceOriginalMAC,
 					MTU:        1500,
 				}},
 			}}),
@@ -191,11 +215,11 @@ var _ = Describe("netpod", func() {
 	It("setup masquerade binding", func() {
 		nmstatestub := nmstateStub{status: nmstate.Status{
 			Interfaces: []nmstate.Interface{{
-				Name:       "eth0",
+				Name:       defaultPrimaryPodIfaceName,
 				Index:      0,
 				TypeName:   nmstate.TypeVETH,
 				State:      nmstate.IfaceStateUp,
-				MacAddress: "12:34:56:78:90:ab",
+				MacAddress: defaultPodIfaceOriginalMAC,
 				MTU:        1500,
 				IPv4: nmstate.IP{
 					Enabled: pointer.P(true),
@@ -232,28 +256,28 @@ var _ = Describe("netpod", func() {
 			nmstate.Spec{
 				Interfaces: []nmstate.Interface{
 					{
-						Name:       "k6t-eth0",
+						Name:       defaultPodBridgeName,
 						TypeName:   nmstate.TypeBridge,
 						State:      nmstate.IfaceStateUp,
-						MacAddress: "02:00:00:00:00:00",
+						MacAddress: defaultPodBridgeMACAddress,
 						MTU:        1500,
 						IPv4: nmstate.IP{
 							Enabled: pointer.P(true),
-							Address: []nmstate.IPAddress{{IP: "10.0.2.1", PrefixLen: 24}},
+							Address: []nmstate.IPAddress{{IP: defaultPodBridgeIPv4Address, PrefixLen: 24}},
 						},
 						IPv6: nmstate.IP{
 							Enabled: pointer.P(true),
-							Address: []nmstate.IPAddress{{IP: "fd10:0:2::1", PrefixLen: 120}},
+							Address: []nmstate.IPAddress{{IP: defaultPodBridgeIPv6Address, PrefixLen: 120}},
 						},
 						LinuxStack: nmstate.LinuxIfaceStack{IP4RouteLocalNet: pointer.P(true)},
 						Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 					},
 					{
-						Name:       "tap0",
+						Name:       defaultTapDeviceName,
 						TypeName:   nmstate.TypeTap,
 						State:      nmstate.IfaceStateUp,
 						MTU:        1500,
-						Controller: "k6t-eth0",
+						Controller: defaultPodBridgeName,
 						Tap:        &nmstate.TapDevice{Queues: 0, UID: 0, GID: 0},
 						Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 					},
@@ -264,8 +288,8 @@ var _ = Describe("netpod", func() {
 				},
 			}),
 		)
-		Expect(masqstub.bridgeIfaceSpec.Name).To(Equal("k6t-eth0"))
-		Expect(masqstub.podIfaceSpec.Name).To(Equal("eth0"))
+		Expect(masqstub.bridgeIfaceSpec.Name).To(Equal(defaultPodBridgeName))
+		Expect(masqstub.podIfaceSpec.Name).To(Equal(defaultPrimaryPodIfaceName))
 		Expect(masqstub.vmiIfaceSpec.Name).To(Equal(defaultPodNetworkName))
 		Expect(cache.ReadPodInterfaceCache(&baseCacheCreator, vmiUID, defaultPodNetworkName)).To(Equal(&cache.PodIfaceCacheData{
 			Iface:  &vmiIface,
@@ -278,11 +302,11 @@ var _ = Describe("netpod", func() {
 		const (
 			defaultGatewayIP4Address = "10.222.222.254"
 
-			podIfaceOrignalMAC = "12:34:56:78:90:ab"
+			podIfaceOrignalMAC = defaultPodIfaceOriginalMAC
 		)
 		nmstatestub := nmstateStub{status: nmstate.Status{
 			Interfaces: []nmstate.Interface{{
-				Name:       "eth0",
+				Name:       defaultPrimaryPodIfaceName,
 				Index:      0,
 				TypeName:   nmstate.TypeVETH,
 				State:      nmstate.IfaceStateUp,
@@ -306,29 +330,29 @@ var _ = Describe("netpod", func() {
 			Routes: nmstate.Routes{Running: []nmstate.Route{
 				// Default Route
 				{
-					Destination:      "0.0.0.0/0",
-					NextHopInterface: "eth0",
+					Destination:      defaultRouteDestination,
+					NextHopInterface: defaultPrimaryPodIfaceName,
 					NextHopAddress:   defaultGatewayIP4Address,
 					TableID:          0,
 				},
 				// Local Route (should be ignored)
 				{
 					Destination:      "10.222.222.0/30",
-					NextHopInterface: "eth0",
+					NextHopInterface: defaultPrimaryPodIfaceName,
 					NextHopAddress:   primaryIPv4Address,
 					TableID:          0,
 				},
 				// Static Route
 				{
 					Destination:      "192.168.1.0/24",
-					NextHopInterface: "eth0",
+					NextHopInterface: defaultPrimaryPodIfaceName,
 					NextHopAddress:   defaultGatewayIP4Address,
 					TableID:          0,
 				},
 				// Static route to a wider subnet containing the local subnet
 				{
 					Destination:      "10.222.0.0/16",
-					NextHopInterface: "eth0",
+					NextHopInterface: defaultPrimaryPodIfaceName,
 					TableID:          0,
 				},
 			}},
@@ -350,7 +374,7 @@ var _ = Describe("netpod", func() {
 			nmstate.Spec{
 				Interfaces: []nmstate.Interface{
 					{
-						Name:     "k6t-eth0",
+						Name:     defaultPodBridgeName,
 						TypeName: nmstate.TypeBridge,
 						State:    nmstate.IfaceStateUp,
 						IPv4: nmstate.IP{
@@ -360,10 +384,10 @@ var _ = Describe("netpod", func() {
 						Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 					},
 					{
-						Name:        "eth0-nic",
+						Name:        defaultPodIfaceBridgeNICName,
 						Index:       0,
-						CopyMacFrom: "k6t-eth0",
-						Controller:  "k6t-eth0",
+						CopyMacFrom: defaultPodBridgeName,
+						Controller:  defaultPodBridgeName,
 						State:       nmstate.IfaceStateUp,
 						IPv4:        ipDisabled,
 						IPv6:        ipDisabled,
@@ -371,16 +395,16 @@ var _ = Describe("netpod", func() {
 						Metadata:    &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 					},
 					{
-						Name:       "tap0",
+						Name:       defaultTapDeviceName,
 						TypeName:   nmstate.TypeTap,
 						State:      nmstate.IfaceStateUp,
 						MTU:        1500,
-						Controller: "k6t-eth0",
+						Controller: defaultPodBridgeName,
 						Tap:        &nmstate.TapDevice{Queues: 0, UID: 0, GID: 0},
 						Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 					},
 					{
-						Name:       "eth0",
+						Name:       defaultPrimaryPodIfaceName,
 						TypeName:   nmstate.TypeDummy,
 						MacAddress: podIfaceOrignalMAC,
 						MTU:        1500,
@@ -420,13 +444,13 @@ var _ = Describe("netpod", func() {
 			"10.222.0.0/16",
 		)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(cache.ReadDHCPInterfaceCache(&baseCacheCreator, "0", "eth0")).To(Equal(expDHCPConfig))
+		Expect(cache.ReadDHCPInterfaceCache(&baseCacheCreator, "0", defaultPrimaryPodIfaceName)).To(Equal(expDHCPConfig))
 	})
 
 	It("setup bridge binding with IP custom primary interface name", func() {
 		const (
 			defaultGatewayIP4Address = "10.222.222.254"
-			podIfaceOrignalMAC       = "12:34:56:78:90:ab"
+			podIfaceOrignalMAC       = defaultPodIfaceOriginalMAC
 			customPrimaryIfaceName   = "cust-iface"
 		)
 		nmstatestub := nmstateStub{status: nmstate.Status{
@@ -455,7 +479,7 @@ var _ = Describe("netpod", func() {
 			Routes: nmstate.Routes{Running: []nmstate.Route{
 				// Default Route
 				{
-					Destination:      "0.0.0.0/0",
+					Destination:      defaultRouteDestination,
 					NextHopInterface: customPrimaryIfaceName,
 					NextHopAddress:   defaultGatewayIP4Address,
 					TableID:          0,
@@ -503,7 +527,7 @@ var _ = Describe("netpod", func() {
 			nmstate.Spec{
 				Interfaces: []nmstate.Interface{
 					{
-						Name:     "k6t-cust-iface",
+						Name:     customPrimaryBridgeName,
 						TypeName: nmstate.TypeBridge,
 						State:    nmstate.IfaceStateUp,
 						IPv4: nmstate.IP{
@@ -515,8 +539,8 @@ var _ = Describe("netpod", func() {
 					{
 						Name:        "cust-iface-nic",
 						Index:       0,
-						CopyMacFrom: "k6t-cust-iface",
-						Controller:  "k6t-cust-iface",
+						CopyMacFrom: customPrimaryBridgeName,
+						Controller:  customPrimaryBridgeName,
 						State:       nmstate.IfaceStateUp,
 						IPv4:        ipDisabled,
 						IPv6:        ipDisabled,
@@ -524,11 +548,11 @@ var _ = Describe("netpod", func() {
 						Metadata:    &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 					},
 					{
-						Name:       "tap0",
+						Name:       defaultTapDeviceName,
 						TypeName:   nmstate.TypeTap,
 						State:      nmstate.IfaceStateUp,
 						MTU:        1500,
-						Controller: "k6t-cust-iface",
+						Controller: customPrimaryBridgeName,
 						Tap:        &nmstate.TapDevice{Queues: 0, UID: 0, GID: 0},
 						Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 					},
@@ -577,11 +601,11 @@ var _ = Describe("netpod", func() {
 	})
 
 	It("setup bridge binding without IP", func() {
-		const podIfaceOrignalMAC = "12:34:56:78:90:ab"
+		const podIfaceOrignalMAC = defaultPodIfaceOriginalMAC
 		const linklocalIPv6Address = "fe80::1"
 		nmstatestub := nmstateStub{status: nmstate.Status{
 			Interfaces: []nmstate.Interface{{
-				Name:       "eth0",
+				Name:       defaultPrimaryPodIfaceName,
 				Index:      0,
 				TypeName:   nmstate.TypeVETH,
 				State:      nmstate.IfaceStateUp,
@@ -613,16 +637,16 @@ var _ = Describe("netpod", func() {
 			nmstate.Spec{
 				Interfaces: []nmstate.Interface{
 					{
-						Name:     "k6t-eth0",
+						Name:     defaultPodBridgeName,
 						TypeName: nmstate.TypeBridge,
 						State:    nmstate.IfaceStateUp,
 						Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 					},
 					{
-						Name:        "eth0-nic",
+						Name:        defaultPodIfaceBridgeNICName,
 						Index:       0,
-						CopyMacFrom: "k6t-eth0",
-						Controller:  "k6t-eth0",
+						CopyMacFrom: defaultPodBridgeName,
+						Controller:  defaultPodBridgeName,
 						State:       nmstate.IfaceStateUp,
 						IPv4:        ipDisabled,
 						IPv6:        ipDisabled,
@@ -630,16 +654,16 @@ var _ = Describe("netpod", func() {
 						Metadata:    &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 					},
 					{
-						Name:       "tap0",
+						Name:       defaultTapDeviceName,
 						TypeName:   nmstate.TypeTap,
 						State:      nmstate.IfaceStateUp,
 						MTU:        1500,
-						Controller: "k6t-eth0",
+						Controller: defaultPodBridgeName,
 						Tap:        &nmstate.TapDevice{Queues: 0, UID: 0, GID: 0},
 						Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 					},
 					{
-						Name:       "eth0",
+						Name:       defaultPrimaryPodIfaceName,
 						TypeName:   nmstate.TypeDummy,
 						MacAddress: podIfaceOrignalMAC,
 						MTU:        1500,
@@ -660,13 +684,13 @@ var _ = Describe("netpod", func() {
 		_, err := cache.ReadPodInterfaceCache(&baseCacheCreator, vmiUID, defaultPodNetworkName)
 		Expect(err).To(HaveOccurred())
 
-		Expect(cache.ReadDHCPInterfaceCache(&baseCacheCreator, "0", "eth0")).To(
+		Expect(cache.ReadDHCPInterfaceCache(&baseCacheCreator, "0", defaultPrimaryPodIfaceName)).To(
 			Equal(&cache.DHCPConfig{IPAMDisabled: true}))
 	})
 
 	It("setup passt binding", func() {
 		nmstatestub := nmstateStub{status: nmstate.Status{
-			Interfaces: []nmstate.Interface{{Name: "eth0"}},
+			Interfaces: []nmstate.Interface{{Name: defaultPrimaryPodIfaceName}},
 		}}
 
 		vmiIface := v1.Interface{
@@ -719,11 +743,11 @@ var _ = Describe("netpod", func() {
 			nmstatestub = nmstateStub{status: nmstate.Status{
 				Interfaces: []nmstate.Interface{
 					{
-						Name:       "eth0",
+						Name:       defaultPrimaryPodIfaceName,
 						Index:      0,
 						TypeName:   nmstate.TypeVETH,
 						State:      nmstate.IfaceStateUp,
-						MacAddress: "12:34:56:78:90:ab",
+						MacAddress: defaultPodIfaceOriginalMAC,
 						MTU:        1500,
 						IPv4: nmstate.IP{
 							Enabled: pointer.P(true),
@@ -791,28 +815,28 @@ var _ = Describe("netpod", func() {
 
 			expectedPrimaryNetIfaces := []nmstate.Interface{
 				{
-					Name:       "k6t-eth0",
+					Name:       defaultPodBridgeName,
 					TypeName:   nmstate.TypeBridge,
 					State:      nmstate.IfaceStateUp,
-					MacAddress: "02:00:00:00:00:00",
+					MacAddress: defaultPodBridgeMACAddress,
 					MTU:        1500,
 					IPv4: nmstate.IP{
 						Enabled: pointer.P(true),
-						Address: []nmstate.IPAddress{{IP: "10.0.2.1", PrefixLen: 24}},
+						Address: []nmstate.IPAddress{{IP: defaultPodBridgeIPv4Address, PrefixLen: 24}},
 					},
 					IPv6: nmstate.IP{
 						Enabled: pointer.P(true),
-						Address: []nmstate.IPAddress{{IP: "fd10:0:2::1", PrefixLen: 120}},
+						Address: []nmstate.IPAddress{{IP: defaultPodBridgeIPv6Address, PrefixLen: 120}},
 					},
 					LinuxStack: nmstate.LinuxIfaceStack{IP4RouteLocalNet: pointer.P(true)},
 					Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 				},
 				{
-					Name:       "tap0",
+					Name:       defaultTapDeviceName,
 					TypeName:   nmstate.TypeTap,
 					State:      nmstate.IfaceStateUp,
 					MTU:        1500,
-					Controller: "k6t-eth0",
+					Controller: defaultPodBridgeName,
 					Tap:        &nmstate.TapDevice{Queues: 0, UID: 0, GID: 0},
 					Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 				},
@@ -846,7 +870,7 @@ var _ = Describe("netpod", func() {
 						expectedPrimaryNetIfaces[1],
 						// Secondary network
 						{
-							Name:     "k6t-914f438d88d",
+							Name:     hashedSecondaryBridgeName,
 							TypeName: nmstate.TypeBridge,
 							State:    nmstate.IfaceStateUp,
 							Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: secondaryNetworkName},
@@ -854,8 +878,8 @@ var _ = Describe("netpod", func() {
 						{
 							Name:        "914f438d88d-nic",
 							Index:       secondaryPodInterfaceIndex,
-							CopyMacFrom: "k6t-914f438d88d",
-							Controller:  "k6t-914f438d88d",
+							CopyMacFrom: hashedSecondaryBridgeName,
+							Controller:  hashedSecondaryBridgeName,
 							State:       nmstate.IfaceStateUp,
 							IPv4:        ipDisabled,
 							IPv6:        ipDisabled,
@@ -867,7 +891,7 @@ var _ = Describe("netpod", func() {
 							TypeName:   nmstate.TypeTap,
 							State:      nmstate.IfaceStateUp,
 							MTU:        1500,
-							Controller: "k6t-914f438d88d",
+							Controller: hashedSecondaryBridgeName,
 							Tap:        &nmstate.TapDevice{Queues: 0, UID: 0, GID: 0},
 							Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: secondaryNetworkName},
 						},
@@ -887,8 +911,8 @@ var _ = Describe("netpod", func() {
 					},
 				}),
 			)
-			Expect(masqstub.bridgeIfaceSpec.Name).To(Equal("k6t-eth0"))
-			Expect(masqstub.podIfaceSpec.Name).To(Equal("eth0"))
+			Expect(masqstub.bridgeIfaceSpec.Name).To(Equal(defaultPodBridgeName))
+			Expect(masqstub.podIfaceSpec.Name).To(Equal(defaultPrimaryPodIfaceName))
 			Expect(masqstub.vmiIfaceSpec.Name).To(Equal(defaultPodNetworkName))
 			Expect(cache.ReadPodInterfaceCache(&baseCacheCreator, vmiUID, defaultPodNetworkName)).To(Equal(&cache.PodIfaceCacheData{
 				Iface:  &specInterfaces[0],
@@ -919,34 +943,34 @@ var _ = Describe("netpod", func() {
 					Interfaces: []nmstate.Interface{
 						// Primary network
 						{
-							Name:       "k6t-eth0",
+							Name:       defaultPodBridgeName,
 							TypeName:   nmstate.TypeBridge,
 							State:      nmstate.IfaceStateUp,
-							MacAddress: "02:00:00:00:00:00",
+							MacAddress: defaultPodBridgeMACAddress,
 							MTU:        1500,
 							IPv4: nmstate.IP{
 								Enabled: pointer.P(true),
-								Address: []nmstate.IPAddress{{IP: "10.0.2.1", PrefixLen: 24}},
+								Address: []nmstate.IPAddress{{IP: defaultPodBridgeIPv4Address, PrefixLen: 24}},
 							},
 							IPv6: nmstate.IP{
 								Enabled: pointer.P(true),
-								Address: []nmstate.IPAddress{{IP: "fd10:0:2::1", PrefixLen: 120}},
+								Address: []nmstate.IPAddress{{IP: defaultPodBridgeIPv6Address, PrefixLen: 120}},
 							},
 							LinuxStack: nmstate.LinuxIfaceStack{IP4RouteLocalNet: pointer.P(true)},
 							Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 						},
 						{
-							Name:       "tap0",
+							Name:       defaultTapDeviceName,
 							TypeName:   nmstate.TypeTap,
 							State:      nmstate.IfaceStateUp,
 							MTU:        1500,
-							Controller: "k6t-eth0",
+							Controller: defaultPodBridgeName,
 							Tap:        &nmstate.TapDevice{Queues: 0, UID: 0, GID: 0},
 							Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 						},
 						// Secondary network with `absent` marking.
 						{
-							Name:     "k6t-914f438d88d",
+							Name:     hashedSecondaryBridgeName,
 							TypeName: nmstate.TypeBridge,
 							State:    nmstate.IfaceStateAbsent,
 							Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: secondaryNetworkName},
@@ -956,7 +980,7 @@ var _ = Describe("netpod", func() {
 							TypeName:   nmstate.TypeTap,
 							State:      nmstate.IfaceStateAbsent,
 							MTU:        1500,
-							Controller: "k6t-914f438d88d",
+							Controller: hashedSecondaryBridgeName,
 							Tap:        &nmstate.TapDevice{Queues: 0, UID: 0, GID: 0},
 							Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: secondaryNetworkName},
 						},
@@ -977,8 +1001,8 @@ var _ = Describe("netpod", func() {
 					},
 				}),
 			)
-			Expect(masqstub.bridgeIfaceSpec.Name).To(Equal("k6t-eth0"))
-			Expect(masqstub.podIfaceSpec.Name).To(Equal("eth0"))
+			Expect(masqstub.bridgeIfaceSpec.Name).To(Equal(defaultPodBridgeName))
+			Expect(masqstub.podIfaceSpec.Name).To(Equal(defaultPrimaryPodIfaceName))
 			Expect(masqstub.vmiIfaceSpec.Name).To(Equal(defaultPodNetworkName))
 		})
 
@@ -998,34 +1022,34 @@ var _ = Describe("netpod", func() {
 					Interfaces: []nmstate.Interface{
 						// Primary network
 						{
-							Name:       "k6t-eth0",
+							Name:       defaultPodBridgeName,
 							TypeName:   nmstate.TypeBridge,
 							State:      nmstate.IfaceStateUp,
-							MacAddress: "02:00:00:00:00:00",
+							MacAddress: defaultPodBridgeMACAddress,
 							MTU:        1500,
 							IPv4: nmstate.IP{
 								Enabled: pointer.P(true),
-								Address: []nmstate.IPAddress{{IP: "10.0.2.1", PrefixLen: 24}},
+								Address: []nmstate.IPAddress{{IP: defaultPodBridgeIPv4Address, PrefixLen: 24}},
 							},
 							IPv6: nmstate.IP{
 								Enabled: pointer.P(true),
-								Address: []nmstate.IPAddress{{IP: "fd10:0:2::1", PrefixLen: 120}},
+								Address: []nmstate.IPAddress{{IP: defaultPodBridgeIPv6Address, PrefixLen: 120}},
 							},
 							LinuxStack: nmstate.LinuxIfaceStack{IP4RouteLocalNet: pointer.P(true)},
 							Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 						},
 						{
-							Name:       "tap0",
+							Name:       defaultTapDeviceName,
 							TypeName:   nmstate.TypeTap,
 							State:      nmstate.IfaceStateUp,
 							MTU:        1500,
-							Controller: "k6t-eth0",
+							Controller: defaultPodBridgeName,
 							Tap:        &nmstate.TapDevice{Queues: 0, UID: 0, GID: 0},
 							Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 						},
 						// Secondary network
 						{
-							Name:     "k6t-net1",
+							Name:     orderedSecondaryBridgeName,
 							TypeName: nmstate.TypeBridge,
 							State:    nmstate.IfaceStateUp,
 							Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: secondaryNetworkName},
@@ -1033,8 +1057,8 @@ var _ = Describe("netpod", func() {
 						{
 							Name:        "net1-nic",
 							Index:       secondaryPodInterfaceIndex,
-							CopyMacFrom: "k6t-net1",
-							Controller:  "k6t-net1",
+							CopyMacFrom: orderedSecondaryBridgeName,
+							Controller:  orderedSecondaryBridgeName,
 							State:       nmstate.IfaceStateUp,
 							IPv4:        ipDisabled,
 							IPv6:        ipDisabled,
@@ -1046,7 +1070,7 @@ var _ = Describe("netpod", func() {
 							TypeName:   nmstate.TypeTap,
 							State:      nmstate.IfaceStateUp,
 							MTU:        1500,
-							Controller: "k6t-net1",
+							Controller: orderedSecondaryBridgeName,
 							Tap:        &nmstate.TapDevice{Queues: 0, UID: 0, GID: 0},
 							Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: secondaryNetworkName},
 						},
@@ -1066,8 +1090,8 @@ var _ = Describe("netpod", func() {
 					},
 				}),
 			)
-			Expect(masqstub.bridgeIfaceSpec.Name).To(Equal("k6t-eth0"))
-			Expect(masqstub.podIfaceSpec.Name).To(Equal("eth0"))
+			Expect(masqstub.bridgeIfaceSpec.Name).To(Equal(defaultPodBridgeName))
+			Expect(masqstub.podIfaceSpec.Name).To(Equal(defaultPrimaryPodIfaceName))
 			Expect(masqstub.vmiIfaceSpec.Name).To(Equal(defaultPodNetworkName))
 		})
 	})
@@ -1086,7 +1110,7 @@ var _ = Describe("netpod", func() {
 		vmiIfaceStatuses := []v1.VirtualMachineInstanceNetworkInterface{
 			{
 				Name:             defaultPodNetworkName,
-				PodInterfaceName: "eth0",
+				PodInterfaceName: defaultPrimaryPodIfaceName,
 				QueueCount:       previousQueueCount,
 				InfoSource:       vmispec.InfoSourceDomain,
 			},
@@ -1094,11 +1118,11 @@ var _ = Describe("netpod", func() {
 
 		nmstatestub := nmstateStub{status: nmstate.Status{
 			Interfaces: []nmstate.Interface{{
-				Name:       "eth0",
+				Name:       defaultPrimaryPodIfaceName,
 				Index:      0,
 				TypeName:   nmstate.TypeVETH,
 				State:      nmstate.IfaceStateUp,
-				MacAddress: "12:34:56:78:90:ab",
+				MacAddress: defaultPodIfaceOriginalMAC,
 				MTU:        1500,
 				IPv4: nmstate.IP{
 					Enabled: pointer.P(true),
@@ -1111,8 +1135,8 @@ var _ = Describe("netpod", func() {
 			Routes: nmstate.Routes{Running: []nmstate.Route{
 				// Default Route
 				{
-					Destination:      "0.0.0.0/0",
-					NextHopInterface: "eth0",
+					Destination:      defaultRouteDestination,
+					NextHopInterface: defaultPrimaryPodIfaceName,
 					NextHopAddress:   "10.0.0.1",
 					TableID:          0,
 				},
@@ -1130,7 +1154,7 @@ var _ = Describe("netpod", func() {
 		Expect(netPod.Setup()).To(Succeed())
 
 		index := slices.IndexFunc(nmstatestub.spec.Interfaces, func(iface nmstate.Interface) bool {
-			return iface.Name == "tap0"
+			return iface.Name == defaultTapDeviceName
 		})
 		Expect(index).To(BeNumerically(">=", 0))
 
@@ -1140,14 +1164,14 @@ var _ = Describe("netpod", func() {
 	It("setup bridge binding preserves MAC address after live migration", func() {
 		const (
 			defaultGatewayIP4Address = "10.222.222.254"
-			podIfaceNewMAC           = "aa:bb:cc:dd:ee:ff" // New MAC after migration
-			originalMAC              = "12:34:56:78:90:ab" // Original MAC from VMI status
+			podIfaceNewMAC           = "aa:bb:cc:dd:ee:ff"        // New MAC after migration
+			originalMAC              = defaultPodIfaceOriginalMAC // Original MAC from VMI status
 		)
 
 		// nmstatestub with the NEW pod interface MAC (post-migration)
 		nmstatestub := nmstateStub{status: nmstate.Status{
 			Interfaces: []nmstate.Interface{{
-				Name:       "eth0",
+				Name:       defaultPrimaryPodIfaceName,
 				Index:      0,
 				TypeName:   nmstate.TypeVETH,
 				State:      nmstate.IfaceStateUp,
@@ -1170,8 +1194,8 @@ var _ = Describe("netpod", func() {
 			}},
 			Routes: nmstate.Routes{Running: []nmstate.Route{
 				{
-					Destination:      "0.0.0.0/0",
-					NextHopInterface: "eth0",
+					Destination:      defaultRouteDestination,
+					NextHopInterface: defaultPrimaryPodIfaceName,
 					NextHopAddress:   defaultGatewayIP4Address,
 					TableID:          0,
 				},
@@ -1206,18 +1230,18 @@ var _ = Describe("netpod", func() {
 			defaultGatewayIP4Address,
 		)
 		Expect(err).NotTo(HaveOccurred())
-		Expect(cache.ReadDHCPInterfaceCache(&baseCacheCreator, "0", "eth0")).To(Equal(expDHCPConfig))
+		Expect(cache.ReadDHCPInterfaceCache(&baseCacheCreator, "0", defaultPrimaryPodIfaceName)).To(Equal(expDHCPConfig))
 	})
 
 	DescribeTable("setup unhandled bindings", func(binding v1.InterfaceBindingMethod, expNmstateSpec nmstate.Spec) {
 		nmstatestub := nmstateStub{status: nmstate.Status{
 			Interfaces: []nmstate.Interface{
 				{
-					Name:       "eth0",
+					Name:       defaultPrimaryPodIfaceName,
 					Index:      0,
 					TypeName:   nmstate.TypeVETH,
 					State:      nmstate.IfaceStateUp,
-					MacAddress: "12:34:56:78:90:ab",
+					MacAddress: defaultPodIfaceOriginalMAC,
 					MTU:        1500,
 				},
 			},
@@ -1270,27 +1294,27 @@ var _ = Describe("netpod", func() {
 			nmstatestub = &nmstateStub{status: nmstate.Status{
 				Interfaces: []nmstate.Interface{
 					{
-						Name:       "eth0",
+						Name:       defaultPrimaryPodIfaceName,
 						Index:      0,
 						TypeName:   nmstate.TypeVETH,
 						State:      nmstate.IfaceStateUp,
-						MacAddress: "12:34:56:78:90:ab",
+						MacAddress: defaultPodIfaceOriginalMAC,
 						MTU:        1500,
 					},
 					{
-						Name:       "pod7087ef4cd1f",
+						Name:       testNet1PodIfaceName,
 						Index:      0,
 						TypeName:   nmstate.TypeVETH,
 						State:      nmstate.IfaceStateUp,
-						MacAddress: "22:34:56:78:90:ab",
+						MacAddress: testNet1PodIfaceMACAddress,
 						MTU:        1500,
 					},
 					{
-						Name:       "podbc6cc93fa1e",
+						Name:       testNet2PodIfaceName,
 						Index:      0,
 						TypeName:   nmstate.TypeVETH,
 						State:      nmstate.IfaceStateUp,
-						MacAddress: "32:34:56:78:90:ab",
+						MacAddress: testNet2PodIfaceMACAddress,
 						MTU:        1500,
 					},
 				},
@@ -1329,10 +1353,10 @@ var _ = Describe("netpod", func() {
 					Interfaces: []nmstate.Interface{
 						// Primary network
 						{
-							Name:       "k6t-eth0",
+							Name:       defaultPodBridgeName,
 							TypeName:   nmstate.TypeBridge,
 							State:      nmstate.IfaceStateUp,
-							MacAddress: "02:00:00:00:00:00",
+							MacAddress: defaultPodBridgeMACAddress,
 							MTU:        1500,
 							IPv4:       nmstate.IP{Enabled: pointer.P(false)},
 							IPv6:       nmstate.IP{Enabled: pointer.P(false)},
@@ -1340,49 +1364,49 @@ var _ = Describe("netpod", func() {
 							Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 						},
 						{
-							Name:       "tap0",
+							Name:       defaultTapDeviceName,
 							TypeName:   nmstate.TypeTap,
 							State:      nmstate.IfaceStateUp,
 							MTU:        1500,
-							Controller: "k6t-eth0",
+							Controller: defaultPodBridgeName,
 							Tap:        &nmstate.TapDevice{Queues: 0, UID: 0, GID: 0},
 							Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 						},
 						// Secondary network with `absent` marking.
 						{
-							Name:     "k6t-7087ef4cd1f",
+							Name:     testNet1BridgeName,
 							TypeName: nmstate.TypeBridge,
 							State:    nmstate.IfaceStateAbsent,
 							Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: testNet1},
 						},
 						{
-							Name:       "tap7087ef4cd1f",
+							Name:       testNet1TapName,
 							TypeName:   nmstate.TypeTap,
 							State:      nmstate.IfaceStateAbsent,
 							MTU:        1500,
-							Controller: "k6t-7087ef4cd1f",
+							Controller: testNet1BridgeName,
 							Tap:        &nmstate.TapDevice{Queues: 0, UID: 0, GID: 0},
 							Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: testNet1},
 						},
 						{
-							Name:       "pod7087ef4cd1f",
+							Name:       testNet1PodIfaceName,
 							TypeName:   nmstate.TypeDummy,
 							State:      nmstate.IfaceStateAbsent,
-							MacAddress: "22:34:56:78:90:ab",
+							MacAddress: testNet1PodIfaceMACAddress,
 							MTU:        1500,
 							Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: testNet1},
 						},
 						// Third network.
 						{
-							Name:     "k6t-bc6cc93fa1e",
+							Name:     testNet2BridgeName,
 							TypeName: nmstate.TypeBridge,
 							State:    nmstate.IfaceStateUp,
 							Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: testNet2},
 						},
 						{
 							Name:        "bc6cc93fa1e-nic",
-							CopyMacFrom: "k6t-bc6cc93fa1e",
-							Controller:  "k6t-bc6cc93fa1e",
+							CopyMacFrom: testNet2BridgeName,
+							Controller:  testNet2BridgeName,
 							State:       nmstate.IfaceStateUp,
 							IPv4:        ipDisabled,
 							IPv6:        ipDisabled,
@@ -1390,18 +1414,18 @@ var _ = Describe("netpod", func() {
 							Metadata:    &nmstate.IfaceMetadata{Pid: 0, NetworkName: testNet2},
 						},
 						{
-							Name:       "tapbc6cc93fa1e",
+							Name:       testNet2TapName,
 							TypeName:   nmstate.TypeTap,
 							State:      nmstate.IfaceStateUp,
 							MTU:        1500,
-							Controller: "k6t-bc6cc93fa1e",
+							Controller: testNet2BridgeName,
 							Tap:        &nmstate.TapDevice{Queues: 0, UID: 0, GID: 0},
 							Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: testNet2},
 						},
 						{
-							Name:       "podbc6cc93fa1e",
+							Name:       testNet2PodIfaceName,
 							TypeName:   nmstate.TypeDummy,
-							MacAddress: "32:34:56:78:90:ab",
+							MacAddress: testNet2PodIfaceMACAddress,
 							MTU:        1500,
 							Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: testNet2},
 						},
@@ -1435,10 +1459,10 @@ var _ = Describe("netpod", func() {
 					Interfaces: []nmstate.Interface{
 						// Primary network
 						{
-							Name:       "k6t-eth0",
+							Name:       defaultPodBridgeName,
 							TypeName:   nmstate.TypeBridge,
 							State:      nmstate.IfaceStateUp,
-							MacAddress: "02:00:00:00:00:00",
+							MacAddress: defaultPodBridgeMACAddress,
 							MTU:        1500,
 							IPv4:       nmstate.IP{Enabled: pointer.P(false)},
 							IPv6:       nmstate.IP{Enabled: pointer.P(false)},
@@ -1446,59 +1470,59 @@ var _ = Describe("netpod", func() {
 							Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 						},
 						{
-							Name:       "tap0",
+							Name:       defaultTapDeviceName,
 							TypeName:   nmstate.TypeTap,
 							State:      nmstate.IfaceStateUp,
 							MTU:        1500,
-							Controller: "k6t-eth0",
+							Controller: defaultPodBridgeName,
 							Tap:        &nmstate.TapDevice{Queues: 0, UID: 0, GID: 0},
 							Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 						},
 						// Secondary network with `absent` marking.
 						{
-							Name:     "k6t-7087ef4cd1f",
+							Name:     testNet1BridgeName,
 							TypeName: nmstate.TypeBridge,
 							State:    nmstate.IfaceStateAbsent,
 							Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: testNet1},
 						},
 						{
-							Name:       "tap7087ef4cd1f",
+							Name:       testNet1TapName,
 							TypeName:   nmstate.TypeTap,
 							State:      nmstate.IfaceStateAbsent,
 							MTU:        1500,
-							Controller: "k6t-7087ef4cd1f",
+							Controller: testNet1BridgeName,
 							Tap:        &nmstate.TapDevice{Queues: 0, UID: 0, GID: 0},
 							Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: testNet1},
 						},
 						{
-							Name:       "pod7087ef4cd1f",
+							Name:       testNet1PodIfaceName,
 							TypeName:   nmstate.TypeDummy,
 							State:      nmstate.IfaceStateAbsent,
-							MacAddress: "22:34:56:78:90:ab",
+							MacAddress: testNet1PodIfaceMACAddress,
 							MTU:        1500,
 							Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: testNet1},
 						},
 						// Third network.
 						{
-							Name:     "k6t-bc6cc93fa1e",
+							Name:     testNet2BridgeName,
 							TypeName: nmstate.TypeBridge,
 							State:    nmstate.IfaceStateAbsent,
 							Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: testNet2},
 						},
 						{
-							Name:       "tapbc6cc93fa1e",
+							Name:       testNet2TapName,
 							TypeName:   nmstate.TypeTap,
 							State:      nmstate.IfaceStateAbsent,
 							MTU:        1500,
-							Controller: "k6t-bc6cc93fa1e",
+							Controller: testNet2BridgeName,
 							Tap:        &nmstate.TapDevice{Queues: 0, UID: 0, GID: 0},
 							Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: testNet2},
 						},
 						{
-							Name:       "podbc6cc93fa1e",
+							Name:       testNet2PodIfaceName,
 							TypeName:   nmstate.TypeDummy,
 							State:      nmstate.IfaceStateAbsent,
-							MacAddress: "32:34:56:78:90:ab",
+							MacAddress: testNet2PodIfaceMACAddress,
 							MTU:        1500,
 							Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: testNet2},
 						},
@@ -1539,10 +1563,10 @@ var _ = Describe("netpod", func() {
 					Interfaces: []nmstate.Interface{
 						// Primary network
 						{
-							Name:       "k6t-eth0",
+							Name:       defaultPodBridgeName,
 							TypeName:   nmstate.TypeBridge,
 							State:      nmstate.IfaceStateUp,
-							MacAddress: "02:00:00:00:00:00",
+							MacAddress: defaultPodBridgeMACAddress,
 							MTU:        1500,
 							IPv4:       nmstate.IP{Enabled: pointer.P(false)},
 							IPv6:       nmstate.IP{Enabled: pointer.P(false)},
@@ -1550,25 +1574,25 @@ var _ = Describe("netpod", func() {
 							Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 						},
 						{
-							Name:       "tap0",
+							Name:       defaultTapDeviceName,
 							TypeName:   nmstate.TypeTap,
 							State:      nmstate.IfaceStateUp,
 							MTU:        1500,
-							Controller: "k6t-eth0",
+							Controller: defaultPodBridgeName,
 							Tap:        &nmstate.TapDevice{Queues: 0, UID: 0, GID: 0},
 							Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 						},
 						// Secondary network.
 						{
-							Name:     "k6t-7087ef4cd1f",
+							Name:     testNet1BridgeName,
 							TypeName: nmstate.TypeBridge,
 							State:    nmstate.IfaceStateUp,
 							Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: testNet1},
 						},
 						{
 							Name:        "7087ef4cd1f-nic",
-							CopyMacFrom: "k6t-7087ef4cd1f",
-							Controller:  "k6t-7087ef4cd1f",
+							CopyMacFrom: testNet1BridgeName,
+							Controller:  testNet1BridgeName,
 							State:       nmstate.IfaceStateUp,
 							IPv4:        ipDisabled,
 							IPv6:        ipDisabled,
@@ -1576,42 +1600,42 @@ var _ = Describe("netpod", func() {
 							Metadata:    &nmstate.IfaceMetadata{Pid: 0, NetworkName: testNet1},
 						},
 						{
-							Name:       "tap7087ef4cd1f",
+							Name:       testNet1TapName,
 							TypeName:   nmstate.TypeTap,
 							State:      nmstate.IfaceStateUp,
 							MTU:        1500,
-							Controller: "k6t-7087ef4cd1f",
+							Controller: testNet1BridgeName,
 							Tap:        &nmstate.TapDevice{Queues: 0, UID: 0, GID: 0},
 							Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: testNet1},
 						},
 						{
-							Name:       "pod7087ef4cd1f",
+							Name:       testNet1PodIfaceName,
 							TypeName:   nmstate.TypeDummy,
-							MacAddress: "22:34:56:78:90:ab",
+							MacAddress: testNet1PodIfaceMACAddress,
 							MTU:        1500,
 							Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: testNet1},
 						},
 						// Third network.
 						{
-							Name:     "k6t-bc6cc93fa1e",
+							Name:     testNet2BridgeName,
 							TypeName: nmstate.TypeBridge,
 							State:    nmstate.IfaceStateAbsent,
 							Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: testNet2},
 						},
 						{
-							Name:       "tapbc6cc93fa1e",
+							Name:       testNet2TapName,
 							TypeName:   nmstate.TypeTap,
 							State:      nmstate.IfaceStateAbsent,
 							MTU:        1500,
-							Controller: "k6t-bc6cc93fa1e",
+							Controller: testNet2BridgeName,
 							Tap:        &nmstate.TapDevice{Queues: 0, UID: 0, GID: 0},
 							Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: testNet2},
 						},
 						{
-							Name:       "podbc6cc93fa1e",
+							Name:       testNet2PodIfaceName,
 							TypeName:   nmstate.TypeDummy,
 							State:      nmstate.IfaceStateAbsent,
-							MacAddress: "32:34:56:78:90:ab",
+							MacAddress: testNet2PodIfaceMACAddress,
 							MTU:        1500,
 							Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: testNet2},
 						},
@@ -1658,27 +1682,27 @@ var _ = Describe("netpod", func() {
 		nmstatestub := &nmstateStub{status: nmstate.Status{
 			Interfaces: []nmstate.Interface{
 				{
-					Name:       "eth0",
+					Name:       defaultPrimaryPodIfaceName,
 					Index:      0,
 					TypeName:   nmstate.TypeVETH,
 					State:      nmstate.IfaceStateUp,
-					MacAddress: "12:34:56:78:90:ab",
+					MacAddress: defaultPodIfaceOriginalMAC,
 					MTU:        1500,
 				},
 				{
-					Name:       "pod7087ef4cd1f",
+					Name:       testNet1PodIfaceName,
 					Index:      0,
 					TypeName:   nmstate.TypeVETH,
 					State:      nmstate.IfaceStateUp,
-					MacAddress: "22:34:56:78:90:ab",
+					MacAddress: testNet1PodIfaceMACAddress,
 					MTU:        1500,
 				},
 				{
-					Name:       "podbc6cc93fa1e",
+					Name:       testNet2PodIfaceName,
 					Index:      0,
 					TypeName:   nmstate.TypeVETH,
 					State:      nmstate.IfaceStateUp,
-					MacAddress: "32:34:56:78:90:ab",
+					MacAddress: testNet2PodIfaceMACAddress,
 					MTU:        1500,
 				},
 			},
@@ -1729,10 +1753,10 @@ var _ = Describe("netpod", func() {
 				Interfaces: []nmstate.Interface{
 					// Primary network
 					{
-						Name:       "k6t-eth0",
+						Name:       defaultPodBridgeName,
 						TypeName:   nmstate.TypeBridge,
 						State:      nmstate.IfaceStateUp,
-						MacAddress: "02:00:00:00:00:00",
+						MacAddress: defaultPodBridgeMACAddress,
 						MTU:        1500,
 						IPv4:       nmstate.IP{Enabled: pointer.P(false)},
 						IPv6:       nmstate.IP{Enabled: pointer.P(false)},
@@ -1740,25 +1764,25 @@ var _ = Describe("netpod", func() {
 						Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 					},
 					{
-						Name:       "tap0",
+						Name:       defaultTapDeviceName,
 						TypeName:   nmstate.TypeTap,
 						State:      nmstate.IfaceStateUp,
 						MTU:        1500,
-						Controller: "k6t-eth0",
+						Controller: defaultPodBridgeName,
 						Tap:        &nmstate.TapDevice{Queues: 0, UID: 0, GID: 0},
 						Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 					},
 					// Secondary network.
 					{
-						Name:     "k6t-7087ef4cd1f",
+						Name:     testNet1BridgeName,
 						TypeName: nmstate.TypeBridge,
 						State:    nmstate.IfaceStateUp,
 						Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: testNet1},
 					},
 					{
 						Name:        "7087ef4cd1f-nic",
-						CopyMacFrom: "k6t-7087ef4cd1f",
-						Controller:  "k6t-7087ef4cd1f",
+						CopyMacFrom: testNet1BridgeName,
+						Controller:  testNet1BridgeName,
 						State:       nmstate.IfaceStateUp,
 						IPv4:        ipDisabled,
 						IPv6:        ipDisabled,
@@ -1766,42 +1790,42 @@ var _ = Describe("netpod", func() {
 						Metadata:    &nmstate.IfaceMetadata{Pid: 0, NetworkName: testNet1},
 					},
 					{
-						Name:       "tap7087ef4cd1f",
+						Name:       testNet1TapName,
 						TypeName:   nmstate.TypeTap,
 						State:      nmstate.IfaceStateUp,
 						MTU:        1500,
-						Controller: "k6t-7087ef4cd1f",
+						Controller: testNet1BridgeName,
 						Tap:        &nmstate.TapDevice{Queues: 0, UID: 0, GID: 0},
 						Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: testNet1},
 					},
 					{
-						Name:       "pod7087ef4cd1f",
+						Name:       testNet1PodIfaceName,
 						TypeName:   nmstate.TypeDummy,
-						MacAddress: "22:34:56:78:90:ab",
+						MacAddress: testNet1PodIfaceMACAddress,
 						MTU:        1500,
 						Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: testNet1},
 					},
 					// Third network.
 					{
-						Name:     "k6t-bc6cc93fa1e",
+						Name:     testNet2BridgeName,
 						TypeName: nmstate.TypeBridge,
 						State:    nmstate.IfaceStateAbsent,
 						Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: testNet2},
 					},
 					{
-						Name:       "tapbc6cc93fa1e",
+						Name:       testNet2TapName,
 						TypeName:   nmstate.TypeTap,
 						State:      nmstate.IfaceStateAbsent,
 						MTU:        1500,
-						Controller: "k6t-bc6cc93fa1e",
+						Controller: testNet2BridgeName,
 						Tap:        &nmstate.TapDevice{Queues: 0, UID: 0, GID: 0},
 						Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: testNet2},
 					},
 					{
-						Name:       "podbc6cc93fa1e",
+						Name:       testNet2PodIfaceName,
 						TypeName:   nmstate.TypeDummy,
 						State:      nmstate.IfaceStateAbsent,
-						MacAddress: "32:34:56:78:90:ab",
+						MacAddress: testNet2PodIfaceMACAddress,
 						MTU:        1500,
 						Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: testNet2},
 					},
@@ -1839,11 +1863,11 @@ var _ = Describe("netpod", func() {
 		})
 
 		It("setup succeeds", func() {
-			const podIfaceOrignalMAC = "12:34:56:78:90:ab"
+			const podIfaceOrignalMAC = defaultPodIfaceOriginalMAC
 
 			nmstatestub := nmstateStub{status: nmstate.Status{
 				Interfaces: []nmstate.Interface{{
-					Name:       "eth0",
+					Name:       defaultPrimaryPodIfaceName,
 					Index:      0,
 					TypeName:   nmstate.TypeVETH,
 					State:      nmstate.IfaceStateUp,
@@ -1882,33 +1906,33 @@ var _ = Describe("netpod", func() {
 				nmstate.Spec{
 					Interfaces: []nmstate.Interface{
 						{
-							Name:     "k6t-eth0",
+							Name:     defaultPodBridgeName,
 							TypeName: nmstate.TypeBridge,
 							State:    nmstate.IfaceStateUp,
 							Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 						},
 						{
-							Name:        "eth0-nic",
+							Name:        defaultPodIfaceBridgeNICName,
 							Index:       0,
 							State:       nmstate.IfaceStateUp,
-							CopyMacFrom: "k6t-eth0",
-							Controller:  "k6t-eth0",
+							CopyMacFrom: defaultPodBridgeName,
+							Controller:  defaultPodBridgeName,
 							IPv4:        ipDisabled,
 							IPv6:        ipDisabled,
 							LinuxStack:  nmstate.LinuxIfaceStack{PortLearning: pointer.P(false)},
 							Metadata:    &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 						},
 						{
-							Name:       "tap0",
+							Name:       defaultTapDeviceName,
 							TypeName:   nmstate.TypeTap,
 							State:      nmstate.IfaceStateUp,
 							MTU:        1500,
-							Controller: "k6t-eth0",
+							Controller: defaultPodBridgeName,
 							Tap:        &nmstate.TapDevice{Queues: 0, UID: 0, GID: 0},
 							Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 						},
 						{
-							Name:       "eth0",
+							Name:       defaultPrimaryPodIfaceName,
 							TypeName:   nmstate.TypeDummy,
 							MacAddress: podIfaceOrignalMAC,
 							MTU:        1500,

--- a/pkg/network/setup/netstat_test.go
+++ b/pkg/network/setup/netstat_test.go
@@ -35,6 +35,8 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )
 
+const primaryIfaceName = "eth0"
+
 var _ = Describe("netstat", func() {
 	var setup testSetup
 
@@ -338,7 +340,7 @@ var _ = Describe("netstat", func() {
 			Expect(setup.Vmi.Status.Interfaces).To(Equal([]v1.VirtualMachineInstanceNetworkInterface{
 				{
 					Name:          primaryNetworkName,
-					InterfaceName: "eth0",
+					InterfaceName: primaryIfaceName,
 					IP:            primaryPodIPv4,
 					IPs:           []string{primaryPodIPv4, primaryPodIPv6},
 					MAC:           primaryMAC,
@@ -622,7 +624,7 @@ var _ = Describe("netstat", func() {
 		Expect(setup.Vmi.Status.Interfaces).To(Equal([]v1.VirtualMachineInstanceNetworkInterface{
 			{
 				Name:          primaryNetworkName,
-				InterfaceName: "eth0",
+				InterfaceName: primaryIfaceName,
 				IP:            primaryPodIPv4,
 				IPs:           []string{primaryPodIPv4, primaryGaIPv6},
 				MAC:           primaryMAC,
@@ -668,7 +670,7 @@ var _ = Describe("netstat", func() {
 		Expect(setup.Vmi.Status.Interfaces).To(Equal([]v1.VirtualMachineInstanceNetworkInterface{
 			{
 				Name:          secondaryNetworkName,
-				InterfaceName: "eth0",
+				InterfaceName: primaryIfaceName,
 				IP:            secondaryGaIPv4,
 				IPs:           []string{secondaryGaIPv4, secondaryGaIPv4LLA, secondaryGaIPv6, secondaryGaLLAIPv6},
 				MAC:           secondaryMAC,

--- a/pkg/network/vmispec/defaults_test.go
+++ b/pkg/network/vmispec/defaults_test.go
@@ -30,6 +30,7 @@ import (
 )
 
 var _ = Describe("Default pod network", func() {
+	const mynetName = "mynet"
 	DescribeTable("It should not automatically add the pod network to the VMI", func(vmi *v1.VirtualMachineInstance) {
 		origSpec := vmi.Spec.DeepCopy()
 
@@ -40,8 +41,8 @@ var _ = Describe("Default pod network", func() {
 		Entry("when AutoattachPodInterface is false", libvmi.New(libvmi.WithAutoAttachPodInterface(false))),
 		Entry("when at least one network and one interface are specified",
 			libvmi.New(
-				libvmi.WithInterface(v1.Interface{Name: "mynet"}),
-				libvmi.WithNetwork(&v1.Network{Name: "mynet"}),
+				libvmi.WithInterface(v1.Interface{Name: mynetName}),
+				libvmi.WithNetwork(&v1.Network{Name: mynetName}),
 			),
 		),
 	)

--- a/pkg/network/vmispec/network_test.go
+++ b/pkg/network/vmispec/network_test.go
@@ -29,7 +29,10 @@ import (
 	"kubevirt.io/kubevirt/pkg/network/vmispec"
 )
 
+const draClaimName = "claim1"
+
 var _ = Describe("Network", func() {
+	const vfRequest = "vf"
 	podNetwork := createPodNetwork("default")
 	draNetwork := *libvmi.DRANetwork("dra-net", "sriov", "vf1")
 	multusDefaultNetwork := createMultusDefaultNetwork("network0", "default/nad0")
@@ -113,8 +116,8 @@ var _ = Describe("Network", func() {
 						Name: "dra-1",
 						NetworkSource: v1.NetworkSource{
 							ResourceClaim: &v1.ClaimRequest{
-								ClaimName:   "claim1",
-								RequestName: "vf",
+								ClaimName:   draClaimName,
+								RequestName: vfRequest,
 							},
 						},
 					},
@@ -122,8 +125,8 @@ var _ = Describe("Network", func() {
 						Name: "dra-dup",
 						NetworkSource: v1.NetworkSource{
 							ResourceClaim: &v1.ClaimRequest{
-								ClaimName:   "claim1",
-								RequestName: "vf",
+								ClaimName:   draClaimName,
+								RequestName: vfRequest,
 							},
 						},
 					},
@@ -155,7 +158,7 @@ var _ = Describe("Network", func() {
 						Name: "dra-net",
 						NetworkSource: v1.NetworkSource{
 							ResourceClaim: &v1.ClaimRequest{
-								ClaimName: "claim1",
+								ClaimName: draClaimName,
 							},
 						},
 					},

--- a/pkg/storage/oci/oci_test.go
+++ b/pkg/storage/oci/oci_test.go
@@ -40,6 +40,7 @@ import (
 var _ = Describe("OCI Builder", func() {
 	const (
 		architecture  = "amd64"
+		diskVolume    = "disk"
 		osName        = "linux"
 		schemaVersion = 2
 	)
@@ -110,7 +111,7 @@ var _ = Describe("OCI Builder", func() {
 	It("should set disk size annotation from file size", func() {
 		diskPath := createTestDisk()
 		builder := NewVMBuilder(emptyConfigJSON(), architecture, []DiskInfo{
-			{VolumeName: "disk", FilePath: diskPath},
+			{VolumeName: diskVolume, FilePath: diskPath},
 		})
 
 		Expect(builder.Prepare(context.Background())).To(Succeed())
@@ -128,14 +129,14 @@ var _ = Describe("OCI Builder", func() {
 		var manifest ocispec.Manifest
 		Expect(json.Unmarshal(files[blobPath(index.Manifests[0].Digest)], &manifest)).To(Succeed())
 		Expect(manifest.Layers).To(HaveLen(1))
-		Expect(manifest.Layers[0].Annotations).To(HaveKeyWithValue(annotationDiskName, "disk"))
+		Expect(manifest.Layers[0].Annotations).To(HaveKeyWithValue(annotationDiskName, diskVolume))
 		Expect(manifest.Layers[0].Annotations).To(HaveKeyWithValue(annotationDiskSize, expectedSize))
 	})
 
 	It("should default architecture to amd64 when empty", func() {
 		diskPath := createTestDisk()
 		builder := NewVMBuilder(emptyConfigJSON(), "", []DiskInfo{
-			{VolumeName: "disk", FilePath: diskPath},
+			{VolumeName: diskVolume, FilePath: diskPath},
 		})
 
 		Expect(builder.Prepare(context.Background())).To(Succeed())
@@ -245,7 +246,7 @@ var _ = Describe("OCI Builder", func() {
 	It("should return TotalTarSize matching actual TAR length", func() {
 		diskPath := createTestDisk()
 		builder := NewVMBuilder(emptyConfigJSON(), architecture, []DiskInfo{
-			{VolumeName: "disk", FilePath: diskPath},
+			{VolumeName: diskVolume, FilePath: diskPath},
 		})
 		Expect(builder.Prepare(context.Background())).To(Succeed())
 
@@ -296,7 +297,7 @@ var _ = Describe("OCI Builder", func() {
 	It("should fail WriteTar when context is canceled", func() {
 		diskPath := createTestDisk()
 		builder := NewVMBuilder(emptyConfigJSON(), architecture, []DiskInfo{
-			{VolumeName: "disk", FilePath: diskPath},
+			{VolumeName: diskVolume, FilePath: diskPath},
 		})
 		Expect(builder.Prepare(context.Background())).To(Succeed())
 
@@ -313,7 +314,7 @@ var _ = Describe("OCI Builder", func() {
 		cancel()
 
 		builder := NewVMBuilder(emptyConfigJSON(), architecture, []DiskInfo{
-			{VolumeName: "disk", FilePath: diskPath},
+			{VolumeName: diskVolume, FilePath: diskPath},
 		})
 		Expect(builder.Prepare(ctx)).To(MatchError(ContainSubstring("context canceled")))
 	})

--- a/pkg/storage/pod/annotations/generator_test.go
+++ b/pkg/storage/pod/annotations/generator_test.go
@@ -45,10 +45,16 @@ var _ = Describe("Annotations Generator", func() {
 		expectedPostHookBackupCommand = `["/usr/bin/virt-freezer", "--unfreeze", "--name", "testvmi", "--namespace", "testns"]`
 	)
 
+	const (
+		containerNameCompute = "compute"
+		skipTrue             = "true"
+		skipFalse            = "false"
+	)
+
 	expectedAnnotations := map[string]string{
-		"pre.hook.backup.velero.io/container":  "compute",
+		"pre.hook.backup.velero.io/container":  containerNameCompute,
 		"pre.hook.backup.velero.io/command":    expectedPreHookBackupCommand,
-		"post.hook.backup.velero.io/container": "compute",
+		"post.hook.backup.velero.io/container": containerNameCompute,
 		"post.hook.backup.velero.io/command":   expectedPostHookBackupCommand,
 		"pre.hook.backup.velero.io/timeout":    "60s",
 	}
@@ -72,7 +78,7 @@ var _ = Describe("Annotations Generator", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(annotations).To(BeEmpty())
 		},
-		Entry("with lowercase 'true'", "true"),
+		Entry("with lowercase 'true'", skipTrue),
 		Entry("with capitalized 'True'", "True"),
 		Entry("with uppercase 'TRUE'", "TRUE"),
 		Entry("with '1'", "1"),
@@ -92,7 +98,7 @@ var _ = Describe("Annotations Generator", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(annotations).To(Equal(expectedAnnotations))
 		},
-		Entry("with lowercase 'false'", "false"),
+		Entry("with lowercase 'false'", skipFalse),
 		Entry("with capitalized 'False'", "False"),
 		Entry("with uppercase 'FALSE'", "FALSE"),
 		Entry("with '0'", "0"),
@@ -105,7 +111,7 @@ var _ = Describe("Annotations Generator", func() {
 		vmi := libvmi.New(libvmi.WithNamespace(testNamespace), libvmi.WithName(vmiName))
 		kubeVirtCR := &v1.KubeVirt{}
 		kubeVirtCR.Annotations = map[string]string{
-			velero.SkipHooksAnnotation: "true",
+			velero.SkipHooksAnnotation: skipTrue,
 		}
 
 		generator := annotations.NewGenerator(&crProvider{cr: kubeVirtCR})
@@ -117,11 +123,11 @@ var _ = Describe("Annotations Generator", func() {
 	It("VMI annotation should take precedence over KubeVirt CR annotation", func() {
 		vmi := libvmi.New(libvmi.WithNamespace(testNamespace), libvmi.WithName(vmiName))
 		vmi.Annotations = map[string]string{
-			velero.SkipHooksAnnotation: "false",
+			velero.SkipHooksAnnotation: skipFalse,
 		}
 		kubeVirtCR := &v1.KubeVirt{}
 		kubeVirtCR.Annotations = map[string]string{
-			velero.SkipHooksAnnotation: "true",
+			velero.SkipHooksAnnotation: skipTrue,
 		}
 
 		generator := annotations.NewGenerator(&crProvider{cr: kubeVirtCR})

--- a/pkg/storage/reservation/pr_test.go
+++ b/pkg/storage/reservation/pr_test.go
@@ -32,6 +32,12 @@ import (
 	"kubevirt.io/kubevirt/pkg/storage/reservation"
 )
 
+const (
+	lun0DiskName = "lun0"
+	disk0Name    = "disk0"
+	lun1Name     = "lun1"
+)
+
 func newFakePVCStore(pvcs ...*k8sv1.PersistentVolumeClaim) cache.Store {
 	store := cache.NewStore(cache.MetaNamespaceKeyFunc)
 	for _, pvc := range pvcs {
@@ -82,13 +88,13 @@ var _ = Describe("PersistentReservation", func() {
 	Context("PersistentReservationPVCLabels", func() {
 		It("should return no labels when there are no PR disks", func() {
 			vmi := &v1.VirtualMachineInstance{
-				ObjectMeta: metav1.ObjectMeta{Namespace: "default"},
+				ObjectMeta: metav1.ObjectMeta{Namespace: k8sv1.NamespaceDefault},
 				Spec: v1.VirtualMachineInstanceSpec{
 					Domain: v1.DomainSpec{
 						Devices: v1.Devices{
 							Disks: []v1.Disk{
 								{
-									Name:       "disk0",
+									Name:       disk0Name,
 									DiskDevice: v1.DiskDevice{Disk: &v1.DiskTarget{Bus: v1.DiskBusVirtio}},
 								},
 							},
@@ -96,7 +102,7 @@ var _ = Describe("PersistentReservation", func() {
 					},
 					Volumes: []v1.Volume{
 						{
-							Name: "disk0",
+							Name: disk0Name,
 							VolumeSource: v1.VolumeSource{
 								PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{},
 							},
@@ -112,13 +118,13 @@ var _ = Describe("PersistentReservation", func() {
 
 		It("should return no labels when LUN has reservation disabled", func() {
 			vmi := &v1.VirtualMachineInstance{
-				ObjectMeta: metav1.ObjectMeta{Namespace: "default"},
+				ObjectMeta: metav1.ObjectMeta{Namespace: k8sv1.NamespaceDefault},
 				Spec: v1.VirtualMachineInstanceSpec{
 					Domain: v1.DomainSpec{
 						Devices: v1.Devices{
 							Disks: []v1.Disk{
 								{
-									Name:       "lun0",
+									Name:       lun0DiskName,
 									DiskDevice: v1.DiskDevice{LUN: &v1.LunTarget{Bus: v1.DiskBusSCSI, Reservation: false}},
 								},
 							},
@@ -126,7 +132,7 @@ var _ = Describe("PersistentReservation", func() {
 					},
 					Volumes: []v1.Volume{
 						{
-							Name: "lun0",
+							Name: lun0DiskName,
 							VolumeSource: v1.VolumeSource{
 								PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{},
 							},
@@ -141,8 +147,8 @@ var _ = Describe("PersistentReservation", func() {
 		})
 
 		It("should return a label with PVC UID as key for a single PR PVC", func() {
-			pvc := newPVC("default", "my-shared-pvc", "uid-1234")
-			vmi := newVMIWithPRPVC("default", "lun0", "my-shared-pvc")
+			pvc := newPVC(k8sv1.NamespaceDefault, "my-shared-pvc", "uid-1234")
+			vmi := newVMIWithPRPVC(k8sv1.NamespaceDefault, lun0DiskName, "my-shared-pvc")
 
 			labels, err := reservation.PersistentReservationPVCLabels(vmi, newFakePVCStore(pvc))
 			Expect(err).ToNot(HaveOccurred())
@@ -151,16 +157,16 @@ var _ = Describe("PersistentReservation", func() {
 		})
 
 		It("should handle DataVolume sources", func() {
-			pvc := newPVC("default", "my-dv", "uid-dv-1")
+			pvc := newPVC(k8sv1.NamespaceDefault, "my-dv", "uid-dv-1")
 
 			vmi := &v1.VirtualMachineInstance{
-				ObjectMeta: metav1.ObjectMeta{Namespace: "default"},
+				ObjectMeta: metav1.ObjectMeta{Namespace: k8sv1.NamespaceDefault},
 				Spec: v1.VirtualMachineInstanceSpec{
 					Domain: v1.DomainSpec{
 						Devices: v1.Devices{
 							Disks: []v1.Disk{
 								{
-									Name:       "lun0",
+									Name:       lun0DiskName,
 									DiskDevice: v1.DiskDevice{LUN: &v1.LunTarget{Bus: v1.DiskBusSCSI, Reservation: true}},
 								},
 							},
@@ -168,7 +174,7 @@ var _ = Describe("PersistentReservation", func() {
 					},
 					Volumes: []v1.Volume{
 						{
-							Name: "lun0",
+							Name: lun0DiskName,
 							VolumeSource: v1.VolumeSource{
 								DataVolume: &v1.DataVolumeSource{Name: "my-dv"},
 							},
@@ -184,21 +190,21 @@ var _ = Describe("PersistentReservation", func() {
 		})
 
 		It("should return labels for multiple PR PVCs", func() {
-			pvcA := newPVC("default", "pvc-a", "uid-a")
-			pvcB := newPVC("default", "pvc-b", "uid-b")
+			pvcA := newPVC(k8sv1.NamespaceDefault, "pvc-a", "uid-a")
+			pvcB := newPVC(k8sv1.NamespaceDefault, "pvc-b", "uid-b")
 
 			vmi := &v1.VirtualMachineInstance{
-				ObjectMeta: metav1.ObjectMeta{Namespace: "default"},
+				ObjectMeta: metav1.ObjectMeta{Namespace: k8sv1.NamespaceDefault},
 				Spec: v1.VirtualMachineInstanceSpec{
 					Domain: v1.DomainSpec{
 						Devices: v1.Devices{
 							Disks: []v1.Disk{
 								{
-									Name:       "lun0",
+									Name:       lun0DiskName,
 									DiskDevice: v1.DiskDevice{LUN: &v1.LunTarget{Bus: v1.DiskBusSCSI, Reservation: true}},
 								},
 								{
-									Name:       "lun1",
+									Name:       lun1Name,
 									DiskDevice: v1.DiskDevice{LUN: &v1.LunTarget{Bus: v1.DiskBusSCSI, Reservation: true}},
 								},
 							},
@@ -206,7 +212,7 @@ var _ = Describe("PersistentReservation", func() {
 					},
 					Volumes: []v1.Volume{
 						{
-							Name: "lun0",
+							Name: lun0DiskName,
 							VolumeSource: v1.VolumeSource{
 								PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
 									PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{ClaimName: "pvc-a"},
@@ -214,7 +220,7 @@ var _ = Describe("PersistentReservation", func() {
 							},
 						},
 						{
-							Name: "lun1",
+							Name: lun1Name,
 							VolumeSource: v1.VolumeSource{
 								PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
 									PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{ClaimName: "pvc-b"},
@@ -234,13 +240,13 @@ var _ = Describe("PersistentReservation", func() {
 
 		It("should return no labels when disk has no matching volume", func() {
 			vmi := &v1.VirtualMachineInstance{
-				ObjectMeta: metav1.ObjectMeta{Namespace: "default"},
+				ObjectMeta: metav1.ObjectMeta{Namespace: k8sv1.NamespaceDefault},
 				Spec: v1.VirtualMachineInstanceSpec{
 					Domain: v1.DomainSpec{
 						Devices: v1.Devices{
 							Disks: []v1.Disk{
 								{
-									Name:       "lun0",
+									Name:       lun0DiskName,
 									DiskDevice: v1.DiskDevice{LUN: &v1.LunTarget{Bus: v1.DiskBusSCSI, Reservation: true}},
 								},
 							},
@@ -263,7 +269,7 @@ var _ = Describe("PersistentReservation", func() {
 						Devices: v1.Devices{
 							Disks: []v1.Disk{
 								{
-									Name:       "lun0",
+									Name:       lun0DiskName,
 									DiskDevice: v1.DiskDevice{LUN: &v1.LunTarget{Bus: v1.DiskBusSCSI, Reservation: true}},
 								},
 							},
@@ -271,7 +277,7 @@ var _ = Describe("PersistentReservation", func() {
 					},
 					Volumes: []v1.Volume{
 						{
-							Name: "lun0",
+							Name: lun0DiskName,
 							VolumeSource: v1.VolumeSource{
 								ContainerDisk: &v1.ContainerDiskSource{Image: "test"},
 							},

--- a/pkg/virt-handler/ksm/ksm.go
+++ b/pkg/virt-handler/ksm/ksm.go
@@ -56,6 +56,8 @@ const (
 	ksmLoopIntervalMinutes = 3 * time.Minute
 	requiredMemInfoFields  = 2
 	ksmFilePermissions     = 0o600
+	trueString             = "true"
+	falseString            = "false"
 )
 
 var (
@@ -248,7 +250,7 @@ func (k *Handler) disableKSM() {
 		return
 	}
 
-	if value, found := node.GetAnnotations()[v1.KSMHandlerManagedAnnotation]; found && value == "true" {
+	if value, found := node.GetAnnotations()[v1.KSMHandlerManagedAnnotation]; found && value == trueString {
 		if err := os.WriteFile(ksmRunPath, []byte("0\n"), ksmFilePermissions); err != nil {
 			log.DefaultLogger().Errorf("Unable to write ksm: %s", err.Error())
 		}

--- a/pkg/virt-handler/ksm/ksm_test.go
+++ b/pkg/virt-handler/ksm/ksm_test.go
@@ -50,7 +50,9 @@ const (
 	memAvailablePressure   = 5183928
 	memAvailableNoPressure = 39207804
 
-	testNodeName = "test-node"
+	testLabelKey     = "test_label"
+	testNodeName     = "test-node"
+	testKubevirtName = "kubevirt"
 )
 
 var _ = Describe("KSM", func() {
@@ -160,24 +162,24 @@ var _ = Describe("KSM", func() {
 		alternativeLabelSelector := &metav1.LabelSelector{
 			MatchExpressions: []metav1.LabelSelectorRequirement{
 				{
-					Key:      "test_label",
+					Key:      testLabelKey,
 					Operator: metav1.LabelSelectorOpIn,
-					Values:   []string{"true"},
+					Values:   []string{trueString},
 				},
 			},
 		}
 		BeforeEach(func() {
 			kv = &kubevirtv1.KubeVirt{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "kubevirt",
-					Namespace: "kubevirt",
+					Name:      testKubevirtName,
+					Namespace: testKubevirtName,
 				},
 				Spec: kubevirtv1.KubeVirtSpec{
 					Configuration: kubevirtv1.KubeVirtConfiguration{
 						KSMConfiguration: &kubevirtv1.KSMConfiguration{
 							NodeLabelSelector: &metav1.LabelSelector{
 								MatchLabels: map[string]string{
-									"test_label": "true",
+									testLabelKey: trueString,
 								},
 							},
 						},
@@ -205,9 +207,9 @@ var _ = Describe("KSM", func() {
 			Expect(node.Labels).To(HaveKeyWithValue(kubevirtv1.KSMEnabledLabel, expectedLabelValue))
 		},
 			Entry("should add KSM label if the node labels match ksmConfiguration.nodeLabelSelector",
-				map[string]string{"test_label": "true"}, "true"),
+				map[string]string{testLabelKey: trueString}, trueString),
 			Entry("should not add KSM label if the node labels match ksmConfiguration.nodeLabelSelector",
-				map[string]string{"no_macthing_label": "true"}, "false"),
+				map[string]string{"no_macthing_label": trueString}, falseString),
 		)
 
 		DescribeTable("with memory pressure, should", func(
@@ -248,32 +250,32 @@ var _ = Describe("KSM", func() {
 			Expect(string(bytes.TrimSpace(running))).To(Equal(expectedKsmValue))
 		},
 			Entry("enable ksm if the node labels match ksmConfiguration.nodeLabelSelector",
-				"0\n", nil, map[string]string{"test_label": "true"}, make(map[string]string),
-				HaveKeyWithValue(kubevirtv1.KSMEnabledLabel, "true"),
-				HaveKeyWithValue(kubevirtv1.KSMHandlerManagedAnnotation, "true"),
+				"0\n", nil, map[string]string{testLabelKey: trueString}, make(map[string]string),
+				HaveKeyWithValue(kubevirtv1.KSMEnabledLabel, trueString),
+				HaveKeyWithValue(kubevirtv1.KSMHandlerManagedAnnotation, trueString),
 				"1",
 			),
 			Entry("disable ksm if the node labels does not match ksmConfiguration.nodeLabelSelector "+
 				"and the node has the KSMHandlerManagedAnnotation annotation",
-				"1\n", nil, map[string]string{"test_label": "false"},
-				map[string]string{kubevirtv1.KSMHandlerManagedAnnotation: "true"},
-				HaveKeyWithValue(kubevirtv1.KSMEnabledLabel, "false"),
-				HaveKeyWithValue(kubevirtv1.KSMHandlerManagedAnnotation, "false"),
+				"1\n", nil, map[string]string{testLabelKey: falseString},
+				map[string]string{kubevirtv1.KSMHandlerManagedAnnotation: trueString},
+				HaveKeyWithValue(kubevirtv1.KSMEnabledLabel, falseString),
+				HaveKeyWithValue(kubevirtv1.KSMHandlerManagedAnnotation, falseString),
 				"0",
 			),
 			Entry(", with alternative label selector, enable ksm if the node labels match "+
 				"ksmConfiguration.nodeLabelSelector",
-				"0\n", alternativeLabelSelector, map[string]string{"test_label": "true"}, make(map[string]string),
-				HaveKeyWithValue(kubevirtv1.KSMEnabledLabel, "true"),
-				HaveKeyWithValue(kubevirtv1.KSMHandlerManagedAnnotation, "true"),
+				"0\n", alternativeLabelSelector, map[string]string{testLabelKey: trueString}, make(map[string]string),
+				HaveKeyWithValue(kubevirtv1.KSMEnabledLabel, trueString),
+				HaveKeyWithValue(kubevirtv1.KSMHandlerManagedAnnotation, trueString),
 				"1",
 			),
 			Entry(", with alternative label selector, disable ksm if the node labels does not match "+
 				"ksmConfiguration.nodeLabelSelector and the node has the KSMHandlerManagedAnnotation annotation",
-				"1\n", alternativeLabelSelector, map[string]string{"test_label": "false"},
-				map[string]string{kubevirtv1.KSMHandlerManagedAnnotation: "true"},
-				HaveKeyWithValue(kubevirtv1.KSMEnabledLabel, "false"),
-				HaveKeyWithValue(kubevirtv1.KSMHandlerManagedAnnotation, "false"),
+				"1\n", alternativeLabelSelector, map[string]string{testLabelKey: falseString},
+				map[string]string{kubevirtv1.KSMHandlerManagedAnnotation: trueString},
+				HaveKeyWithValue(kubevirtv1.KSMEnabledLabel, falseString),
+				HaveKeyWithValue(kubevirtv1.KSMHandlerManagedAnnotation, falseString),
 				"0",
 			),
 		)
@@ -283,7 +285,7 @@ var _ = Describe("KSM", func() {
 			node := &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   testNodeName,
-					Labels: map[string]string{"test_label": "true"},
+					Labels: map[string]string{testLabelKey: trueString},
 				},
 			}
 			expected := ksmState{
@@ -342,7 +344,7 @@ var _ = Describe("KSM", func() {
 			node := &v1.Node{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:   testNodeName,
-					Labels: map[string]string{"test_label": "true"},
+					Labels: map[string]string{testLabelKey: trueString},
 					Annotations: map[string]string{
 						kubevirtv1.KSMPagesBoostOverride:      "123",
 						kubevirtv1.KSMPagesDecayOverride:      "45", // Out of bounds, should use default: -50

--- a/pkg/virt-launcher/metadata/metadata_test.go
+++ b/pkg/virt-launcher/metadata/metadata_test.go
@@ -28,6 +28,8 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-launcher/metadata"
 )
 
+const testFailureReason = "test123"
+
 var _ = Describe("Metadata", func() {
 	var metadataCache *metadata.Cache
 
@@ -42,8 +44,7 @@ var _ = Describe("Metadata", func() {
 	})
 
 	It("Store and load data", func() {
-		const test123 = "test123"
-		origData := api.MigrationMetadata{FailureReason: test123}
+		origData := api.MigrationMetadata{FailureReason: testFailureReason}
 
 		metadataCache.Migration.Store(origData)
 
@@ -53,22 +54,18 @@ var _ = Describe("Metadata", func() {
 	})
 
 	It("Mutate uninitialized data in a safe block", func() {
-		const test123 = "test123"
-
 		metadataCache.Migration.WithSafeBlock(func(m *api.MigrationMetadata, initialized bool) {
 			Expect(initialized).To(BeFalse())
 			Expect(*m).To(Equal(api.MigrationMetadata{}))
 
-			m.FailureReason = test123
+			m.FailureReason = testFailureReason
 		})
 		newData, exists := metadataCache.Migration.Load()
 		Expect(exists).To(BeTrue())
-		Expect(newData).To(Equal(api.MigrationMetadata{FailureReason: test123}))
+		Expect(newData).To(Equal(api.MigrationMetadata{FailureReason: testFailureReason}))
 	})
 
 	It("Mutate existing data in a safe block", func() {
-		const test123 = "test123"
-
 		origData := api.MigrationMetadata{FailureReason: "origin-data"}
 		metadataCache.Migration.Store(origData)
 
@@ -76,29 +73,27 @@ var _ = Describe("Metadata", func() {
 			Expect(initialized).To(BeTrue())
 			Expect(*m).To(Equal(origData))
 
-			m.FailureReason = test123
+			m.FailureReason = testFailureReason
 		})
 		newData, exists := metadataCache.Migration.Load()
 		Expect(exists).To(BeTrue())
-		Expect(newData).To(Equal(api.MigrationMetadata{FailureReason: test123}))
+		Expect(newData).To(Equal(api.MigrationMetadata{FailureReason: testFailureReason}))
 	})
 
 	It("Notify and listen when cache data store", func() {
-		const test123 = "test123"
-		metadataCache.Migration.Store(api.MigrationMetadata{FailureReason: test123})
+		metadataCache.Migration.Store(api.MigrationMetadata{FailureReason: testFailureReason})
 
 		Expect(metadataCache.Listen()).Should(Receive())
 	})
 
 	It("Do not notify when cache data set", func() {
-		const test123 = "test123"
-		metadataCache.Migration.Set(api.MigrationMetadata{FailureReason: test123})
+		metadataCache.Migration.Set(api.MigrationMetadata{FailureReason: testFailureReason})
 
 		Expect(metadataCache.Listen()).ShouldNot(Receive())
 	})
 
 	It("Reset notification signal", func() {
-		metadataCache.Migration.Store(api.MigrationMetadata{FailureReason: "test123"})
+		metadataCache.Migration.Store(api.MigrationMetadata{FailureReason: testFailureReason})
 
 		metadataCache.ResetNotification()
 
@@ -106,7 +101,7 @@ var _ = Describe("Metadata", func() {
 	})
 
 	It("Notify multiple times and listen to a single cache data change", func() {
-		metadataCache.Migration.Store(api.MigrationMetadata{FailureReason: "test123"})
+		metadataCache.Migration.Store(api.MigrationMetadata{FailureReason: testFailureReason})
 		metadataCache.Migration.Store(api.MigrationMetadata{FailureReason: "test456"})
 		metadataCache.Migration.Store(api.MigrationMetadata{FailureReason: "test789"})
 
@@ -116,18 +111,17 @@ var _ = Describe("Metadata", func() {
 
 	It("Notify when the data is mutated in a safe block", func() {
 		metadataCache.Migration.WithSafeBlock(func(m *api.MigrationMetadata, initialized bool) {
-			m.FailureReason = "test123"
+			m.FailureReason = testFailureReason
 		})
 		Expect(metadataCache.Listen()).Should(Receive())
 	})
 
 	It("Do not notify when the data is not mutated in a safe block", func() {
-		const test123 = "test123"
-		metadataCache.Migration.Store(api.MigrationMetadata{FailureReason: test123})
+		metadataCache.Migration.Store(api.MigrationMetadata{FailureReason: testFailureReason})
 		Expect(metadataCache.Listen()).Should(Receive())
 
 		metadataCache.Migration.WithSafeBlock(func(m *api.MigrationMetadata, initialized bool) {
-			m.FailureReason = test123
+			m.FailureReason = testFailureReason
 		})
 
 		Expect(metadataCache.Listen()).ShouldNot(Receive())

--- a/pkg/virt-launcher/virtwrap/access-credentials/access_credentials_test.go
+++ b/pkg/virt-launcher/virtwrap/access-credentials/access_credentials_test.go
@@ -56,6 +56,7 @@ import (
 )
 
 var _ = Describe("AccessCredentials", func() {
+	const injectedSSHKey = "ssh some injected key"
 	var mockLibvirt *testing.Libvirt
 	var ctrl *gomock.Controller
 	var manager *AccessCredentialManager
@@ -121,7 +122,7 @@ var _ = Describe("AccessCredentials", func() {
 		const domName = "some-domain"
 		const user = "someowner"
 
-		authorizedKeys := []string{"ssh some injected key"}
+		authorizedKeys := []string{injectedSSHKey}
 
 		mockLibvirt.ConnectionEXPECT().LookupDomainByName(domName).Return(mockLibvirt.VirtDomain, nil).Times(1)
 		mockLibvirt.DomainEXPECT().AuthorizedSSHKeysSet(user, authorizedKeys, gomock.Any()).Return(nil).Times(1)
@@ -137,7 +138,7 @@ var _ = Describe("AccessCredentials", func() {
 		const user = "someowner"
 		const filePath = "/home/someowner/.ssh"
 
-		authorizedKeys := []string{"ssh some injected key"}
+		authorizedKeys := []string{injectedSSHKey}
 
 		mockLibvirt.ConnectionEXPECT().LookupDomainByName(domName).Return(mockLibvirt.VirtDomain, nil).Times(1)
 		// The AuthorizedSSHKeysSet method fails so a backward compatible code will be used.
@@ -219,7 +220,7 @@ var _ = Describe("AccessCredentials", func() {
 		const domName = "some-domain"
 		const user = "someowner"
 
-		authorizedKeys := []string{"ssh some injected key"}
+		authorizedKeys := []string{injectedSSHKey}
 
 		mockLibvirt.ConnectionEXPECT().LookupDomainByName(domName).Return(mockLibvirt.VirtDomain, nil).Times(1)
 		// The AuthorizedSSHKeysSet method fails so a backward compatible code will be used.

--- a/pkg/virt-launcher/virtwrap/agent-poller/agent_parser_test.go
+++ b/pkg/virt-launcher/virtwrap/agent-poller/agent_parser_test.go
@@ -27,10 +27,12 @@ import (
 )
 
 var _ = Describe("Qemu agent poller", func() {
+	const frozenStatus = "frozen"
+	const version41 = "4.1"
 	Context("receiving a reply from the agent", func() {
 		It("should parse FSFreezeStatus", func() {
 			jsonInput := `{"return":"frozen"}`
-			expectedFSFreezeStatus := api.FSFreeze{Status: "frozen"}
+			expectedFSFreezeStatus := api.FSFreeze{Status: frozenStatus}
 			Expect(ParseFSFreezeStatus(jsonInput)).To(Equal(expectedFSFreezeStatus))
 		})
 
@@ -53,7 +55,7 @@ var _ = Describe("Qemu agent poller", func() {
                 }
             }`
 
-			expectedAgent := AgentInfo{Version: "4.1"}
+			expectedAgent := AgentInfo{Version: version41}
 			Expect(parseAgent(jsonInput)).To(Equal(expectedAgent))
 		})
 

--- a/pkg/virt-launcher/virtwrap/agent-poller/agent_poller_test.go
+++ b/pkg/virt-launcher/virtwrap/agent-poller/agent_poller_test.go
@@ -33,6 +33,9 @@ import (
 )
 
 var _ = Describe("Qemu agent poller", func() {
+	const frozenStatus = "frozen"
+	const version100 = "1.0.0"
+	const version41 = "4.1"
 	var fakeInterfaces []api.InterfaceStatus
 	var fakeFSFreezeStatus api.FSFreeze
 	var fakeInfo api.GuestOSInfo
@@ -47,14 +50,14 @@ var _ = Describe("Qemu agent poller", func() {
 			},
 		}
 		fakeFSFreezeStatus = api.FSFreeze{
-			Status: "frozen",
+			Status: frozenStatus,
 		}
 		fakeInfo = api.GuestOSInfo{
 			Name:          "TestGuestOSName",
 			KernelRelease: "1.1.0-Generic",
-			Version:       "1.0.0",
+			Version:       version100,
 			PrettyName:    "TestGuestOSName 1.0.0",
-			VersionId:     "1.0.0",
+			VersionId:     version100,
 			KernelVersion: "1.1.0",
 			Machine:       "x86_64",
 			Id:            "testguestos",
@@ -107,7 +110,7 @@ var _ = Describe("Qemu agent poller", func() {
 
 	Context("with AsyncAgentStore", func() {
 		It("should store and load the data", func() {
-			agentVersion := AgentInfo{Version: "4.1"}
+			agentVersion := AgentInfo{Version: version41}
 			agentStore.Store(GetAgent, agentVersion)
 			agent := agentStore.GetGA()
 

--- a/pkg/virt-launcher/virtwrap/converter/compute/balloon.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/balloon.go
@@ -25,6 +25,11 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )
 
+const (
+	modelNone    = "none"
+	iommuEnabled = "on"
+)
+
 type BalloonDomainConfigurator struct {
 	useLaunchSecuritySEV  bool
 	useLaunchSecurityPV   bool
@@ -50,7 +55,7 @@ func (b BalloonDomainConfigurator) Configure(vmi *v1.VirtualMachineInstance, dom
 	domain.Spec.Devices.Ballooning = newBalloon
 
 	if vmi.Spec.Domain.Devices.AutoattachMemBalloon != nil && !*vmi.Spec.Domain.Devices.AutoattachMemBalloon {
-		newBalloon.Model = "none"
+		newBalloon.Model = modelNone
 		return nil
 	}
 
@@ -62,7 +67,7 @@ func (b BalloonDomainConfigurator) Configure(vmi *v1.VirtualMachineInstance, dom
 
 	if b.useLaunchSecuritySEV || b.useLaunchSecurityPV {
 		newBalloon.Driver = &api.MemBalloonDriver{
-			IOMMU: "on",
+			IOMMU: iommuEnabled,
 		}
 	}
 

--- a/pkg/virt-launcher/virtwrap/converter/compute/balloon_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/balloon_test.go
@@ -28,6 +28,8 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter/compute"
 )
 
+const balloonModelNone = "none"
+
 var _ = Describe("Balloon Domain Configurator", func() {
 	const (
 		useSEV = true
@@ -50,17 +52,17 @@ var _ = Describe("Balloon Domain Configurator", func() {
 
 		expectedDomain := newDomainWithBallooning(
 			api.MemBalloon{
-				Model:             "virtio-non-transitional",
+				Model:             virtioNonTransitional,
 				Driver:            expectedDriver,
-				FreePageReporting: "off",
+				FreePageReporting: stateOff,
 			},
 		)
 		Expect(domain).To(Equal(expectedDomain))
 	},
 		Entry("neither SEV nor PV", !useSEV, !usePV, nil),
-		Entry("SEV enabled", useSEV, !usePV, &api.MemBalloonDriver{IOMMU: "on"}),
-		Entry("PV enabled", !useSEV, usePV, &api.MemBalloonDriver{IOMMU: "on"}),
-		Entry("Both SEV and PV enabled", useSEV, usePV, &api.MemBalloonDriver{IOMMU: "on"}),
+		Entry("SEV enabled", useSEV, !usePV, &api.MemBalloonDriver{IOMMU: stateOn}),
+		Entry("PV enabled", !useSEV, usePV, &api.MemBalloonDriver{IOMMU: stateOn}),
+		Entry("Both SEV and PV enabled", useSEV, usePV, &api.MemBalloonDriver{IOMMU: stateOn}),
 	)
 
 	DescribeTable("free page reporting", func(enabled bool, expected string) {
@@ -83,8 +85,8 @@ var _ = Describe("Balloon Domain Configurator", func() {
 		})
 		Expect(domain).To(Equal(expectedDomain))
 	},
-		Entry("enabled", true, "on"),
-		Entry("disabled", false, "off"),
+		Entry("enabled", true, stateOn),
+		Entry("disabled", false, stateOff),
 	)
 
 	DescribeTable("memballoon stats period", func(period uint, expectedStats *api.Stats) {
@@ -102,8 +104,8 @@ var _ = Describe("Balloon Domain Configurator", func() {
 		Expect(configurator.Configure(vmi, &domain)).To(Succeed())
 
 		expectedDomain := newDomainWithBallooning(api.MemBalloon{
-			Model:             "virtio-non-transitional",
-			FreePageReporting: "off",
+			Model:             virtioNonTransitional,
+			FreePageReporting: stateOff,
 			Stats:             expectedStats,
 		})
 		Expect(domain).To(Equal(expectedDomain))
@@ -128,7 +130,7 @@ var _ = Describe("Balloon Domain Configurator", func() {
 
 		expectedDomain := newDomainWithBallooning(
 			api.MemBalloon{
-				Model: "none",
+				Model: balloonModelNone,
 			},
 		)
 		Expect(domain).To(Equal(expectedDomain))

--- a/pkg/virt-launcher/virtwrap/converter/compute/channels.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/channels.go
@@ -26,6 +26,11 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )
 
+const (
+	socketTypeUnix = "unix"
+	socketModeBind = "bind"
+)
+
 type ChannelsDomainConfigurator struct{}
 
 func (c ChannelsDomainConfigurator) Configure(vmi *v1.VirtualMachineInstance, domain *api.Domain) error {
@@ -40,7 +45,7 @@ func (c ChannelsDomainConfigurator) Configure(vmi *v1.VirtualMachineInstance, do
 
 func newGuestAgentChannel() api.Channel {
 	return api.Channel{
-		Type:   "unix",
+		Type:   socketTypeUnix,
 		Source: nil, // let libvirt decide which path to use
 		Target: &api.ChannelTarget{
 			Name: "org.qemu.guest_agent.0",
@@ -51,9 +56,9 @@ func newGuestAgentChannel() api.Channel {
 
 func newDownwardMetricsChannel() api.Channel {
 	return api.Channel{
-		Type: "unix",
+		Type: socketTypeUnix,
 		Source: &api.ChannelSource{
-			Mode: "bind",
+			Mode: socketModeBind,
 			Path: downwardmetrics.DownwardMetricsChannelSocket,
 		},
 		Target: &api.ChannelTarget{

--- a/pkg/virt-launcher/virtwrap/converter/compute/channels_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/channels_test.go
@@ -31,6 +31,11 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter/compute"
 )
 
+const (
+	channelTypeUnix       = "unix"
+	channelGuestAgentName = "org.qemu.guest_agent.0"
+)
+
 var _ = Describe("Channels Domain Configurator", func() {
 	It("Should always configure guest-agent channel", func() {
 		vmi := libvmi.New()
@@ -43,10 +48,10 @@ var _ = Describe("Channels Domain Configurator", func() {
 				Devices: api.Devices{
 					Channels: []api.Channel{
 						{
-							Type:   "unix",
+							Type:   channelTypeUnix,
 							Source: nil,
 							Target: &api.ChannelTarget{
-								Name: "org.qemu.guest_agent.0",
+								Name: channelGuestAgentName,
 								Type: v1.VirtIO,
 							},
 						},
@@ -68,17 +73,17 @@ var _ = Describe("Channels Domain Configurator", func() {
 				Devices: api.Devices{
 					Channels: []api.Channel{
 						{
-							Type:   "unix",
+							Type:   channelTypeUnix,
 							Source: nil,
 							Target: &api.ChannelTarget{
-								Name: "org.qemu.guest_agent.0",
+								Name: channelGuestAgentName,
 								Type: v1.VirtIO,
 							},
 						},
 						{
-							Type: "unix",
+							Type: channelTypeUnix,
 							Source: &api.ChannelSource{
-								Mode: "bind",
+								Mode: modeBind,
 								Path: downwardmetrics.DownwardMetricsChannelSocket,
 							},
 							Target: &api.ChannelTarget{

--- a/pkg/virt-launcher/virtwrap/converter/compute/clock_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/clock_test.go
@@ -32,6 +32,18 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter/compute"
 )
 
+const (
+	clockOffsetUTC         = "utc"
+	clockTickPolicyCatchup = "catchup"
+	clockTickPolicyDelay   = "delay"
+	clockTimerNameKVM      = "kvmclock"
+	clockTimerNameHPET     = "hpet"
+	clockTimerNameHyperv   = "hypervclock"
+	clockTimerNameRTC      = "rtc"
+	clockTimerNamePIT      = "pit"
+	clockTimerNameTSC      = "tsc"
+)
+
 var _ = Describe("Clock Domain Configurator", func() {
 	It("should not set clock when clock is unspecified on the VMI", func() {
 		vmi := libvmi.New()
@@ -69,8 +81,8 @@ var _ = Describe("Clock Domain Configurator", func() {
 				},
 			})),
 			&api.Clock{
-				Offset:     "utc",
-				Adjustment: "reset",
+				Offset:     clockOffsetUTC,
+				Adjustment: watchdogActionReset,
 			},
 		),
 		Entry("utc offset with seconds adjustment",
@@ -82,7 +94,7 @@ var _ = Describe("Clock Domain Configurator", func() {
 				},
 			})),
 			&api.Clock{
-				Offset:     "utc",
+				Offset:     clockOffsetUTC,
 				Adjustment: "3600",
 			},
 		),
@@ -98,7 +110,7 @@ var _ = Describe("Clock Domain Configurator", func() {
 			})),
 			&api.Clock{
 				Timer: []api.Timer{
-					{Name: "rtc", Track: "guest", TickPolicy: "catchup", Present: "yes"},
+					{Name: clockTimerNameRTC, Track: "guest", TickPolicy: clockTickPolicyCatchup, Present: osYes},
 				},
 			},
 		),
@@ -113,7 +125,7 @@ var _ = Describe("Clock Domain Configurator", func() {
 			})),
 			&api.Clock{
 				Timer: []api.Timer{
-					{Name: "pit", TickPolicy: "delay", Present: "no"},
+					{Name: clockTimerNamePIT, TickPolicy: clockTickPolicyDelay, Present: "no"},
 				},
 			},
 		),
@@ -125,7 +137,7 @@ var _ = Describe("Clock Domain Configurator", func() {
 			})),
 			&api.Clock{
 				Timer: []api.Timer{
-					{Name: "kvmclock", Present: "yes"},
+					{Name: clockTimerNameKVM, Present: osYes},
 				},
 			},
 		),
@@ -140,7 +152,7 @@ var _ = Describe("Clock Domain Configurator", func() {
 			})),
 			&api.Clock{
 				Timer: []api.Timer{
-					{Name: "hpet", TickPolicy: "delay", Present: "yes"},
+					{Name: clockTimerNameHPET, TickPolicy: clockTickPolicyDelay, Present: osYes},
 				},
 			},
 		),
@@ -154,7 +166,7 @@ var _ = Describe("Clock Domain Configurator", func() {
 			})),
 			&api.Clock{
 				Timer: []api.Timer{
-					{Name: "hypervclock", Present: "yes"},
+					{Name: clockTimerNameHyperv, Present: osYes},
 				},
 			},
 		),
@@ -172,14 +184,14 @@ var _ = Describe("Clock Domain Configurator", func() {
 				},
 			})),
 			&api.Clock{
-				Offset:     "utc",
-				Adjustment: "reset",
+				Offset:     clockOffsetUTC,
+				Adjustment: watchdogActionReset,
 				Timer: []api.Timer{
-					{Name: "rtc", Track: "wall", TickPolicy: "delay", Present: "yes"},
-					{Name: "pit", TickPolicy: "catchup", Present: "yes"},
-					{Name: "kvmclock", Present: "yes"},
-					{Name: "hpet", TickPolicy: "catchup", Present: "yes"},
-					{Name: "hypervclock", Present: "yes"},
+					{Name: "rtc", Track: "wall", TickPolicy: clockTickPolicyDelay, Present: osYes},
+					{Name: "pit", TickPolicy: clockTickPolicyCatchup, Present: osYes},
+					{Name: clockTimerNameKVM, Present: osYes},
+					{Name: clockTimerNameHPET, TickPolicy: clockTickPolicyCatchup, Present: osYes},
+					{Name: clockTimerNameHyperv, Present: osYes},
 				},
 			},
 		),
@@ -190,7 +202,7 @@ var _ = Describe("Clock Domain Configurator", func() {
 			),
 			&api.Clock{
 				Timer: []api.Timer{
-					{Name: "tsc", Frequency: "1234567890"},
+					{Name: clockTimerNameTSC, Frequency: "1234567890"},
 				},
 			},
 		),
@@ -208,11 +220,11 @@ var _ = Describe("Clock Domain Configurator", func() {
 				libvmistatus.WithStatus(libvmistatus.New(withTSCFrequency(9999))),
 			),
 			&api.Clock{
-				Offset:     "utc",
-				Adjustment: "reset",
+				Offset:     clockOffsetUTC,
+				Adjustment: watchdogActionReset,
 				Timer: []api.Timer{
-					{Name: "kvmclock", Present: "yes"},
-					{Name: "tsc", Frequency: "9999"},
+					{Name: clockTimerNameKVM, Present: osYes},
+					{Name: clockTimerNameTSC, Frequency: "9999"},
 				},
 			},
 		),

--- a/pkg/virt-launcher/virtwrap/converter/compute/console_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/console_test.go
@@ -33,10 +33,15 @@ import (
 )
 
 var _ = Describe("Console Domain Configurator", func() {
-	const uid = "test-uid"
+	const (
+		uid               = "test-uid"
+		consoleTypeSerial = "serial"
+		consoleTypePTY    = "pty"
+		consoleTypeUnix   = "unix"
+	)
 	serialPort := uint(0)
 	socketPath := fmt.Sprintf("%s/%s/virt-serial%d", util.VirtPrivateDir, uid, serialPort)
-	serialType := "serial"
+	serialType := consoleTypeSerial
 
 	DescribeTable("should configure serial console when AutoattachSerialConsole is not disabled",
 		func(autoattach *bool) {
@@ -51,7 +56,7 @@ var _ = Describe("Console Domain Configurator", func() {
 					Devices: api.Devices{
 						Consoles: []api.Console{
 							{
-								Type: "pty",
+								Type: consoleTypePTY,
 								Target: &api.ConsoleTarget{
 									Type: &serialType,
 									Port: &serialPort,
@@ -60,9 +65,9 @@ var _ = Describe("Console Domain Configurator", func() {
 						},
 						Serials: []api.Serial{
 							{
-								Type: "unix",
+								Type: consoleTypeUnix,
 								Source: &api.SerialSource{
-									Mode: "bind",
+									Mode: modeBind,
 									Path: socketPath,
 								},
 								Target: &api.SerialTarget{
@@ -99,7 +104,7 @@ var _ = Describe("Console Domain Configurator", func() {
 				Devices: api.Devices{
 					Consoles: []api.Console{
 						{
-							Type: "pty",
+							Type: consoleTypePTY,
 							Target: &api.ConsoleTarget{
 								Type: &serialType,
 								Port: &serialPort,
@@ -108,9 +113,9 @@ var _ = Describe("Console Domain Configurator", func() {
 					},
 					Serials: []api.Serial{
 						{
-							Type: "unix",
+							Type: consoleTypeUnix,
 							Source: &api.SerialSource{
-								Mode: "bind",
+								Mode: modeBind,
 								Path: socketPath,
 							},
 							Target: &api.SerialTarget{
@@ -118,7 +123,7 @@ var _ = Describe("Console Domain Configurator", func() {
 							},
 							Log: &api.SerialLog{
 								File:   socketPath + "-log",
-								Append: "on",
+								Append: stateOn,
 							},
 						},
 					},

--- a/pkg/virt-launcher/virtwrap/converter/compute/controllers.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/controllers.go
@@ -33,6 +33,7 @@ import (
 
 const (
 	defaultIOThread = uint(1)
+	unitKiB         = "KiB"
 )
 
 type ControllersDomainConfigurator struct {
@@ -63,7 +64,7 @@ func (c ControllersDomainConfigurator) Configure(vmi *v1.VirtualMachineInstance,
 	var controllerDriver *api.ControllerDriver
 	if c.useLaunchSecuritySEV || c.useLaunchSecurityPV {
 		controllerDriver = &api.ControllerDriver{
-			IOMMU: "on",
+			IOMMU: iommuEnabled,
 		}
 	}
 
@@ -129,14 +130,14 @@ func ControllersWithVirtioSerialModel(model string) controllersOption {
 }
 
 func newUSBController(usbNeeded bool) api.Controller {
-	usbControllerModel := "none"
+	usbControllerModel := modelNone
 
 	if usbNeeded {
 		usbControllerModel = "qemu-xhci"
 	}
 
 	return api.Controller{
-		Type:  "usb",
+		Type:  busUSB,
 		Index: "0",
 		Model: usbControllerModel,
 	}
@@ -158,7 +159,7 @@ func newPCIControllerWithHole64Disabled() api.Controller {
 		Model: "pcie-root",
 		PCIHole64: &api.PCIHole64{
 			Value: 0,
-			Unit:  "KiB",
+			Unit:  unitKiB,
 		},
 	}
 }

--- a/pkg/virt-launcher/virtwrap/converter/compute/controllers_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/controllers_test.go
@@ -30,6 +30,15 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter/compute"
 )
 
+const (
+	controllerModelNone            = "none"
+	controllerTypeVirtioSerial     = "virtio-serial"
+	controllerModelQEMUXHCI        = "qemu-xhci"
+	controllerTypeSCSI             = "scsi"
+	controllerModelVirtioTestModel = "virtio-test-model"
+	controllerModelTestModel       = "test-model"
+)
+
 var _ = Describe("Controllers Domain Configurator", func() {
 	const (
 		usbNeeded                   = true
@@ -67,61 +76,61 @@ var _ = Describe("Controllers Domain Configurator", func() {
 			!usbNeeded,
 			0,
 			[]api.Controller{
-				{Type: "usb", Index: "0", Model: "none"},
-				{Type: "virtio-serial", Index: "0", Model: "virtio-test-model"},
+				{Type: usbRedirBusUSB, Index: "0", Model: controllerModelNone},
+				{Type: controllerTypeVirtioSerial, Index: "0", Model: controllerModelVirtioTestModel},
 			}),
 		Entry("when USB is needed and disk hotplug is disabled",
 			libvmi.New(withHotplugDisabled()),
 			usbNeeded,
 			0,
 			[]api.Controller{
-				{Type: "usb", Index: "0", Model: "qemu-xhci"},
-				{Type: "virtio-serial", Index: "0", Model: "virtio-test-model"},
+				{Type: usbRedirBusUSB, Index: "0", Model: controllerModelQEMUXHCI},
+				{Type: controllerTypeVirtioSerial, Index: "0", Model: controllerModelVirtioTestModel},
 			}),
 		Entry("when USB is NOT needed and disk hotplug is enabled",
 			libvmi.New(),
 			!usbNeeded,
 			0,
 			[]api.Controller{
-				{Type: "usb", Index: "0", Model: "none"},
-				{Type: "scsi", Index: "0", Model: "test-model"},
-				{Type: "virtio-serial", Index: "0", Model: "virtio-test-model"},
+				{Type: usbRedirBusUSB, Index: "0", Model: controllerModelNone},
+				{Type: controllerTypeSCSI, Index: "0", Model: controllerModelTestModel},
+				{Type: controllerTypeVirtioSerial, Index: "0", Model: controllerModelVirtioTestModel},
 			}),
 		Entry("when USB is needed and disk hotplug is enabled",
 			libvmi.New(),
 			usbNeeded,
 			0,
 			[]api.Controller{
-				{Type: "usb", Index: "0", Model: "qemu-xhci"},
-				{Type: "scsi", Index: "0", Model: "test-model"},
-				{Type: "virtio-serial", Index: "0", Model: "virtio-test-model"},
+				{Type: usbRedirBusUSB, Index: "0", Model: controllerModelQEMUXHCI},
+				{Type: controllerTypeSCSI, Index: "0", Model: controllerModelTestModel},
+				{Type: controllerTypeVirtioSerial, Index: "0", Model: controllerModelVirtioTestModel},
 			}),
 		Entry("when VMI has SCSI disk and disk hotplug is disabled",
 			libvmi.New(withHotplugDisabled(), libvmi.WithDisk("scsi-disk", v1.DiskBusSCSI)),
 			!usbNeeded,
 			0,
 			[]api.Controller{
-				{Type: "usb", Index: "0", Model: "none"},
-				{Type: "scsi", Index: "0", Model: "test-model"},
-				{Type: "virtio-serial", Index: "0", Model: "virtio-test-model"},
+				{Type: usbRedirBusUSB, Index: "0", Model: controllerModelNone},
+				{Type: controllerTypeSCSI, Index: "0", Model: controllerModelTestModel},
+				{Type: controllerTypeVirtioSerial, Index: "0", Model: controllerModelVirtioTestModel},
 			}),
 		Entry("when VMI has SCSI disk and disk hotplug is enabled",
 			libvmi.New(libvmi.WithDisk("scsi-disk", v1.DiskBusSCSI)),
 			!usbNeeded,
 			0,
 			[]api.Controller{
-				{Type: "usb", Index: "0", Model: "none"},
-				{Type: "scsi", Index: "0", Model: "test-model"},
-				{Type: "virtio-serial", Index: "0", Model: "virtio-test-model"},
+				{Type: usbRedirBusUSB, Index: "0", Model: controllerModelNone},
+				{Type: controllerTypeSCSI, Index: "0", Model: controllerModelTestModel},
+				{Type: controllerTypeVirtioSerial, Index: "0", Model: controllerModelVirtioTestModel},
 			}),
 		Entry("when VMI has SCSI disk and USB is needed",
 			libvmi.New(libvmi.WithDisk("scsi-disk", v1.DiskBusSCSI)),
 			usbNeeded,
 			0,
 			[]api.Controller{
-				{Type: "usb", Index: "0", Model: "qemu-xhci"},
-				{Type: "scsi", Index: "0", Model: "test-model"},
-				{Type: "virtio-serial", Index: "0", Model: "virtio-test-model"},
+				{Type: usbRedirBusUSB, Index: "0", Model: controllerModelQEMUXHCI},
+				{Type: controllerTypeSCSI, Index: "0", Model: controllerModelTestModel},
+				{Type: controllerTypeVirtioSerial, Index: "0", Model: controllerModelVirtioTestModel},
 			}),
 		Entry("when VMI has SCSI disk with dedicatedIOThread and Virtio disk, VMI has 4 shared IO threads",
 			libvmi.New(
@@ -131,11 +140,11 @@ var _ = Describe("Controllers Domain Configurator", func() {
 			!usbNeeded,
 			4,
 			[]api.Controller{
-				{Type: "usb", Index: "0", Model: "none"},
-				{Type: "scsi", Index: "0", Model: "test-model", Driver: &api.ControllerDriver{
+				{Type: usbRedirBusUSB, Index: "0", Model: controllerModelNone},
+				{Type: controllerTypeSCSI, Index: "0", Model: controllerModelTestModel, Driver: &api.ControllerDriver{
 					Queues: pointer.P[uint](1), IOThread: pointer.P[uint](2),
 				}},
-				{Type: "virtio-serial", Index: "0", Model: "virtio-test-model"},
+				{Type: controllerTypeVirtioSerial, Index: "0", Model: controllerModelVirtioTestModel},
 			}),
 		Entry("when VMI has SCSI disk with dedicatedIOThread and Virtio disks, VMI has 2 shared IO threads, should roll over controller thread",
 			libvmi.New(
@@ -146,11 +155,11 @@ var _ = Describe("Controllers Domain Configurator", func() {
 			!usbNeeded,
 			2,
 			[]api.Controller{
-				{Type: "usb", Index: "0", Model: "none"},
-				{Type: "scsi", Index: "0", Model: "test-model", Driver: &api.ControllerDriver{
+				{Type: usbRedirBusUSB, Index: "0", Model: controllerModelNone},
+				{Type: controllerTypeSCSI, Index: "0", Model: controllerModelTestModel, Driver: &api.ControllerDriver{
 					Queues: pointer.P[uint](1), IOThread: pointer.P[uint](1),
 				}},
-				{Type: "virtio-serial", Index: "0", Model: "virtio-test-model"},
+				{Type: controllerTypeVirtioSerial, Index: "0", Model: controllerModelVirtioTestModel},
 			}),
 		Entry("when VMI has multiple SCSI disks with dedicatedIOThread, VMI has 4 shared IO threads",
 			libvmi.New(
@@ -160,29 +169,29 @@ var _ = Describe("Controllers Domain Configurator", func() {
 			!usbNeeded,
 			4,
 			[]api.Controller{
-				{Type: "usb", Index: "0", Model: "none"},
-				{Type: "scsi", Index: "0", Model: "test-model", Driver: &api.ControllerDriver{
+				{Type: usbRedirBusUSB, Index: "0", Model: controllerModelNone},
+				{Type: controllerTypeSCSI, Index: "0", Model: controllerModelTestModel, Driver: &api.ControllerDriver{
 					Queues: pointer.P[uint](1), IOThread: pointer.P[uint](1),
 				}},
-				{Type: "virtio-serial", Index: "0", Model: "virtio-test-model"},
+				{Type: controllerTypeVirtioSerial, Index: "0", Model: controllerModelVirtioTestModel},
 			}),
 		Entry("when VMI has SCSI disk with dedicatedIOThread and VMI has no IOThreads",
 			libvmi.New(libvmi.WithDisk("scsi-disk", v1.DiskBusSCSI)),
 			!usbNeeded,
 			0,
 			[]api.Controller{
-				{Type: "usb", Index: "0", Model: "none"},
-				{Type: "scsi", Index: "0", Model: "test-model"},
-				{Type: "virtio-serial", Index: "0", Model: "virtio-test-model"},
+				{Type: usbRedirBusUSB, Index: "0", Model: controllerModelNone},
+				{Type: controllerTypeSCSI, Index: "0", Model: controllerModelTestModel},
+				{Type: controllerTypeVirtioSerial, Index: "0", Model: controllerModelVirtioTestModel},
 			}),
 		Entry("when VMI has SCSI disk without dedicatedIOThread and VMI has IOThreads",
 			libvmi.New(libvmi.WithDisk("scsi-disk", v1.DiskBusSCSI)),
 			!usbNeeded,
 			4,
 			[]api.Controller{
-				{Type: "usb", Index: "0", Model: "none"},
-				{Type: "scsi", Index: "0", Model: "test-model"},
-				{Type: "virtio-serial", Index: "0", Model: "virtio-test-model"},
+				{Type: usbRedirBusUSB, Index: "0", Model: controllerModelNone},
+				{Type: controllerTypeSCSI, Index: "0", Model: controllerModelTestModel},
+				{Type: controllerTypeVirtioSerial, Index: "0", Model: controllerModelVirtioTestModel},
 			}),
 	)
 
@@ -210,42 +219,42 @@ var _ = Describe("Controllers Domain Configurator", func() {
 			libvmi.New(),
 			!pciHole64DisablingSupported,
 			[]api.Controller{
-				{Type: "usb", Index: "0", Model: "none"},
-				{Type: "scsi", Index: "0", Model: "test-model"},
-				{Type: "virtio-serial", Index: "0", Model: "virtio-test-model"},
+				{Type: usbRedirBusUSB, Index: "0", Model: controllerModelNone},
+				{Type: controllerTypeSCSI, Index: "0", Model: controllerModelTestModel},
+				{Type: controllerTypeVirtioSerial, Index: "0", Model: controllerModelVirtioTestModel},
 			}),
 		Entry("when arch does not support PCIHole64 disabling, annotation set",
 			libvmi.New(libvmi.WithAnnotation(v1.DisablePCIHole64, "true")),
 			!pciHole64DisablingSupported,
 			[]api.Controller{
-				{Type: "usb", Index: "0", Model: "none"},
-				{Type: "scsi", Index: "0", Model: "test-model"},
-				{Type: "virtio-serial", Index: "0", Model: "virtio-test-model"},
+				{Type: usbRedirBusUSB, Index: "0", Model: controllerModelNone},
+				{Type: controllerTypeSCSI, Index: "0", Model: controllerModelTestModel},
+				{Type: controllerTypeVirtioSerial, Index: "0", Model: controllerModelVirtioTestModel},
 			}),
 		Entry("when arch supports PCIHole64 disabling, annotation not set",
 			libvmi.New(),
 			pciHole64DisablingSupported,
 			[]api.Controller{
-				{Type: "usb", Index: "0", Model: "none"},
-				{Type: "scsi", Index: "0", Model: "test-model"},
-				{Type: "virtio-serial", Index: "0", Model: "virtio-test-model"},
+				{Type: usbRedirBusUSB, Index: "0", Model: controllerModelNone},
+				{Type: controllerTypeSCSI, Index: "0", Model: controllerModelTestModel},
+				{Type: controllerTypeVirtioSerial, Index: "0", Model: controllerModelVirtioTestModel},
 			}),
 		Entry("when arch supports PCIHole64 disabling, annotation set to false",
 			libvmi.New(libvmi.WithAnnotation(v1.DisablePCIHole64, "false")),
 			pciHole64DisablingSupported,
 			[]api.Controller{
-				{Type: "usb", Index: "0", Model: "none"},
-				{Type: "scsi", Index: "0", Model: "test-model"},
-				{Type: "virtio-serial", Index: "0", Model: "virtio-test-model"},
+				{Type: usbRedirBusUSB, Index: "0", Model: controllerModelNone},
+				{Type: controllerTypeSCSI, Index: "0", Model: controllerModelTestModel},
+				{Type: controllerTypeVirtioSerial, Index: "0", Model: controllerModelVirtioTestModel},
 			}),
 		Entry("when arch supports PCIHole64 disabling and annotation is true",
 			libvmi.New(libvmi.WithAnnotation(v1.DisablePCIHole64, "true")),
 			pciHole64DisablingSupported,
 			[]api.Controller{
-				{Type: "usb", Index: "0", Model: "none"},
-				{Type: "scsi", Index: "0", Model: "test-model"},
+				{Type: usbRedirBusUSB, Index: "0", Model: controllerModelNone},
+				{Type: controllerTypeSCSI, Index: "0", Model: controllerModelTestModel},
 				{Type: "pci", Index: "0", Model: "pcie-root", PCIHole64: &api.PCIHole64{Value: 0, Unit: "KiB"}},
-				{Type: "virtio-serial", Index: "0", Model: "virtio-test-model"},
+				{Type: controllerTypeVirtioSerial, Index: "0", Model: controllerModelVirtioTestModel},
 			}),
 	)
 
@@ -269,14 +278,14 @@ var _ = Describe("Controllers Domain Configurator", func() {
 			libvmi.New(),
 			0,
 			newDomainWithControllers([]api.Controller{
-				{Type: "usb", Index: "0", Model: "none"},
+				{Type: usbRedirBusUSB, Index: "0", Model: controllerModelNone},
 				{
-					Type: "scsi", Index: "0", Model: "test-model",
-					Driver: &api.ControllerDriver{IOMMU: "on"},
+					Type: controllerTypeSCSI, Index: "0", Model: controllerModelTestModel,
+					Driver: &api.ControllerDriver{IOMMU: stateOn},
 				},
 				{
-					Type: "virtio-serial", Index: "0", Model: "virtio-test-model",
-					Driver: &api.ControllerDriver{IOMMU: "on"},
+					Type: controllerTypeVirtioSerial, Index: "0", Model: controllerModelVirtioTestModel,
+					Driver: &api.ControllerDriver{IOMMU: stateOn},
 				},
 			})),
 		Entry("when PV is active, SCSI and virtio-serial get IOMMU driver",
@@ -284,14 +293,14 @@ var _ = Describe("Controllers Domain Configurator", func() {
 			libvmi.New(),
 			0,
 			newDomainWithControllers([]api.Controller{
-				{Type: "usb", Index: "0", Model: "none"},
+				{Type: usbRedirBusUSB, Index: "0", Model: controllerModelNone},
 				{
-					Type: "scsi", Index: "0", Model: "test-model",
-					Driver: &api.ControllerDriver{IOMMU: "on"},
+					Type: controllerTypeSCSI, Index: "0", Model: controllerModelTestModel,
+					Driver: &api.ControllerDriver{IOMMU: stateOn},
 				},
 				{
-					Type: "virtio-serial", Index: "0", Model: "virtio-test-model",
-					Driver: &api.ControllerDriver{IOMMU: "on"},
+					Type: controllerTypeVirtioSerial, Index: "0", Model: controllerModelVirtioTestModel,
+					Driver: &api.ControllerDriver{IOMMU: stateOn},
 				},
 			})),
 		Entry("when SEV is active with SCSI IOThreads, IOMMU is preserved alongside IOThread and Queues",
@@ -302,18 +311,18 @@ var _ = Describe("Controllers Domain Configurator", func() {
 			),
 			4,
 			newDomainWithControllers([]api.Controller{
-				{Type: "usb", Index: "0", Model: "none"},
+				{Type: usbRedirBusUSB, Index: "0", Model: controllerModelNone},
 				{
-					Type: "scsi", Index: "0", Model: "test-model",
+					Type: controllerTypeSCSI, Index: "0", Model: controllerModelTestModel,
 					Driver: &api.ControllerDriver{
-						IOMMU:    "on",
+						IOMMU:    stateOn,
 						Queues:   pointer.P[uint](1),
 						IOThread: pointer.P[uint](2),
 					},
 				},
 				{
-					Type: "virtio-serial", Index: "0", Model: "virtio-test-model",
-					Driver: &api.ControllerDriver{IOMMU: "on"},
+					Type: controllerTypeVirtioSerial, Index: "0", Model: controllerModelVirtioTestModel,
+					Driver: &api.ControllerDriver{IOMMU: stateOn},
 				},
 			})),
 	)
@@ -342,19 +351,19 @@ var _ = Describe("Controllers Domain Configurator", func() {
 		Entry("when serial console is enabled by default (nil)",
 			nil,
 			[]api.Controller{
-				{Type: "usb", Index: "0", Model: "none"},
-				{Type: "virtio-serial", Index: "0", Model: "virtio-test-model"},
+				{Type: usbRedirBusUSB, Index: "0", Model: controllerModelNone},
+				{Type: controllerTypeVirtioSerial, Index: "0", Model: controllerModelVirtioTestModel},
 			}),
 		Entry("when serial console is explicitly enabled",
 			[]libvmi.Option{libvmi.WithAutoattachSerialConsole(true)},
 			[]api.Controller{
-				{Type: "usb", Index: "0", Model: "none"},
-				{Type: "virtio-serial", Index: "0", Model: "virtio-test-model"},
+				{Type: usbRedirBusUSB, Index: "0", Model: controllerModelNone},
+				{Type: controllerTypeVirtioSerial, Index: "0", Model: controllerModelVirtioTestModel},
 			}),
 		Entry("when serial console is disabled",
 			[]libvmi.Option{libvmi.WithAutoattachSerialConsole(false)},
 			[]api.Controller{
-				{Type: "usb", Index: "0", Model: "none"},
+				{Type: usbRedirBusUSB, Index: "0", Model: controllerModelNone},
 			}),
 	)
 })

--- a/pkg/virt-launcher/virtwrap/converter/compute/cpu.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/cpu.go
@@ -28,6 +28,11 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter/vcpu"
 )
 
+const (
+	cpuModeCustom = "custom"
+	cpuModelMax   = "max"
+)
+
 type CPUDomainConfigurator struct {
 	isHotplugSupported       bool
 	requiresMPXCPUValidation bool
@@ -92,20 +97,20 @@ func (c CPUDomainConfigurator) configureCPUModel(vmi *v1.VirtualMachineInstance,
 		if c.crossArchEmulation && isHostCPUMode {
 			// host-passthrough and host-model are incompatible with cross-architecture
 			// TCG emulation. Use "max" which exposes all features QEMU can emulate.
-			domain.Spec.CPU.Mode = "custom"
-			domain.Spec.CPU.Model = "max"
+			domain.Spec.CPU.Mode = cpuModeCustom
+			domain.Spec.CPU.Model = cpuModelMax
 		} else if isHostCPUMode {
 			domain.Spec.CPU.Mode = vmi.Spec.Domain.CPU.Model
 		} else {
-			domain.Spec.CPU.Mode = "custom"
+			domain.Spec.CPU.Mode = cpuModeCustom
 			domain.Spec.CPU.Model = vmi.Spec.Domain.CPU.Model
 		}
 		return
 	}
 
 	if c.crossArchEmulation {
-		domain.Spec.CPU.Mode = "custom"
-		domain.Spec.CPU.Model = "max"
+		domain.Spec.CPU.Mode = cpuModeCustom
+		domain.Spec.CPU.Model = cpuModelMax
 	} else {
 		domain.Spec.CPU.Mode = v1.CPUModeHostModel
 	}
@@ -165,7 +170,7 @@ func (c CPUDomainConfigurator) configureSyntheticNUMA(vmi *v1.VirtualMachineInst
 				ID:     "0",
 				CPUs:   fmt.Sprintf("0-%d", domain.Spec.VCPU.CPUs-1),
 				Memory: &memKiB,
-				Unit:   "KiB",
+				Unit:   unitKiB,
 			},
 		},
 	}

--- a/pkg/virt-launcher/virtwrap/converter/compute/cpu_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/cpu_test.go
@@ -32,6 +32,19 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter/compute"
 )
 
+const (
+	cpuModelSkylakeServer   = "Skylake-Server"
+	cpuFeaturePolicyRequire = "require"
+	cpuFeaturePolicyDisable = "disable"
+	cpuFeatureNameMPX       = "mpx"
+	cpuModelMax             = "max"
+	cpuPlacementStatic      = "static"
+	cpuModeCustom           = "custom"
+	cpuYes                  = "yes"
+	vcpuStateNo             = "no"
+	memoryUnitKiB           = "KiB"
+)
+
 var _ = Describe("CPU Domain Configurator", func() {
 	Context("CPU topology", func() {
 		DescribeTable("should set topology and VCPU count from VMI CPU spec",
@@ -52,28 +65,28 @@ var _ = Describe("CPU Domain Configurator", func() {
 				libvmi.New(),
 				api.Domain{Spec: api.DomainSpec{
 					CPU:  api.CPU{Mode: v1.CPUModeHostModel, Topology: &api.CPUTopology{Sockets: 1, Cores: 1, Threads: 1}},
-					VCPU: &api.VCPU{Placement: "static", CPUs: 1},
+					VCPU: &api.VCPU{Placement: cpuPlacementStatic, CPUs: 1},
 				}},
 			),
 			Entry("with explicit cores, threads, sockets",
 				libvmi.New(libvmi.WithCPUCount(4, 2, 6)),
 				api.Domain{Spec: api.DomainSpec{
 					CPU:  api.CPU{Mode: v1.CPUModeHostModel, Topology: &api.CPUTopology{Sockets: 6, Cores: 4, Threads: 2}},
-					VCPU: &api.VCPU{Placement: "static", CPUs: 48},
+					VCPU: &api.VCPU{Placement: cpuPlacementStatic, CPUs: 48},
 				}},
 			),
 			Entry("with CPU resource request only",
 				libvmi.New(libvmi.WithCPURequest("4")),
 				api.Domain{Spec: api.DomainSpec{
 					CPU:  api.CPU{Mode: v1.CPUModeHostModel, Topology: &api.CPUTopology{Sockets: 4, Cores: 1, Threads: 1}},
-					VCPU: &api.VCPU{Placement: "static", CPUs: 4},
+					VCPU: &api.VCPU{Placement: cpuPlacementStatic, CPUs: 4},
 				}},
 			),
 			Entry("with CPU resource limit only",
 				libvmi.New(libvmi.WithCPULimit("8")),
 				api.Domain{Spec: api.DomainSpec{
 					CPU:  api.CPU{Mode: v1.CPUModeHostModel, Topology: &api.CPUTopology{Sockets: 8, Cores: 1, Threads: 1}},
-					VCPU: &api.VCPU{Placement: "static", CPUs: 8},
+					VCPU: &api.VCPU{Placement: cpuPlacementStatic, CPUs: 8},
 				}},
 			),
 		)
@@ -98,28 +111,28 @@ var _ = Describe("CPU Domain Configurator", func() {
 				libvmi.New(libvmi.WithCPUCount(1, 1, 1)),
 				api.Domain{Spec: api.DomainSpec{
 					CPU:  api.CPU{Mode: v1.CPUModeHostModel, Topology: &api.CPUTopology{Sockets: 1, Cores: 1, Threads: 1}},
-					VCPU: &api.VCPU{Placement: "static", CPUs: 1},
+					VCPU: &api.VCPU{Placement: cpuPlacementStatic, CPUs: 1},
 				}},
 			),
 			Entry("host-model sets mode directly",
 				libvmi.New(libvmi.WithCPUModel(v1.CPUModeHostModel)),
 				api.Domain{Spec: api.DomainSpec{
 					CPU:  api.CPU{Mode: v1.CPUModeHostModel, Topology: &api.CPUTopology{Sockets: 1, Cores: 1, Threads: 1}},
-					VCPU: &api.VCPU{Placement: "static", CPUs: 1},
+					VCPU: &api.VCPU{Placement: cpuPlacementStatic, CPUs: 1},
 				}},
 			),
 			Entry("host-passthrough sets mode directly",
 				libvmi.New(libvmi.WithCPUModel(v1.CPUModeHostPassthrough)),
 				api.Domain{Spec: api.DomainSpec{
 					CPU:  api.CPU{Mode: v1.CPUModeHostPassthrough, Topology: &api.CPUTopology{Sockets: 1, Cores: 1, Threads: 1}},
-					VCPU: &api.VCPU{Placement: "static", CPUs: 1},
+					VCPU: &api.VCPU{Placement: cpuPlacementStatic, CPUs: 1},
 				}},
 			),
 			Entry("custom model sets mode to custom with model name",
-				libvmi.New(libvmi.WithCPUModel("Skylake-Server")),
+				libvmi.New(libvmi.WithCPUModel(cpuModelSkylakeServer)),
 				api.Domain{Spec: api.DomainSpec{
-					CPU:  api.CPU{Mode: "custom", Model: "Skylake-Server", Topology: &api.CPUTopology{Sockets: 1, Cores: 1, Threads: 1}},
-					VCPU: &api.VCPU{Placement: "static", CPUs: 1},
+					CPU:  api.CPU{Mode: cpuModeCustom, Model: cpuModelSkylakeServer, Topology: &api.CPUTopology{Sockets: 1, Cores: 1, Threads: 1}},
+					VCPU: &api.VCPU{Placement: cpuPlacementStatic, CPUs: 1},
 				}},
 			),
 		)
@@ -128,9 +141,9 @@ var _ = Describe("CPU Domain Configurator", func() {
 	Context("CPU features", func() {
 		It("should set features from VMI spec", func() {
 			vmi := libvmi.New(
-				libvmi.WithCPUModel("Skylake-Server"),
-				libvmi.WithCPUFeature("avx2", "require"),
-				libvmi.WithCPUFeature("vmx", "disable"),
+				libvmi.WithCPUModel(cpuModelSkylakeServer),
+				libvmi.WithCPUFeature("avx2", cpuFeaturePolicyRequire),
+				libvmi.WithCPUFeature("vmx", cpuFeaturePolicyDisable),
 			)
 			var domain api.Domain
 
@@ -144,12 +157,12 @@ var _ = Describe("CPU Domain Configurator", func() {
 
 			expectedDomain := api.Domain{Spec: api.DomainSpec{
 				CPU: api.CPU{
-					Mode:     "custom",
-					Model:    "Skylake-Server",
+					Mode:     cpuModeCustom,
+					Model:    cpuModelSkylakeServer,
 					Topology: &api.CPUTopology{Sockets: 1, Cores: 1, Threads: 1},
 					Features: []api.CPUFeature{
-						{Name: "avx2", Policy: "require"},
-						{Name: "vmx", Policy: "disable"},
+						{Name: "avx2", Policy: cpuFeaturePolicyRequire},
+						{Name: "vmx", Policy: cpuFeaturePolicyDisable},
 					},
 				},
 				VCPU: &api.VCPU{Placement: "static", CPUs: 1},
@@ -174,16 +187,16 @@ var _ = Describe("CPU Domain Configurator", func() {
 				Expect(domain).To(Equal(expectedDomain))
 			},
 			Entry("adds mpx disable for custom model when MPX validation is required",
-				libvmi.New(libvmi.WithCPUModel("Skylake-Server")),
+				libvmi.New(libvmi.WithCPUModel(cpuModelSkylakeServer)),
 				true,
 				api.Domain{Spec: api.DomainSpec{
 					CPU: api.CPU{
-						Mode:     "custom",
-						Model:    "Skylake-Server",
+						Mode:     cpuModeCustom,
+						Model:    cpuModelSkylakeServer,
 						Topology: &api.CPUTopology{Sockets: 1, Cores: 1, Threads: 1},
-						Features: []api.CPUFeature{{Name: "mpx", Policy: "disable"}},
+						Features: []api.CPUFeature{{Name: cpuFeatureNameMPX, Policy: cpuFeaturePolicyDisable}},
 					},
-					VCPU: &api.VCPU{Placement: "static", CPUs: 1},
+					VCPU: &api.VCPU{Placement: cpuPlacementStatic, CPUs: 1},
 				}},
 			),
 			Entry("does not add mpx for host-model",
@@ -191,7 +204,7 @@ var _ = Describe("CPU Domain Configurator", func() {
 				true,
 				api.Domain{Spec: api.DomainSpec{
 					CPU:  api.CPU{Mode: v1.CPUModeHostModel, Topology: &api.CPUTopology{Sockets: 1, Cores: 1, Threads: 1}},
-					VCPU: &api.VCPU{Placement: "static", CPUs: 1},
+					VCPU: &api.VCPU{Placement: cpuPlacementStatic, CPUs: 1},
 				}},
 			),
 			Entry("does not add mpx for host-passthrough",
@@ -199,23 +212,23 @@ var _ = Describe("CPU Domain Configurator", func() {
 				true,
 				api.Domain{Spec: api.DomainSpec{
 					CPU:  api.CPU{Mode: v1.CPUModeHostPassthrough, Topology: &api.CPUTopology{Sockets: 1, Cores: 1, Threads: 1}},
-					VCPU: &api.VCPU{Placement: "static", CPUs: 1},
+					VCPU: &api.VCPU{Placement: cpuPlacementStatic, CPUs: 1},
 				}},
 			),
 			Entry("does not add mpx when user already specifies it",
 				libvmi.New(
-					libvmi.WithCPUModel("Skylake-Server"),
-					libvmi.WithCPUFeature("mpx", "require"),
+					libvmi.WithCPUModel(cpuModelSkylakeServer),
+					libvmi.WithCPUFeature(cpuFeatureNameMPX, cpuFeaturePolicyRequire),
 				),
 				true,
 				api.Domain{Spec: api.DomainSpec{
 					CPU: api.CPU{
-						Mode:     "custom",
-						Model:    "Skylake-Server",
+						Mode:     cpuModeCustom,
+						Model:    cpuModelSkylakeServer,
 						Topology: &api.CPUTopology{Sockets: 1, Cores: 1, Threads: 1},
-						Features: []api.CPUFeature{{Name: "mpx", Policy: "require"}},
+						Features: []api.CPUFeature{{Name: cpuFeatureNameMPX, Policy: cpuFeaturePolicyRequire}},
 					},
-					VCPU: &api.VCPU{Placement: "static", CPUs: 1},
+					VCPU: &api.VCPU{Placement: cpuPlacementStatic, CPUs: 1},
 				}},
 			),
 		)
@@ -239,29 +252,29 @@ var _ = Describe("CPU Domain Configurator", func() {
 			Entry("overrides host-model to max",
 				libvmi.New(libvmi.WithCPUModel(v1.CPUModeHostModel)),
 				api.Domain{Spec: api.DomainSpec{
-					CPU:  api.CPU{Mode: "custom", Model: "max", Topology: &api.CPUTopology{Sockets: 1, Cores: 1, Threads: 1}},
-					VCPU: &api.VCPU{Placement: "static", CPUs: 1},
+					CPU:  api.CPU{Mode: cpuModeCustom, Model: cpuModelMax, Topology: &api.CPUTopology{Sockets: 1, Cores: 1, Threads: 1}},
+					VCPU: &api.VCPU{Placement: cpuPlacementStatic, CPUs: 1},
 				}},
 			),
 			Entry("overrides host-passthrough to max",
 				libvmi.New(libvmi.WithCPUModel(v1.CPUModeHostPassthrough)),
 				api.Domain{Spec: api.DomainSpec{
-					CPU:  api.CPU{Mode: "custom", Model: "max", Topology: &api.CPUTopology{Sockets: 1, Cores: 1, Threads: 1}},
-					VCPU: &api.VCPU{Placement: "static", CPUs: 1},
+					CPU:  api.CPU{Mode: cpuModeCustom, Model: cpuModelMax, Topology: &api.CPUTopology{Sockets: 1, Cores: 1, Threads: 1}},
+					VCPU: &api.VCPU{Placement: cpuPlacementStatic, CPUs: 1},
 				}},
 			),
 			Entry("defaults to max when no CPU model is specified",
 				libvmi.New(),
 				api.Domain{Spec: api.DomainSpec{
-					CPU:  api.CPU{Mode: "custom", Model: "max", Topology: &api.CPUTopology{Sockets: 1, Cores: 1, Threads: 1}},
-					VCPU: &api.VCPU{Placement: "static", CPUs: 1},
+					CPU:  api.CPU{Mode: cpuModeCustom, Model: cpuModelMax, Topology: &api.CPUTopology{Sockets: 1, Cores: 1, Threads: 1}},
+					VCPU: &api.VCPU{Placement: cpuPlacementStatic, CPUs: 1},
 				}},
 			),
 			Entry("preserves explicit custom model",
 				libvmi.New(libvmi.WithCPUModel("cortex-a57")),
 				api.Domain{Spec: api.DomainSpec{
-					CPU:  api.CPU{Mode: "custom", Model: "cortex-a57", Topology: &api.CPUTopology{Sockets: 1, Cores: 1, Threads: 1}},
-					VCPU: &api.VCPU{Placement: "static", CPUs: 1},
+					CPU:  api.CPU{Mode: cpuModeCustom, Model: "cortex-a57", Topology: &api.CPUTopology{Sockets: 1, Cores: 1, Threads: 1}},
+					VCPU: &api.VCPU{Placement: cpuPlacementStatic, CPUs: 1},
 				}},
 			),
 		)
@@ -283,7 +296,7 @@ var _ = Describe("CPU Domain Configurator", func() {
 				cpuCount := topology.Sockets * topology.Cores * topology.Threads
 				expectedDomain := api.Domain{Spec: api.DomainSpec{
 					CPU:  api.CPU{Mode: v1.CPUModeHostModel, Topology: topology, NUMA: expectedNUMA},
-					VCPU: &api.VCPU{Placement: "static", CPUs: cpuCount},
+					VCPU: &api.VCPU{Placement: cpuPlacementStatic, CPUs: cpuCount},
 				}}
 				Expect(domain).To(Equal(expectedDomain))
 			},
@@ -368,12 +381,12 @@ var _ = Describe("CPU Domain Configurator", func() {
 					Topology: &api.CPUTopology{Sockets: 4, Cores: 1, Threads: 1},
 					NUMA:     numaWith(4, 128*1024),
 				},
-				VCPU: &api.VCPU{Placement: "static", CPUs: 4},
+				VCPU: &api.VCPU{Placement: cpuPlacementStatic, CPUs: 4},
 				VCPUs: &api.VCPUs{VCPU: []api.VCPUsVCPU{
-					{ID: 0, Enabled: "yes", Hotpluggable: "no"},
-					{ID: 1, Enabled: "yes", Hotpluggable: "yes"},
-					{ID: 2, Enabled: "no", Hotpluggable: "yes"},
-					{ID: 3, Enabled: "no", Hotpluggable: "yes"},
+					{ID: 0, Enabled: cpuYes, Hotpluggable: vcpuStateNo},
+					{ID: 1, Enabled: cpuYes, Hotpluggable: cpuYes},
+					{ID: 2, Enabled: vcpuStateNo, Hotpluggable: cpuYes},
+					{ID: 3, Enabled: vcpuStateNo, Hotpluggable: cpuYes},
 				}},
 			}}
 			Expect(domain).To(Equal(expectedDomain))
@@ -396,7 +409,7 @@ var _ = Describe("CPU Domain Configurator", func() {
 
 			expectedDomain := api.Domain{Spec: api.DomainSpec{
 				CPU:  api.CPU{Mode: v1.CPUModeHostModel, Topology: &api.CPUTopology{Sockets: 1, Cores: 1, Threads: 1}},
-				VCPU: &api.VCPU{Placement: "static", CPUs: 1},
+				VCPU: &api.VCPU{Placement: cpuPlacementStatic, CPUs: 1},
 			}}
 			Expect(domain).To(Equal(expectedDomain))
 		})
@@ -420,12 +433,12 @@ var _ = Describe("CPU Domain Configurator", func() {
 
 			expectedDomain := api.Domain{Spec: api.DomainSpec{
 				CPU:  api.CPU{Mode: v1.CPUModeHostModel, Topology: &api.CPUTopology{Sockets: 4, Cores: 1, Threads: 1}},
-				VCPU: &api.VCPU{Placement: "static", CPUs: 4},
+				VCPU: &api.VCPU{Placement: cpuPlacementStatic, CPUs: 4},
 				VCPUs: &api.VCPUs{VCPU: []api.VCPUsVCPU{
-					{ID: 0, Enabled: "yes", Hotpluggable: "no"},
-					{ID: 1, Enabled: "yes", Hotpluggable: "yes"},
-					{ID: 2, Enabled: "no", Hotpluggable: "yes"},
-					{ID: 3, Enabled: "no", Hotpluggable: "yes"},
+					{ID: 0, Enabled: cpuYes, Hotpluggable: vcpuStateNo},
+					{ID: 1, Enabled: cpuYes, Hotpluggable: cpuYes},
+					{ID: 2, Enabled: vcpuStateNo, Hotpluggable: cpuYes},
+					{ID: 3, Enabled: vcpuStateNo, Hotpluggable: cpuYes},
 				}},
 			}}
 			Expect(domain).To(Equal(expectedDomain))
@@ -448,7 +461,7 @@ var _ = Describe("CPU Domain Configurator", func() {
 
 			expectedDomain := api.Domain{Spec: api.DomainSpec{
 				CPU:  api.CPU{Mode: v1.CPUModeHostModel, Topology: &api.CPUTopology{Sockets: 2, Cores: 1, Threads: 1}},
-				VCPU: &api.VCPU{Placement: "static", CPUs: 2},
+				VCPU: &api.VCPU{Placement: cpuPlacementStatic, CPUs: 2},
 			}}
 			Expect(domain).To(Equal(expectedDomain))
 		})
@@ -467,7 +480,7 @@ var _ = Describe("CPU Domain Configurator", func() {
 
 			expectedDomain := api.Domain{Spec: api.DomainSpec{
 				CPU:  api.CPU{Mode: v1.CPUModeHostModel, Topology: &api.CPUTopology{Sockets: 2, Cores: 1, Threads: 1}},
-				VCPU: &api.VCPU{Placement: "static", CPUs: 2},
+				VCPU: &api.VCPU{Placement: cpuPlacementStatic, CPUs: 2},
 			}}
 			Expect(domain).To(Equal(expectedDomain))
 		})
@@ -489,14 +502,14 @@ var _ = Describe("CPU Domain Configurator", func() {
 
 			expectedDomain := api.Domain{Spec: api.DomainSpec{
 				CPU:  api.CPU{Mode: v1.CPUModeHostModel, Topology: &api.CPUTopology{Sockets: 3, Cores: 2, Threads: 1}},
-				VCPU: &api.VCPU{Placement: "static", CPUs: 6},
+				VCPU: &api.VCPU{Placement: cpuPlacementStatic, CPUs: 6},
 				VCPUs: &api.VCPUs{VCPU: []api.VCPUsVCPU{
-					{ID: 0, Enabled: "yes", Hotpluggable: "no"},
-					{ID: 1, Enabled: "yes", Hotpluggable: "no"},
-					{ID: 2, Enabled: "no", Hotpluggable: "yes"},
-					{ID: 3, Enabled: "no", Hotpluggable: "yes"},
-					{ID: 4, Enabled: "no", Hotpluggable: "yes"},
-					{ID: 5, Enabled: "no", Hotpluggable: "yes"},
+					{ID: 0, Enabled: cpuYes, Hotpluggable: vcpuStateNo},
+					{ID: 1, Enabled: cpuYes, Hotpluggable: vcpuStateNo},
+					{ID: 2, Enabled: vcpuStateNo, Hotpluggable: cpuYes},
+					{ID: 3, Enabled: vcpuStateNo, Hotpluggable: cpuYes},
+					{ID: 4, Enabled: vcpuStateNo, Hotpluggable: cpuYes},
+					{ID: 5, Enabled: vcpuStateNo, Hotpluggable: cpuYes},
 				}},
 			}}
 			Expect(domain).To(Equal(expectedDomain))
@@ -511,7 +524,7 @@ func numaWith(cpuCount uint32, memKiB uint64) *api.NUMA {
 				ID:     "0",
 				CPUs:   fmt.Sprintf("0-%d", cpuCount-1),
 				Memory: &memKiB,
-				Unit:   "KiB",
+				Unit:   memoryUnitKiB,
 			},
 		},
 	}

--- a/pkg/virt-launcher/virtwrap/converter/compute/graphics.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/graphics.go
@@ -89,11 +89,11 @@ func (g GraphicsDomainConfigurator) configureVideoDevice(vmi *v1.VirtualMachineI
 	}
 
 	switch g.architecture {
-	case "amd64":
+	case archAmd64:
 		g.configureAMD64VideoDevice(vmi, domain)
-	case "arm64":
+	case archArm64:
 		g.configureARM64VideoDevice(domain)
-	case "s390x":
+	case archS390x:
 		g.configureS390XVideoDevice(domain)
 	}
 }

--- a/pkg/virt-launcher/virtwrap/converter/compute/graphics_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/graphics_test.go
@@ -33,6 +33,13 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter/compute"
 )
 
+const (
+	graphicsTypeVNC     = "vnc"
+	graphicsListenType  = "socket"
+	graphicsVideoVirtio = "virtio"
+	graphicsVideoVGA    = "vga"
+)
+
 var _ = Describe("Graphics Domain Configurator", func() {
 	Context("AutoattachGraphicsDevice", func() {
 		DescribeTable("should not configure video and VNC when AutoattachGraphicsDevice is false", func(arch string) {
@@ -63,9 +70,9 @@ var _ = Describe("Graphics Domain Configurator", func() {
 						Video: []api.Video{expectedVideo},
 						Graphics: []api.Graphics{
 							{
-								Type: "vnc",
+								Type: graphicsTypeVNC,
 								Listen: &api.GraphicsListen{
-									Type:   "socket",
+									Type:   graphicsListenType,
 									Socket: "/var/run/kubevirt-private/test-uid/virt-vnc",
 								},
 							},
@@ -99,7 +106,7 @@ var _ = Describe("Graphics Domain Configurator", func() {
 
 	Context("Video device configuration", func() {
 		DescribeTable("Should use user-specified video type when provided", func(arch string, bochsForEFI bool) {
-			vmi := libvmi.New(libvmi.WithVideo("virtio"))
+			vmi := libvmi.New(libvmi.WithVideo(graphicsVideoVirtio))
 			var domain api.Domain
 
 			configurator := compute.NewGraphicsDomainConfigurator(arch, bochsForEFI, false)
@@ -111,7 +118,7 @@ var _ = Describe("Graphics Domain Configurator", func() {
 						Video: []api.Video{
 							{
 								Model: api.VideoModel{
-									Type:  "virtio",
+									Type:  graphicsVideoVirtio,
 									Heads: pointer.P(uint(1)),
 									VRam:  pointer.P(uint(16384)),
 								},
@@ -119,9 +126,9 @@ var _ = Describe("Graphics Domain Configurator", func() {
 						},
 						Graphics: []api.Graphics{
 							{
-								Type: "vnc",
+								Type: graphicsTypeVNC,
 								Listen: &api.GraphicsListen{
-									Type:   "socket",
+									Type:   graphicsListenType,
 									Socket: fmt.Sprintf("/var/run/kubevirt-private/%s/virt-vnc", vmi.ObjectMeta.UID),
 								},
 							},
@@ -152,7 +159,7 @@ var _ = Describe("Graphics Domain Configurator", func() {
 						Video: []api.Video{
 							{
 								Model: api.VideoModel{
-									Type:  "vga",
+									Type:  graphicsVideoVGA,
 									Heads: pointer.P(uint(1)),
 									VRam:  pointer.P(uint(16384)),
 								},
@@ -160,9 +167,9 @@ var _ = Describe("Graphics Domain Configurator", func() {
 						},
 						Graphics: []api.Graphics{
 							{
-								Type: "vnc",
+								Type: graphicsTypeVNC,
 								Listen: &api.GraphicsListen{
-									Type:   "socket",
+									Type:   graphicsListenType,
 									Socket: fmt.Sprintf("/var/run/kubevirt-private/%s/virt-vnc", vmi.ObjectMeta.UID),
 								},
 							},
@@ -198,9 +205,9 @@ var _ = Describe("Graphics Domain Configurator", func() {
 						},
 						Graphics: []api.Graphics{
 							{
-								Type: "vnc",
+								Type: graphicsTypeVNC,
 								Listen: &api.GraphicsListen{
-									Type:   "socket",
+									Type:   graphicsListenType,
 									Socket: fmt.Sprintf("/var/run/kubevirt-private/%s/virt-vnc", vmi.ObjectMeta.UID),
 								},
 							},
@@ -217,7 +224,7 @@ var _ = Describe("Graphics Domain Configurator", func() {
 func newExpectedAMD64VideoDevice() api.Video {
 	return api.Video{
 		Model: api.VideoModel{
-			Type:  "vga",
+			Type:  graphicsVideoVGA,
 			Heads: pointer.P(uint(1)),
 			VRam:  pointer.P(uint(16384)),
 		},

--- a/pkg/virt-launcher/virtwrap/converter/compute/hypervisor_features.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/hypervisor_features.go
@@ -25,6 +25,8 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )
 
+const featureStateOff = "off"
+
 type HypervisorFeaturesDomainConfigurator struct {
 	hasVMPort            bool
 	useLaunchSecurityTDX bool
@@ -47,7 +49,7 @@ func (h HypervisorFeaturesDomainConfigurator) Configure(vmi *v1.VirtualMachineIn
 	convertFeaturesToAPIFeatures(vmi.Spec.Domain.Features, domain.Spec.Features, h.useLaunchSecurityTDX)
 
 	if h.hasVMPort {
-		domain.Spec.Features.VMPort = &api.FeatureState{State: "off"}
+		domain.Spec.Features.VMPort = &api.FeatureState{State: featureStateOff}
 	}
 
 	return nil
@@ -90,7 +92,7 @@ func convertFeaturesToAPIFeatures(source *v1.Features, features *api.Features, u
 
 	if useLaunchSecurityTDX {
 		features.PMU = &api.FeatureState{
-			State: "off",
+			State: featureStateOff,
 		}
 	}
 }

--- a/pkg/virt-launcher/virtwrap/converter/compute/hypervisor_features_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/hypervisor_features_test.go
@@ -30,6 +30,12 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter/compute"
 )
 
+const (
+	stateOn             = "on"
+	stateOff            = "off"
+	hypervVendorIDValue = "myvendor"
+)
+
 var _ = Describe("HypervisorFeatures Domain Configurator", func() {
 	It("should initialize Features and return nil when VMI has no features", func() {
 		vmi := libvmi.New()
@@ -102,11 +108,11 @@ var _ = Describe("HypervisorFeatures Domain Configurator", func() {
 	},
 		Entry("hidden true", true, &api.Features{
 			ACPI: &api.FeatureEnabled{},
-			KVM:  &api.FeatureKVM{Hidden: &api.FeatureState{State: "on"}},
+			KVM:  &api.FeatureKVM{Hidden: &api.FeatureState{State: stateOn}},
 		}),
 		Entry("hidden false", false, &api.Features{
 			ACPI: &api.FeatureEnabled{},
-			KVM:  &api.FeatureKVM{Hidden: &api.FeatureState{State: "off"}},
+			KVM:  &api.FeatureKVM{Hidden: &api.FeatureState{State: stateOff}},
 		}),
 	)
 
@@ -123,15 +129,15 @@ var _ = Describe("HypervisorFeatures Domain Configurator", func() {
 	},
 		Entry("nil (defaults to on)", nil, &api.Features{
 			ACPI:       &api.FeatureEnabled{},
-			PVSpinlock: &api.FeaturePVSpinlock{State: "on"},
+			PVSpinlock: &api.FeaturePVSpinlock{State: stateOn},
 		}),
 		Entry("explicitly enabled", new(true), &api.Features{
 			ACPI:       &api.FeatureEnabled{},
-			PVSpinlock: &api.FeaturePVSpinlock{State: "on"},
+			PVSpinlock: &api.FeaturePVSpinlock{State: stateOn},
 		}),
 		Entry("explicitly disabled", new(false), &api.Features{
 			ACPI:       &api.FeatureEnabled{},
-			PVSpinlock: &api.FeaturePVSpinlock{State: "off"},
+			PVSpinlock: &api.FeaturePVSpinlock{State: stateOff},
 		}),
 	)
 
@@ -185,7 +191,7 @@ var _ = Describe("HypervisorFeatures Domain Configurator", func() {
 					},
 					VendorID: &v1.FeatureVendorID{
 						FeatureState: v1.FeatureState{Enabled: new(true)},
-						VendorID:     "myvendor",
+						VendorID:     hypervVendorIDValue,
 					},
 					SyNICTimer: &v1.SyNICTimer{
 						FeatureState: v1.FeatureState{Enabled: new(true)},
@@ -206,26 +212,26 @@ var _ = Describe("HypervisorFeatures Domain Configurator", func() {
 			Expect(domain).To(Equal(newDomainWithFeatures(&api.Features{
 				ACPI: &api.FeatureEnabled{},
 				Hyperv: &api.FeatureHyperv{
-					Relaxed:         &api.FeatureState{State: "on"},
-					VAPIC:           &api.FeatureState{State: "on"},
-					VPIndex:         &api.FeatureState{State: "on"},
-					Runtime:         &api.FeatureState{State: "on"},
-					SyNIC:           &api.FeatureState{State: "on"},
-					Reset:           &api.FeatureState{State: "on"},
-					Frequencies:     &api.FeatureState{State: "on"},
-					Reenlightenment: &api.FeatureState{State: "on"},
-					IPI:             &api.FeatureState{State: "on"},
-					EVMCS:           &api.FeatureState{State: "on"},
-					Spinlocks:       &api.FeatureSpinlocks{State: "on", Retries: &retries},
-					VendorID:        &api.FeatureVendorID{State: "on", Value: "myvendor"},
+					Relaxed:         &api.FeatureState{State: stateOn},
+					VAPIC:           &api.FeatureState{State: stateOn},
+					VPIndex:         &api.FeatureState{State: stateOn},
+					Runtime:         &api.FeatureState{State: stateOn},
+					SyNIC:           &api.FeatureState{State: stateOn},
+					Reset:           &api.FeatureState{State: stateOn},
+					Frequencies:     &api.FeatureState{State: stateOn},
+					Reenlightenment: &api.FeatureState{State: stateOn},
+					IPI:             &api.FeatureState{State: stateOn},
+					EVMCS:           &api.FeatureState{State: stateOn},
+					Spinlocks:       &api.FeatureSpinlocks{State: stateOn, Retries: &retries},
+					VendorID:        &api.FeatureVendorID{State: stateOn, Value: hypervVendorIDValue},
 					SyNICTimer: &api.SyNICTimer{
-						State:  "on",
-						Direct: &api.FeatureState{State: "on"},
+						State:  stateOn,
+						Direct: &api.FeatureState{State: stateOn},
 					},
 					TLBFlush: &api.TLBFlush{
-						State:    "on",
-						Direct:   &api.FeatureState{State: "on"},
-						Extended: &api.FeatureState{State: "on"},
+						State:    stateOn,
+						Direct:   &api.FeatureState{State: stateOn},
+						Extended: &api.FeatureState{State: stateOn},
 					},
 				},
 			})))
@@ -248,10 +254,10 @@ var _ = Describe("HypervisorFeatures Domain Configurator", func() {
 			Expect(domain).To(Equal(newDomainWithFeatures(&api.Features{
 				ACPI: &api.FeatureEnabled{},
 				Hyperv: &api.FeatureHyperv{
-					Relaxed:    &api.FeatureState{State: "on"},
-					Spinlocks:  &api.FeatureSpinlocks{State: "on"},
-					SyNICTimer: &api.SyNICTimer{State: "on"},
-					TLBFlush:   &api.TLBFlush{State: "on"},
+					Relaxed:    &api.FeatureState{State: stateOn},
+					Spinlocks:  &api.FeatureSpinlocks{State: stateOn},
+					SyNICTimer: &api.SyNICTimer{State: stateOn},
+					TLBFlush:   &api.TLBFlush{State: stateOn},
 				},
 			})))
 		})
@@ -271,8 +277,8 @@ var _ = Describe("HypervisorFeatures Domain Configurator", func() {
 			Expect(domain).To(Equal(newDomainWithFeatures(&api.Features{
 				ACPI: &api.FeatureEnabled{},
 				Hyperv: &api.FeatureHyperv{
-					Relaxed: &api.FeatureState{State: "off"},
-					VAPIC:   &api.FeatureState{State: "off"},
+					Relaxed: &api.FeatureState{State: stateOff},
+					VAPIC:   &api.FeatureState{State: stateOff},
 				},
 			})))
 		})
@@ -307,7 +313,7 @@ var _ = Describe("HypervisorFeatures Domain Configurator", func() {
 			Expect(domain).To(Equal(newDomainWithFeatures(&api.Features{
 				ACPI: &api.FeatureEnabled{},
 				Hyperv: &api.FeatureHyperv{
-					Relaxed: &api.FeatureState{State: "on"},
+					Relaxed: &api.FeatureState{State: stateOn},
 				},
 			})))
 		})
@@ -322,7 +328,7 @@ var _ = Describe("HypervisorFeatures Domain Configurator", func() {
 
 		Expect(domain).To(Equal(newDomainWithFeatures(&api.Features{
 			ACPI:   &api.FeatureEnabled{},
-			VMPort: &api.FeatureState{State: "off"},
+			VMPort: &api.FeatureState{State: stateOff},
 		})))
 	})
 
@@ -335,7 +341,7 @@ var _ = Describe("HypervisorFeatures Domain Configurator", func() {
 
 		Expect(domain).To(Equal(newDomainWithFeatures(&api.Features{
 			ACPI: &api.FeatureEnabled{},
-			PMU:  &api.FeatureState{State: "off"},
+			PMU:  &api.FeatureState{State: stateOff},
 		})))
 	})
 })

--- a/pkg/virt-launcher/virtwrap/converter/compute/input_device.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/input_device.go
@@ -27,6 +27,15 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )
 
+const (
+	archAmd64    = "amd64"
+	archArm64    = "arm64"
+	archS390x    = "s390x"
+	busUSB       = "usb"
+	typeTablet   = "tablet"
+	typeKeyboard = "keyboard"
+)
+
 type InputDeviceDomainConfigurator struct {
 	architecture string
 }
@@ -90,28 +99,28 @@ func apiInputDeviceFromV1InputDevice(input v1.Input) (api.Input, error) {
 
 func (i InputDeviceDomainConfigurator) addArchitectureSpecificInputDevices(vmi *v1.VirtualMachineInstance, domain *api.Domain) error {
 	switch i.architecture {
-	case "amd64":
+	case archAmd64:
 		// No architecture-specific input devices required
-	case "arm64":
+	case archArm64:
 		if !hasTabletDevice(vmi) {
 			domain.Spec.Devices.Inputs = append(domain.Spec.Devices.Inputs,
 				api.Input{
-					Bus:  "usb",
-					Type: "tablet",
+					Bus:  busUSB,
+					Type: typeTablet,
 				},
 			)
 		}
 		domain.Spec.Devices.Inputs = append(domain.Spec.Devices.Inputs,
 			api.Input{
-				Bus:  "usb",
-				Type: "keyboard",
+				Bus:  busUSB,
+				Type: typeKeyboard,
 			},
 		)
-	case "s390x":
+	case archS390x:
 		domain.Spec.Devices.Inputs = append(domain.Spec.Devices.Inputs,
 			api.Input{
 				Bus:  "virtio",
-				Type: "keyboard",
+				Type: typeKeyboard,
 			},
 		)
 	}
@@ -121,7 +130,7 @@ func (i InputDeviceDomainConfigurator) addArchitectureSpecificInputDevices(vmi *
 func hasTabletDevice(vmi *v1.VirtualMachineInstance) bool {
 	if vmi.Spec.Domain.Devices.Inputs != nil {
 		for _, device := range vmi.Spec.Domain.Devices.Inputs {
-			if device.Type == "tablet" {
+			if device.Type == typeTablet {
 				return true
 			}
 		}

--- a/pkg/virt-launcher/virtwrap/converter/compute/input_device_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/input_device_test.go
@@ -31,6 +31,13 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter/compute"
 )
 
+const (
+	inputTypeKeyboard = "keyboard"
+	inputBusUSB       = "usb"
+	inputTypeTablet   = "tablet"
+	inputBusVirtio    = "virtio"
+)
+
 var _ = Describe("Input Device Configurator", func() {
 	Context("User-specified input devices", func() {
 		DescribeTable("should configure user-specified input devices", func(arch string, bus v1.InputBus, expectedModel string) {
@@ -45,7 +52,7 @@ var _ = Describe("Input Device Configurator", func() {
 					Devices: api.Devices{
 						Inputs: []api.Input{
 							{
-								Type:  "tablet",
+								Type:  inputTypeTablet,
 								Bus:   bus,
 								Alias: api.NewUserDefinedAlias("my-tablet"),
 								Model: expectedModel,
@@ -81,7 +88,7 @@ var _ = Describe("Input Device Configurator", func() {
 			Expect(err.Error()).To(ContainSubstring(expectedError))
 		},
 			Entry("unsupported bus", v1.InputBus("ps2"), v1.InputTypeTablet, "unsupported bus"),
-			Entry("unsupported type", v1.InputBusUSB, v1.InputType("keyboard"), "unsupported type"),
+			Entry("unsupported type", v1.InputBusUSB, v1.InputType(inputTypeKeyboard), "unsupported type"),
 		)
 	})
 
@@ -101,18 +108,18 @@ var _ = Describe("Input Device Configurator", func() {
 			Entry("amd64 adds no input devices when nil", "amd64", nil, nil),
 			Entry("amd64 adds no input devices when true", "amd64", pointer.P(true), nil),
 			Entry("arm64 adds tablet and keyboard when nil", "arm64", nil, []api.Input{
-				{Type: "tablet", Bus: "usb"},
-				{Type: "keyboard", Bus: "usb"},
+				{Type: inputTypeTablet, Bus: inputBusUSB},
+				{Type: inputTypeKeyboard, Bus: inputBusUSB},
 			}),
 			Entry("arm64 adds tablet and keyboard when true", "arm64", pointer.P(true), []api.Input{
-				{Type: "tablet", Bus: "usb"},
-				{Type: "keyboard", Bus: "usb"},
+				{Type: inputTypeTablet, Bus: inputBusUSB},
+				{Type: inputTypeKeyboard, Bus: inputBusUSB},
 			}),
 			Entry("s390x adds virtio keyboard when nil", "s390x", nil, []api.Input{
-				{Type: "keyboard", Bus: "virtio"},
+				{Type: inputTypeKeyboard, Bus: inputBusVirtio},
 			}),
 			Entry("s390x adds virtio keyboard when true", "s390x", pointer.P(true), []api.Input{
-				{Type: "keyboard", Bus: "virtio"},
+				{Type: inputTypeKeyboard, Bus: inputBusVirtio},
 			}),
 		)
 

--- a/pkg/virt-launcher/virtwrap/converter/compute/iommufd.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/iommufd.go
@@ -25,6 +25,8 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )
 
+const featureYes = "yes"
+
 type IOMMUFDConfigurator struct {
 	iommufdEnabled bool
 }
@@ -38,7 +40,7 @@ func NewIOMMUFDConfigurator(iommufdEnabled bool) IOMMUFDConfigurator {
 func (i IOMMUFDConfigurator) Configure(_ *v1.VirtualMachineInstance, domain *api.Domain) error {
 	if i.iommufdEnabled {
 		domain.Spec.IOMMUFD = &api.IOMMUFD{
-			Enabled: "yes",
+			Enabled: featureYes,
 			FDGroup: "iommu",
 		}
 	}

--- a/pkg/virt-launcher/virtwrap/converter/compute/launch_security.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/launch_security.go
@@ -45,11 +45,11 @@ func (l LaunchSecurityDomainConfigurator) Configure(vmi *v1.VirtualMachineInstan
 	}
 
 	switch l.architecture {
-	case "amd64":
+	case archAmd64:
 		domain.Spec.LaunchSecurity = amd64LaunchSecurity(vmi)
-	case "arm64":
+	case archArm64:
 		domain.Spec.LaunchSecurity = nil
-	case "s390x":
+	case archS390x:
 		// We would want to set launchsecurity with type "s390-pv" here, but this does not work in privileged pod.
 		// Instead, virt-launcher will set iommu=on for all devices manually, which is the same action as what libvirt
 		// would do when the launchsecurity type is set.

--- a/pkg/virt-launcher/virtwrap/converter/compute/memory_backing_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/memory_backing_test.go
@@ -30,6 +30,11 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter/compute"
 )
 
+const (
+	memoryBackingSourceTypeMemfd  = "memfd"
+	memoryBackingAccessModeShared = "shared"
+)
+
 var _ = Describe("MemoryBackingConfigurator", func() {
 	const memfdSupported = true
 
@@ -55,7 +60,7 @@ var _ = Describe("MemoryBackingConfigurator", func() {
 			memfdSupported,
 			&api.MemoryBacking{
 				HugePages: &api.HugePages{},
-				Source:    &api.MemoryBackingSource{Type: "memfd"},
+				Source:    &api.MemoryBackingSource{Type: memoryBackingSourceTypeMemfd},
 			},
 		),
 		Entry("hugepages with memfd annotation false",
@@ -72,16 +77,16 @@ var _ = Describe("MemoryBackingConfigurator", func() {
 			libvmi.New(libvmi.WithFilesystemPVC("test-pvc")),
 			memfdSupported,
 			&api.MemoryBacking{
-				Access: &api.MemoryBackingAccess{Mode: "shared"},
-				Source: &api.MemoryBackingSource{Type: "memfd"},
+				Access: &api.MemoryBackingAccess{Mode: memoryBackingAccessModeShared},
+				Source: &api.MemoryBackingSource{Type: memoryBackingSourceTypeMemfd},
 			},
 		),
 		Entry("passt",
 			libvmi.New(libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithPasstBinding()))),
 			memfdSupported,
 			&api.MemoryBacking{
-				Access: &api.MemoryBackingAccess{Mode: "shared"},
-				Source: &api.MemoryBackingSource{Type: "memfd"},
+				Access: &api.MemoryBackingAccess{Mode: memoryBackingAccessModeShared},
+				Source: &api.MemoryBackingSource{Type: memoryBackingSourceTypeMemfd},
 			},
 		),
 		Entry("hugepages with virtiofs",
@@ -92,8 +97,8 @@ var _ = Describe("MemoryBackingConfigurator", func() {
 			memfdSupported,
 			&api.MemoryBacking{
 				HugePages: &api.HugePages{},
-				Access:    &api.MemoryBackingAccess{Mode: "shared"},
-				Source:    &api.MemoryBackingSource{Type: "memfd"},
+				Access:    &api.MemoryBackingAccess{Mode: memoryBackingAccessModeShared},
+				Source:    &api.MemoryBackingSource{Type: memoryBackingSourceTypeMemfd},
 			},
 		),
 		Entry("hugepages without memfd support",
@@ -107,7 +112,7 @@ var _ = Describe("MemoryBackingConfigurator", func() {
 			libvmi.New(libvmi.WithFilesystemPVC("test-pvc")),
 			!memfdSupported,
 			&api.MemoryBacking{
-				Access: &api.MemoryBackingAccess{Mode: "shared"},
+				Access: &api.MemoryBackingAccess{Mode: memoryBackingAccessModeShared},
 			},
 		),
 	)

--- a/pkg/virt-launcher/virtwrap/converter/compute/os.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/os.go
@@ -88,7 +88,7 @@ func configureBootMenu(vmi *v1.VirtualMachineInstance, domain *api.Domain) {
 	if vmi.ShouldStartPaused() {
 		const bootMenuTimeoutMS = uint(10000)
 		domain.Spec.OS.BootMenu = &api.BootMenu{
-			Enable:  "yes",
+			Enable:  featureYes,
 			Timeout: pointer.P(bootMenuTimeoutMS),
 		}
 	}
@@ -116,8 +116,8 @@ func (o OSDomainConfigurator) configureEFI(vmi *v1.VirtualMachineInstance, domai
 		domain.Spec.OS.Firmware = "efi"
 		domain.Spec.OS.FirmwareInfo = &api.FirmwareInfo{
 			Features: []api.FirmwareFeature{
-				{Enabled: "yes", Name: FirmwareFeatureSecureBoot},
-				{Enabled: "yes", Name: FirmwareFeatureEnrolledKeys},
+				{Enabled: featureYes, Name: FirmwareFeatureSecureBoot},
+				{Enabled: featureYes, Name: FirmwareFeatureEnrolledKeys},
 			},
 		}
 		domain.Spec.OS.BootLoader = nil
@@ -126,7 +126,7 @@ func (o OSDomainConfigurator) configureEFI(vmi *v1.VirtualMachineInstance, domai
 		// variable storage via <varstore> for these descriptors automatically.
 		// For x86_64 pflash firmware, we must keep the explicit <nvram> to preserve
 		// KubeVirt's NVRAM filename convention and prevent format mismatches.
-		if vmi.Spec.Architecture != "arm64" {
+		if vmi.Spec.Architecture != archArm64 {
 			domain.Spec.OS.NVRam = &api.NVRam{
 				Format: "raw",
 				NVRam:  filepath.Join(util.PathForNVram(vmi), vmi.Name+"_VARS.fd"),
@@ -137,7 +137,7 @@ func (o OSDomainConfigurator) configureEFI(vmi *v1.VirtualMachineInstance, domai
 
 	domain.Spec.OS.BootLoader = &api.Loader{
 		Path:     o.efiConfiguration.EFICode,
-		ReadOnly: "yes",
+		ReadOnly: featureYes,
 		Secure:   boolToYesNo(&o.efiConfiguration.SecureLoader, false),
 	}
 

--- a/pkg/virt-launcher/virtwrap/converter/compute/os_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/os_test.go
@@ -36,6 +36,13 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter/compute"
 )
 
+const (
+	acpiTableTypeMSDM = "msdm"
+	acpiTableTypeSLIC = "slic"
+	osYes             = "yes"
+	boolYesNo         = "no"
+)
+
 var _ = Describe("OS Domain Configurator", func() {
 	const (
 		smbiosEnabled    = true
@@ -78,7 +85,7 @@ var _ = Describe("OS Domain Configurator", func() {
 		Entry("boot menu is enabled when VMI starts paused",
 			libvmi.New(withStartStrategy(v1.StartStrategyPaused)),
 			&api.BootMenu{
-				Enable:  "yes",
+				Enable:  osYes,
 				Timeout: pointer.P(uint(10000)),
 			},
 		),
@@ -94,7 +101,7 @@ var _ = Describe("OS Domain Configurator", func() {
 		Expect(domain).To(Equal(expectedDomain))
 	},
 		Entry("when BIOS UseSerial is disabled", !useSerialEnabled, nil),
-		Entry("when BIOS UseSerial is enabled", useSerialEnabled, &api.BIOS{UseSerial: "yes"}),
+		Entry("when BIOS UseSerial is enabled", useSerialEnabled, &api.BIOS{UseSerial: osYes}),
 	)
 
 	DescribeTable("configures kernel args based on VMI firmware settings", func(vmi *v1.VirtualMachineInstance, expectedKernelArgs string) {
@@ -130,7 +137,7 @@ var _ = Describe("OS Domain Configurator", func() {
 				BootLoader: &api.Loader{
 					Type:     "rom",
 					Path:     efiConfig.EFICode,
-					ReadOnly: "yes",
+					ReadOnly: osYes,
 					Secure:   boolToYesNo(false),
 				},
 			}
@@ -151,7 +158,7 @@ var _ = Describe("OS Domain Configurator", func() {
 			expectedOS := api.OS{
 				BootLoader: &api.Loader{
 					Path:     efiConfig.EFICode,
-					ReadOnly: "yes",
+					ReadOnly: osYes,
 					Secure:   boolToYesNo(secureBoot),
 					Type:     "pflash",
 				},
@@ -181,8 +188,8 @@ var _ = Describe("OS Domain Configurator", func() {
 				Firmware: "efi",
 				FirmwareInfo: &api.FirmwareInfo{
 					Features: []api.FirmwareFeature{
-						{Enabled: "yes", Name: compute.FirmwareFeatureSecureBoot},
-						{Enabled: "yes", Name: compute.FirmwareFeatureEnrolledKeys},
+						{Enabled: osYes, Name: compute.FirmwareFeatureSecureBoot},
+						{Enabled: osYes, Name: compute.FirmwareFeatureEnrolledKeys},
 					},
 				},
 				NVRam: &api.NVRam{
@@ -231,17 +238,17 @@ var _ = Describe("OS Domain Configurator", func() {
 		},
 			Entry("SLIC table",
 				libvmi.New(withACPISlic("slic-secret"), withSecretVolume("slic-secret")),
-				[]api.ACPITable{{Type: "slic", Path: filepath.Join(config.SecretSourceDir, "slic-secret", "slic.bin")}},
+				[]api.ACPITable{{Type: acpiTableTypeSLIC, Path: filepath.Join(config.SecretSourceDir, "slic-secret", "slic.bin")}},
 			),
 			Entry("MSDM table",
 				libvmi.New(withACPIMsdm("msdm-secret"), withSecretVolume("msdm-secret")),
-				[]api.ACPITable{{Type: "msdm", Path: filepath.Join(config.SecretSourceDir, "msdm-secret", "msdm.bin")}},
+				[]api.ACPITable{{Type: acpiTableTypeMSDM, Path: filepath.Join(config.SecretSourceDir, "msdm-secret", "msdm.bin")}},
 			),
 			Entry("both SLIC and MSDM tables",
 				libvmi.New(withACPISlicAndMsdm("slic-secret", "msdm-secret"), withSecretVolume("slic-secret"), withSecretVolume("msdm-secret")),
 				[]api.ACPITable{
-					{Type: "slic", Path: filepath.Join(config.SecretSourceDir, "slic-secret", "slic.bin")},
-					{Type: "msdm", Path: filepath.Join(config.SecretSourceDir, "msdm-secret", "msdm.bin")},
+					{Type: acpiTableTypeSLIC, Path: filepath.Join(config.SecretSourceDir, "slic-secret", "slic.bin")},
+					{Type: acpiTableTypeMSDM, Path: filepath.Join(config.SecretSourceDir, "msdm-secret", "msdm.bin")},
 				},
 			),
 		)
@@ -396,9 +403,9 @@ func withConfigMapVolume(volumeName string) libvmi.Option {
 
 func boolToYesNo(b bool) string {
 	if b {
-		return "yes"
+		return osYes
 	}
-	return "no"
+	return boolYesNo
 }
 
 func newDomainWithOS(os api.OS) api.Domain {

--- a/pkg/virt-launcher/virtwrap/converter/compute/qemu_cmd_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/qemu_cmd_test.go
@@ -36,6 +36,13 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter/compute"
 )
 
+const (
+	qemuArgFWCfg               = "-fw_cfg"
+	qemuArgChardev             = "-chardev"
+	qemuArgDevice              = "-device"
+	qemuArgISADebugconFirmware = "isa-debugcon,iobase=0x402,chardev=firmwarelog"
+)
+
 var _ = Describe("QemuCmd Domain Configurator", func() {
 	const (
 		vmiName           = "test-vmi"
@@ -58,7 +65,7 @@ var _ = Describe("QemuCmd Domain Configurator", func() {
 	},
 		Entry("added when annotation contains 'ignition'", "ignition", &api.Commandline{
 			QEMUArg: []api.Arg{
-				{Value: "-fw_cfg"},
+				{Value: qemuArgFWCfg},
 				{Value: fmt.Sprintf("name=opt/com.coreos/config,file=%s/%s",
 					ignition.GetDomainBasePath(vmiName, vmiNamespace), ignition.IgnitionFile)},
 			},
@@ -84,10 +91,10 @@ var _ = Describe("QemuCmd Domain Configurator", func() {
 			strconv.Itoa(util.EXT_LOG_VERBOSITY_THRESHOLD+1),
 			&api.Commandline{
 				QEMUArg: []api.Arg{
-					{Value: "-chardev"},
+					{Value: qemuArgChardev},
 					{Value: fmt.Sprintf("file,id=firmwarelog,path=%s", compute.QEMUSeaBiosDebugPipe)},
-					{Value: "-device"},
-					{Value: "isa-debugcon,iobase=0x402,chardev=firmwarelog"},
+					{Value: qemuArgDevice},
+					{Value: qemuArgISADebugconFirmware},
 				},
 			},
 		),
@@ -125,12 +132,12 @@ var _ = Describe("QemuCmd Domain Configurator", func() {
 		ignitionPath := fmt.Sprintf("%s/%s", ignition.GetDomainBasePath(vmiName, vmiNamespace), ignition.IgnitionFile)
 		Expect(domain).To(Equal(newDomainWithQEMUCmd(&api.Commandline{
 			QEMUArg: []api.Arg{
-				{Value: "-fw_cfg"},
+				{Value: qemuArgFWCfg},
 				{Value: fmt.Sprintf("name=opt/com.coreos/config,file=%s", ignitionPath)},
-				{Value: "-chardev"},
+				{Value: qemuArgChardev},
 				{Value: fmt.Sprintf("file,id=firmwarelog,path=%s", compute.QEMUSeaBiosDebugPipe)},
-				{Value: "-device"},
-				{Value: "isa-debugcon,iobase=0x402,chardev=firmwarelog"},
+				{Value: qemuArgDevice},
+				{Value: qemuArgISADebugconFirmware},
 			},
 		})))
 	})

--- a/pkg/virt-launcher/virtwrap/converter/compute/rng.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/rng.go
@@ -59,7 +59,7 @@ func (r RNGDomainConfigurator) Configure(vmi *v1.VirtualMachineInstance, domain 
 
 	if r.useLaunchSecuritySEV || r.useLaunchSecurityPV {
 		newRng.Driver = &api.RngDriver{
-			IOMMU: "on",
+			IOMMU: iommuEnabled,
 		}
 	}
 

--- a/pkg/virt-launcher/virtwrap/converter/compute/rng_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/rng_test.go
@@ -30,6 +30,14 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter/compute"
 )
 
+const (
+	constBackendModel     = "random"
+	constSource           = "/dev/urandom"
+	rngIommuOn            = "on"
+	rngModelVirtio        = "virtio"
+	virtioNonTransitional = "virtio-non-transitional"
+)
+
 var _ = Describe("RNG Domain Configurator", func() {
 	It("Should not configure RNG device when RNG is unspecified in VMI", func() {
 		vmi := libvmi.New()
@@ -38,7 +46,7 @@ var _ = Describe("RNG Domain Configurator", func() {
 		configurator := compute.NewRNGDomainConfigurator(
 			compute.RNGWithUseLaunchSecuritySEV(false),
 			compute.RNGWithUseLaunchSecurityPV(false),
-			compute.RNGWithVirtioModel("virtio"),
+			compute.RNGWithVirtioModel(rngModelVirtio),
 		)
 
 		Expect(configurator.Configure(vmi, &domain)).To(Succeed())
@@ -56,7 +64,7 @@ var _ = Describe("RNG Domain Configurator", func() {
 			configurator := compute.NewRNGDomainConfigurator(
 				compute.RNGWithUseLaunchSecuritySEV(true),
 				compute.RNGWithUseLaunchSecurityPV(false),
-				compute.RNGWithVirtioModel("virtio-non-transitional"),
+				compute.RNGWithVirtioModel(virtioNonTransitional),
 			)
 
 			Expect(configurator.Configure(vmi, &domain)).To(Succeed())
@@ -65,14 +73,14 @@ var _ = Describe("RNG Domain Configurator", func() {
 				Spec: api.DomainSpec{
 					Devices: api.Devices{
 						Rng: &api.Rng{
-							Model: "virtio-non-transitional",
+							Model: virtioNonTransitional,
 							Backend: &api.RngBackend{
-								Model:  "random",
-								Source: "/dev/urandom",
+								Model:  constBackendModel,
+								Source: constSource,
 							},
 							Address: nil,
 							Driver: &api.RngDriver{
-								IOMMU: "on",
+								IOMMU: rngIommuOn,
 							},
 						},
 					},
@@ -93,7 +101,7 @@ var _ = Describe("RNG Domain Configurator", func() {
 			configurator := compute.NewRNGDomainConfigurator(
 				compute.RNGWithUseLaunchSecuritySEV(false),
 				compute.RNGWithUseLaunchSecurityPV(true),
-				compute.RNGWithVirtioModel("virtio"),
+				compute.RNGWithVirtioModel(rngModelVirtio),
 			)
 
 			Expect(configurator.Configure(vmi, &domain)).To(Succeed())
@@ -102,14 +110,14 @@ var _ = Describe("RNG Domain Configurator", func() {
 				Spec: api.DomainSpec{
 					Devices: api.Devices{
 						Rng: &api.Rng{
-							Model: "virtio",
+							Model: rngModelVirtio,
 							Backend: &api.RngBackend{
-								Model:  "random",
-								Source: "/dev/urandom",
+								Model:  constBackendModel,
+								Source: constSource,
 							},
 							Address: nil,
 							Driver: &api.RngDriver{
-								IOMMU: "on",
+								IOMMU: rngIommuOn,
 							},
 						},
 					},

--- a/pkg/virt-launcher/virtwrap/converter/compute/sound.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/sound.go
@@ -27,6 +27,8 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )
 
+const soundModelIch9 = "ich9"
+
 type SoundDomainConfigurator struct{}
 
 func (s SoundDomainConfigurator) Configure(vmi *v1.VirtualMachineInstance, domain *api.Domain) error {
@@ -38,8 +40,8 @@ func (s SoundDomainConfigurator) Configure(vmi *v1.VirtualMachineInstance, domai
 	model := vmiSoundDevice.Model
 	switch model {
 	case "":
-		model = "ich9"
-	case "ich9", "ac97":
+		model = soundModelIch9
+	case soundModelIch9, "ac97":
 	default:
 		return fmt.Errorf("invalid model: %s", model)
 	}

--- a/pkg/virt-launcher/virtwrap/converter/compute/sound_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/sound_test.go
@@ -30,6 +30,11 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter/compute"
 )
 
+const (
+	modelIch9 = "ich9"
+	modelAc97 = "ac97"
+)
+
 var _ = Describe("Sound Domain Configurator", func() {
 	const deviceName = "sound-device"
 	It("Should not configure a sound device when sound is unspecified in VMI", func() {
@@ -59,15 +64,15 @@ var _ = Describe("Sound Domain Configurator", func() {
 		},
 		Entry("when only name is specified",
 			v1.SoundDevice{Name: deviceName},
-			api.SoundCard{Alias: api.NewUserDefinedAlias(deviceName), Model: "ich9"},
+			api.SoundCard{Alias: api.NewUserDefinedAlias(deviceName), Model: modelIch9},
 		),
 		Entry("when name and ich9 model are specified",
-			v1.SoundDevice{Name: deviceName, Model: "ich9"},
-			api.SoundCard{Alias: api.NewUserDefinedAlias(deviceName), Model: "ich9"},
+			v1.SoundDevice{Name: deviceName, Model: modelIch9},
+			api.SoundCard{Alias: api.NewUserDefinedAlias(deviceName), Model: modelIch9},
 		),
 		Entry("when name and ac97 model are specified",
-			v1.SoundDevice{Name: deviceName, Model: "ac97"},
-			api.SoundCard{Alias: api.NewUserDefinedAlias(deviceName), Model: "ac97"},
+			v1.SoundDevice{Name: deviceName, Model: modelAc97},
+			api.SoundCard{Alias: api.NewUserDefinedAlias(deviceName), Model: modelAc97},
 		),
 	)
 

--- a/pkg/virt-launcher/virtwrap/converter/compute/sysinfo.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/sysinfo.go
@@ -25,6 +25,13 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )
 
+const (
+	sysInfoManufacturer = "manufacturer"
+	sysInfoSKU          = "sku"
+	sysInfoSerial       = "serial"
+	sysInfoVersion      = "version"
+)
+
 type SMBIOS struct {
 	Manufacturer string
 	Product      string
@@ -61,17 +68,17 @@ func buildSystem(firmware *v1.Firmware, smBIOS *SMBIOS) []api.Entry {
 		systemEntries = []api.Entry{{Name: "uuid", Value: string(firmware.UUID)}}
 
 		if firmware.Serial != "" {
-			systemEntries = append(systemEntries, api.Entry{Name: "serial", Value: firmware.Serial})
+			systemEntries = append(systemEntries, api.Entry{Name: sysInfoSerial, Value: firmware.Serial})
 		}
 	}
 
 	if smBIOS != nil {
 		systemEntries = append(systemEntries,
-			api.Entry{Name: "manufacturer", Value: smBIOS.Manufacturer},
+			api.Entry{Name: sysInfoManufacturer, Value: smBIOS.Manufacturer},
 			api.Entry{Name: "family", Value: smBIOS.Family},
 			api.Entry{Name: "product", Value: smBIOS.Product},
-			api.Entry{Name: "sku", Value: smBIOS.SKU},
-			api.Entry{Name: "version", Value: smBIOS.Version},
+			api.Entry{Name: sysInfoSKU, Value: smBIOS.SKU},
+			api.Entry{Name: sysInfoVersion, Value: smBIOS.Version},
 		)
 	}
 
@@ -84,10 +91,10 @@ func buildChassis(chassis *v1.Chassis) []api.Entry {
 	}
 
 	return []api.Entry{
-		{Name: "manufacturer", Value: chassis.Manufacturer},
+		{Name: sysInfoManufacturer, Value: chassis.Manufacturer},
 		{Name: "version", Value: chassis.Version},
-		{Name: "serial", Value: chassis.Serial},
+		{Name: sysInfoSerial, Value: chassis.Serial},
 		{Name: "asset", Value: chassis.Asset},
-		{Name: "sku", Value: chassis.Sku},
+		{Name: sysInfoSKU, Value: chassis.Sku},
 	}
 }

--- a/pkg/virt-launcher/virtwrap/converter/compute/sysinfo_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/sysinfo_test.go
@@ -30,6 +30,12 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter/compute"
 )
 
+const (
+	sysinfoTypeSMBIOS = "smbios"
+	sysinfoUUID       = "uuid"
+	sysinfoSerial     = "serial"
+)
+
 var _ = Describe("SysInfo Domain Configurator", func() {
 	const (
 		expectedUUID   = "1234567890"
@@ -40,6 +46,8 @@ var _ = Describe("SysInfo Domain Configurator", func() {
 		expectedProduct      = "product"
 		expectedSKU          = "sku"
 		expectedVersion      = "version"
+
+		expectedAsset = "asset"
 
 		expectedChassisManufacturer = "chassisManufacturer"
 		expectedChassisVersion      = "chassisVersion"
@@ -89,15 +97,15 @@ var _ = Describe("SysInfo Domain Configurator", func() {
 			"Without firmware chassis and cluster-wide SMBIOS",
 			libvmi.New(),
 			nil,
-			api.SysInfo{Type: "smbios"},
+			api.SysInfo{Type: sysinfoTypeSMBIOS},
 		),
 		Entry(
 			"With firmware UUID",
 			libvmi.New(libvmi.WithFirmwareUUID(expectedUUID)),
 			nil,
 			api.SysInfo{
-				Type:   "smbios",
-				System: []api.Entry{{Name: "uuid", Value: expectedUUID}},
+				Type:   sysinfoTypeSMBIOS,
+				System: []api.Entry{{Name: sysinfoUUID, Value: expectedUUID}},
 			},
 		),
 		Entry(
@@ -108,10 +116,10 @@ var _ = Describe("SysInfo Domain Configurator", func() {
 			),
 			nil,
 			api.SysInfo{
-				Type: "smbios",
+				Type: sysinfoTypeSMBIOS,
 				System: []api.Entry{
-					{Name: "uuid", Value: expectedUUID},
-					{Name: "serial", Value: expectedSerial},
+					{Name: sysinfoUUID, Value: expectedUUID},
+					{Name: sysinfoSerial, Value: expectedSerial},
 				},
 			},
 		),
@@ -123,15 +131,15 @@ var _ = Describe("SysInfo Domain Configurator", func() {
 			),
 			&clusterWideSMBIOS,
 			api.SysInfo{
-				Type: "smbios",
+				Type: sysinfoTypeSMBIOS,
 				System: []api.Entry{
-					{Name: "uuid", Value: expectedUUID},
-					{Name: "serial", Value: expectedSerial},
-					{Name: "manufacturer", Value: expectedManufacturer},
-					{Name: "family", Value: expectedFamily},
-					{Name: "product", Value: expectedProduct},
-					{Name: "sku", Value: expectedSKU},
-					{Name: "version", Value: expectedVersion},
+					{Name: sysinfoUUID, Value: expectedUUID},
+					{Name: sysinfoSerial, Value: expectedSerial},
+					{Name: expectedManufacturer, Value: expectedManufacturer},
+					{Name: expectedFamily, Value: expectedFamily},
+					{Name: expectedProduct, Value: expectedProduct},
+					{Name: expectedSKU, Value: expectedSKU},
+					{Name: expectedVersion, Value: expectedVersion},
 				},
 			},
 		),
@@ -140,13 +148,13 @@ var _ = Describe("SysInfo Domain Configurator", func() {
 			libvmi.New(),
 			&clusterWideSMBIOS,
 			api.SysInfo{
-				Type: "smbios",
+				Type: sysinfoTypeSMBIOS,
 				System: []api.Entry{
-					{Name: "manufacturer", Value: expectedManufacturer},
-					{Name: "family", Value: expectedFamily},
-					{Name: "product", Value: expectedProduct},
-					{Name: "sku", Value: expectedSKU},
-					{Name: "version", Value: expectedVersion},
+					{Name: expectedManufacturer, Value: expectedManufacturer},
+					{Name: expectedFamily, Value: expectedFamily},
+					{Name: expectedProduct, Value: expectedProduct},
+					{Name: expectedSKU, Value: expectedSKU},
+					{Name: expectedVersion, Value: expectedVersion},
 				},
 			},
 		),
@@ -159,22 +167,22 @@ var _ = Describe("SysInfo Domain Configurator", func() {
 			),
 			&clusterWideSMBIOS,
 			api.SysInfo{
-				Type: "smbios",
+				Type: sysinfoTypeSMBIOS,
 				System: []api.Entry{
-					{Name: "uuid", Value: expectedUUID},
-					{Name: "serial", Value: expectedSerial},
-					{Name: "manufacturer", Value: expectedManufacturer},
-					{Name: "family", Value: expectedFamily},
-					{Name: "product", Value: expectedProduct},
-					{Name: "sku", Value: expectedSKU},
-					{Name: "version", Value: expectedVersion},
+					{Name: sysinfoUUID, Value: expectedUUID},
+					{Name: sysinfoSerial, Value: expectedSerial},
+					{Name: expectedManufacturer, Value: expectedManufacturer},
+					{Name: expectedFamily, Value: expectedFamily},
+					{Name: expectedProduct, Value: expectedProduct},
+					{Name: expectedSKU, Value: expectedSKU},
+					{Name: expectedVersion, Value: expectedVersion},
 				},
 				Chassis: []api.Entry{
-					{Name: "manufacturer", Value: expectedChassisManufacturer},
-					{Name: "version", Value: expectedChassisVersion},
-					{Name: "serial", Value: expectedChassisSerial},
-					{Name: "asset", Value: expectedChassisAsset},
-					{Name: "sku", Value: expectedChassisSKU},
+					{Name: expectedManufacturer, Value: expectedChassisManufacturer},
+					{Name: expectedVersion, Value: expectedChassisVersion},
+					{Name: sysinfoSerial, Value: expectedChassisSerial},
+					{Name: expectedAsset, Value: expectedChassisAsset},
+					{Name: expectedSKU, Value: expectedChassisSKU},
 				},
 			},
 		),
@@ -183,13 +191,13 @@ var _ = Describe("SysInfo Domain Configurator", func() {
 			libvmi.New(withChassis(&chassis)),
 			nil,
 			api.SysInfo{
-				Type: "smbios",
+				Type: sysinfoTypeSMBIOS,
 				Chassis: []api.Entry{
-					{Name: "manufacturer", Value: expectedChassisManufacturer},
-					{Name: "version", Value: expectedChassisVersion},
-					{Name: "serial", Value: expectedChassisSerial},
-					{Name: "asset", Value: expectedChassisAsset},
-					{Name: "sku", Value: expectedChassisSKU},
+					{Name: expectedManufacturer, Value: expectedChassisManufacturer},
+					{Name: expectedVersion, Value: expectedChassisVersion},
+					{Name: sysinfoSerial, Value: expectedChassisSerial},
+					{Name: expectedAsset, Value: expectedChassisAsset},
+					{Name: expectedSKU, Value: expectedChassisSKU},
 				},
 			},
 		),

--- a/pkg/virt-launcher/virtwrap/converter/compute/tpm.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/tpm.go
@@ -42,7 +42,7 @@ func (t TPMDomainConfigurator) Configure(vmi *v1.VirtualMachineInstance, domain 
 	}
 
 	if tpm.HasPersistentDevice(&vmi.Spec) {
-		newTPMDevice.Backend.PersistentState = "yes"
+		newTPMDevice.Backend.PersistentState = featureYes
 
 		// tpm-crb is not technically required for persistence, but since there was a desire for both,
 		//   we decided to introduce them together. Ultimately, we should use tpm-crb for all cases,

--- a/pkg/virt-launcher/virtwrap/converter/compute/tpm_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/tpm_test.go
@@ -28,6 +28,12 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter/compute"
 )
 
+const (
+	tpmBackendTypeEmulator = "emulator"
+	tpmBackendVersion20    = "2.0"
+	tpmPersistentStateYes  = "yes"
+)
+
 var _ = Describe("TPM Domain Configurator", func() {
 	It("Should not configure a TPM device when TPM is unspecified in VMI", func() {
 		vmi := libvmi.New()
@@ -50,8 +56,8 @@ var _ = Describe("TPM Domain Configurator", func() {
 						{
 							Model: "tpm-tis",
 							Backend: api.TPMBackend{
-								Type:    "emulator",
-								Version: "2.0",
+								Type:    tpmBackendTypeEmulator,
+								Version: tpmBackendVersion20,
 							},
 						},
 					},
@@ -74,9 +80,9 @@ var _ = Describe("TPM Domain Configurator", func() {
 						{
 							Model: "tpm-crb",
 							Backend: api.TPMBackend{
-								Type:            "emulator",
-								Version:         "2.0",
-								PersistentState: "yes",
+								Type:            tpmBackendTypeEmulator,
+								Version:         tpmBackendVersion20,
+								PersistentState: tpmPersistentStateYes,
 							},
 						},
 					},

--- a/pkg/virt-launcher/virtwrap/converter/compute/usb_redir.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/usb_redir.go
@@ -44,10 +44,10 @@ func (UsbRedirectDeviceDomainConfigurator) Configure(vmi *v1.VirtualMachineInsta
 	for i := 0; i < v1.UsbClientPassthroughMaxNumberOf; i++ {
 		path := fmt.Sprintf("/var/run/kubevirt-private/%s/virt-usbredir-%d", vmi.ObjectMeta.UID, i)
 		redirectDevices[i] = api.RedirectedDevice{
-			Type: "unix",
-			Bus:  "usb",
+			Type: socketTypeUnix,
+			Bus:  busUSB,
 			Source: api.RedirectedDeviceSource{
-				Mode: "bind",
+				Mode: socketModeBind,
 				Path: path,
 			},
 		}

--- a/pkg/virt-launcher/virtwrap/converter/compute/usb_redir_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/usb_redir_test.go
@@ -33,6 +33,12 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter/compute"
 )
 
+const (
+	modeBind         = "bind"
+	usbRedirTypeUnix = "unix"
+	usbRedirBusUSB   = "usb"
+)
+
 var _ = Describe("USB Redirect Device Domain Configurator", func() {
 	Context("When ClientPassthrough is nil", func() {
 		It("should return not configure any redirect devices", func() {
@@ -66,10 +72,10 @@ var _ = Describe("USB Redirect Device Domain Configurator", func() {
 			for i := 0; i < v1.UsbClientPassthroughMaxNumberOf; i++ {
 				path := fmt.Sprintf("/var/run/kubevirt-private/%s/virt-usbredir-%d", vmiUID, i)
 				expectedDomain.Spec.Devices.Redirs[i] = api.RedirectedDevice{
-					Type: "unix",
-					Bus:  "usb",
+					Type: usbRedirTypeUnix,
+					Bus:  usbRedirBusUSB,
 					Source: api.RedirectedDeviceSource{
-						Mode: "bind",
+						Mode: modeBind,
 						Path: path,
 					},
 				}

--- a/pkg/virt-launcher/virtwrap/converter/compute/vsock_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/vsock_test.go
@@ -37,6 +37,11 @@ import (
 	"kubevirt.io/kubevirt/pkg/vsock/mode"
 )
 
+const (
+	autostartNo = "no"
+	vsockModel  = "virtio-non-transitional"
+)
+
 var _ = Describe("VSOCK Domain Configurator", func() {
 	var fakeProc string
 
@@ -72,9 +77,9 @@ var _ = Describe("VSOCK Domain Configurator", func() {
 			Spec: api.DomainSpec{
 				Devices: api.Devices{
 					VSOCK: &api.VSOCK{
-						Model: "virtio-non-transitional",
+						Model: vsockModel,
 						CID: api.CID{
-							Auto:    "no",
+							Auto:    autostartNo,
 							Address: expectedVSOCKID,
 						},
 					},
@@ -102,9 +107,9 @@ var _ = Describe("VSOCK Domain Configurator", func() {
 			Spec: api.DomainSpec{
 				Devices: api.Devices{
 					VSOCK: &api.VSOCK{
-						Model: "virtio-non-transitional",
+						Model: vsockModel,
 						CID: api.CID{
-							Auto:    "no",
+							Auto:    autostartNo,
 							Address: vsock.LocalCID,
 						},
 					},

--- a/pkg/virt-launcher/virtwrap/converter/compute/watchdog.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/watchdog.go
@@ -46,7 +46,7 @@ func (w WatchdogDomainConfigurator) Configure(vmi *v1.VirtualMachineInstance, do
 	var newWatchdogDevice api.Watchdog
 
 	switch w.architecture {
-	case "amd64":
+	case archAmd64:
 		if vmiWatchdog.I6300ESB == nil {
 			return fmt.Errorf("watchdog %s can't be mapped, no watchdog type specified", vmiWatchdog.Name)
 		}
@@ -56,9 +56,9 @@ func (w WatchdogDomainConfigurator) Configure(vmi *v1.VirtualMachineInstance, do
 			"i6300esb",
 			string(vmiWatchdog.I6300ESB.Action),
 		)
-	case "arm64":
+	case archArm64:
 		return fmt.Errorf("watchdog is not supported on architecture ARM64")
-	case "s390x":
+	case archS390x:
 		if vmiWatchdog.Diag288 == nil {
 			return fmt.Errorf("watchdog %s can't be mapped, no watchdog type specified", vmiWatchdog.Name)
 		}

--- a/pkg/virt-launcher/virtwrap/converter/compute/watchdog_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/watchdog_test.go
@@ -30,6 +30,11 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter/compute"
 )
 
+const (
+	watchdogNameDiag    = "diagwatchdog"
+	watchdogActionReset = "reset"
+)
+
 var _ = Describe("Watchdog Domain Configurator", func() {
 	DescribeTable("Should not configure watchdog when watchdog is unspecified", func(architecture string) {
 		vmi := libvmi.New()
@@ -82,7 +87,7 @@ var _ = Describe("Watchdog Domain Configurator", func() {
 		Entry("s390x with Diag288",
 			"s390x",
 			v1.Watchdog{
-				Name: "diagwatchdog",
+				Name: watchdogNameDiag,
 				WatchdogDevice: v1.WatchdogDevice{
 					Diag288: &v1.Diag288Watchdog{
 						Action: v1.WatchdogActionReset,
@@ -90,9 +95,9 @@ var _ = Describe("Watchdog Domain Configurator", func() {
 				},
 			},
 			api.Watchdog{
-				Alias:  api.NewUserDefinedAlias("diagwatchdog"),
+				Alias:  api.NewUserDefinedAlias(watchdogNameDiag),
 				Model:  "diag288",
-				Action: "reset",
+				Action: watchdogActionReset,
 			},
 		),
 	)
@@ -119,7 +124,7 @@ var _ = Describe("Watchdog Domain Configurator", func() {
 		),
 		Entry("s390x with nil Diag288",
 			"s390x",
-			v1.Watchdog{Name: "diagwatchdog"},
+			v1.Watchdog{Name: watchdogNameDiag},
 			"can't be mapped",
 		),
 	)

--- a/pkg/virt-launcher/virtwrap/converter/kvm/configurator.go
+++ b/pkg/virt-launcher/virtwrap/converter/kvm/configurator.go
@@ -48,6 +48,8 @@ func ResetEmulatorBinaryExistsFunc() {
 	emulatorBinaryExists = defaultEmulatorBinaryExists
 }
 
+const domainTypeQEMU = "qemu"
+
 type KvmDomainConfigurator struct {
 	allowEmulation          bool
 	kvmAvailable            bool
@@ -89,7 +91,7 @@ func (k KvmDomainConfigurator) Configure(vmi *v1.VirtualMachineInstance, domain 
 		logger.Infof("Cross-architecture emulation: host=%s, guest=%s. Using software emulation.",
 			k.hostArchitecture, vmi.Spec.Architecture)
 
-		domain.Spec.Type = "qemu"
+		domain.Spec.Type = domainTypeQEMU
 
 		path := emulatorPath(vmi.Spec.Architecture)
 		if path == "" {
@@ -109,7 +111,7 @@ func (k KvmDomainConfigurator) Configure(vmi *v1.VirtualMachineInstance, domain 
 		}
 
 		log.DefaultLogger().Infof("kvm not present. Using software emulation.")
-		domain.Spec.Type = "qemu"
+		domain.Spec.Type = domainTypeQEMU
 	}
 
 	return nil

--- a/pkg/virt-launcher/virtwrap/converter/kvm/configurator_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/kvm/configurator_test.go
@@ -81,6 +81,8 @@ var _ = Describe("Hypervisor Domain Configurator", func() {
 	Context("Cross-architecture emulation", func() {
 		const (
 			crossArchAllowed = true
+			guestArchARM64   = "arm64"
+			hostArchAMD64    = "amd64"
 		)
 
 		BeforeEach(func() {
@@ -95,9 +97,9 @@ var _ = Describe("Hypervisor Domain Configurator", func() {
 		})
 
 		It("Should set domain type to qemu and emulator path for cross-arch", func() {
-			vmi.Spec.Architecture = "arm64"
+			vmi.Spec.Architecture = guestArchARM64
 			configurator := kvm.NewKvmDomainConfiguratorWithCrossArch(
-				emulationAllowed, kvmEnabled, crossArchAllowed, "amd64",
+				emulationAllowed, kvmEnabled, crossArchAllowed, hostArchAMD64,
 			)
 			Expect(configurator.Configure(vmi, &domain)).To(Succeed())
 			Expect(domain.Spec.Type).To(Equal("qemu"))
@@ -105,9 +107,9 @@ var _ = Describe("Hypervisor Domain Configurator", func() {
 		})
 
 		It("Should return error when cross-arch feature gate is disabled", func() {
-			vmi.Spec.Architecture = "arm64"
+			vmi.Spec.Architecture = guestArchARM64
 			configurator := kvm.NewKvmDomainConfiguratorWithCrossArch(
-				emulationAllowed, kvmEnabled, !crossArchAllowed, "amd64",
+				emulationAllowed, kvmEnabled, !crossArchAllowed, hostArchAMD64,
 			)
 			err := configurator.Configure(vmi, &domain)
 			Expect(err).To(HaveOccurred())
@@ -115,9 +117,9 @@ var _ = Describe("Hypervisor Domain Configurator", func() {
 		})
 
 		It("Should succeed for cross-arch even when useEmulation is disabled", func() {
-			vmi.Spec.Architecture = "arm64"
+			vmi.Spec.Architecture = guestArchARM64
 			configurator := kvm.NewKvmDomainConfiguratorWithCrossArch(
-				!emulationAllowed, kvmEnabled, crossArchAllowed, "amd64",
+				!emulationAllowed, kvmEnabled, crossArchAllowed, hostArchAMD64,
 			)
 			Expect(configurator.Configure(vmi, &domain)).To(Succeed())
 			Expect(domain.Spec.Type).To(Equal("qemu"))
@@ -125,9 +127,9 @@ var _ = Describe("Hypervisor Domain Configurator", func() {
 		})
 
 		It("Should not trigger cross-arch when guest matches host", func() {
-			vmi.Spec.Architecture = "amd64"
+			vmi.Spec.Architecture = hostArchAMD64
 			configurator := kvm.NewKvmDomainConfiguratorWithCrossArch(
-				emulationAllowed, kvmEnabled, crossArchAllowed, "amd64",
+				emulationAllowed, kvmEnabled, crossArchAllowed, hostArchAMD64,
 			)
 			Expect(configurator.Configure(vmi, &domain)).To(Succeed())
 			Expect(domain.Spec.Type).To(Equal(""))
@@ -136,16 +138,16 @@ var _ = Describe("Hypervisor Domain Configurator", func() {
 		It("Should not trigger cross-arch when guest architecture is empty", func() {
 			vmi.Spec.Architecture = ""
 			configurator := kvm.NewKvmDomainConfiguratorWithCrossArch(
-				emulationAllowed, kvmEnabled, crossArchAllowed, "amd64",
+				emulationAllowed, kvmEnabled, crossArchAllowed, hostArchAMD64,
 			)
 			Expect(configurator.Configure(vmi, &domain)).To(Succeed())
 			Expect(domain.Spec.Type).To(Equal(""))
 		})
 
 		It("Should set correct emulator path for amd64 guest on arm64 host", func() {
-			vmi.Spec.Architecture = "amd64"
+			vmi.Spec.Architecture = hostArchAMD64
 			configurator := kvm.NewKvmDomainConfiguratorWithCrossArch(
-				emulationAllowed, kvmEnabled, crossArchAllowed, "arm64",
+				emulationAllowed, kvmEnabled, crossArchAllowed, guestArchARM64,
 			)
 			Expect(configurator.Configure(vmi, &domain)).To(Succeed())
 			Expect(domain.Spec.Type).To(Equal("qemu"))
@@ -155,7 +157,7 @@ var _ = Describe("Hypervisor Domain Configurator", func() {
 		It("Should set correct emulator path for s390x guest", func() {
 			vmi.Spec.Architecture = "s390x"
 			configurator := kvm.NewKvmDomainConfiguratorWithCrossArch(
-				emulationAllowed, kvmEnabled, crossArchAllowed, "amd64",
+				emulationAllowed, kvmEnabled, crossArchAllowed, hostArchAMD64,
 			)
 			Expect(configurator.Configure(vmi, &domain)).To(Succeed())
 			Expect(domain.Spec.Type).To(Equal("qemu"))
@@ -167,9 +169,9 @@ var _ = Describe("Hypervisor Domain Configurator", func() {
 				return fmt.Errorf("required emulator binary not found: %s", path)
 			})
 
-			vmi.Spec.Architecture = "arm64"
+			vmi.Spec.Architecture = guestArchARM64
 			configurator := kvm.NewKvmDomainConfiguratorWithCrossArch(
-				emulationAllowed, kvmEnabled, crossArchAllowed, "amd64",
+				emulationAllowed, kvmEnabled, crossArchAllowed, hostArchAMD64,
 			)
 			err := configurator.Configure(vmi, &domain)
 			Expect(err).To(HaveOccurred())
@@ -180,7 +182,7 @@ var _ = Describe("Hypervisor Domain Configurator", func() {
 		It("Should return error for unsupported guest architecture", func() {
 			vmi.Spec.Architecture = "riscv64"
 			configurator := kvm.NewKvmDomainConfiguratorWithCrossArch(
-				emulationAllowed, kvmEnabled, crossArchAllowed, "amd64",
+				emulationAllowed, kvmEnabled, crossArchAllowed, hostArchAMD64,
 			)
 			err := configurator.Configure(vmi, &domain)
 			Expect(err).To(HaveOccurred())

--- a/pkg/virt-launcher/virtwrap/converter/network/configurator_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/network/configurator_test.go
@@ -79,7 +79,7 @@ var _ = Describe("Network Domain Configurator", func() {
 			"when an interface using a non-tap binding plugin is specified",
 			libvmi.New(
 				libvmi.WithInterface(
-					libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithBindingPlugin(v1.PluginBinding{Name: "passt"})),
+					libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithBindingPlugin(v1.PluginBinding{Name: passtBindingPluginName})),
 				),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 			),

--- a/pkg/virt-launcher/virtwrap/converter/network/passt_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/network/passt_test.go
@@ -34,9 +34,16 @@ import (
 )
 
 const (
-	ifaceTypeVhostUser = "vhostuser"
+	defaultNetworkName      = "default"
+	defaultPodInterfaceName = "eth0"
+	excludeYes              = "yes"
+	ifaceTypeVhostUser      = "vhostuser"
 	//nolint:gosec //linter is confusing passt for password
 	passtLogFilePath           = "/var/run/kubevirt/passt.log"
+	portForwardProtocolTCP     = "tcp"
+	portForwardProtocolUDP     = "udp"
+	portProtocolTCP            = "TCP"
+	portProtocolUDP            = "UDP"
 	virtioModel                = "virtio-non-transitional"
 	multusSecondaryNetworkName = "multus-network"
 	nadName                    = "multus-nad"
@@ -57,24 +64,35 @@ var _ = Describe("Passt Network Domain Configurator", func() {
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					libvmistatus.WithStatus(
 						libvmistatus.New(
-							libvmistatus.WithInterfaceStatus(v1.VirtualMachineInstanceNetworkInterface{Name: "not-default", PodInterfaceName: "eth0"}),
+							libvmistatus.WithInterfaceStatus(v1.VirtualMachineInstanceNetworkInterface{
+								Name:             "not-default",
+								PodInterfaceName: defaultPodInterfaceName,
+							}),
 						),
 					),
 				),
 			),
 			Entry("no matching status entry",
 				libvmi.New(
+<<<<<<< HEAD
 					libvmi.WithInterface(libvmi.NewInterface("default", libvmi.WithPasstBinding())),
+=======
+					libvmi.WithInterface(libvmi.InterfaceDeviceWithPasstBinding(defaultNetworkName)),
+>>>>>>> 2ca51adea2 (virt-launcher: fix goconst linter issues)
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 				),
 			),
 			Entry("empty PodInterfaceName in status",
 				libvmi.New(
+<<<<<<< HEAD
 					libvmi.WithInterface(libvmi.NewInterface("default", libvmi.WithPasstBinding())),
+=======
+					libvmi.WithInterface(libvmi.InterfaceDeviceWithPasstBinding(defaultNetworkName)),
+>>>>>>> 2ca51adea2 (virt-launcher: fix goconst linter issues)
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					libvmistatus.WithStatus(
 						libvmistatus.New(
-							libvmistatus.WithInterfaceStatus(v1.VirtualMachineInstanceNetworkInterface{Name: "default"}),
+							libvmistatus.WithInterfaceStatus(v1.VirtualMachineInstanceNetworkInterface{Name: defaultNetworkName}),
 						),
 					),
 				),
@@ -85,7 +103,7 @@ var _ = Describe("Passt Network Domain Configurator", func() {
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					libvmistatus.WithStatus(
 						libvmistatus.New(
-							libvmistatus.WithInterfaceStatus(v1.VirtualMachineInstanceNetworkInterface{Name: "default"}),
+							libvmistatus.WithInterfaceStatus(v1.VirtualMachineInstanceNetworkInterface{Name: defaultNetworkName}),
 						),
 					),
 				),
@@ -99,7 +117,10 @@ var _ = Describe("Passt Network Domain Configurator", func() {
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					libvmistatus.WithStatus(
 						libvmistatus.New(
-							libvmistatus.WithInterfaceStatus(v1.VirtualMachineInstanceNetworkInterface{Name: iface.Name, PodInterfaceName: "eth0"}),
+							libvmistatus.WithInterfaceStatus(v1.VirtualMachineInstanceNetworkInterface{
+								Name:             iface.Name,
+								PodInterfaceName: defaultPodInterfaceName,
+							}),
 						),
 					),
 				)
@@ -113,14 +134,14 @@ var _ = Describe("Passt Network Domain Configurator", func() {
 			},
 			Entry("passt binding",
 				newPasstInterface(),
-				newPasstDomainInterface("default", virtioModel,
+				newPasstDomainInterface(defaultNetworkName, virtioModel,
 					withPasstBackend(),
 					withPasstPortForwardAll(),
 				),
 			),
 			Entry("PCI address",
 				newPasstInterface(withIfacePCI("0000:02:02.0")),
-				newPasstDomainInterface("default", virtioModel,
+				newPasstDomainInterface(defaultNetworkName, virtioModel,
 					withPasstBackend(),
 					withPasstPortForwardAll(),
 					withPCIAddress("0000:02:02.0"),
@@ -128,7 +149,7 @@ var _ = Describe("Passt Network Domain Configurator", func() {
 			),
 			Entry("MAC address",
 				newPasstInterface(withIfaceMAC("02:02:02:02:02:02")),
-				newPasstDomainInterface("default", virtioModel,
+				newPasstDomainInterface(defaultNetworkName, virtioModel,
 					withPasstBackend(),
 					withPasstPortForwardAll(),
 					withMAC("02:02:02:02:02:02"),
@@ -136,7 +157,7 @@ var _ = Describe("Passt Network Domain Configurator", func() {
 			),
 			Entry("ACPI address",
 				newPasstInterface(withIfaceACPI(2)),
-				newPasstDomainInterface("default", virtioModel,
+				newPasstDomainInterface(defaultNetworkName, virtioModel,
 					withPasstBackend(),
 					withPasstPortForwardAll(),
 					withACPI(2),
@@ -144,27 +165,27 @@ var _ = Describe("Passt Network Domain Configurator", func() {
 			),
 			Entry("non virtio model",
 				newPasstInterface(withIfaceModel("e1000")),
-				newPasstDomainInterface("default", "e1000",
+				newPasstDomainInterface(defaultNetworkName, "e1000",
 					withPasstBackend(),
 					withPasstPortForwardAll(),
 				),
 			),
 			Entry("tcp ports (should forward tcp ports only)",
 				newPasstInterface(withIfacePorts([]v1.Port{
-					{Protocol: "TCP", Port: 1},
-					{Protocol: "TCP", Port: 4},
+					{Protocol: portProtocolTCP, Port: 1},
+					{Protocol: portProtocolTCP, Port: 4},
 				})),
-				newPasstDomainInterface("default", virtioModel,
+				newPasstDomainInterface(defaultNetworkName, virtioModel,
 					withPasstBackend(),
 					withPasstPortForwardTCP([]uint{1, 4}),
 				),
 			),
 			Entry("udp ports (should forward udp ports only)",
 				newPasstInterface(withIfacePorts([]v1.Port{
-					{Protocol: "UDP", Port: 2},
-					{Protocol: "UDP", Port: 3},
+					{Protocol: portProtocolUDP, Port: 2},
+					{Protocol: portProtocolUDP, Port: 3},
 				})),
-				newPasstDomainInterface("default", virtioModel,
+				newPasstDomainInterface(defaultNetworkName, virtioModel,
 					withPasstBackend(),
 					withPasstPortForwardUDP([]uint{2, 3}),
 				),
@@ -172,11 +193,11 @@ var _ = Describe("Passt Network Domain Configurator", func() {
 			Entry("both tcp and udp ports",
 				newPasstInterface(withIfacePorts([]v1.Port{
 					{Port: 1},
-					{Protocol: "UDP", Port: 2},
-					{Protocol: "UDP", Port: 3},
-					{Protocol: "TCP", Port: 4},
+					{Protocol: portProtocolUDP, Port: 2},
+					{Protocol: portProtocolUDP, Port: 3},
+					{Protocol: portProtocolTCP, Port: 4},
 				})),
-				newPasstDomainInterface("default", virtioModel,
+				newPasstDomainInterface(defaultNetworkName, virtioModel,
 					withPasstBackend(),
 					withPasstPortForwardTCP([]uint{1, 4}),
 					withPasstPortForwardUDP([]uint{2, 3}),
@@ -195,16 +216,23 @@ var _ = Describe("Passt Network Domain Configurator", func() {
 			},
 			Entry("virtio transitional enabled",
 				libvmi.New(
+<<<<<<< HEAD
 					libvmi.WithInterface(libvmi.NewInterface("default", libvmi.WithPasstBinding())),
+=======
+					libvmi.WithInterface(libvmi.InterfaceDeviceWithPasstBinding(defaultNetworkName)),
+>>>>>>> 2ca51adea2 (virt-launcher: fix goconst linter issues)
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					libvmistatus.WithStatus(
 						libvmistatus.New(
-							libvmistatus.WithInterfaceStatus(v1.VirtualMachineInstanceNetworkInterface{Name: "default", PodInterfaceName: "eth0"}),
+							libvmistatus.WithInterfaceStatus(v1.VirtualMachineInstanceNetworkInterface{
+								Name:             defaultNetworkName,
+								PodInterfaceName: defaultPodInterfaceName,
+							}),
 						),
 					),
 				),
 				"virtio-transitional",
-				newPasstDomainInterface("default", "virtio-transitional",
+				newPasstDomainInterface(defaultNetworkName, "virtio-transitional",
 					withPasstBackend(),
 					withPasstPortForwardAll(),
 				),
@@ -212,16 +240,23 @@ var _ = Describe("Passt Network Domain Configurator", func() {
 			Entry("isitio proxy injection enabled",
 				libvmi.New(
 					libvmi.WithAnnotation("sidecar.istio.io/inject", "true"),
+<<<<<<< HEAD
 					libvmi.WithInterface(libvmi.NewInterface("default", libvmi.WithPasstBinding())),
+=======
+					libvmi.WithInterface(libvmi.InterfaceDeviceWithPasstBinding(defaultNetworkName)),
+>>>>>>> 2ca51adea2 (virt-launcher: fix goconst linter issues)
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					libvmistatus.WithStatus(
 						libvmistatus.New(
-							libvmistatus.WithInterfaceStatus(v1.VirtualMachineInstanceNetworkInterface{Name: "default", PodInterfaceName: "eth0"}),
+							libvmistatus.WithInterfaceStatus(v1.VirtualMachineInstanceNetworkInterface{
+								Name:             defaultNetworkName,
+								PodInterfaceName: defaultPodInterfaceName,
+							}),
 						),
 					),
 				),
 				virtioModel,
-				newPasstDomainInterface("default", virtioModel,
+				newPasstDomainInterface(defaultNetworkName, virtioModel,
 					withPasstBackend(),
 					withPasstPortForwardIstio(),
 				),
@@ -230,7 +265,11 @@ var _ = Describe("Passt Network Domain Configurator", func() {
 
 		It("should not override other interfaces", func() {
 			vmi := libvmi.New(
+<<<<<<< HEAD
 				libvmi.WithInterface(libvmi.NewInterface("default", libvmi.WithPasstBinding())),
+=======
+				libvmi.WithInterface(libvmi.InterfaceDeviceWithPasstBinding(defaultNetworkName)),
+>>>>>>> 2ca51adea2 (virt-launcher: fix goconst linter issues)
 				libvmi.WithInterface(v1.Interface{
 					Name: multusSecondaryNetworkName,
 					InterfaceBindingMethod: v1.InterfaceBindingMethod{
@@ -242,7 +281,7 @@ var _ = Describe("Passt Network Domain Configurator", func() {
 				libvmistatus.WithStatus(
 					libvmistatus.New(
 						libvmistatus.WithInterfaceStatus(
-							v1.VirtualMachineInstanceNetworkInterface{Name: "default", PodInterfaceName: "eth0"}),
+							v1.VirtualMachineInstanceNetworkInterface{Name: defaultNetworkName, PodInterfaceName: defaultPodInterfaceName}),
 						libvmistatus.WithInterfaceStatus(
 							v1.VirtualMachineInstanceNetworkInterface{Name: multusSecondaryNetworkName, PodInterfaceName: "eth1"}),
 					),
@@ -257,7 +296,7 @@ var _ = Describe("Passt Network Domain Configurator", func() {
 			var domain api.Domain
 			Expect(configurator.Configure(vmi, &domain)).To(Succeed())
 
-			expectedPasstIface := newPasstDomainInterface("default", virtioModel,
+			expectedPasstIface := newPasstDomainInterface(defaultNetworkName, virtioModel,
 				withPasstBackend(),
 				withPasstPortForwardAll(),
 			)
@@ -270,11 +309,18 @@ var _ = Describe("Passt Network Domain Configurator", func() {
 
 		It("should set domain interface correctly when executed more than once", func() {
 			vmi := libvmi.New(
+<<<<<<< HEAD
 				libvmi.WithInterface(libvmi.NewInterface("default", libvmi.WithPasstBinding())),
+=======
+				libvmi.WithInterface(libvmi.InterfaceDeviceWithPasstBinding(defaultNetworkName)),
+>>>>>>> 2ca51adea2 (virt-launcher: fix goconst linter issues)
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 				libvmistatus.WithStatus(
 					libvmistatus.New(
-						libvmistatus.WithInterfaceStatus(v1.VirtualMachineInstanceNetworkInterface{Name: "default", PodInterfaceName: "eth0"}),
+						libvmistatus.WithInterfaceStatus(v1.VirtualMachineInstanceNetworkInterface{
+							Name:             defaultNetworkName,
+							PodInterfaceName: defaultPodInterfaceName,
+						}),
 					),
 				),
 			)
@@ -283,7 +329,7 @@ var _ = Describe("Passt Network Domain Configurator", func() {
 				network.WithVirtioModel(virtioModel),
 			)
 
-			expectedDomainIface := newPasstDomainInterface("default", virtioModel,
+			expectedDomainIface := newPasstDomainInterface(defaultNetworkName, virtioModel,
 				withPasstBackend(),
 				withPasstPortForwardAll(),
 			)
@@ -300,11 +346,15 @@ var _ = Describe("Passt Network Domain Configurator", func() {
 
 		It("should set domain interface source link to the optional one if exists", func() {
 			vmi := libvmi.New(
+<<<<<<< HEAD
 				libvmi.WithInterface(libvmi.NewInterface("default", libvmi.WithPasstBinding())),
+=======
+				libvmi.WithInterface(libvmi.InterfaceDeviceWithPasstBinding(defaultNetworkName)),
+>>>>>>> 2ca51adea2 (virt-launcher: fix goconst linter issues)
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 			)
 			vmi.Status.Interfaces = []v1.VirtualMachineInstanceNetworkInterface{
-				{Name: "default", PodInterfaceName: "ovn-udn1"},
+				{Name: defaultNetworkName, PodInterfaceName: "ovn-udn1"},
 			}
 
 			configurator := network.NewDomainConfigurator(network.WithVirtioModel(virtioModel))
@@ -312,7 +362,7 @@ var _ = Describe("Passt Network Domain Configurator", func() {
 			var domain api.Domain
 			Expect(configurator.Configure(vmi, &domain)).To(Succeed())
 
-			expectedDomainIface := newPasstDomainInterface("default", virtioModel,
+			expectedDomainIface := newPasstDomainInterface(defaultNetworkName, virtioModel,
 				withPasstBackend(),
 				withPasstPortForwardAll(),
 				withSourceDevice("ovn-udn1"),
@@ -331,7 +381,7 @@ func newPasstDomainInterface(networkName, modelType string, options ...passtOpti
 		Model: &api.Model{Type: modelType},
 		Type:  ifaceTypeVhostUser,
 		Source: api.InterfaceSource{
-			Device: "eth0",
+			Device: defaultPodInterfaceName,
 		},
 	}
 
@@ -354,8 +404,8 @@ func withPasstBackend() passtOption {
 func withPasstPortForwardAll() passtOption {
 	return func(iface *api.Interface) {
 		iface.PortForward = []api.InterfacePortForward{
-			{Proto: "tcp"},
-			{Proto: "udp"},
+			{Proto: portForwardProtocolTCP},
+			{Proto: portForwardProtocolUDP},
 		}
 	}
 }
@@ -369,7 +419,7 @@ func withPasstPortForwardTCP(ports []uint) passtOption {
 		if iface.PortForward == nil {
 			iface.PortForward = []api.InterfacePortForward{}
 		}
-		iface.PortForward = append(iface.PortForward, api.InterfacePortForward{Proto: "tcp", Ranges: ranges})
+		iface.PortForward = append(iface.PortForward, api.InterfacePortForward{Proto: portForwardProtocolTCP, Ranges: ranges})
 	}
 }
 
@@ -382,7 +432,7 @@ func withPasstPortForwardUDP(ports []uint) passtOption {
 		if iface.PortForward == nil {
 			iface.PortForward = []api.InterfacePortForward{}
 		}
-		iface.PortForward = append(iface.PortForward, api.InterfacePortForward{Proto: "udp", Ranges: ranges})
+		iface.PortForward = append(iface.PortForward, api.InterfacePortForward{Proto: portForwardProtocolUDP, Ranges: ranges})
 	}
 }
 
@@ -390,18 +440,18 @@ func withPasstPortForwardIstio() passtOption {
 	return func(iface *api.Interface) {
 		iface.PortForward = []api.InterfacePortForward{
 			{
-				Proto: "tcp",
+				Proto: portForwardProtocolTCP,
 				Ranges: []api.InterfacePortForwardRange{
-					{Start: 15000, Exclude: "yes"},
-					{Start: 15001, Exclude: "yes"},
-					{Start: 15004, Exclude: "yes"},
-					{Start: 15006, Exclude: "yes"},
-					{Start: 15008, Exclude: "yes"},
-					{Start: 15009, Exclude: "yes"},
-					{Start: 15020, Exclude: "yes"},
-					{Start: 15021, Exclude: "yes"},
-					{Start: 15053, Exclude: "yes"},
-					{Start: 15090, Exclude: "yes"},
+					{Start: 15000, Exclude: excludeYes},
+					{Start: 15001, Exclude: excludeYes},
+					{Start: 15004, Exclude: excludeYes},
+					{Start: 15006, Exclude: excludeYes},
+					{Start: 15008, Exclude: excludeYes},
+					{Start: 15009, Exclude: excludeYes},
+					{Start: 15020, Exclude: excludeYes},
+					{Start: 15021, Exclude: excludeYes},
+					{Start: 15053, Exclude: excludeYes},
+					{Start: 15090, Exclude: excludeYes},
 				},
 			},
 		}

--- a/pkg/virt-launcher/virtwrap/converter/network/passt_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/network/passt_test.go
@@ -40,6 +40,7 @@ const (
 	ifaceTypeVhostUser      = "vhostuser"
 	//nolint:gosec //linter is confusing passt for password
 	passtLogFilePath           = "/var/run/kubevirt/passt.log"
+	passtBindingPluginName     = "passt"
 	portForwardProtocolTCP     = "tcp"
 	portForwardProtocolUDP     = "udp"
 	portProtocolTCP            = "TCP"
@@ -74,21 +75,13 @@ var _ = Describe("Passt Network Domain Configurator", func() {
 			),
 			Entry("no matching status entry",
 				libvmi.New(
-<<<<<<< HEAD
-					libvmi.WithInterface(libvmi.NewInterface("default", libvmi.WithPasstBinding())),
-=======
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithPasstBinding(defaultNetworkName)),
->>>>>>> 2ca51adea2 (virt-launcher: fix goconst linter issues)
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 				),
 			),
 			Entry("empty PodInterfaceName in status",
 				libvmi.New(
-<<<<<<< HEAD
-					libvmi.WithInterface(libvmi.NewInterface("default", libvmi.WithPasstBinding())),
-=======
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithPasstBinding(defaultNetworkName)),
->>>>>>> 2ca51adea2 (virt-launcher: fix goconst linter issues)
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					libvmistatus.WithStatus(
 						libvmistatus.New(
@@ -216,11 +209,7 @@ var _ = Describe("Passt Network Domain Configurator", func() {
 			},
 			Entry("virtio transitional enabled",
 				libvmi.New(
-<<<<<<< HEAD
-					libvmi.WithInterface(libvmi.NewInterface("default", libvmi.WithPasstBinding())),
-=======
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithPasstBinding(defaultNetworkName)),
->>>>>>> 2ca51adea2 (virt-launcher: fix goconst linter issues)
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					libvmistatus.WithStatus(
 						libvmistatus.New(
@@ -240,11 +229,8 @@ var _ = Describe("Passt Network Domain Configurator", func() {
 			Entry("isitio proxy injection enabled",
 				libvmi.New(
 					libvmi.WithAnnotation("sidecar.istio.io/inject", "true"),
-<<<<<<< HEAD
-					libvmi.WithInterface(libvmi.NewInterface("default", libvmi.WithPasstBinding())),
-=======
+
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithPasstBinding(defaultNetworkName)),
->>>>>>> 2ca51adea2 (virt-launcher: fix goconst linter issues)
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					libvmistatus.WithStatus(
 						libvmistatus.New(
@@ -265,11 +251,8 @@ var _ = Describe("Passt Network Domain Configurator", func() {
 
 		It("should not override other interfaces", func() {
 			vmi := libvmi.New(
-<<<<<<< HEAD
-				libvmi.WithInterface(libvmi.NewInterface("default", libvmi.WithPasstBinding())),
-=======
+
 				libvmi.WithInterface(libvmi.InterfaceDeviceWithPasstBinding(defaultNetworkName)),
->>>>>>> 2ca51adea2 (virt-launcher: fix goconst linter issues)
 				libvmi.WithInterface(v1.Interface{
 					Name: multusSecondaryNetworkName,
 					InterfaceBindingMethod: v1.InterfaceBindingMethod{
@@ -309,11 +292,8 @@ var _ = Describe("Passt Network Domain Configurator", func() {
 
 		It("should set domain interface correctly when executed more than once", func() {
 			vmi := libvmi.New(
-<<<<<<< HEAD
-				libvmi.WithInterface(libvmi.NewInterface("default", libvmi.WithPasstBinding())),
-=======
+
 				libvmi.WithInterface(libvmi.InterfaceDeviceWithPasstBinding(defaultNetworkName)),
->>>>>>> 2ca51adea2 (virt-launcher: fix goconst linter issues)
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 				libvmistatus.WithStatus(
 					libvmistatus.New(
@@ -346,11 +326,8 @@ var _ = Describe("Passt Network Domain Configurator", func() {
 
 		It("should set domain interface source link to the optional one if exists", func() {
 			vmi := libvmi.New(
-<<<<<<< HEAD
-				libvmi.WithInterface(libvmi.NewInterface("default", libvmi.WithPasstBinding())),
-=======
+
 				libvmi.WithInterface(libvmi.InterfaceDeviceWithPasstBinding(defaultNetworkName)),
->>>>>>> 2ca51adea2 (virt-launcher: fix goconst linter issues)
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 			)
 			vmi.Status.Interfaces = []v1.VirtualMachineInstanceNetworkInterface{
@@ -395,7 +372,7 @@ func newPasstDomainInterface(networkName, modelType string, options ...passtOpti
 func withPasstBackend() passtOption {
 	return func(iface *api.Interface) {
 		iface.Backend = &api.InterfaceBackend{
-			Type:    "passt",
+			Type:    passtBindingPluginName,
 			LogFile: passtLogFilePath,
 		}
 	}

--- a/pkg/virt-launcher/virtwrap/converter/translate/translate.go
+++ b/pkg/virt-launcher/virtwrap/converter/translate/translate.go
@@ -32,6 +32,11 @@ import (
 	api "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )
 
+const (
+	commandlineXMLName = "commandline"
+	argValueXMLName    = "value"
+)
+
 // ToLibvirtDomain converts a KubeVirt DomainSpec to a libvirtxml Domain
 // by marshaling to XML and unmarshaling into the libvirtxml type.
 // Callers must verify the Plugins feature gate is enabled before calling.
@@ -122,7 +127,7 @@ func parseQEMUCommandline(domainXML string) ([]api.Arg, []api.Env, bool) {
 				continue
 			}
 			switch t.Name.Local {
-			case "commandline":
+			case commandlineXMLName:
 				inCommandline = true
 				hasCommandline = true
 			case "arg":
@@ -137,7 +142,7 @@ func parseQEMUCommandline(domainXML string) ([]api.Arg, []api.Env, bool) {
 				}
 			}
 		case xml.EndElement:
-			if t.Name.Space == qemuNamespace && t.Name.Local == "commandline" {
+			if t.Name.Space == qemuNamespace && t.Name.Local == commandlineXMLName {
 				inCommandline = false
 			}
 		}
@@ -148,7 +153,7 @@ func parseQEMUCommandline(domainXML string) ([]api.Arg, []api.Env, bool) {
 
 func parseArgAttrs(t xml.StartElement) api.Arg {
 	for _, attr := range t.Attr {
-		if attr.Name.Local == "value" {
+		if attr.Name.Local == argValueXMLName {
 			return api.Arg{Value: attr.Value}
 		}
 	}

--- a/pkg/virt-launcher/virtwrap/converter/translate/translate_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/translate/translate_test.go
@@ -30,36 +30,52 @@ import (
 	api "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )
 
+const (
+	domainTypeKVM   = "kvm"
+	diskTypeFile    = "file"
+	diskDeviceDisk  = "disk"
+	diskBusVirtio   = "virtio"
+	diskDeviceVDA   = "vda"
+	diskDriverQEMU  = "qemu"
+	diskDriverRaw   = "raw"
+	ifaceTypeBridge = "bridge"
+	ifaceBridgeName = "br0"
+	ifaceMAC        = "52:54:00:00:00:01"
+	testUID         = "test-uid-12345"
+	testVMName      = "test-vm"
+	diskDeviceCDROM = "cdrom"
+)
+
 var _ = Describe("Domain translation", func() {
 	Context("ToLibvirtDomain", func() {
 		It("should convert a minimal DomainSpec", func() {
-			spec := api.NewMinimalDomainSpec("test-vm")
-			spec.Type = "kvm"
+			spec := api.NewMinimalDomainSpec(testVMName)
+			spec.Type = domainTypeKVM
 			domain, err := ToLibvirtDomain(spec)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(domain).ToNot(BeNil())
-			Expect(domain.Name).To(Equal("test-vm"))
-			Expect(domain.Type).To(Equal("kvm"))
+			Expect(domain.Name).To(Equal(testVMName))
+			Expect(domain.Type).To(Equal(domainTypeKVM))
 
 			assertDomainSpecRoundTrip(spec)
 		})
 
 		It("should convert a DomainSpec with file disk", func() {
-			spec := api.NewMinimalDomainSpec("test-vm")
+			spec := api.NewMinimalDomainSpec(testVMName)
 			spec.Devices.Disks = []api.Disk{
 				{
-					Type:   "file",
-					Device: "disk",
+					Type:   diskTypeFile,
+					Device: diskDeviceDisk,
 					Source: api.DiskSource{
 						File: "/var/run/libvirt/images/disk.img",
 					},
 					Target: api.DiskTarget{
-						Bus:    "virtio",
-						Device: "vda",
+						Bus:    diskBusVirtio,
+						Device: diskDeviceVDA,
 					},
 					Driver: &api.DiskDriver{
-						Name: "qemu",
-						Type: "raw",
+						Name: diskDriverQEMU,
+						Type: diskDriverRaw,
 					},
 				},
 			}
@@ -74,15 +90,15 @@ var _ = Describe("Domain translation", func() {
 		})
 
 		It("should convert a DomainSpec with bridge interface", func() {
-			spec := api.NewMinimalDomainSpec("test-vm")
+			spec := api.NewMinimalDomainSpec(testVMName)
 			spec.Devices.Interfaces = []api.Interface{
 				{
-					Type: "bridge",
+					Type: ifaceTypeBridge,
 					Source: api.InterfaceSource{
-						Bridge: "br0",
+						Bridge: ifaceBridgeName,
 					},
-					Model: &api.Model{Type: "virtio"},
-					MAC:   &api.MAC{MAC: "52:54:00:00:00:01"},
+					Model: &api.Model{Type: diskBusVirtio},
+					MAC:   &api.MAC{MAC: ifaceMAC},
 				},
 			}
 
@@ -90,13 +106,13 @@ var _ = Describe("Domain translation", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(domain.Devices.Interfaces).To(HaveLen(1))
 			Expect(domain.Devices.Interfaces[0].Source.Bridge).ToNot(BeNil())
-			Expect(domain.Devices.Interfaces[0].Source.Bridge.Bridge).To(Equal("br0"))
+			Expect(domain.Devices.Interfaces[0].Source.Bridge.Bridge).To(Equal(ifaceBridgeName))
 
 			assertDomainSpecRoundTrip(spec)
 		})
 
 		It("should convert a DomainSpec with QEMU commandline", func() {
-			spec := api.NewMinimalDomainSpec("test-vm")
+			spec := api.NewMinimalDomainSpec(testVMName)
 			spec.XmlNS = "http://libvirt.org/schemas/domain/qemu/1.0"
 			spec.QEMUCmd = &api.Commandline{
 				QEMUArg: []api.Arg{
@@ -122,10 +138,10 @@ var _ = Describe("Domain translation", func() {
 		})
 
 		It("should preserve metadata through conversion", func() {
-			spec := api.NewMinimalDomainSpec("test-vm")
+			spec := api.NewMinimalDomainSpec(testVMName)
 			spec.Metadata = api.Metadata{
 				KubeVirt: api.KubeVirtMetadata{
-					UID: "test-uid-12345",
+					UID: testUID,
 					GracePeriod: &api.GracePeriodMetadata{
 						DeletionGracePeriodSeconds: 30,
 					},
@@ -135,7 +151,7 @@ var _ = Describe("Domain translation", func() {
 			domain, err := ToLibvirtDomain(spec)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(domain.Metadata).ToNot(BeNil())
-			Expect(domain.Metadata.XML).To(ContainSubstring("test-uid-12345"))
+			Expect(domain.Metadata.XML).To(ContainSubstring(testUID))
 		})
 
 		It("should handle an empty DomainSpec", func() {
@@ -146,7 +162,7 @@ var _ = Describe("Domain translation", func() {
 		})
 
 		It("should handle a DomainSpec with empty devices", func() {
-			spec := api.NewMinimalDomainSpec("test-vm")
+			spec := api.NewMinimalDomainSpec(testVMName)
 			spec.Devices = api.Devices{}
 			domain, err := ToLibvirtDomain(spec)
 			Expect(err).ToNot(HaveOccurred())
@@ -162,16 +178,16 @@ var _ = Describe("Domain translation", func() {
 
 	Context("FromLibvirtDomain", func() {
 		It("should convert a libvirtxml Domain back to DomainSpec", func() {
-			spec := api.NewMinimalDomainSpec("test-vm")
-			spec.Type = "kvm"
+			spec := api.NewMinimalDomainSpec(testVMName)
+			spec.Type = domainTypeKVM
 			domain, err := ToLibvirtDomain(spec)
 			Expect(err).ToNot(HaveOccurred())
 
 			spec2, err := FromLibvirtDomain(domain)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(spec2).ToNot(BeNil())
-			Expect(spec2.Name).To(Equal("test-vm"))
-			Expect(spec2.Type).To(Equal("kvm"))
+			Expect(spec2.Name).To(Equal(testVMName))
+			Expect(spec2.Type).To(Equal(domainTypeKVM))
 		})
 
 		It("should return error for nil libvirtxml Domain", func() {
@@ -182,7 +198,7 @@ var _ = Describe("Domain translation", func() {
 
 		It("should set XmlNS but not QEMUCmd when QEMUCommandline has no args or envs", func() {
 			domain := &libvirtxml.Domain{
-				Name:            "test-vm",
+				Name:            testVMName,
 				QEMUCommandline: &libvirtxml.DomainQEMUCommandline{},
 			}
 			spec, err := FromLibvirtDomain(domain)
@@ -193,15 +209,15 @@ var _ = Describe("Domain translation", func() {
 
 		It("should gracefully handle libvirt-only fields that have no KubeVirt equivalent", func() {
 			domain := &libvirtxml.Domain{
-				Name: "test-vm",
-				Type: "kvm",
+				Name: testVMName,
+				Type: domainTypeKVM,
 				QEMUCapabilities: &libvirtxml.DomainQEMUCapabilities{
 					Add: []libvirtxml.DomainQEMUCapabilitiesEntry{{Name: "cap-test"}},
 				},
 			}
 			spec, err := FromLibvirtDomain(domain)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(spec.Name).To(Equal("test-vm"))
+			Expect(spec.Name).To(Equal(testVMName))
 		})
 	})
 
@@ -347,10 +363,10 @@ var _ = Describe("Domain translation", func() {
 
 	Context("Round-trip fidelity", func() {
 		It("should round-trip a DomainSpec with metadata", func() {
-			spec := api.NewMinimalDomainSpec("test-vm")
+			spec := api.NewMinimalDomainSpec(testVMName)
 			spec.Metadata = api.Metadata{
 				KubeVirt: api.KubeVirtMetadata{
-					UID: "test-uid-12345",
+					UID: testUID,
 					GracePeriod: &api.GracePeriodMetadata{
 						DeletionGracePeriodSeconds: 30,
 					},
@@ -363,13 +379,13 @@ var _ = Describe("Domain translation", func() {
 			roundTripped, err := FromLibvirtDomain(domain)
 			Expect(err).ToNot(HaveOccurred())
 
-			Expect(roundTripped.Metadata.KubeVirt.UID).To(Equal(types.UID("test-uid-12345")))
+			Expect(roundTripped.Metadata.KubeVirt.UID).To(Equal(types.UID(testUID)))
 			Expect(roundTripped.Metadata.KubeVirt.GracePeriod).ToNot(BeNil())
 			Expect(roundTripped.Metadata.KubeVirt.GracePeriod.DeletionGracePeriodSeconds).To(Equal(int64(30)))
 		})
 
 		It("should round-trip a DomainSpec with CPU topology", func() {
-			spec := api.NewMinimalDomainSpec("test-vm")
+			spec := api.NewMinimalDomainSpec(testVMName)
 			spec.CPU = api.CPU{
 				Mode: "host-passthrough",
 				Topology: &api.CPUTopology{
@@ -386,7 +402,7 @@ var _ = Describe("Domain translation", func() {
 		})
 
 		It("should round-trip a DomainSpec with OS and boot order", func() {
-			spec := api.NewMinimalDomainSpec("test-vm")
+			spec := api.NewMinimalDomainSpec(testVMName)
 			spec.OS = api.OS{
 				Type: api.OSType{
 					OS:      "hvm",
@@ -395,14 +411,14 @@ var _ = Describe("Domain translation", func() {
 				},
 				BootOrder: []api.Boot{
 					{Dev: "hd"},
-					{Dev: "cdrom"},
+					{Dev: diskDeviceCDROM},
 				},
 			}
 			assertDomainSpecRoundTrip(spec)
 		})
 
 		It("should round-trip a DomainSpec with clock and timers", func() {
-			spec := api.NewMinimalDomainSpec("test-vm")
+			spec := api.NewMinimalDomainSpec(testVMName)
 			spec.Clock = &api.Clock{
 				Offset: "utc",
 				Timer: []api.Timer{
@@ -415,7 +431,7 @@ var _ = Describe("Domain translation", func() {
 		})
 
 		It("should round-trip a DomainSpec with features", func() {
-			spec := api.NewMinimalDomainSpec("test-vm")
+			spec := api.NewMinimalDomainSpec(testVMName)
 			spec.Features = &api.Features{
 				ACPI: &api.FeatureEnabled{},
 				APIC: &api.FeatureEnabled{},
@@ -425,30 +441,30 @@ var _ = Describe("Domain translation", func() {
 		})
 
 		It("should round-trip a DomainSpec with multiple devices", func() {
-			spec := api.NewMinimalDomainSpec("test-vm")
+			spec := api.NewMinimalDomainSpec(testVMName)
 			spec.Devices.Disks = []api.Disk{
 				{
-					Type:   "file",
-					Device: "disk",
+					Type:   diskTypeFile,
+					Device: diskDeviceDisk,
 					Source: api.DiskSource{File: "/images/disk1.img"},
-					Target: api.DiskTarget{Bus: "virtio", Device: "vda"},
-					Driver: &api.DiskDriver{Name: "qemu", Type: "raw"},
+					Target: api.DiskTarget{Bus: diskBusVirtio, Device: diskDeviceVDA},
+					Driver: &api.DiskDriver{Name: diskDriverQEMU, Type: diskDriverRaw},
 				},
 				{
-					Type:     "file",
-					Device:   "cdrom",
+					Type:     diskTypeFile,
+					Device:   diskDeviceCDROM,
 					Source:   api.DiskSource{File: "/images/cloud-init.iso"},
 					Target:   api.DiskTarget{Bus: "sata", Device: "sda"},
-					Driver:   &api.DiskDriver{Name: "qemu", Type: "raw"},
+					Driver:   &api.DiskDriver{Name: diskDriverQEMU, Type: diskDriverRaw},
 					ReadOnly: &api.ReadOnly{},
 				},
 			}
 			spec.Devices.Interfaces = []api.Interface{
 				{
-					Type:   "bridge",
-					Source: api.InterfaceSource{Bridge: "br0"},
-					Model:  &api.Model{Type: "virtio"},
-					MAC:    &api.MAC{MAC: "52:54:00:00:00:01"},
+					Type:   ifaceTypeBridge,
+					Source: api.InterfaceSource{Bridge: ifaceBridgeName},
+					Model:  &api.Model{Type: diskBusVirtio},
+					MAC:    &api.MAC{MAC: ifaceMAC},
 				},
 			}
 			assertDomainSpecRoundTrip(spec)

--- a/pkg/virtctl/adm/logverbosity/logverbosity.go
+++ b/pkg/virtctl/adm/logverbosity/logverbosity.go
@@ -21,9 +21,21 @@ import (
 	"kubevirt.io/kubevirt/pkg/virtctl/templates"
 )
 
+const (
+	virtAPIComponent        = "virt-api"
+	virtControllerComponent = "virt-controller"
+	virtHandlerComponent    = "virt-handler"
+	virtLauncherComponent   = "virt-launcher"
+	virtOperatorComponent   = "virt-operator"
+	virtAPIJSON             = "virtAPI"
+	virtControllerJSON      = "virtController"
+	virtHandlerJSON         = "virtHandler"
+	virtLauncherJSON        = "virtLauncher"
+	virtOperatorJSON        = "virtOperator"
+)
+
 type Command struct{}
 
-// for command parsing
 const (
 	// Verbosity must be 0-9.
 	// https://kubernetes.io/docs/reference/kubectl/cheatsheet/#kubectl-output-verbosity-and-debugging
@@ -46,12 +58,12 @@ var isReset bool
 // https://kubevirt.io/user-guide/operations/debug/#setting-verbosity-per-kubevirt-component
 // TODO: set verbosity per nodes
 var virtComponents = map[string]*uint{
-	"virt-api":        new(uint),
-	"virt-controller": new(uint),
-	"virt-handler":    new(uint),
-	"virt-launcher":   new(uint),
-	"virt-operator":   new(uint),
-	allComponents:     new(uint),
+	virtAPIComponent:        new(uint),
+	virtControllerComponent: new(uint),
+	virtHandlerComponent:    new(uint),
+	virtLauncherComponent:   new(uint),
+	virtOperatorComponent:   new(uint),
+	allComponents:           new(uint),
 }
 
 // operation type of log-verbosity command
@@ -90,7 +102,7 @@ func NewCommand() *cobra.Command {
 		RunE:    c.RunE,
 	}
 
-	cmd.Flags().UintVar(virtComponents["virt-api"], "virt-api", NoFlag, "show/set virt-api log verbosity (0-9)")
+	cmd.Flags().UintVar(virtComponents[virtAPIComponent], virtAPIComponent, NoFlag, "show/set virt-api log verbosity (0-9)")
 	// A flag without an argument should only be used for boolean flags.
 	// However, we want to use a flag without an argument (e.g. --virt-api) to show verbosity.
 	// To do this, we set the default value (NoOptDefVal=noArg) when the flag has no argument.
@@ -98,19 +110,20 @@ func NewCommand() *cobra.Command {
 	// The caveat is that there is no way to distinguish between user-specified 10 and NoOptDefVal=noArg after the following point.
 	// https://github.com/kubevirt/kubevirt/blob/main/vendor/github.com/spf13/pflag/flag.go#L989
 	// So, we accept "flag=10" but the operation is "show" instead of "set".
-	cmd.Flags().Lookup("virt-api").NoOptDefVal = strconv.FormatUint(noArg, 10)
+	cmd.Flags().Lookup(virtAPIComponent).NoOptDefVal = strconv.FormatUint(noArg, 10)
 
-	cmd.Flags().UintVar(virtComponents["virt-controller"], "virt-controller", NoFlag, "show/set virt-controller log verbosity (0-9)")
-	cmd.Flags().Lookup("virt-controller").NoOptDefVal = strconv.FormatUint(noArg, 10)
+	cmd.Flags().UintVar(virtComponents[virtControllerComponent], virtControllerComponent, NoFlag,
+		"show/set virt-controller log verbosity (0-9)")
+	cmd.Flags().Lookup(virtControllerComponent).NoOptDefVal = strconv.FormatUint(noArg, 10)
 
-	cmd.Flags().UintVar(virtComponents["virt-handler"], "virt-handler", NoFlag, "show/set virt-handler log verbosity (0-9)")
-	cmd.Flags().Lookup("virt-handler").NoOptDefVal = strconv.FormatUint(noArg, 10)
+	cmd.Flags().UintVar(virtComponents[virtHandlerComponent], virtHandlerComponent, NoFlag, "show/set virt-handler log verbosity (0-9)")
+	cmd.Flags().Lookup(virtHandlerComponent).NoOptDefVal = strconv.FormatUint(noArg, 10)
 
-	cmd.Flags().UintVar(virtComponents["virt-launcher"], "virt-launcher", NoFlag, "show/set virt-launcher log verbosity (0-9)")
-	cmd.Flags().Lookup("virt-launcher").NoOptDefVal = strconv.FormatUint(noArg, 10)
+	cmd.Flags().UintVar(virtComponents[virtLauncherComponent], virtLauncherComponent, NoFlag, "show/set virt-launcher log verbosity (0-9)")
+	cmd.Flags().Lookup(virtLauncherComponent).NoOptDefVal = strconv.FormatUint(noArg, 10)
 
-	cmd.Flags().UintVar(virtComponents["virt-operator"], "virt-operator", NoFlag, "show/set virt-operator log verbosity (0-9)")
-	cmd.Flags().Lookup("virt-operator").NoOptDefVal = strconv.FormatUint(noArg, 10)
+	cmd.Flags().UintVar(virtComponents[virtOperatorComponent], virtOperatorComponent, NoFlag, "show/set virt-operator log verbosity (0-9)")
+	cmd.Flags().Lookup(virtOperatorComponent).NoOptDefVal = strconv.FormatUint(noArg, 10)
 
 	cmd.Flags().UintVar(virtComponents[allComponents], allComponents, NoFlag, "show/set all component log verbosity (0-9)")
 	cmd.Flags().Lookup(allComponents).NoOptDefVal = strconv.FormatUint(noArg, 10)
@@ -161,12 +174,12 @@ func usage() string {
 // component name to JSON name
 func getJSONNameByComponentName(componentName string) string {
 	componentNameToJSONName := map[string]string{
-		"virt-api":        "virtAPI",
-		"virt-controller": "virtController",
-		"virt-handler":    "virtHandler",
-		"virt-launcher":   "virtLauncher",
-		"virt-operator":   "virtOperator",
-		allComponents:     allComponents,
+		virtAPIComponent:        virtAPIJSON,
+		virtControllerComponent: virtControllerJSON,
+		virtHandlerComponent:    virtHandlerJSON,
+		virtLauncherComponent:   virtLauncherJSON,
+		virtOperatorComponent:   virtOperatorJSON,
+		allComponents:           allComponents,
 	}
 	return componentNameToJSONName[componentName]
 }
@@ -236,11 +249,11 @@ func createShowMessage(currentLv map[string]uint) []string {
 	// fill the unattended verbosity with default verbosity
 	// key: JSONName, value: verbosity
 	verbosityVal := map[string]uint{
-		"virtAPI":        virtconfig.DefaultVirtAPILogVerbosity,
-		"virtController": virtconfig.DefaultVirtControllerLogVerbosity,
-		"virtHandler":    virtconfig.DefaultVirtHandlerLogVerbosity,
-		"virtLauncher":   virtconfig.DefaultVirtLauncherLogVerbosity,
-		"virtOperator":   virtconfig.DefaultVirtOperatorLogVerbosity,
+		virtAPIJSON:        virtconfig.DefaultVirtAPILogVerbosity,
+		virtControllerJSON: virtconfig.DefaultVirtControllerLogVerbosity,
+		virtHandlerJSON:    virtconfig.DefaultVirtHandlerLogVerbosity,
+		virtLauncherJSON:   virtconfig.DefaultVirtLauncherLogVerbosity,
+		virtOperatorJSON:   virtconfig.DefaultVirtOperatorLogVerbosity,
 	}
 
 	// update the verbosity based on the existing verbosity in the KubeVirt CR

--- a/pkg/virtctl/adm/logverbosity/logverbosity_test.go
+++ b/pkg/virtctl/adm/logverbosity/logverbosity_test.go
@@ -22,6 +22,11 @@ import (
 	"kubevirt.io/kubevirt/pkg/virtctl/testing"
 )
 
+const (
+	admCommand          = "adm"
+	logVerbosityCommand = "log-verbosity"
+)
+
 var _ = Describe("Log Verbosity", func() {
 	var kvInterface *kubecli.MockKubeVirtInterface
 
@@ -202,7 +207,7 @@ var _ = Describe("Log Verbosity", func() {
 
 		Context("with empty set of flags", func() {
 			It("should fail (return help)", func() {
-				cmd := testing.NewRepeatableVirtctlCommand("adm", "log-verbosity")
+				cmd := testing.NewRepeatableVirtctlCommand(admCommand, logVerbosityCommand)
 				err := cmd()
 				Expect(err).NotTo(Succeed())
 				Expect(err).To(MatchError(ContainSubstring("no flag specified - expecting at least one flag")))
@@ -211,7 +216,7 @@ var _ = Describe("Log Verbosity", func() {
 
 		DescribeTable("should fail handled by the CLI package", func(args ...string) {
 			argStr := strings.Join(args, ",")
-			cmd := testing.NewRepeatableVirtctlCommand("adm", "log-verbosity", argStr)
+			cmd := testing.NewRepeatableVirtctlCommand(admCommand, logVerbosityCommand, argStr)
 			Expect(cmd()).NotTo(Succeed())
 		},
 			Entry("reset and all coexist", "--reset", "--all=3"),
@@ -222,7 +227,7 @@ var _ = Describe("Log Verbosity", func() {
 		)
 
 		DescribeTable("should fail handled by error handler", func(output string, args ...string) {
-			commandAndArgs := []string{"adm", "log-verbosity"}
+			commandAndArgs := []string{admCommand, logVerbosityCommand}
 			commandAndArgs = append(commandAndArgs, args...)
 			_, err := testing.NewRepeatableVirtctlCommandWithOut(commandAndArgs...)()
 			Expect(err).NotTo(Succeed())
@@ -396,7 +401,7 @@ func commonSetup(kvInterface *kubecli.MockKubeVirtInterface, kvs *v1.KubeVirtLis
 }
 
 func commonShowTest(output []uint, args ...string) {
-	commandAndArgs := []string{"adm", "log-verbosity"}
+	commandAndArgs := []string{admCommand, logVerbosityCommand}
 	commandAndArgs = append(commandAndArgs, args...)
 	bytes, err := testing.NewRepeatableVirtctlCommandWithOut(commandAndArgs...)()
 	Expect(err).To(Succeed())
@@ -406,7 +411,7 @@ func commonShowTest(output []uint, args ...string) {
 }
 
 func commonSetCommand(args ...string) {
-	commandAndArgs := []string{"adm", "log-verbosity"}
+	commandAndArgs := []string{admCommand, logVerbosityCommand}
 	commandAndArgs = append(commandAndArgs, args...)
 	cmd := testing.NewRepeatableVirtctlCommand(commandAndArgs...)
 	Expect(cmd()).To(Succeed())

--- a/pkg/virtctl/create/vm/vm.go
+++ b/pkg/virtctl/create/vm/vm.go
@@ -107,6 +107,7 @@ const (
 	accessCredUserInvalidError           = "user cannot be specified with selected access credential type and method"
 	accessCredMethodFlagMismatchErrorFmt = "method param and value passed to --%s have to match: %s vs %s"
 	randSuffixLength                     = 5
+	dataSourceKind                       = "DataSource"
 )
 
 type createVM struct {
@@ -366,7 +367,7 @@ func dataVolumeValidToInferFrom(vm *v1.VirtualMachine, name string) error {
 			if dvt.Spec.Source != nil && (dvt.Spec.Source.PVC != nil || dvt.Spec.Source.Registry != nil || dvt.Spec.Source.Snapshot != nil) {
 				return nil
 			}
-			if dvt.Spec.SourceRef != nil && dvt.Spec.SourceRef.Kind == "DataSource" {
+			if dvt.Spec.SourceRef != nil && dvt.Spec.SourceRef.Kind == dataSourceKind {
 				return nil
 			}
 			return fmt.Errorf(
@@ -1350,7 +1351,7 @@ func withVolumeSourceRefDataSource(paramStr string) (*cdiv1.DataVolumeSpec, *uin
 
 	spec := &cdiv1.DataVolumeSpec{
 		SourceRef: &cdiv1.DataVolumeSourceRef{
-			Kind: "DataSource",
+			Kind: dataSourceKind,
 			Name: name,
 		},
 	}

--- a/pkg/virtctl/create/vm/vm_test.go
+++ b/pkg/virtctl/create/vm/vm_test.go
@@ -29,7 +29,13 @@ import (
 	"kubevirt.io/kubevirt/pkg/virtctl/testing"
 )
 
-const runCmdGAManageSSH = "runcmd:\n  - [ setsebool, -P, 'virt_qemu_ga_manage_ssh', 'on' ]"
+const (
+	runCmdGAManageSSH = "runcmd:\n  - [ setsebool, -P, 'virt_qemu_ga_manage_ssh', 'on' ]"
+	certConfigMapName = "my-cert"
+	vddkUUID          = "123e-11"
+	vddkBackingFile   = "backing-file"
+	testThumbprint    = "test-thumbprint"
+)
 
 var _ = Describe("create vm", func() {
 	const (
@@ -51,7 +57,16 @@ chpasswd: { expire: False }`
 
 	Context("Manifest is created successfully", func() {
 		const (
+			dataSourceKind        = "DataSource"
 			importedVolumeRegexp  = `imported-volume-\w{5}`
+			importSecretRef       = "test-credentials"
+			pvcSourceName         = "pvc"
+			secretRefName         = "secret-ref"
+			snapshotVolumeName    = "snapshot"
+			sourceNamespace       = k8sv1.NamespaceDefault
+			sourceDataSourceName  = "datasource"
+			sourceURL             = "http://url.com"
+			sshAccessSecretName   = "my-keys"
 			sysprepDisk           = "sysprepdisk"
 			sysprepConfigMap      = "configMap"
 			sysprepSecret         = "secret"
@@ -433,7 +448,7 @@ chpasswd: { expire: False }`
 				Expect(vm.Spec.DataVolumeTemplates[0].Name).To(Equal(dvtName))
 			}
 			Expect(vm.Spec.DataVolumeTemplates[0].Spec.SourceRef).ToNot(BeNil())
-			Expect(vm.Spec.DataVolumeTemplates[0].Spec.SourceRef.Kind).To(Equal("DataSource"))
+			Expect(vm.Spec.DataVolumeTemplates[0].Spec.SourceRef.Kind).To(Equal(dataSourceKind))
 			Expect(vm.Spec.DataVolumeTemplates[0].Spec.SourceRef.Name).To(Equal(dsName))
 			if dsNamespace == "" {
 				Expect(vm.Spec.DataVolumeTemplates[0].Spec.SourceRef.Namespace).To(BeNil())
@@ -536,7 +551,7 @@ chpasswd: { expire: False }`
 			}
 
 			if (source != nil && (source.PVC != nil || source.Registry != nil || source.Snapshot != nil)) ||
-				(sourceRef != nil && sourceRef.Kind == "DataSource") {
+				(sourceRef != nil && sourceRef.Kind == dataSourceKind) {
 				// In this case inference should be possible
 				Expect(vm.Spec.Instancetype).ToNot(BeNil())
 				Expect(vm.Spec.Instancetype.InferFromVolume).To(Equal(vm.Spec.Template.Spec.Volumes[0].Name))
@@ -553,27 +568,27 @@ chpasswd: { expire: False }`
 			Entry("with blank source", "type:blank,size:256Mi", "", "256Mi", 0, &cdiv1.DataVolumeSource{Blank: &cdiv1.DataVolumeBlankImage{}}, nil),
 			Entry("with blank source and bootorder", "type:blank,size:256Mi,bootorder:1", "", "256Mi", 1, &cdiv1.DataVolumeSource{Blank: &cdiv1.DataVolumeBlankImage{}}, nil),
 			Entry("with blank source and name", "type:blank,size:256Mi,name:blank-name", "blank-name", "256Mi", 0, &cdiv1.DataVolumeSource{Blank: &cdiv1.DataVolumeBlankImage{}}, nil),
-			Entry("with GCS source", "type:gcs,size:256Mi,url:http://url.com,secretref:test-credentials", "", "256Mi", 0, &cdiv1.DataVolumeSource{GCS: &cdiv1.DataVolumeSourceGCS{URL: "http://url.com", SecretRef: "test-credentials"}}, nil),
-			Entry("with GCS source and bootorder", "type:gcs,size:256Mi,url:http://url.com,secretref:test-credentials,bootorder:2", "", "256Mi", 2, &cdiv1.DataVolumeSource{GCS: &cdiv1.DataVolumeSourceGCS{URL: "http://url.com", SecretRef: "test-credentials"}}, nil),
-			Entry("with http source", "type:http,size:256Mi,url:http://url.com", "", "256Mi", 0, &cdiv1.DataVolumeSource{HTTP: &cdiv1.DataVolumeSourceHTTP{URL: "http://url.com"}}, nil),
-			Entry("with http source and bootorder", "type:http,size:256Mi,url:http://url.com,bootorder:3", "", "256Mi", 3, &cdiv1.DataVolumeSource{HTTP: &cdiv1.DataVolumeSourceHTTP{URL: "http://url.com"}}, nil),
-			Entry("with imageio source", "type:imageio,size:256Mi,url:http://url.com,diskid:1,secretref:secret-ref", "", "256Mi", 0, &cdiv1.DataVolumeSource{Imageio: &cdiv1.DataVolumeSourceImageIO{DiskID: "1", SecretRef: "secret-ref", URL: "http://url.com"}}, nil),
-			Entry("with imageio source and bootorder", "type:imageio,size:256Mi,url:http://url.com,diskid:1,secretref:secret-ref,bootorder:4", "", "256Mi", 4, &cdiv1.DataVolumeSource{Imageio: &cdiv1.DataVolumeSourceImageIO{DiskID: "1", SecretRef: "secret-ref", URL: "http://url.com"}}, nil),
-			Entry("with PVC source", "type:pvc,size:256Mi,src:default/pvc", "", "256Mi", 0, &cdiv1.DataVolumeSource{PVC: &cdiv1.DataVolumeSourcePVC{Name: "pvc", Namespace: "default"}}, nil),
-			Entry("with PVC source and bootorder", "type:pvc,size:256Mi,src:default/pvc,name:imported-volume,bootorder:5", "imported-volume", "256Mi", 5, &cdiv1.DataVolumeSource{PVC: &cdiv1.DataVolumeSourcePVC{Name: "pvc", Namespace: "default"}}, nil),
-			Entry("with PVC source without size", "type:pvc,src:default/pvc,name:imported-volume", "imported-volume", "", 0, &cdiv1.DataVolumeSource{PVC: &cdiv1.DataVolumeSourcePVC{Name: "pvc", Namespace: "default"}}, nil),
-			Entry("with registry source", "type:registry,size:256Mi,certconfigmap:my-cert,pullmethod:pod,url:http://url.com,secretref:secret-ref,name:imported-volume", "imported-volume", "256Mi", 0, &cdiv1.DataVolumeSource{Registry: &cdiv1.DataVolumeSourceRegistry{CertConfigMap: pointer.P("my-cert"), PullMethod: pointer.P(cdiv1.RegistryPullMethod("pod")), URL: pointer.P("http://url.com"), SecretRef: pointer.P("secret-ref")}}, nil),
-			Entry("with registry source and bootorder", "type:registry,size:256Mi,certconfigmap:my-cert,pullmethod:pod,url:http://url.com,secretref:secret-ref,name:imported-volume,bootorder:6", "imported-volume", "256Mi", 6, &cdiv1.DataVolumeSource{Registry: &cdiv1.DataVolumeSourceRegistry{CertConfigMap: pointer.P("my-cert"), PullMethod: pointer.P(cdiv1.RegistryPullMethod("pod")), URL: pointer.P("http://url.com"), SecretRef: pointer.P("secret-ref")}}, nil),
-			Entry("with S3 source", "type:s3,size:256Mi,url:http://url.com,certconfigmap:my-cert,secretref:secret-ref", "", "256Mi", 0, &cdiv1.DataVolumeSource{S3: &cdiv1.DataVolumeSourceS3{CertConfigMap: "my-cert", SecretRef: "secret-ref", URL: "http://url.com"}}, nil),
-			Entry("with S3 source and bootorder", "type:s3,size:256Mi,url:http://url.com,certconfigmap:my-cert,secretref:secret-ref,bootorder:7", "", "256Mi", 7, &cdiv1.DataVolumeSource{S3: &cdiv1.DataVolumeSourceS3{CertConfigMap: "my-cert", SecretRef: "secret-ref", URL: "http://url.com"}}, nil),
-			Entry("with VDDK source", "type:vddk,size:256Mi,backingfile:backing-file,initimageurl:http://url.com,uuid:123e-11,url:http://url.com,thumbprint:test-thumbprint,secretref:test-credentials", "", "256Mi", 0, &cdiv1.DataVolumeSource{VDDK: &cdiv1.DataVolumeSourceVDDK{BackingFile: "backing-file", InitImageURL: "http://url.com", UUID: "123e-11", URL: "http://url.com", Thumbprint: "test-thumbprint", SecretRef: "test-credentials"}}, nil),
-			Entry("with VDDK source and bootorder", "type:vddk,size:256Mi,backingfile:backing-file,initimageurl:http://url.com,uuid:123e-11,url:http://url.com,thumbprint:test-thumbprint,secretref:test-credentials,bootorder:8", "", "256Mi", 8, &cdiv1.DataVolumeSource{VDDK: &cdiv1.DataVolumeSourceVDDK{BackingFile: "backing-file", InitImageURL: "http://url.com", UUID: "123e-11", URL: "http://url.com", Thumbprint: "test-thumbprint", SecretRef: "test-credentials"}}, nil),
-			Entry("with Snapshot source", "type:snapshot,size:256Mi,src:default/snapshot,name:imported-volume", "imported-volume", "256Mi", 0, &cdiv1.DataVolumeSource{Snapshot: &cdiv1.DataVolumeSourceSnapshot{Name: "snapshot", Namespace: "default"}}, nil),
-			Entry("with Snapshot source and bootorder", "type:snapshot,size:256Mi,src:default/snapshot,name:imported-volume,bootorder:9", "imported-volume", "256Mi", 9, &cdiv1.DataVolumeSource{Snapshot: &cdiv1.DataVolumeSourceSnapshot{Name: "snapshot", Namespace: "default"}}, nil),
-			Entry("with Snapshot source without size", "type:snapshot,src:default/snapshot,name:imported-volume", "imported-volume", "", 0, &cdiv1.DataVolumeSource{Snapshot: &cdiv1.DataVolumeSourceSnapshot{Name: "snapshot", Namespace: "default"}}, nil),
-			Entry("with DataSource source", "type:ds,src:default/datasource,name:imported-ds", "imported-ds", "", 0, nil, &cdiv1.DataVolumeSourceRef{Kind: "DataSource", Name: "datasource", Namespace: pointer.P("default")}),
-			Entry("with DataSource source without namespace", "type:ds,src:datasource", "", "", 0, nil, &cdiv1.DataVolumeSourceRef{Kind: "DataSource", Name: "datasource"}),
-			Entry("with DataSource source and bootorder", "type:ds,src:default/datasource,name:imported-ds,bootorder:1", "imported-ds", "", 1, nil, &cdiv1.DataVolumeSourceRef{Kind: "DataSource", Name: "datasource", Namespace: pointer.P("default")}),
+			Entry("with GCS source", "type:gcs,size:256Mi,url:"+sourceURL+",secretref:"+importSecretRef, "", "256Mi", 0, &cdiv1.DataVolumeSource{GCS: &cdiv1.DataVolumeSourceGCS{URL: sourceURL, SecretRef: importSecretRef}}, nil),
+			Entry("with GCS source and bootorder", "type:gcs,size:256Mi,url:"+sourceURL+",secretref:"+importSecretRef+",bootorder:2", "", "256Mi", 2, &cdiv1.DataVolumeSource{GCS: &cdiv1.DataVolumeSourceGCS{URL: sourceURL, SecretRef: importSecretRef}}, nil),
+			Entry("with http source", "type:http,size:256Mi,url:"+sourceURL, "", "256Mi", 0, &cdiv1.DataVolumeSource{HTTP: &cdiv1.DataVolumeSourceHTTP{URL: sourceURL}}, nil),
+			Entry("with http source and bootorder", "type:http,size:256Mi,url:"+sourceURL+",bootorder:3", "", "256Mi", 3, &cdiv1.DataVolumeSource{HTTP: &cdiv1.DataVolumeSourceHTTP{URL: sourceURL}}, nil),
+			Entry("with imageio source", "type:imageio,size:256Mi,url:"+sourceURL+",diskid:1,secretref:"+secretRefName, "", "256Mi", 0, &cdiv1.DataVolumeSource{Imageio: &cdiv1.DataVolumeSourceImageIO{DiskID: "1", SecretRef: secretRefName, URL: sourceURL}}, nil),
+			Entry("with imageio source and bootorder", "type:imageio,size:256Mi,url:"+sourceURL+",diskid:1,secretref:"+secretRefName+",bootorder:4", "", "256Mi", 4, &cdiv1.DataVolumeSource{Imageio: &cdiv1.DataVolumeSourceImageIO{DiskID: "1", SecretRef: secretRefName, URL: sourceURL}}, nil),
+			Entry("with PVC source", "type:pvc,size:256Mi,src:"+sourceNamespace+"/"+pvcSourceName, "", "256Mi", 0, &cdiv1.DataVolumeSource{PVC: &cdiv1.DataVolumeSourcePVC{Name: pvcSourceName, Namespace: sourceNamespace}}, nil),
+			Entry("with PVC source and bootorder", "type:pvc,size:256Mi,src:"+sourceNamespace+"/"+pvcSourceName+",name:imported-volume,bootorder:5", "imported-volume", "256Mi", 5, &cdiv1.DataVolumeSource{PVC: &cdiv1.DataVolumeSourcePVC{Name: pvcSourceName, Namespace: sourceNamespace}}, nil),
+			Entry("with PVC source without size", "type:pvc,src:"+sourceNamespace+"/"+pvcSourceName+",name:imported-volume", "imported-volume", "", 0, &cdiv1.DataVolumeSource{PVC: &cdiv1.DataVolumeSourcePVC{Name: pvcSourceName, Namespace: sourceNamespace}}, nil),
+			Entry("with registry source", "type:registry,size:256Mi,certconfigmap:my-cert,pullmethod:pod,url:"+sourceURL+",secretref:"+secretRefName+",name:imported-volume", "imported-volume", "256Mi", 0, &cdiv1.DataVolumeSource{Registry: &cdiv1.DataVolumeSourceRegistry{CertConfigMap: pointer.P(certConfigMapName), PullMethod: pointer.P(cdiv1.RegistryPullMethod("pod")), URL: pointer.P(sourceURL), SecretRef: pointer.P(secretRefName)}}, nil),
+			Entry("with registry source and bootorder", "type:registry,size:256Mi,certconfigmap:my-cert,pullmethod:pod,url:"+sourceURL+",secretref:"+secretRefName+",name:imported-volume,bootorder:6", "imported-volume", "256Mi", 6, &cdiv1.DataVolumeSource{Registry: &cdiv1.DataVolumeSourceRegistry{CertConfigMap: pointer.P(certConfigMapName), PullMethod: pointer.P(cdiv1.RegistryPullMethod("pod")), URL: pointer.P(sourceURL), SecretRef: pointer.P(secretRefName)}}, nil),
+			Entry("with S3 source", "type:s3,size:256Mi,url:"+sourceURL+",certconfigmap:my-cert,secretref:"+secretRefName, "", "256Mi", 0, &cdiv1.DataVolumeSource{S3: &cdiv1.DataVolumeSourceS3{CertConfigMap: certConfigMapName, SecretRef: secretRefName, URL: sourceURL}}, nil),
+			Entry("with S3 source and bootorder", "type:s3,size:256Mi,url:"+sourceURL+",certconfigmap:my-cert,secretref:"+secretRefName+",bootorder:7", "", "256Mi", 7, &cdiv1.DataVolumeSource{S3: &cdiv1.DataVolumeSourceS3{CertConfigMap: certConfigMapName, SecretRef: secretRefName, URL: sourceURL}}, nil),
+			Entry("with VDDK source", "type:vddk,size:256Mi,backingfile:backing-file,initimageurl:"+sourceURL+",uuid:123e-11,url:"+sourceURL+",thumbprint:"+testThumbprint+",secretref:"+importSecretRef, "", "256Mi", 0, &cdiv1.DataVolumeSource{VDDK: &cdiv1.DataVolumeSourceVDDK{BackingFile: vddkBackingFile, InitImageURL: sourceURL, UUID: vddkUUID, URL: sourceURL, Thumbprint: testThumbprint, SecretRef: importSecretRef}}, nil),
+			Entry("with VDDK source and bootorder", "type:vddk,size:256Mi,backingfile:backing-file,initimageurl:"+sourceURL+",uuid:123e-11,url:"+sourceURL+",thumbprint:"+testThumbprint+",secretref:"+importSecretRef+",bootorder:8", "", "256Mi", 8, &cdiv1.DataVolumeSource{VDDK: &cdiv1.DataVolumeSourceVDDK{BackingFile: vddkBackingFile, InitImageURL: sourceURL, UUID: vddkUUID, URL: sourceURL, Thumbprint: testThumbprint, SecretRef: importSecretRef}}, nil),
+			Entry("with Snapshot source", "type:snapshot,size:256Mi,src:"+sourceNamespace+"/"+snapshotVolumeName+",name:imported-volume", "imported-volume", "256Mi", 0, &cdiv1.DataVolumeSource{Snapshot: &cdiv1.DataVolumeSourceSnapshot{Name: snapshotVolumeName, Namespace: sourceNamespace}}, nil),
+			Entry("with Snapshot source and bootorder", "type:snapshot,size:256Mi,src:"+sourceNamespace+"/"+snapshotVolumeName+",name:imported-volume,bootorder:9", "imported-volume", "256Mi", 9, &cdiv1.DataVolumeSource{Snapshot: &cdiv1.DataVolumeSourceSnapshot{Name: snapshotVolumeName, Namespace: sourceNamespace}}, nil),
+			Entry("with Snapshot source without size", "type:snapshot,src:"+sourceNamespace+"/"+snapshotVolumeName+",name:imported-volume", "imported-volume", "", 0, &cdiv1.DataVolumeSource{Snapshot: &cdiv1.DataVolumeSourceSnapshot{Name: snapshotVolumeName, Namespace: sourceNamespace}}, nil),
+			Entry("with DataSource source", "type:ds,src:"+sourceNamespace+"/"+sourceDataSourceName+",name:imported-ds", "imported-ds", "", 0, nil, &cdiv1.DataVolumeSourceRef{Kind: dataSourceKind, Name: sourceDataSourceName, Namespace: pointer.P(sourceNamespace)}),
+			Entry("with DataSource source without namespace", "type:ds,src:"+sourceDataSourceName, "", "", 0, nil, &cdiv1.DataVolumeSourceRef{Kind: dataSourceKind, Name: sourceDataSourceName}),
+			Entry("with DataSource source and bootorder", "type:ds,src:"+sourceNamespace+"/"+sourceDataSourceName+",name:imported-ds,bootorder:1", "imported-ds", "", 1, nil, &cdiv1.DataVolumeSourceRef{Kind: dataSourceKind, Name: sourceDataSourceName, Namespace: pointer.P(sourceNamespace)}),
 		)
 
 		DescribeTable("VM with multiple volume-import sources and name", func(params1, params2 string, src1, src2 *cdiv1.DataVolumeSource) {
@@ -608,7 +623,7 @@ chpasswd: { expire: False }`
 			Expect(vm.Spec.Preference).To(BeNil())
 		},
 			Entry("with blank source", "type:blank,size:256Mi,name:volume-source1", "type:blank,size:256Mi,name:volume-source2", &cdiv1.DataVolumeSource{Blank: &cdiv1.DataVolumeBlankImage{}}, &cdiv1.DataVolumeSource{Blank: &cdiv1.DataVolumeBlankImage{}}),
-			Entry("with blank source and http source", "type:blank,size:256Mi,name:volume-source1", "type:http,size:256Mi,url:http://url.com,name:volume-source2", &cdiv1.DataVolumeSource{Blank: &cdiv1.DataVolumeBlankImage{}}, &cdiv1.DataVolumeSource{HTTP: &cdiv1.DataVolumeSourceHTTP{URL: "http://url.com"}}),
+			Entry("with blank source and http source", "type:blank,size:256Mi,name:volume-source1", "type:http,size:256Mi,url:"+sourceURL+",name:volume-source2", &cdiv1.DataVolumeSource{Blank: &cdiv1.DataVolumeBlankImage{}}, &cdiv1.DataVolumeSource{HTTP: &cdiv1.DataVolumeSourceHTTP{URL: sourceURL}}),
 		)
 
 		DescribeTable("VM with specified clone pvc", func(params, dvtName, dvtSize string, bootOrder int) {
@@ -1040,7 +1055,7 @@ chpasswd: { expire: False }`
 						SSHPublicKey: &v1.SSHPublicKeyAccessCredential{
 							Source: v1.SSHPublicKeyAccessCredentialSource{
 								Secret: &v1.AccessCredentialSecretSource{
-									SecretName: "my-keys",
+									SecretName: sshAccessSecretName,
 								},
 							},
 							PropagationMethod: v1.SSHPublicKeyAccessCredentialPropagationMethod{
@@ -1096,7 +1111,7 @@ chpasswd: { expire: False }`
 					SSHPublicKey: &v1.SSHPublicKeyAccessCredential{
 						Source: v1.SSHPublicKeyAccessCredentialSource{
 							Secret: &v1.AccessCredentialSecretSource{
-								SecretName: "my-keys",
+								SecretName: sshAccessSecretName,
 							},
 						},
 						PropagationMethod: v1.SSHPublicKeyAccessCredentialPropagationMethod{
@@ -1132,7 +1147,7 @@ chpasswd: { expire: False }`
 					SSHPublicKey: &v1.SSHPublicKeyAccessCredential{
 						Source: v1.SSHPublicKeyAccessCredentialSource{
 							Secret: &v1.AccessCredentialSecretSource{
-								SecretName: "my-keys",
+								SecretName: sshAccessSecretName,
 							},
 						},
 						PropagationMethod: v1.SSHPublicKeyAccessCredentialPropagationMethod{
@@ -1237,7 +1252,7 @@ chpasswd: { expire: False }`
 			Expect(vm.Spec.DataVolumeTemplates).To(HaveLen(1))
 			Expect(vm.Spec.DataVolumeTemplates[0].Name).To(MatchRegexp(importedVolumeRegexp))
 			Expect(vm.Spec.DataVolumeTemplates[0].Spec.SourceRef).ToNot(BeNil())
-			Expect(vm.Spec.DataVolumeTemplates[0].Spec.SourceRef.Kind).To(Equal("DataSource"))
+			Expect(vm.Spec.DataVolumeTemplates[0].Spec.SourceRef.Kind).To(Equal(dataSourceKind))
 			Expect(vm.Spec.DataVolumeTemplates[0].Spec.SourceRef.Namespace).To(PointTo(Equal(dsNamespace)))
 			Expect(vm.Spec.DataVolumeTemplates[0].Spec.SourceRef.Name).To(Equal(dsName))
 			Expect(vm.Spec.DataVolumeTemplates[0].Spec.Storage.Resources.Requests[k8sv1.ResourceStorage]).To(Equal(resource.MustParse(dvtSize)))
@@ -1333,7 +1348,7 @@ chpasswd: { expire: False }`
 				vmName     = "my-vm"
 				cdSource   = "src:my.registry/my-image:my-tag"
 				user       = "my-user"
-				secretName = "my-keys"
+				secretName = sshAccessSecretName
 			)
 
 			out, err := runCmd(

--- a/pkg/virtctl/scp/scp_test.go
+++ b/pkg/virtctl/scp/scp_test.go
@@ -9,6 +9,12 @@ import (
 )
 
 var _ = Describe("SCP", func() {
+	const transferFileName = "myfile.yaml"
+	const testCirrosUsername = "cirros"
+	const myNamespace = "mynamespace"
+	const remoteVMIName = "remote"
+	const remoteKind = "vmi"
+
 	DescribeTable("ParseTarget", func(arg0, arg1 string, expLocal *scp.LocalArgument, expRemote *scp.RemoteArgument, expToRemote bool) {
 		local, remote, toRemote, err := scp.ParseTarget(arg0, arg1)
 		Expect(err).ToNot(HaveOccurred())
@@ -17,18 +23,18 @@ var _ = Describe("SCP", func() {
 		Expect(toRemote).To(Equal(expToRemote))
 	},
 		Entry("copy to remote location",
-			"myfile.yaml", "cirros@vmi/remote/mynamespace:myfile.yaml",
-			&scp.LocalArgument{Path: "myfile.yaml"},
+			transferFileName, testCirrosUsername+"@vmi/remote/mynamespace:"+transferFileName,
+			&scp.LocalArgument{Path: transferFileName},
 			&scp.RemoteArgument{
-				Kind: "vmi", Namespace: "mynamespace", Name: "remote", Username: "cirros", Path: "myfile.yaml",
+				Kind: remoteKind, Namespace: myNamespace, Name: remoteVMIName, Username: testCirrosUsername, Path: transferFileName,
 			},
 			true,
 		),
 		Entry("copy from remote location",
-			"cirros@vmi/remote/mynamespace:myfile.yaml", "myfile.yaml",
-			&scp.LocalArgument{Path: "myfile.yaml"},
+			testCirrosUsername+"@vmi/remote/mynamespace:"+transferFileName, transferFileName,
+			&scp.LocalArgument{Path: transferFileName},
 			&scp.RemoteArgument{
-				Kind: "vmi", Namespace: "mynamespace", Name: "remote", Username: "cirros", Path: "myfile.yaml",
+				Kind: remoteKind, Namespace: myNamespace, Name: remoteVMIName, Username: testCirrosUsername, Path: transferFileName,
 			},
 			false,
 		),
@@ -39,12 +45,13 @@ var _ = Describe("SCP", func() {
 		Expect(err).To(MatchError(expectedError))
 	},
 		Entry("when two local locations are specified",
-			"myfile.yaml", "otherfile.yaml",
-			"none of the two provided locations seems to be a remote location: \"myfile.yaml\" to \"otherfile.yaml\"",
+			transferFileName, "otherfile.yaml",
+			"none of the two provided locations seems to be a remote location: \""+transferFileName+"\" to \"otherfile.yaml\"",
 		),
 		Entry("when two remote locations are specified",
-			"remotenode:myfile.yaml", "othernode:otherfile.yaml",
-			"copying from a remote location to another remote location is not supported: \"remotenode:myfile.yaml\" to \"othernode:otherfile.yaml\"",
+			"remotenode:"+transferFileName, "othernode:otherfile.yaml",
+			"copying from a remote location to another remote location is not supported: \"remotenode:"+
+				transferFileName+"\" to \"othernode:otherfile.yaml\"",
 		),
 	)
 

--- a/pkg/virtctl/template/convert/convert_test.go
+++ b/pkg/virtctl/template/convert/convert_test.go
@@ -52,6 +52,9 @@ const (
 
 	formatYAML = "yaml"
 	formatJSON = "json"
+
+	vmKind         = "VirtualMachine"
+	testLabelValue = "test-value"
 )
 
 var _ = Describe("Convert command", func() {
@@ -109,7 +112,7 @@ var _ = Describe("Convert command", func() {
 				Object: &virtv1.VirtualMachine{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: "kubevirt.io/v1",
-						Kind:       "VirtualMachine",
+						Kind:       vmKind,
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "another-vm",
@@ -269,10 +272,10 @@ func newOpenShiftTemplate() *ocpv1.Template {
 			Name:      "test-template",
 			Namespace: metav1.NamespaceDefault,
 			Labels: map[string]string{
-				"test-label": "test-value",
+				"test-label": testLabelValue,
 			},
 			Annotations: map[string]string{
-				"test-annotation": "test-value",
+				"test-annotation": testLabelValue,
 			},
 		},
 		Message: "This is a test template",
@@ -295,7 +298,7 @@ func newOpenShiftTemplate() *ocpv1.Template {
 				Object: &virtv1.VirtualMachine{
 					TypeMeta: metav1.TypeMeta{
 						APIVersion: virtv1.GroupVersion.String(),
-						Kind:       "VirtualMachine",
+						Kind:       vmKind,
 					},
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "${NAME}",

--- a/pkg/virtctl/template/process/process_test.go
+++ b/pkg/virtctl/template/process/process_test.go
@@ -19,8 +19,6 @@
 
 package process_test
 
-const subresourceProcess = "process"
-
 import (
 	"context"
 	"encoding/json"

--- a/pkg/virtctl/template/process/process_test.go
+++ b/pkg/virtctl/template/process/process_test.go
@@ -19,6 +19,8 @@
 
 package process_test
 
+const subresourceProcess = "process"
+
 import (
 	"context"
 	"encoding/json"
@@ -51,9 +53,15 @@ import (
 )
 
 const (
+	subresourceProcessCmd = "template"
+	subresourceProcess    = "process"
+	testNamespace         = "test-ns"
+	testVMName            = "test-vm"
+)
+
+const (
 	param1Name        = "NAME"
 	param1Placeholder = "${NAME}"
-	param1Val         = "test-vm"
 	param2Name        = "PREFERENCE"
 	param2Placeholder = "${PREFERENCE}"
 	param2Val         = "fedora"
@@ -114,7 +122,7 @@ var _ = Describe("Process command", func() {
 
 			out, err := runCmd(
 				setFlag(fileFlag, file),
-				setParamFlag(param1Name, param1Val),
+				setParamFlag(param1Name, testVMName),
 				setParamFlag(param2Name, param2Val),
 				setFlag(outputFlag, output),
 			)
@@ -122,7 +130,7 @@ var _ = Describe("Process command", func() {
 
 			var vm virtv1.VirtualMachine
 			Expect(unmarshalFn(out, &vm)).To(Succeed())
-			Expect(vm.Name).To(Equal(param1Val))
+			Expect(vm.Name).To(Equal(testVMName))
 			Expect(vm.Spec.Preference.Name).To(Equal(param2Val))
 		},
 			Entry("when template is JSON and output format is JSON", marshalJSON, json.Unmarshal, formatJSON),
@@ -139,7 +147,7 @@ var _ = Describe("Process command", func() {
 			Expect(os.WriteFile(file, marshalFn(newVirtualMachineTemplate()), 0o600)).To(Succeed())
 
 			params := map[string]string{
-				param1Name: param1Val,
+				param1Name: testVMName,
 				param2Name: param2Val,
 			}
 			paramsFile := filepath.Join(GinkgoT().TempDir(), "params")
@@ -154,7 +162,7 @@ var _ = Describe("Process command", func() {
 
 			var vm virtv1.VirtualMachine
 			Expect(unmarshalFn(out, &vm)).To(Succeed())
-			Expect(vm.Name).To(Equal(param1Val))
+			Expect(vm.Name).To(Equal(testVMName))
 			Expect(vm.Spec.Preference.Name).To(Equal(param2Val))
 		},
 			Entry("when input format is JSON and output format is JSON", marshalJSON, json.Unmarshal, formatJSON),
@@ -197,7 +205,7 @@ var _ = Describe("Process command", func() {
 
 			_, err := runCmd(
 				setFlag(fileFlag, file),
-				setParamFlag(param1Name, param1Val),
+				setParamFlag(param1Name, testVMName),
 			)
 			Expect(err).To(MatchError(ContainSubstring("references undefined parameter PREFERENCE")))
 		})
@@ -222,7 +230,7 @@ var _ = Describe("Process command", func() {
 
 			out, errOut, err := runCmdWithErr(
 				setFlag(fileFlag, file),
-				setParamFlag(param1Name, param1Val),
+				setParamFlag(param1Name, testVMName),
 				setParamFlag(param2Name, param2Val),
 			)
 			Expect(err).ToNot(HaveOccurred())
@@ -230,7 +238,7 @@ var _ = Describe("Process command", func() {
 
 			var vm virtv1.VirtualMachine
 			Expect(yaml.Unmarshal(out, &vm)).To(Succeed())
-			Expect(vm.Name).To(Equal(param1Val))
+			Expect(vm.Name).To(Equal(testVMName))
 		})
 
 		It("should fail and warn when template contains both undefined and unused parameters", func() {
@@ -309,10 +317,7 @@ var _ = Describe("Process command", func() {
 		)
 
 		Context("should call subresource APIs", func() {
-			const (
-				subresourceCreate  = "create"
-				subresourceProcess = "process"
-			)
+			const subresourceCreate = "create"
 
 			var expectedSubresource string
 
@@ -327,7 +332,7 @@ var _ = Describe("Process command", func() {
 					opts, ok := c.GetObject().(*subresourcesv1beta1.ProcessOptions)
 					Expect(ok).To(BeTrue())
 					Expect(opts.Parameters).To(Equal(map[string]string{
-						param1Name: param1Val,
+						param1Name: testVMName,
 						param2Name: param2Val,
 					}))
 
@@ -353,7 +358,7 @@ var _ = Describe("Process command", func() {
 
 				args := []string{
 					setFlag(createFlag, strconv.FormatBool(create)),
-					setParamFlag(param1Name, param1Val),
+					setParamFlag(param1Name, testVMName),
 					setParamFlag(param2Name, param2Val),
 				}
 				if positional {
@@ -384,7 +389,7 @@ var _ = Describe("Process command", func() {
 				}
 
 				params := map[string]string{
-					param1Name: param1Val,
+					param1Name: testVMName,
 					param2Name: param2Val,
 				}
 				paramsFile := filepath.Join(GinkgoT().TempDir(), "params")
@@ -419,7 +424,7 @@ var _ = Describe("Process command", func() {
 		DescribeTable("should use local processing when --local flag is set", func(positional bool) {
 			args := []string{
 				setFlag(localFlag, "true"),
-				setParamFlag(param1Name, param1Val),
+				setParamFlag(param1Name, testVMName),
 				setParamFlag(param2Name, param2Val),
 			}
 			if positional {
@@ -432,7 +437,7 @@ var _ = Describe("Process command", func() {
 
 			var vm virtv1.VirtualMachine
 			Expect(yaml.Unmarshal(out, &vm)).To(Succeed())
-			Expect(vm.Name).To(Equal(param1Val))
+			Expect(vm.Name).To(Equal(testVMName))
 			Expect(vm.Spec.Preference.Name).To(Equal(param2Val))
 
 			Expect(kvtesting.FilterActions(&tplClient.Fake, "create", templateapi.PluralResourceName, "process")).To(BeEmpty())
@@ -559,12 +564,12 @@ func setParamFlag(k, v string) string {
 }
 
 func runCmd(extraArgs ...string) ([]byte, error) {
-	args := append([]string{"template", "process"}, extraArgs...)
+	args := append([]string{subresourceProcessCmd, subresourceProcess}, extraArgs...)
 	return testing.NewRepeatableVirtctlCommandWithOut(args...)()
 }
 
 func runCmdWithErr(extraArgs ...string) (out, errOut []byte, err error) {
-	args := append([]string{"template", "process"}, extraArgs...)
+	args := append([]string{subresourceProcessCmd, subresourceProcess}, extraArgs...)
 	return testing.NewRepeatableVirtctlCommandWithOutAndErr(args...)()
 }
 

--- a/tests/console/console.go
+++ b/tests/console/console.go
@@ -113,7 +113,7 @@ func RunCommand(vmi *v1.VirtualMachineInstance, command string, timeout time.Dur
 		&expect.BExp{R: PromptExpression},
 		&expect.BSnd{S: command + "\n"},
 		&expect.BExp{R: PromptExpression},
-		&expect.BSnd{S: "echo $?\n"},
+		&expect.BSnd{S: EchoLastReturnValue},
 		&expect.BCas{C: []expect.Caser{
 			&expect.Case{
 				R: ShellSuccessRegexp,

--- a/tests/console/login.go
+++ b/tests/console/login.go
@@ -20,6 +20,7 @@ import (
 const (
 	connectionTimeout = 10 * time.Second
 	promptTimeout     = 5 * time.Second
+	fedoraUser        = "fedora\n"
 )
 
 // LoginToFunction represents any of the LoginTo* functions
@@ -165,13 +166,13 @@ func LoginToFedora(vmi *v1.VirtualMachineInstance, timeout ...time.Duration) err
 				// Using only "login: " would match things like "Last failed login: Tue Jun  9 22:25:30 UTC 2020 on ttyS0"
 				// and in case the VM's did not get hostname form DHCP server try the default hostname
 				R:  regexp.MustCompile(fmt.Sprintf(`(localhost|fedora|%s|%s) login: `, vmi.Name, hostName)),
-				S:  "fedora\n",
+				S:  fedoraUser,
 				T:  expect.Next(),
 				Rt: 10,
 			},
 			&expect.Case{
 				R:  regexp.MustCompile(`Password:`),
-				S:  "fedora\n",
+				S:  fedoraUser,
 				T:  expect.Next(),
 				Rt: 10,
 			},
@@ -240,11 +241,11 @@ func configureConsole(expecter expect.Expecter, shouldSudo bool) error {
 	batch := []expect.Batcher{
 		&expect.BSnd{S: "stty cols 500 rows 500\n"},
 		&expect.BExp{R: PromptExpression},
-		&expect.BSnd{S: "echo $?\n"},
+		&expect.BSnd{S: EchoLastReturnValue},
 		&expect.BExp{R: RetValueWithPrompt("0")},
 		&expect.BSnd{S: fmt.Sprintf("%sdmesg -n 1\n", sudoString)},
 		&expect.BExp{R: PromptExpression},
-		&expect.BSnd{S: "echo $?\n"},
+		&expect.BSnd{S: EchoLastReturnValue},
 		&expect.BExp{R: RetValueWithPrompt("0")},
 	}
 	const configureConsoleTimeout = 60 * time.Second

--- a/tests/infrastructure/node-labeller.go
+++ b/tests/infrastructure/node-labeller.go
@@ -51,7 +51,10 @@ import (
 )
 
 var _ = Describe(SIGSerial("Node-labeller", func() {
-	const trueStr = "true"
+	const (
+		trueStr = "true"
+		addOp   = "add"
+	)
 
 	var (
 		virtClient               kubecli.KubevirtClient
@@ -109,7 +112,7 @@ var _ = Describe(SIGSerial("Node-labeller", func() {
 				node.Labels[nonExistingCPUModelLabel] = trueStr
 				p := []patch{
 					{
-						Op:    "add",
+						Op:    addOp,
 						Path:  "/metadata/labels",
 						Value: node.Labels,
 					},
@@ -118,7 +121,7 @@ var _ = Describe(SIGSerial("Node-labeller", func() {
 					node.Annotations[v1.LabellerSkipNodeAnnotation] = trueStr
 
 					p = append(p, patch{
-						Op:    "add",
+						Op:    addOp,
 						Path:  "/metadata/annotations",
 						Value: node.Annotations,
 					})

--- a/tests/infrastructure/prometheus.go
+++ b/tests/infrastructure/prometheus.go
@@ -202,7 +202,7 @@ var _ = Describe(SIGSerial("[rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com]
 	It("[test_id:4138]should be exposed and registered on the metrics endpoint", func() {
 		epsList, err := virtClient.DiscoveryV1().EndpointSlices(flags.KubeVirtInstallNamespace).List(
 			context.Background(), metav1.ListOptions{
-				LabelSelector: "kubernetes.io/service-name=kubevirt-prometheus-metrics",
+				LabelSelector: kubevirtMetricsSelector,
 			})
 		Expect(err).ToNot(HaveOccurred())
 		// should only have one EndpointSlice
@@ -241,7 +241,7 @@ var _ = Describe(SIGSerial("[rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com]
 	It("[test_id:4139]should return Prometheus metrics", func() {
 		endpointSliceList, err := virtClient.DiscoveryV1().EndpointSlices(flags.KubeVirtInstallNamespace).List(
 			context.Background(), metav1.ListOptions{
-				LabelSelector: "kubernetes.io/service-name=kubevirt-prometheus-metrics",
+				LabelSelector: kubevirtMetricsSelector,
 			})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(endpointSliceList.Items).ToNot(BeEmpty(), "Expected at least one EndpointSlice")
@@ -405,7 +405,7 @@ func countReadyAndLeaderPods(pod *k8sv1.Pod, component string) (foundMetrics map
 	readyMetric := fmt.Sprintf("kubevirt_virt_%s_ready_status 1", component)
 	endpointSliceList, err := virtClient.DiscoveryV1().EndpointSlices(flags.KubeVirtInstallNamespace).List(
 		context.Background(), metav1.ListOptions{
-			LabelSelector: "kubernetes.io/service-name=kubevirt-prometheus-metrics",
+			LabelSelector: kubevirtMetricsSelector,
 		})
 	if err != nil {
 		return nil, err

--- a/tests/infrastructure/security.go
+++ b/tests/infrastructure/security.go
@@ -77,7 +77,7 @@ var _ = Describe(SIGSerial("Node Restriction", decorators.RequiresTwoSchedulable
 			pod,
 			"virt-handler",
 			[]string{
-				"cat",
+				shellCatCommand,
 				"/var/run/secrets/kubernetes.io/serviceaccount/token",
 			},
 		)

--- a/tests/infrastructure/taints-and-tolerations.go
+++ b/tests/infrastructure/taints-and-tolerations.go
@@ -44,6 +44,8 @@ import (
 )
 
 var _ = Describe(SIGSerial("[rfe_id:4126][crit:medium][vendor:cnv-qe@redhat.com][level:component]Taints and toleration", func() {
+	const criticalAddonsOnly = "CriticalAddonsOnly"
+
 	var virtClient kubecli.KubevirtClient
 	BeforeEach(func() {
 		virtClient = kubevirt.Client()
@@ -88,7 +90,7 @@ var _ = Describe(SIGSerial("[rfe_id:4126][crit:medium][vendor:cnv-qe@redhat.com]
 			possiblyTaintedNodeName = nodeName
 
 			taints := append(selectedNode.Spec.Taints, k8sv1.Taint{
-				Key:    "CriticalAddonsOnly",
+				Key:    criticalAddonsOnly,
 				Value:  "",
 				Effect: k8sv1.TaintEffectNoExecute,
 			})
@@ -113,7 +115,7 @@ var _ = Describe(SIGSerial("[rfe_id:4126][crit:medium][vendor:cnv-qe@redhat.com]
 			var hasTaint bool
 			var otherTaints []k8sv1.Taint
 			for _, taint := range selectedNode.Spec.Taints {
-				if taint.Key == "CriticalAddonsOnly" {
+				if taint.Key == criticalAddonsOnly {
 					hasTaint = true
 				} else {
 					otherTaints = append(otherTaints, taint)

--- a/tests/infrastructure/virt-handler.go
+++ b/tests/infrastructure/virt-handler.go
@@ -42,6 +42,12 @@ import (
 	"kubevirt.io/kubevirt/tests/libnode"
 )
 
+const (
+	ksmRunPath              = "/sys/kernel/mm/ksm/run"
+	kubevirtMetricsSelector = "kubernetes.io/service-name=kubevirt-prometheus-metrics"
+	shellCatCommand         = "cat"
+)
+
 var _ = Describe(SIGSerial("virt-handler", decorators.WgS390x, func() {
 	var (
 		virtClient       kubecli.KubevirtClient
@@ -55,7 +61,7 @@ var _ = Describe(SIGSerial("virt-handler", decorators.WgS390x, func() {
 
 		nodesWithKSM := make([]string, 0)
 		for _, node := range nodes.Items {
-			command := []string{"cat", "/sys/kernel/mm/ksm/run"}
+			command := []string{shellCatCommand, ksmRunPath}
 			_, err := libnode.ExecuteCommandInVirtHandlerPod(node.Name, command)
 			if err == nil {
 				nodesWithKSM = append(nodesWithKSM, node.Name)
@@ -118,7 +124,7 @@ var _ = Describe(SIGSerial("virt-handler", decorators.WgS390x, func() {
 		By("Ensure ksm is enabled and annotation is added in the expected nodes")
 		for _, node := range nodesToEnableKSM {
 			Eventually(func() (string, error) {
-				command := []string{"cat", "/sys/kernel/mm/ksm/run"}
+				command := []string{shellCatCommand, ksmRunPath}
 				ksmValue, err := libnode.ExecuteCommandInVirtHandlerPod(node, command)
 				if err != nil {
 					return "", err
@@ -142,7 +148,7 @@ var _ = Describe(SIGSerial("virt-handler", decorators.WgS390x, func() {
 		By("Ensure ksm is disabled and annotation is set to false in the expected nodes")
 		for _, node := range nodesToEnableKSM {
 			Eventually(func() (string, error) {
-				command := []string{"cat", "/sys/kernel/mm/ksm/run"}
+				command := []string{shellCatCommand, ksmRunPath}
 				ksmValue, err := libnode.ExecuteCommandInVirtHandlerPod(node, command)
 				if err != nil {
 					return "", err

--- a/tests/instancetype/inference.go
+++ b/tests/instancetype/inference.go
@@ -40,9 +40,10 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 	)
 
 	const (
-		inferFromVolumeName     = "volume"
-		dataVolumeTemplateName  = "datatemplate"
-		dvSuccessTimeoutSeconds = 180
+		inferFromVolumeName      = "volume"
+		dataVolumeTemplateName   = "datatemplate"
+		dvSuccessTimeoutSeconds  = 180
+		datasourceGeneratePrefix = "datasource-"
 	)
 
 	createAndValidateVirtualMachine := func() {
@@ -210,7 +211,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 				// TODO - Replace with libds?
 				dataSource := &cdiv1beta1.DataSource{
 					ObjectMeta: metav1.ObjectMeta{
-						GenerateName: "datasource-",
+						GenerateName: datasourceGeneratePrefix,
 						Namespace:    namespace,
 					},
 					Spec: cdiv1beta1.DataSourceSpec{
@@ -252,7 +253,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 				// TODO - Replace with libds?
 				dataSource := &cdiv1beta1.DataSource{
 					ObjectMeta: metav1.ObjectMeta{
-						GenerateName: "datasource-",
+						GenerateName: datasourceGeneratePrefix,
 						Namespace:    namespace,
 						Labels: map[string]string{
 							instancetypeapi.DefaultInstancetypeLabel:     instancetype.Name,

--- a/tests/instancetype/inference.go
+++ b/tests/instancetype/inference.go
@@ -135,7 +135,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 
 		vm = &virtv1.VirtualMachine{
 			ObjectMeta: metav1.ObjectMeta{
-				GenerateName: "vm-",
+				GenerateName: vmGenerateNamePrefix,
 				Namespace:    namespace,
 			},
 			Spec: virtv1.VirtualMachineSpec{

--- a/tests/instancetype/instancetype.go
+++ b/tests/instancetype/instancetype.go
@@ -26,6 +26,11 @@ import (
 
 const timeout = 300 * time.Second
 
+const (
+	requiredAnnotation1  = "required-annotation-1"
+	preferredAnnotation2 = "preferred-annotation-2"
+)
+
 var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-compute] Instancetype and Preferences", decorators.SigCompute, decorators.SigComputeInstancetype, func() {
 	var virtClient kubecli.KubevirtClient
 
@@ -157,7 +162,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 		It("[test_id:CNV-9095] should apply instancetype and preferences to VMI", func() {
 			instancetype := builder.NewInstancetypeFromVMI(vmi)
 			instancetype.Spec.Annotations = map[string]string{
-				"required-annotation-1": "1",
+				requiredAnnotation1:     "1",
 				"required-annotation-2": "2",
 			}
 			instancetype, err := virtClient.VirtualMachineInstancetype(testsuite.GetTestNamespace(instancetype)).
@@ -188,8 +193,8 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			preference.Spec.PreferredSubdomain = pointer.P("non-existent-subdomain")
 			preference.Spec.Annotations = map[string]string{
 				"preferred-annotation-1": "1",
-				"preferred-annotation-2": "use-vm-value",
-				"required-annotation-1":  "use-instancetype-value",
+				preferredAnnotation2:     "use-vm-value",
+				requiredAnnotation1:      "use-instancetype-value",
 			}
 
 			preference, err = virtClient.VirtualMachinePreference(testsuite.GetTestNamespace(preference)).
@@ -202,7 +207,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 				libvmi.WithRunStrategy(virtv1.RunStrategyAlways),
 			)
 			vm.Spec.Template.ObjectMeta.Annotations = map[string]string{
-				"preferred-annotation-2": "2",
+				preferredAnnotation2: "2",
 			}
 			vm, err = virtClient.VirtualMachine(testsuite.GetTestNamespace(vm)).Create(context.Background(), vm, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
@@ -240,10 +245,10 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			Expect(vmi.Annotations[virtv1.ClusterInstancetypeAnnotation]).To(Equal(""))
 			Expect(vmi.Annotations[virtv1.PreferenceAnnotation]).To(Equal(preference.Name))
 			Expect(vmi.Annotations[virtv1.ClusterPreferenceAnnotation]).To(Equal(""))
-			Expect(vmi.Annotations).To(HaveKeyWithValue("required-annotation-1", "1"))
+			Expect(vmi.Annotations).To(HaveKeyWithValue(requiredAnnotation1, "1"))
 			Expect(vmi.Annotations).To(HaveKeyWithValue("required-annotation-2", "2"))
 			Expect(vmi.Annotations).To(HaveKeyWithValue("preferred-annotation-1", "1"))
-			Expect(vmi.Annotations).To(HaveKeyWithValue("preferred-annotation-2", "2"))
+			Expect(vmi.Annotations).To(HaveKeyWithValue(preferredAnnotation2, "2"))
 		})
 
 		It("[test_id:CNV-9302] should apply preferences to default network interface", func() {

--- a/tests/instancetype/requirements.go
+++ b/tests/instancetype/requirements.go
@@ -20,6 +20,14 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
+const (
+	instancetypeGenerateNamePrefix = "instancetype-"
+	preferenceGenerateNamePrefix   = "preference-"
+	virtualMachineInstancetypeKind = "VirtualMachineInstancetype"
+	virtualMachinePreferenceKind   = "VirtualMachinePreference"
+	vmGenerateNamePrefix           = "vm-"
+)
+
 var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-compute] Preference requirements", decorators.SigCompute, decorators.SigComputeInstancetype, decorators.WgS390x, func() {
 	var (
 		guestMemory2GB = resource.MustParse("2Gi")
@@ -57,7 +65,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 		Entry("VirtualMachineInstancetype meets CPU requirements",
 			&instancetypev1beta1.VirtualMachineInstancetype{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "instancetype-",
+					GenerateName: instancetypeGenerateNamePrefix,
 				},
 				Spec: instancetypev1beta1.VirtualMachineInstancetypeSpec{
 					CPU: instancetypev1beta1.CPUInstancetype{
@@ -67,7 +75,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			},
 			&instancetypev1beta1.VirtualMachinePreference{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "preference-",
+					GenerateName: preferenceGenerateNamePrefix,
 				},
 				Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{
 					Requirements: &instancetypev1beta1.PreferenceRequirements{
@@ -79,15 +87,15 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			},
 			&virtv1.VirtualMachine{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "vm-",
+					GenerateName: vmGenerateNamePrefix,
 				},
 				Spec: virtv1.VirtualMachineSpec{
 					RunStrategy: pointer.P(virtv1.RunStrategyHalted),
 					Instancetype: &virtv1.InstancetypeMatcher{
-						Kind: "VirtualMachineInstancetype",
+						Kind: virtualMachineInstancetypeKind,
 					},
 					Preference: &virtv1.PreferenceMatcher{
-						Kind: "VirtualMachinePreference",
+						Kind: virtualMachinePreferenceKind,
 					},
 					Template: &virtv1.VirtualMachineInstanceTemplateSpec{
 						Spec: virtv1.VirtualMachineInstanceSpec{
@@ -100,7 +108,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 		Entry("VirtualMachineInstancetype meets Memory requirements",
 			&instancetypev1beta1.VirtualMachineInstancetype{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "instancetype-",
+					GenerateName: instancetypeGenerateNamePrefix,
 				},
 				Spec: instancetypev1beta1.VirtualMachineInstancetypeSpec{
 					Memory: instancetypev1beta1.MemoryInstancetype{
@@ -110,7 +118,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			},
 			&instancetypev1beta1.VirtualMachinePreference{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "preference-",
+					GenerateName: preferenceGenerateNamePrefix,
 				},
 				Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{
 					Requirements: &instancetypev1beta1.PreferenceRequirements{
@@ -122,15 +130,15 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			},
 			&virtv1.VirtualMachine{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "vm-",
+					GenerateName: vmGenerateNamePrefix,
 				},
 				Spec: virtv1.VirtualMachineSpec{
 					RunStrategy: pointer.P(virtv1.RunStrategyHalted),
 					Instancetype: &virtv1.InstancetypeMatcher{
-						Kind: "VirtualMachineInstancetype",
+						Kind: virtualMachineInstancetypeKind,
 					},
 					Preference: &virtv1.PreferenceMatcher{
-						Kind: "VirtualMachinePreference",
+						Kind: virtualMachinePreferenceKind,
 					},
 					Template: &virtv1.VirtualMachineInstanceTemplateSpec{
 						Spec: virtv1.VirtualMachineInstanceSpec{
@@ -144,7 +152,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			nil,
 			&instancetypev1beta1.VirtualMachinePreference{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "preference-",
+					GenerateName: preferenceGenerateNamePrefix,
 				},
 				Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{
 					Requirements: &instancetypev1beta1.PreferenceRequirements{
@@ -156,12 +164,12 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			},
 			&virtv1.VirtualMachine{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "vm-",
+					GenerateName: vmGenerateNamePrefix,
 				},
 				Spec: virtv1.VirtualMachineSpec{
 					RunStrategy: pointer.P(virtv1.RunStrategyHalted),
 					Preference: &virtv1.PreferenceMatcher{
-						Kind: "VirtualMachinePreference",
+						Kind: virtualMachinePreferenceKind,
 					},
 					Template: &virtv1.VirtualMachineInstanceTemplateSpec{
 						Spec: virtv1.VirtualMachineInstanceSpec{
@@ -181,7 +189,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			nil,
 			&instancetypev1beta1.VirtualMachinePreference{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "preference-",
+					GenerateName: preferenceGenerateNamePrefix,
 				},
 				Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{
 					CPU: &instancetypev1beta1.CPUPreferences{
@@ -196,12 +204,12 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			},
 			&virtv1.VirtualMachine{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "vm-",
+					GenerateName: vmGenerateNamePrefix,
 				},
 				Spec: virtv1.VirtualMachineSpec{
 					RunStrategy: pointer.P(virtv1.RunStrategyHalted),
 					Preference: &virtv1.PreferenceMatcher{
-						Kind: "VirtualMachinePreference",
+						Kind: virtualMachinePreferenceKind,
 					},
 					Template: &virtv1.VirtualMachineInstanceTemplateSpec{
 						Spec: virtv1.VirtualMachineInstanceSpec{
@@ -221,7 +229,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			nil,
 			&instancetypev1beta1.VirtualMachinePreference{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "preference-",
+					GenerateName: preferenceGenerateNamePrefix,
 				},
 				Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{
 					Requirements: &instancetypev1beta1.PreferenceRequirements{
@@ -233,12 +241,12 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			},
 			&virtv1.VirtualMachine{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "vm-",
+					GenerateName: vmGenerateNamePrefix,
 				},
 				Spec: virtv1.VirtualMachineSpec{
 					RunStrategy: pointer.P(virtv1.RunStrategyHalted),
 					Preference: &virtv1.PreferenceMatcher{
-						Kind: "VirtualMachinePreference",
+						Kind: virtualMachinePreferenceKind,
 					},
 					Template: &virtv1.VirtualMachineInstanceTemplateSpec{
 						Spec: virtv1.VirtualMachineInstanceSpec{
@@ -252,7 +260,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			nil,
 			&instancetypev1beta1.VirtualMachinePreference{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "preference-",
+					GenerateName: preferenceGenerateNamePrefix,
 				},
 				Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{
 					CPU: &instancetypev1beta1.CPUPreferences{
@@ -267,12 +275,12 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			},
 			&virtv1.VirtualMachine{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "vm-",
+					GenerateName: vmGenerateNamePrefix,
 				},
 				Spec: virtv1.VirtualMachineSpec{
 					RunStrategy: pointer.P(virtv1.RunStrategyHalted),
 					Preference: &virtv1.PreferenceMatcher{
-						Kind: "VirtualMachinePreference",
+						Kind: virtualMachinePreferenceKind,
 					},
 					Template: &virtv1.VirtualMachineInstanceTemplateSpec{
 						Spec: virtv1.VirtualMachineInstanceSpec{
@@ -292,7 +300,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			nil,
 			&instancetypev1beta1.VirtualMachinePreference{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "preference-",
+					GenerateName: preferenceGenerateNamePrefix,
 				},
 				Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{
 					CPU: &instancetypev1beta1.CPUPreferences{
@@ -307,12 +315,12 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			},
 			&virtv1.VirtualMachine{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "vm-",
+					GenerateName: vmGenerateNamePrefix,
 				},
 				Spec: virtv1.VirtualMachineSpec{
 					RunStrategy: pointer.P(virtv1.RunStrategyHalted),
 					Preference: &virtv1.PreferenceMatcher{
-						Kind: "VirtualMachinePreference",
+						Kind: virtualMachinePreferenceKind,
 					},
 					Template: &virtv1.VirtualMachineInstanceTemplateSpec{
 						Spec: virtv1.VirtualMachineInstanceSpec{
@@ -332,7 +340,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			nil,
 			&instancetypev1beta1.VirtualMachinePreference{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "preference-",
+					GenerateName: preferenceGenerateNamePrefix,
 				},
 				Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{
 					Requirements: &instancetypev1beta1.PreferenceRequirements{
@@ -344,12 +352,12 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			},
 			&virtv1.VirtualMachine{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "vm-",
+					GenerateName: vmGenerateNamePrefix,
 				},
 				Spec: virtv1.VirtualMachineSpec{
 					RunStrategy: pointer.P(virtv1.RunStrategyHalted),
 					Preference: &virtv1.PreferenceMatcher{
-						Kind: "VirtualMachinePreference",
+						Kind: virtualMachinePreferenceKind,
 					},
 					Template: &virtv1.VirtualMachineInstanceTemplateSpec{
 						Spec: virtv1.VirtualMachineInstanceSpec{
@@ -385,7 +393,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 		Entry("VirtualMachineInstancetype does not meet CPU requirements",
 			&instancetypev1beta1.VirtualMachineInstancetype{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "instancetype-",
+					GenerateName: instancetypeGenerateNamePrefix,
 				},
 				Spec: instancetypev1beta1.VirtualMachineInstancetypeSpec{
 					CPU: instancetypev1beta1.CPUInstancetype{
@@ -395,7 +403,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			},
 			&instancetypev1beta1.VirtualMachinePreference{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "preference-",
+					GenerateName: preferenceGenerateNamePrefix,
 				},
 				Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{
 					Requirements: &instancetypev1beta1.PreferenceRequirements{
@@ -407,15 +415,15 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			},
 			&virtv1.VirtualMachine{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "vm-",
+					GenerateName: vmGenerateNamePrefix,
 				},
 				Spec: virtv1.VirtualMachineSpec{
 					RunStrategy: pointer.P(virtv1.RunStrategyHalted),
 					Instancetype: &virtv1.InstancetypeMatcher{
-						Kind: "VirtualMachineInstancetype",
+						Kind: virtualMachineInstancetypeKind,
 					},
 					Preference: &virtv1.PreferenceMatcher{
-						Kind: "VirtualMachinePreference",
+						Kind: virtualMachinePreferenceKind,
 					},
 					Template: &virtv1.VirtualMachineInstanceTemplateSpec{
 						Spec: virtv1.VirtualMachineInstanceSpec{
@@ -429,7 +437,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 		Entry("VirtualMachineInstancetype does not meet Memory requirements",
 			&instancetypev1beta1.VirtualMachineInstancetype{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "instancetype-",
+					GenerateName: instancetypeGenerateNamePrefix,
 				},
 				Spec: instancetypev1beta1.VirtualMachineInstancetypeSpec{
 					Memory: instancetypev1beta1.MemoryInstancetype{
@@ -439,7 +447,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			},
 			&instancetypev1beta1.VirtualMachinePreference{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "preference-",
+					GenerateName: preferenceGenerateNamePrefix,
 				},
 				Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{
 					Requirements: &instancetypev1beta1.PreferenceRequirements{
@@ -451,15 +459,15 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			},
 			&virtv1.VirtualMachine{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "vm-",
+					GenerateName: vmGenerateNamePrefix,
 				},
 				Spec: virtv1.VirtualMachineSpec{
 					RunStrategy: pointer.P(virtv1.RunStrategyHalted),
 					Instancetype: &virtv1.InstancetypeMatcher{
-						Kind: "VirtualMachineInstancetype",
+						Kind: virtualMachineInstancetypeKind,
 					},
 					Preference: &virtv1.PreferenceMatcher{
-						Kind: "VirtualMachinePreference",
+						Kind: virtualMachinePreferenceKind,
 					},
 					Template: &virtv1.VirtualMachineInstanceTemplateSpec{
 						Spec: virtv1.VirtualMachineInstanceSpec{
@@ -474,7 +482,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			nil,
 			&instancetypev1beta1.VirtualMachinePreference{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "preference-",
+					GenerateName: preferenceGenerateNamePrefix,
 				},
 				Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{
 					Requirements: &instancetypev1beta1.PreferenceRequirements{
@@ -486,12 +494,12 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			},
 			&virtv1.VirtualMachine{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "vm-",
+					GenerateName: vmGenerateNamePrefix,
 				},
 				Spec: virtv1.VirtualMachineSpec{
 					RunStrategy: pointer.P(virtv1.RunStrategyHalted),
 					Preference: &virtv1.PreferenceMatcher{
-						Kind: "VirtualMachinePreference",
+						Kind: virtualMachinePreferenceKind,
 					},
 					Template: &virtv1.VirtualMachineInstanceTemplateSpec{
 						Spec: virtv1.VirtualMachineInstanceSpec{
@@ -512,7 +520,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			nil,
 			&instancetypev1beta1.VirtualMachinePreference{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "preference-",
+					GenerateName: preferenceGenerateNamePrefix,
 				},
 				Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{
 					CPU: &instancetypev1beta1.CPUPreferences{
@@ -527,12 +535,12 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			},
 			&virtv1.VirtualMachine{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "vm-",
+					GenerateName: vmGenerateNamePrefix,
 				},
 				Spec: virtv1.VirtualMachineSpec{
 					RunStrategy: pointer.P(virtv1.RunStrategyHalted),
 					Preference: &virtv1.PreferenceMatcher{
-						Kind: "VirtualMachinePreference",
+						Kind: virtualMachinePreferenceKind,
 					},
 					Template: &virtv1.VirtualMachineInstanceTemplateSpec{
 						Spec: virtv1.VirtualMachineInstanceSpec{
@@ -553,7 +561,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			nil,
 			&instancetypev1beta1.VirtualMachinePreference{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "preference-",
+					GenerateName: preferenceGenerateNamePrefix,
 				},
 				Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{
 					CPU: &instancetypev1beta1.CPUPreferences{
@@ -568,12 +576,12 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			},
 			&virtv1.VirtualMachine{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "vm-",
+					GenerateName: vmGenerateNamePrefix,
 				},
 				Spec: virtv1.VirtualMachineSpec{
 					RunStrategy: pointer.P(virtv1.RunStrategyHalted),
 					Preference: &virtv1.PreferenceMatcher{
-						Kind: "VirtualMachinePreference",
+						Kind: virtualMachinePreferenceKind,
 					},
 					Template: &virtv1.VirtualMachineInstanceTemplateSpec{
 						Spec: virtv1.VirtualMachineInstanceSpec{
@@ -594,7 +602,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			nil,
 			&instancetypev1beta1.VirtualMachinePreference{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "preference-",
+					GenerateName: preferenceGenerateNamePrefix,
 				},
 				Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{
 					CPU: &instancetypev1beta1.CPUPreferences{
@@ -609,12 +617,12 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			},
 			&virtv1.VirtualMachine{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "vm-",
+					GenerateName: vmGenerateNamePrefix,
 				},
 				Spec: virtv1.VirtualMachineSpec{
 					RunStrategy: pointer.P(virtv1.RunStrategyHalted),
 					Preference: &virtv1.PreferenceMatcher{
-						Kind: "VirtualMachinePreference",
+						Kind: virtualMachinePreferenceKind,
 					},
 					Template: &virtv1.VirtualMachineInstanceTemplateSpec{
 						Spec: virtv1.VirtualMachineInstanceSpec{
@@ -635,7 +643,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			nil,
 			&instancetypev1beta1.VirtualMachinePreference{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "preference-",
+					GenerateName: preferenceGenerateNamePrefix,
 				},
 				Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{
 					Requirements: &instancetypev1beta1.PreferenceRequirements{
@@ -647,12 +655,12 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			},
 			&virtv1.VirtualMachine{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "vm-",
+					GenerateName: vmGenerateNamePrefix,
 				},
 				Spec: virtv1.VirtualMachineSpec{
 					RunStrategy: pointer.P(virtv1.RunStrategyHalted),
 					Preference: &virtv1.PreferenceMatcher{
-						Kind: "VirtualMachinePreference",
+						Kind: virtualMachinePreferenceKind,
 					},
 					Template: &virtv1.VirtualMachineInstanceTemplateSpec{
 						Spec: virtv1.VirtualMachineInstanceSpec{
@@ -671,7 +679,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			nil,
 			&instancetypev1beta1.VirtualMachinePreference{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "preference-",
+					GenerateName: preferenceGenerateNamePrefix,
 				},
 				Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{
 					Requirements: &instancetypev1beta1.PreferenceRequirements{
@@ -683,12 +691,12 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 			},
 			&virtv1.VirtualMachine{
 				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "vm-",
+					GenerateName: vmGenerateNamePrefix,
 				},
 				Spec: virtv1.VirtualMachineSpec{
 					RunStrategy: pointer.P(virtv1.RunStrategyHalted),
 					Preference: &virtv1.PreferenceMatcher{
-						Kind: "VirtualMachinePreference",
+						Kind: virtualMachinePreferenceKind,
 					},
 					Template: &virtv1.VirtualMachineInstanceTemplateSpec{
 						Spec: virtv1.VirtualMachineInstanceSpec{

--- a/tests/launchsecurity/sev.go
+++ b/tests/launchsecurity/sev.go
@@ -48,6 +48,8 @@ import (
 	"kubevirt.io/kubevirt/tests/libwait"
 )
 
+const virshCmd = "virsh"
+
 var _ = Describe("[sig-compute]AMD Secure Encrypted Virtualization (SEV)", decorators.SEV, decorators.SigCompute, func() {
 	const (
 		diskSecret = "qwerty123"
@@ -363,7 +365,7 @@ var _ = Describe("[sig-compute]AMD Secure Encrypted Virtualization (SEV)", decor
 			Eventually(matcher.ThisVMI(vmi), 60).Should(matcher.BeInPhase(v1.Scheduled))
 
 			By("Querying virsh nodesevinfo")
-			nodeSevInfo := libpod.RunCommandOnVmiPod(vmi, []string{"virsh", "nodesevinfo"})
+			nodeSevInfo := libpod.RunCommandOnVmiPod(vmi, []string{virshCmd, "nodesevinfo"})
 			Expect(nodeSevInfo).ToNot(BeEmpty())
 			entries := parseVirshInfo(nodeSevInfo, []string{"pdh", "cert-chain"})
 			expectedSEVPlatformInfo.PDH = entries["pdh"]
@@ -383,7 +385,7 @@ var _ = Describe("[sig-compute]AMD Secure Encrypted Virtualization (SEV)", decor
 			Eventually(matcher.ThisVMI(vmi), 60).Should(And(matcher.BeRunning(), matcher.HaveConditionTrue(v1.VirtualMachineInstancePaused)))
 
 			By("Querying virsh domlaunchsecinfo 1")
-			domLaunchSecInfo := libpod.RunCommandOnVmiPod(vmi, []string{"virsh", "domlaunchsecinfo", "1"})
+			domLaunchSecInfo := libpod.RunCommandOnVmiPod(vmi, []string{virshCmd, "domlaunchsecinfo", "1"})
 			Expect(domLaunchSecInfo).ToNot(BeEmpty())
 			entries = parseVirshInfo(domLaunchSecInfo, []string{
 				"sev-measurement", "sev-api-major", "sev-api-minor", "sev-build-id", "sev-policy",

--- a/tests/libpod/render.go
+++ b/tests/libpod/render.go
@@ -31,13 +31,15 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
+const testAppLabelValue = "test"
+
 func RenderPrivilegedPod(name string, cmd, args []string) *v1.Pod {
 	pod := v1.Pod{
 		ObjectMeta: v12.ObjectMeta{
 			Namespace:    testsuite.NamespacePrivileged,
 			GenerateName: name,
 			Labels: map[string]string{
-				v13.AppLabel: "test",
+				v13.AppLabel: testAppLabelValue,
 			},
 		},
 		Spec: v1.PodSpec{
@@ -64,7 +66,7 @@ func RenderPod(name string, cmd, args []string) *v1.Pod {
 		ObjectMeta: v12.ObjectMeta{
 			GenerateName: name,
 			Labels: map[string]string{
-				v13.AppLabel: "test",
+				v13.AppLabel: testAppLabelValue,
 			},
 		},
 		Spec: v1.PodSpec{
@@ -115,17 +117,19 @@ func renderPrivilegedContainerSpec(imgPath, name string, cmd, args []string) v1.
 	}
 }
 
+const hostpathMount = "hostpath-mount"
+
 func RenderHostPathPod(
 	podName, dir string, hostPathType v1.HostPathType, mountPropagation v1.MountPropagationMode, cmd, args []string,
 ) *v1.Pod {
 	pod := RenderPrivilegedPod(podName, cmd, args)
 	pod.Spec.Containers[0].VolumeMounts = append(pod.Spec.Containers[0].VolumeMounts, v1.VolumeMount{
-		Name:             "hostpath-mount",
+		Name:             hostpathMount,
 		MountPropagation: &mountPropagation,
 		MountPath:        dir,
 	})
 	pod.Spec.Volumes = append(pod.Spec.Volumes, v1.Volume{
-		Name: "hostpath-mount",
+		Name: hostpathMount,
 		VolumeSource: v1.VolumeSource{
 			HostPath: &v1.HostPathVolumeSource{
 				Path: dir,
@@ -139,9 +143,11 @@ func RenderHostPathPod(
 
 func RenderTargetcliPod(name, disksPVC string) *v1.Pod {
 	const (
-		disks   = "disks"
-		dbus    = "dbus"
-		modules = "modules"
+		disks      = "disks"
+		dbus       = "dbus"
+		modules    = "modules"
+		varRunDbus = "/var/run/dbus"
+		libModules = "/lib/modules"
 	)
 	hostPathDirectory := v1.HostPathDirectory
 	targetcliContainer := renderPrivilegedContainerSpec(
@@ -156,19 +162,19 @@ func RenderTargetcliPod(name, disksPVC string) *v1.Pod {
 		{
 			Name:      dbus,
 			ReadOnly:  false,
-			MountPath: "/var/run/dbus",
+			MountPath: varRunDbus,
 		},
 		{
 			Name:      modules,
 			ReadOnly:  false,
-			MountPath: "/lib/modules",
+			MountPath: libModules,
 		},
 	}
 	return &v1.Pod{
 		ObjectMeta: v12.ObjectMeta{
 			Name: name,
 			Labels: map[string]string{
-				v13.AppLabel: "test",
+				v13.AppLabel: testAppLabelValue,
 			},
 		},
 		Spec: v1.PodSpec{
@@ -189,7 +195,7 @@ func RenderTargetcliPod(name, disksPVC string) *v1.Pod {
 					Name: dbus,
 					VolumeSource: v1.VolumeSource{
 						HostPath: &v1.HostPathVolumeSource{
-							Path: "/var/run/dbus",
+							Path: varRunDbus,
 							Type: &hostPathDirectory,
 						},
 					},
@@ -198,7 +204,7 @@ func RenderTargetcliPod(name, disksPVC string) *v1.Pod {
 					Name: modules,
 					VolumeSource: v1.VolumeSource{
 						HostPath: &v1.HostPathVolumeSource{
-							Path: "/lib/modules",
+							Path: libModules,
 							Type: &hostPathDirectory,
 						},
 					},

--- a/tests/monitoring/component_monitoring.go
+++ b/tests/monitoring/component_monitoring.go
@@ -54,6 +54,10 @@ const (
 	randNodeSelectorSuffixLength   = 8
 	lowReadySingletonWorkloadCount = 1
 	lowReadyDeploymentRunningCount = 2
+	tailFParam                     = "-f"
+	virtOperatorDeploymentName     = "virt-operator"
+	devNull                        = "/dev/null"
+	tailCommand                    = "tail"
 )
 
 type alerts struct {
@@ -87,7 +91,7 @@ var (
 		lowReadyAlert:        "LowReadyVirtHandlerCount",
 	}
 	virtOperator = alerts{
-		deploymentName:       "virt-operator",
+		deploymentName:       virtOperatorDeploymentName,
 		downAlert:            "VirtOperatorDown",
 		noReadyAlert:         "NoReadyVirtOperator",
 		restErrorsBurtsAlert: "VirtOperatorRESTErrorsBurst",
@@ -234,7 +238,7 @@ var _ = Describe("[sig-monitoring]Component Monitoring", Serial, Ordered, decora
 
 			badContainer := daemonSet.Spec.Template.Spec.Containers[0]
 			badContainer.Image = libregistry.GetUtilityImageFromRegistry("vm-killer")
-			badContainer.Command = []string{"tail", "-f", "/dev/null"}
+			badContainer.Command = []string{tailCommand, tailFParam, devNull}
 			badContainer.Args = []string{}
 			badContainer.ReadinessProbe = nil
 			badContainer.LivenessProbe = nil
@@ -539,7 +543,7 @@ func lowReadyDecoyPodSpecFromTemplate(spec corev1.PodSpec) corev1.PodSpec {
 	Expect(out.Containers).NotTo(BeEmpty())
 	c := &out.Containers[0]
 	c.Image = libregistry.GetUtilityImageFromRegistry("vm-killer")
-	c.Command = []string{"tail", "-f", "/dev/null"}
+	c.Command = []string{tailCommand, tailFParam, devNull}
 	c.Args = nil
 	c.ReadinessProbe = nil
 	c.LivenessProbe = nil

--- a/tests/monitoring/metrics.go
+++ b/tests/monitoring/metrics.go
@@ -48,6 +48,11 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
+const (
+	metricLabelName      = "name"
+	metricLabelNamespace = "namespace"
+)
+
 var _ = Describe("[sig-monitoring]Metrics", decorators.SigMonitoring, func() {
 	var virtClient kubecli.KubevirtClient
 	var metrics *libmonitoring.QueryRequestResult
@@ -131,11 +136,11 @@ var _ = Describe("[sig-monitoring]Metrics", decorators.SigMonitoring, func() {
 
 		It("should contain VNIC metrics", func() {
 			labels := map[string]string{
-				"namespace":    vm.Namespace,
-				"name":         vm.Name,
-				"binding_type": "core",
-				"network":      "pod networking",
-				"binding_name": "masquerade",
+				metricLabelNamespace: vm.Namespace,
+				metricLabelName:      vm.Name,
+				"binding_type":       "core",
+				"network":            "pod networking",
+				"binding_name":       "masquerade",
 			}
 
 			By("Verifying VM vnic info metric")
@@ -157,8 +162,8 @@ var _ = Describe("[sig-monitoring]Metrics", decorators.SigMonitoring, func() {
 				Name: "kubevirt_vm_disk_allocated_size_bytes",
 			})
 			labels := map[string]string{
-				"namespace":             vm.Namespace,
-				"name":                  vm.Name,
+				metricLabelNamespace:    vm.Namespace,
+				metricLabelName:         vm.Name,
 				"persistentvolumeclaim": "test-vm-pvc",
 				"volume_mode":           "Filesystem",
 				"device":                "testdisk",
@@ -172,8 +177,8 @@ var _ = Describe("[sig-monitoring]Metrics", decorators.SigMonitoring, func() {
 				Name: "kubevirt_vm_labels",
 			})
 			labels := map[string]string{
-				"namespace":                 vm.Namespace,
-				"name":                      vm.Name,
+				metricLabelNamespace:        vm.Namespace,
+				metricLabelName:             vm.Name,
 				"label_vm_kubevirt_io_test": "test-vm-labels",
 			}
 			Expect(metrics.Data.Result).To(ContainElement(gomegaContainsMetricMatcher(metric, labels)))
@@ -210,8 +215,8 @@ var _ = Describe("[sig-monitoring]Metrics", decorators.SigMonitoring, func() {
 			By("Waiting until vmi sync metrics are removed")
 			Eventually(func() error {
 				_, err := libmonitoring.GetMetricValueWithLabels(virtClient, "kubevirt_vmi_sync_total", map[string]string{
-					"namespace": vmiRef.Namespace,
-					"name":      vmiRef.Name,
+					metricLabelNamespace: vmiRef.Namespace,
+					metricLabelName:      vmiRef.Name,
 				})
 				return err
 			}, 3*time.Minute, 10*time.Second).Should(HaveOccurred())
@@ -304,17 +309,17 @@ func setupSharedVM(virtClient kubecli.KubevirtClient) *v1.VirtualMachine {
 	vm := createRunningVM(virtClient, vmi, v1.RunStrategyAlways, true)
 
 	By("Waiting for the VM to be reported")
-	libmonitoring.WaitForMetricValueWithLabels(virtClient, "namespace:kubevirt_vm:sum", 1, map[string]string{"namespace": vm.Namespace}, 1)
+	libmonitoring.WaitForMetricValueWithLabels(virtClient, "namespace:kubevirt_vm:sum", 1, map[string]string{metricLabelNamespace: vm.Namespace}, 1)
 
 	By("Waiting for the VMI to be reported")
 	labels := map[string]string{
-		"namespace": vm.Namespace,
-		"name":      vm.Name,
+		metricLabelNamespace: vm.Namespace,
+		metricLabelName:      vm.Name,
 	}
 	libmonitoring.WaitForMetricValueWithLabels(virtClient, "kubevirt_vmi_info", 1, labels, 1)
 
 	By("Waiting for the VM domainstats metrics to be reported")
-	fsLabels := map[string]string{"namespace": vm.Namespace, "name": vm.Name}
+	fsLabels := map[string]string{metricLabelNamespace: vm.Namespace, metricLabelName: vm.Name}
 	libmonitoring.WaitForMetricValueWithLabelsToBe(
 		virtClient, "kubevirt_vmi_filesystem_capacity_bytes", fsLabels, 0, ">", 0,
 	)

--- a/tests/monitoring/metrics.go
+++ b/tests/monitoring/metrics.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/onsi/gomega/types"
 	"github.com/prometheus/client_golang/prometheus"
+
 	"github.com/rhobs/operator-observability-toolkit/pkg/operatormetrics"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -49,8 +50,10 @@ import (
 )
 
 const (
-	metricLabelName      = "name"
-	metricLabelNamespace = "namespace"
+	metricLabelName                          = "name"
+	metricLabelNamespace                     = "namespace"
+	vmiPhaseTransitionTimeFromDeletionMetric = "kubevirt_vmi_phase_transition_time_from_deletion_seconds"
+	testVMPVC                                = "test-vm-pvc"
 )
 
 var _ = Describe("[sig-monitoring]Metrics", decorators.SigMonitoring, func() {
@@ -100,7 +103,7 @@ var _ = Describe("[sig-monitoring]Metrics", decorators.SigMonitoring, func() {
 			"kubevirt_vmi_dirty_rate_bytes_per_second": true,
 
 			// Verify separately after deletion
-			"kubevirt_vmi_phase_transition_time_from_deletion_seconds": true,
+			vmiPhaseTransitionTimeFromDeletionMetric: true,
 
 			// Needs a guest crash - tested in VM Monitoring, guest panic metrics
 			"kubevirt_vmi_guest_os_panic_total": true,
@@ -164,7 +167,7 @@ var _ = Describe("[sig-monitoring]Metrics", decorators.SigMonitoring, func() {
 			labels := map[string]string{
 				metricLabelNamespace:    vm.Namespace,
 				metricLabelName:         vm.Name,
-				"persistentvolumeclaim": "test-vm-pvc",
+				"persistentvolumeclaim": testVMPVC,
 				"volume_mode":           "Filesystem",
 				"device":                "testdisk",
 			}
@@ -192,7 +195,7 @@ var _ = Describe("[sig-monitoring]Metrics", decorators.SigMonitoring, func() {
 			}
 
 			metric := operatormetrics.NewHistogram(operatormetrics.MetricOpts{
-				Name: "kubevirt_vmi_phase_transition_time_from_deletion_seconds",
+				Name: vmiPhaseTransitionTimeFromDeletionMetric,
 			}, prometheus.HistogramOpts{})
 
 			By("Waiting for the VMI to terminate")
@@ -233,7 +236,7 @@ var _ = Describe("[sig-monitoring]Metrics", decorators.SigMonitoring, func() {
 
 		It("kubevirt workqueue metrics should include controllers names", func() {
 			names := []string{
-				"virt-operator",
+				virtOperatorDeploymentName,
 				"virt-handler-node-labeller",
 				"virt-handler-source",
 				"virt-handler-target",
@@ -293,7 +296,7 @@ func fetchPrometheusMetrics(virtClient kubecli.KubevirtClient, query string) *li
 }
 
 func setupSharedVM(virtClient kubecli.KubevirtClient) *v1.VirtualMachine {
-	vmDiskPVC := "test-vm-pvc"
+	vmDiskPVC := testVMPVC
 	dv := libstorage.CreateBlankFSDataVolume(vmDiskPVC, testsuite.GetTestNamespace(nil), "512Mi", nil)
 	iface := *v1.DefaultMasqueradeNetworkInterface()
 
@@ -309,7 +312,8 @@ func setupSharedVM(virtClient kubecli.KubevirtClient) *v1.VirtualMachine {
 	vm := createRunningVM(virtClient, vmi, v1.RunStrategyAlways, true)
 
 	By("Waiting for the VM to be reported")
-	libmonitoring.WaitForMetricValueWithLabels(virtClient, "namespace:kubevirt_vm:sum", 1, map[string]string{metricLabelNamespace: vm.Namespace}, 1)
+	libmonitoring.WaitForMetricValueWithLabels(virtClient,
+		"namespace:kubevirt_vm:sum", 1, map[string]string{metricLabelNamespace: vm.Namespace}, 1)
 
 	By("Waiting for the VMI to be reported")
 	labels := map[string]string{

--- a/tests/monitoring/vm_monitoring.go
+++ b/tests/monitoring/vm_monitoring.go
@@ -61,6 +61,8 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
+const metricLabelVMI = "vmi"
+
 var _ = Describe("[sig-monitoring]VM Monitoring", decorators.SigMonitoring, func() {
 	var (
 		err        error
@@ -128,7 +130,7 @@ var _ = Describe("[sig-monitoring]VM Monitoring", decorators.SigMonitoring, func
 			)
 
 			By("Checking that the VM metrics are available")
-			metricLabels := map[string]string{"name": vm.Name, "namespace": vm.Namespace}
+			metricLabels := map[string]string{metricLabelName: vm.Name, metricLabelNamespace: vm.Namespace}
 			for _, metric := range cpuMetrics {
 				checkMetricTo(
 					metric, metricLabels, BeNumerically(">=", 0), "VM metrics should be available for a running VM",
@@ -152,7 +154,7 @@ var _ = Describe("[sig-monitoring]VM Monitoring", decorators.SigMonitoring, func
 			time.Sleep(prometheusScrapeWait)
 
 			By("Checking that the VM metrics are available")
-			metricLabels := map[string]string{"name": vm.Name, "namespace": vm.Namespace}
+			metricLabels := map[string]string{metricLabelName: vm.Name, metricLabelNamespace: vm.Namespace}
 			for _, metric := range cpuMetrics {
 				checkMetricTo(
 					metric, metricLabels, BeNumerically(">=", 0), "VM metrics should be available for a paused VM",
@@ -167,7 +169,7 @@ var _ = Describe("[sig-monitoring]VM Monitoring", decorators.SigMonitoring, func
 			)
 
 			By("Checking that the VM metrics are not available")
-			metricLabels := map[string]string{"name": vm.Name, "namespace": vm.Namespace}
+			metricLabels := map[string]string{metricLabelName: vm.Name, metricLabelNamespace: vm.Namespace}
 			for _, metric := range cpuMetrics {
 				checkMetricTo(
 					metric, metricLabels, BeNumerically("==", -1), "VM metrics should not be available for a stopped VM",
@@ -237,9 +239,9 @@ var _ = Describe("[sig-monitoring]VM Monitoring", decorators.SigMonitoring, func
 			libstorage.WaitSnapshotSucceeded(virtClient, vm.Namespace, snapshot.Name)
 
 			labels := map[string]string{
-				"name":          snapshot.Spec.Source.Name,
-				"snapshot_name": snapshot.Name,
-				"namespace":     snapshot.Namespace,
+				metricLabelName:      snapshot.Spec.Source.Name,
+				"snapshot_name":      snapshot.Name,
+				metricLabelNamespace: snapshot.Namespace,
 			}
 			libmonitoring.WaitForMetricValueWithLabelsToBe(
 				virtClient, "kubevirt_vmsnapshot_succeeded_timestamp_seconds", labels, 0, ">", 0,
@@ -314,7 +316,7 @@ var _ = Describe("[sig-monitoring]VM Monitoring", decorators.SigMonitoring, func
 	Context("VM dirty rate metrics", func() {
 		getDirtyRateMetricValue := func(vm *v1.VirtualMachine) float64 {
 			const dirtyRateMetric = "kubevirt_vmi_dirty_rate_bytes_per_second"
-			metricLabels := map[string]string{"name": vm.Name, "namespace": vm.Namespace}
+			metricLabels := map[string]string{metricLabelName: vm.Name, metricLabelNamespace: vm.Namespace}
 
 			var metricValue float64
 			EventuallyWithOffset(1, func() (err error) {
@@ -408,7 +410,7 @@ var _ = Describe("[sig-monitoring]VM Monitoring", decorators.SigMonitoring, func
 				Expect(err).ToNot(HaveOccurred())
 			}
 
-			nsLabels := map[string]string{"namespace": testsuite.GetTestNamespace(nil)}
+			nsLabels := map[string]string{metricLabelNamespace: testsuite.GetTestNamespace(nil)}
 			libmonitoring.WaitForMetricValueWithLabels(
 				virtClient, "namespace:kubevirt_vm:sum", expectedVMCount, nsLabels, 1,
 			)
@@ -440,8 +442,8 @@ var _ = Describe("[sig-monitoring]VM Monitoring", decorators.SigMonitoring, func
 			libmonitoring.WaitForMetricValue(virtClient, "kubevirt_vmi_migrations_in_running_phase", 0)
 
 			labels := map[string]string{
-				"vmi":       vmi.Name,
-				"namespace": vmi.Namespace,
+				metricLabelVMI:       vmi.Name,
+				metricLabelNamespace: vmi.Namespace,
 			}
 			libmonitoring.WaitForMetricValueWithLabels(virtClient, "kubevirt_vmi_migration_succeeded", 1, labels, 1)
 
@@ -466,8 +468,8 @@ var _ = Describe("[sig-monitoring]VM Monitoring", decorators.SigMonitoring, func
 			)
 			vmi = libvmops.RunVMIAndExpectLaunch(vmi, flags.StartupTimeoutSecondsHuge())
 			labels := map[string]string{
-				"vmi":       vmi.Name,
-				"namespace": vmi.Namespace,
+				metricLabelVMI:       vmi.Name,
+				metricLabelNamespace: vmi.Namespace,
 			}
 
 			By("Starting the Migration")
@@ -655,8 +657,8 @@ var _ = Describe("[sig-monitoring]VM Monitoring", decorators.SigMonitoring, func
 
 			By("verifying the guest OS panic metric was incremented")
 			labels := map[string]string{
-				"namespace": vmi.Namespace,
-				"name":      vmi.Name,
+				metricLabelNamespace: vmi.Namespace,
+				metricLabelName:      vmi.Name,
 			}
 			libmonitoring.WaitForMetricValueWithLabelsToBe(virtClient, "kubevirt_vmi_guest_os_panic_total", labels, 1, ">=", 1)
 		})
@@ -708,7 +710,7 @@ func validateLastConnectionMetricValue(vmi *v1.VirtualMachineInstance, formerVal
 	var err error
 	var metricValue float64
 	virtClient := kubevirt.Client()
-	labels := map[string]string{"vmi": vmi.Name, "namespace": vmi.Namespace}
+	labels := map[string]string{metricLabelVMI: vmi.Name, metricLabelNamespace: vmi.Namespace}
 
 	EventuallyWithOffset(1, func() float64 {
 		metricValue, err = libmonitoring.GetMetricValueWithLabels(

--- a/tests/network/bindingplugin.go
+++ b/tests/network/bindingplugin.go
@@ -46,6 +46,9 @@ import (
 const (
 	vmiReadyTimeoutPasst      = 180
 	vmiReadyTimeoutManagedTap = 30
+	ipamTypeKey               = "type"
+	hostLocalIPAMType         = "host-local"
+	subnetKey                 = "subnet"
 )
 
 var _ = Describe(SIG("network binding plugin", Serial, decorators.NetCustomBindingPlugins, func() {
@@ -210,8 +213,8 @@ var _ = Describe(SIG("network binding plugin", Serial, decorators.NetCustomBindi
 				linuxBridgeNADName,
 				"br10",
 				libnet.WithIPAM(map[string]string{
-					"type":   "host-local",
-					"subnet": "10.1.1.0/24",
+					ipamTypeKey: hostLocalIPAMType,
+					subnetKey:   "10.1.1.0/24",
 				}),
 			)
 			_, err := libnet.CreateNetAttachDef(context.Background(), namespace, netAttachDef)

--- a/tests/network/passt.go
+++ b/tests/network/passt.go
@@ -52,6 +52,7 @@ import (
 const (
 	vmiReadyTimeout = 180
 	tcpProtocol     = "TCP"
+	udpProtocol     = "UDP"
 	httpPortName    = "http"
 )
 
@@ -66,7 +67,7 @@ var _ = Describe(SIG(" VirtualMachineInstance with passt network binding", func(
 			libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name,
 				libvmi.WithPasstBinding(),
 				libvmi.WithMac(testMACAddr),
-libvmi.WithPorts(v1.Port{Port: 1234, Protocol: tcpProtocol}),
+				libvmi.WithPorts(v1.Port{Port: 1234, Protocol: tcpProtocol}),
 				libvmi.WithPciAddress(testPCIAddr),
 			)),
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
@@ -166,13 +167,20 @@ libvmi.WithPorts(v1.Port{Port: 1234, Protocol: tcpProtocol}),
 		BeforeAll(func() {
 			namespace := testsuite.GetTestNamespace(nil)
 
+			ports := []v1.Port{
+				{Port: udpPortForIPv4, Protocol: udpProtocol},
+				{Port: udpPortForIPv6, Protocol: udpProtocol},
+			}
+			passtIface := libvmi.InterfaceDeviceWithPasstBinding(v1.DefaultPodNetwork().Name)
+			passtIface.Ports = ports
+
 			By("Starting server VMI")
 			serverVMI = libvmifact.NewAlpineWithTestTooling(
 				libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name,
 					libvmi.WithPasstBinding(),
 					libvmi.WithPorts(
-						v1.Port{Port: udpPortForIPv4, Protocol: "UDP"},
-						v1.Port{Port: udpPortForIPv6, Protocol: "UDP"},
+						v1.Port{Port: udpPortForIPv4, Protocol: udpProtocol},
+						v1.Port{Port: udpPortForIPv6, Protocol: udpProtocol},
 					),
 				)),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
@@ -373,7 +381,7 @@ func createClientServerPasstVMIsWithTCPServer(tcpPort int) (client, server *v1.V
 	serverVMI := libvmifact.NewAlpineWithTestTooling(
 		libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name,
 			libvmi.WithPasstBinding(),
-			libvmi.WithPorts(v1.Port{Name: "http", Port: int32(tcpPort), Protocol: tcpProtocol}), //nolint:gosec // tcpPort is a test constant
+			libvmi.WithPorts(v1.Port{Name: httpPortName, Port: int32(tcpPort), Protocol: tcpProtocol}), //nolint:gosec // tcpPort is a test constant
 		)),
 		libvmi.WithNetwork(v1.DefaultPodNetwork()),
 	)

--- a/tests/network/passt.go
+++ b/tests/network/passt.go
@@ -51,6 +51,8 @@ import (
 
 const (
 	vmiReadyTimeout = 180
+	tcpProtocol     = "TCP"
+	httpPortName    = "http"
 )
 
 var _ = Describe(SIG(" VirtualMachineInstance with passt network binding", func() {
@@ -59,11 +61,12 @@ var _ = Describe(SIG(" VirtualMachineInstance with passt network binding", func(
 	It("should apply the interface configuration", func() {
 		const testMACAddr = "02:02:02:02:02:02"
 		const testPCIAddr = "0000:01:00.0"
+
 		vmi := libvmifact.NewAlpineWithTestTooling(
 			libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name,
 				libvmi.WithPasstBinding(),
 				libvmi.WithMac(testMACAddr),
-				libvmi.WithPorts(v1.Port{Port: 1234, Protocol: "TCP"}),
+libvmi.WithPorts(v1.Port{Port: 1234, Protocol: tcpProtocol}),
 				libvmi.WithPciAddress(testPCIAddr),
 			)),
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
@@ -317,10 +320,9 @@ var _ = Describe(SIG(" VirtualMachineInstance with passt network binding", func(
 )
 
 func withPasstInterfaceWithPort() libvmi.Option {
-	return libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name,
-		libvmi.WithPasstBinding(),
-		libvmi.WithPorts(v1.Port{Port: 1234, Protocol: "TCP"}),
-	))
+	iface := libvmi.InterfaceDeviceWithPasstBinding(v1.DefaultPodNetwork().Name)
+	iface.Ports = []v1.Port{{Port: 1234, Protocol: tcpProtocol}}
+	return libvmi.WithInterface(iface)
 }
 
 func assertSourcePodContainersTerminate(labelSelector, fieldSelector string, vmi *v1.VirtualMachineInstance) bool {
@@ -371,7 +373,7 @@ func createClientServerPasstVMIsWithTCPServer(tcpPort int) (client, server *v1.V
 	serverVMI := libvmifact.NewAlpineWithTestTooling(
 		libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name,
 			libvmi.WithPasstBinding(),
-			libvmi.WithPorts(v1.Port{Name: "http", Port: int32(tcpPort), Protocol: "TCP"}), //nolint:gosec // tcpPort is a test constant
+			libvmi.WithPorts(v1.Port{Name: "http", Port: int32(tcpPort), Protocol: tcpProtocol}), //nolint:gosec // tcpPort is a test constant
 		)),
 		libvmi.WithNetwork(v1.DefaultPodNetwork()),
 	)

--- a/tests/numa/numa.go
+++ b/tests/numa/numa.go
@@ -104,6 +104,11 @@ var _ = Describe("[sig-compute]NUMA", Serial, decorators.SigCompute, func() {
 		})
 })
 
+const (
+	binBash = "/bin/bash"
+	bashC   = "-c"
+)
+
 func getQEMUPID(handlerPod *k8sv1.Pod, vmi *v1.VirtualMachineInstance) string {
 	var stdout, stderr string
 	const (
@@ -115,8 +120,8 @@ func getQEMUPID(handlerPod *k8sv1.Pod, vmi *v1.VirtualMachineInstance) string {
 	Eventually(func() (err error) {
 		stdout, stderr, err = exec.ExecuteCommandOnPodWithResults(handlerPod, "virt-handler",
 			[]string{
-				"/bin/bash",
-				"-c",
+				binBash,
+				bashC,
 				fmt.Sprintf("grep -l '[g]uest=%s_%s' /proc/*/cmdline", vmi.Namespace, vmi.Name),
 			})
 		return err
@@ -134,8 +139,8 @@ func getQEMUPID(handlerPod *k8sv1.Pod, vmi *v1.VirtualMachineInstance) string {
 func getNUMAMapping(virtClient kubecli.KubevirtClient, pod *k8sv1.Pod, pid string) string {
 	stdout, stderr, err := exec.ExecuteCommandOnPodWithResults(pod, "virt-handler",
 		[]string{
-			"/bin/bash",
-			"-c",
+			binBash,
+			bashC,
 			fmt.Sprintf("trap '' URG && cat /proc/%v/numa_maps", pid),
 		})
 	Expect(err).ToNot(HaveOccurred(), stderr)

--- a/tests/virtctl/guestfs.go
+++ b/tests/virtctl/guestfs.go
@@ -130,7 +130,7 @@ func execCommandLibguestfsPod(podName, namespace string, args []string) (stdout,
 func guestfsCmd(pvcClaim, namespace string, setGroup bool, extraArgs ...string) func() error {
 	args := append([]string{
 		"guestfs", pvcClaim,
-		"--namespace", namespace,
+		namespaceFlag, namespace,
 	}, extraArgs...)
 	if setGroup {
 		const testGroup = "2000"

--- a/tests/virtctl/guestfs.go
+++ b/tests/virtctl/guestfs.go
@@ -40,6 +40,13 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
+const (
+	guestfishCmd    = "guestfish"
+	guestfishArgA   = "-a"
+	guestfishRunCmd = "run"
+	diskImagePath   = "/disk/disk.img"
+)
+
 var _ = Describe(SIG("[sig-storage]Guestfs", decorators.SigStorage, func() {
 	var (
 		pvcClaim string
@@ -102,7 +109,7 @@ var _ = Describe(SIG("[sig-storage]Guestfs", decorators.SigStorage, func() {
 				libstorage.CreateBlockPVC(pvcClaim, testsuite.GetTestNamespace(nil), "500Mi", libstorage.WithStorageProfile())
 				runGuestfsOnPVC(done, pvcClaim, testsuite.GetTestNamespace(nil), setGroup)
 				stdout, stderr, err := execCommandLibguestfsPod(
-					getGuestfsPodName(pvcClaim), testsuite.GetTestNamespace(nil), []string{"guestfish", "-a", "/dev/vda", "run"},
+					getGuestfsPodName(pvcClaim), testsuite.GetTestNamespace(nil), []string{guestfishCmd, guestfishArgA, "/dev/vda", guestfishRunCmd},
 				)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(stderr).To(BeEmpty())
@@ -170,11 +177,11 @@ func guestfsWithSync(done chan struct{}, cmd func() error) {
 }
 
 func verifyCanRunOnFSPVC(podName, namespace string) {
-	stdout, stderr, err := execCommandLibguestfsPod(podName, namespace, []string{"qemu-img", "create", "/disk/disk.img", "500M"})
+	stdout, stderr, err := execCommandLibguestfsPod(podName, namespace, []string{"qemu-img", "create", diskImagePath, "500M"})
 	Expect(stderr).To(BeEmpty())
 	Expect(stdout).To(ContainSubstring("Formatting"))
 	Expect(err).ToNot(HaveOccurred())
-	stdout, stderr, err = execCommandLibguestfsPod(podName, namespace, []string{"guestfish", "-a", "/disk/disk.img", "run"})
+	stdout, stderr, err = execCommandLibguestfsPod(podName, namespace, []string{guestfishCmd, guestfishArgA, diskImagePath, guestfishRunCmd})
 	Expect(stderr).To(BeEmpty())
 	Expect(stdout).To(BeEmpty())
 	Expect(err).ToNot(HaveOccurred())

--- a/tests/virtctl/imageupload.go
+++ b/tests/virtctl/imageupload.go
@@ -51,7 +51,8 @@ import (
 )
 
 const (
-	pvcSize = "100Mi"
+	namespaceFlag = "--namespace"
+	pvcSize       = "100Mi"
 )
 
 var _ = Describe(SIG("[sig-storage]ImageUpload", decorators.SigStorage, func() {
@@ -320,7 +321,7 @@ func createArchive(sourceFilesNames ...string) string {
 func runImageUploadCmd(args ...string) error {
 	_args := append([]string{
 		"image-upload",
-		"--namespace", testsuite.GetTestNamespace(nil),
+		namespaceFlag, testsuite.GetTestNamespace(nil),
 		"--size", pvcSize,
 		"--insecure",
 	}, args...)

--- a/tests/virtctl/memorydump.go
+++ b/tests/virtctl/memorydump.go
@@ -50,7 +50,11 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-const memoryDumpCmd = "memory-dump"
+const (
+	memoryDumpCmd = "memory-dump"
+	bashArgC      = "-c"
+	binSH         = "/bin/sh"
+)
 
 var _ = Describe(SIG("[sig-storage]Memory dump", decorators.SigStorage, func() {
 	const (
@@ -265,7 +269,7 @@ func verifyMemoryDumpPVC(pvc *k8sv1.PersistentVolumeClaim, previousOut string, s
 	const randNameTail = 5
 	pod := libstorage.RenderPodWithPVC(
 		"pod-"+rand.String(randNameTail),
-		[]string{"/bin/bash", "-c", "touch /tmp/startup; while true; do echo hello; sleep 2; done"},
+		[]string{"/bin/bash", bashArgC, "touch /tmp/startup; while true; do echo hello; sleep 2; done"},
 		nil, pvc,
 	)
 	pod.Spec.Containers[0].ReadinessProbe = &k8sv1.Probe{
@@ -282,7 +286,7 @@ func verifyMemoryDumpPVC(pvc *k8sv1.PersistentVolumeClaim, previousOut string, s
 
 	lsOut, err := exec.ExecuteCommandOnPod(
 		pod, pod.Spec.Containers[0].Name,
-		[]string{"/bin/sh", "-c", fmt.Sprintf("ls -1 %s", libstorage.DefaultPvcMountPath)},
+		[]string{binSH, bashArgC, fmt.Sprintf("ls -1 %s", libstorage.DefaultPvcMountPath)},
 	)
 	lsOut = strings.TrimSpace(lsOut)
 	Expect(err).ToNot(HaveOccurred())
@@ -290,7 +294,7 @@ func verifyMemoryDumpPVC(pvc *k8sv1.PersistentVolumeClaim, previousOut string, s
 
 	wcOut, err := exec.ExecuteCommandOnPod(
 		pod, pod.Spec.Containers[0].Name,
-		[]string{"/bin/sh", "-c", fmt.Sprintf("ls -1 %s | wc -l", libstorage.DefaultPvcMountPath)},
+		[]string{binSH, bashArgC, fmt.Sprintf("ls -1 %s | wc -l", libstorage.DefaultPvcMountPath)},
 	)
 	wcOut = strings.TrimSpace(wcOut)
 	Expect(err).ToNot(HaveOccurred())

--- a/tests/virtctl/memorydump.go
+++ b/tests/virtctl/memorydump.go
@@ -50,6 +50,8 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
+const memoryDumpCmd = "memory-dump"
+
 var _ = Describe(SIG("[sig-storage]Memory dump", decorators.SigStorage, func() {
 	const (
 		randNameTail    = 5
@@ -170,24 +172,24 @@ var _ = Describe(SIG("[sig-storage]Memory dump", decorators.SigStorage, func() {
 
 func runMemoryDumpGetCmd(name string, args ...string) error {
 	_args := append([]string{
-		"memory-dump", "get", name,
-		"--namespace", testsuite.GetTestNamespace(nil),
+		memoryDumpCmd, "get", name,
+		namespaceFlag, testsuite.GetTestNamespace(nil),
 	}, args...)
 	return newRepeatableVirtctlCommand(_args...)()
 }
 
 func runMemoryDumpDownloadCmd(name string, args ...string) error {
 	_args := append([]string{
-		"memory-dump", "download", name,
-		"--namespace", testsuite.GetTestNamespace(nil),
+		memoryDumpCmd, "download", name,
+		namespaceFlag, testsuite.GetTestNamespace(nil),
 	}, args...)
 	return newRepeatableVirtctlCommand(_args...)()
 }
 
 func runMemoryDumpRemoveCmd(name string, args ...string) error {
 	_args := append([]string{
-		"memory-dump", "remove", name,
-		"--namespace", testsuite.GetTestNamespace(nil),
+		memoryDumpCmd, "remove", name,
+		namespaceFlag, testsuite.GetTestNamespace(nil),
 	}, args...)
 	return newRepeatableVirtctlCommand(_args...)()
 }

--- a/tests/virtctl/ssh_scp.go
+++ b/tests/virtctl/ssh_scp.go
@@ -125,7 +125,7 @@ func runSSHCommand(name, user, keyFile string) {
 	libssh.DisableSSHAgent()
 	args := []string{
 		"ssh",
-		"--namespace", testsuite.GetTestNamespace(nil),
+		namespaceFlag, testsuite.GetTestNamespace(nil),
 		"--username", user,
 		"--identity-file", keyFile,
 		"-t", "-o StrictHostKeyChecking=no",
@@ -141,7 +141,7 @@ func runSCPCommand(src, dst, keyFile string, recursive bool) {
 	libssh.DisableSSHAgent()
 	args := []string{
 		"scp",
-		"--namespace", testsuite.GetTestNamespace(nil),
+		namespaceFlag, testsuite.GetTestNamespace(nil),
 		"--username", "root",
 		"--identity-file", keyFile,
 		"-t", "-o StrictHostKeyChecking=no",

--- a/tests/virtctl/ssh_scp.go
+++ b/tests/virtctl/ssh_scp.go
@@ -44,10 +44,16 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
+const (
+	ttyFlag                  = "-t"
+	usernameFlag             = "--username"
+	identityFileFlag         = "--identity-file"
+	strictHostKeyCheckingOpt = "-o StrictHostKeyChecking=no"
+	userKnownHostsFileOpt    = "-o UserKnownHostsFile=/dev/null"
+)
+
 var _ = Describe(SIG("[sig-compute]SSH and SCP", decorators.SigCompute, Ordered, decorators.OncePerOrderedCleanup, func() {
-	const (
-		randSuffixLen = 8
-	)
+	const randSuffixLen = 8
 
 	var (
 		keyFile string
@@ -126,10 +132,10 @@ func runSSHCommand(name, user, keyFile string) {
 	args := []string{
 		"ssh",
 		namespaceFlag, testsuite.GetTestNamespace(nil),
-		"--username", user,
-		"--identity-file", keyFile,
-		"-t", "-o StrictHostKeyChecking=no",
-		"-t", "-o UserKnownHostsFile=/dev/null",
+		usernameFlag, user,
+		identityFileFlag, keyFile,
+		ttyFlag, strictHostKeyCheckingOpt,
+		ttyFlag, userKnownHostsFileOpt,
 		"--command", "true",
 		"vmi/" + name,
 	}
@@ -142,10 +148,10 @@ func runSCPCommand(src, dst, keyFile string, recursive bool) {
 	args := []string{
 		"scp",
 		namespaceFlag, testsuite.GetTestNamespace(nil),
-		"--username", "root",
-		"--identity-file", keyFile,
-		"-t", "-o StrictHostKeyChecking=no",
-		"-t", "-o UserKnownHostsFile=/dev/null",
+		usernameFlag, "root",
+		identityFileFlag, keyFile,
+		ttyFlag, strictHostKeyCheckingOpt,
+		ttyFlag, userKnownHostsFileOpt,
 	}
 	if recursive {
 		args = append(args, "--recursive")


### PR DESCRIPTION
### What this PR does

The goconst linter was disabled temporarily[1] as part of the upgrade to go v1.26.4 - https://github.com/kubevirt/kubevirt/pull/18116

This PR aims to reintroduce the goconst linter and fix the resulting issues that are raised by it. 

I have tried to break up the commits by component so that the  SIG reviewers can target the relevant commits to them.

Very open to suggestions on better names for any of the constants as naming things can be hard. 

[1] https://github.com/kubevirt/kubevirt/pull/18116/changes/6944aad23b2242897efb6a600eb0deb118eca408

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

