### PR TITLE
libvmi: deprecate legacy interface builder functions

### DIFF
--- a/pkg/libvmi/network.go
+++ b/pkg/libvmi/network.go
@@ -136,62 +136,63 @@ func WithState(state kvirtv1.InterfaceState) InterfaceOption {
 	}
 }
 
-// InterfaceDeviceWithMasqueradeBinding returns an Interface named "default" with masquerade binding.
+// Deprecated: Use NewInterface with WithMasqueradeBinding instead.
 func InterfaceDeviceWithMasqueradeBinding(ports ...kvirtv1.Port) kvirtv1.Interface {
 	return NewInterface(kvirtv1.DefaultPodNetwork().Name, WithMasqueradeBinding(), WithPorts(ports...))
 }
 
-// InterfaceDeviceWithBridgeBinding returns an Interface with bridge binding.
+// Deprecated: Use NewInterface with WithBridgeBinding instead.
 func InterfaceDeviceWithBridgeBinding(name string) kvirtv1.Interface {
 	return NewInterface(name, WithBridgeBinding())
 }
 
-// InterfaceDeviceWithSRIOVBinding returns an Interface with SRIOV binding.
+// Deprecated: Use NewInterface with WithSRIOVBinding instead.
 func InterfaceDeviceWithSRIOVBinding(name string) kvirtv1.Interface {
 	return NewInterface(name, WithSRIOVBinding())
 }
 
-// InterfaceDeviceWithPasstBinding returns an Interface with passtBinding.
+// Deprecated: Use NewInterface with WithPasstBinding instead.
 func InterfaceDeviceWithPasstBinding(name string) kvirtv1.Interface {
 	return NewInterface(name, WithPasstBinding())
 }
 
-// InterfaceWithPasstBinding returns an Interface named "default" with passt binding plugin.
+// Deprecated: Use NewInterface with WithBindingPlugin instead.
 func InterfaceWithPasstBindingPlugin(ports ...kvirtv1.Port) kvirtv1.Interface {
 	const passtBindingName = "passt"
 	return NewInterface(kvirtv1.DefaultPodNetwork().Name,
 		WithBindingPlugin(kvirtv1.PluginBinding{Name: passtBindingName}), WithPorts(ports...))
 }
 
-// InterfaceWithMacvtapBindingPlugin returns an Interface named "default" with "macvtap" binding plugin.
+// Deprecated: Use NewInterface with WithBindingPlugin instead.
 func InterfaceWithMacvtapBindingPlugin(name string) kvirtv1.Interface {
 	const macvtapBindingName = "macvtap"
 	return NewInterface(name, WithBindingPlugin(kvirtv1.PluginBinding{Name: macvtapBindingName}))
 }
 
+// Deprecated: Use NewInterface with WithBindingPlugin instead.
 func InterfaceWithBindingPlugin(name string, binding kvirtv1.PluginBinding, ports ...kvirtv1.Port) kvirtv1.Interface {
 	return NewInterface(name, WithBindingPlugin(binding), WithPorts(ports...))
 }
 
-// InterfaceWithMac decorates an existing Interface with a MAC address.
+// Deprecated: Use NewInterface with WithMac instead.
 func InterfaceWithMac(iface kvirtv1.Interface, macAddress string) kvirtv1.Interface {
 	WithMac(macAddress)(&iface)
 	return iface
 }
 
-// InterfaceWithPciAddress decorates an existing Interface with a guest PCI address.
+// Deprecated: Use NewInterface with WithPciAddress instead.
 func InterfaceWithPciAddress(iface kvirtv1.Interface, pciAddress string) kvirtv1.Interface {
 	WithPciAddress(pciAddress)(&iface)
 	return iface
 }
 
-// InterfaceWithTag decorates an existing Interface with a tag.
+// Deprecated: Use NewInterface with WithTag instead.
 func InterfaceWithTag(iface kvirtv1.Interface, tag string) kvirtv1.Interface {
 	WithTag(tag)(&iface)
 	return iface
 }
 
-// InterfaceWithModel decorates an existing Interface with a model.
+// Deprecated: Use NewInterface with WithModel instead.
 func InterfaceWithModel(iface kvirtv1.Interface, model string) kvirtv1.Interface {
 	WithModel(model)(&iface)
 	return iface


### PR DESCRIPTION
### What this PR does
#### Before this PR:
Legacy interface builder functions (`InterfaceDeviceWith*`, `InterfaceWith*`) have no deprecation markers, making it unclear to contributors which API to use.

#### After this PR:
All legacy interface constructors and decorators are marked with `// Deprecated:` godoc comments, pointing to `NewInterface` with the appropriate option functions as replacements.

No code changes - only comments.

### References

Follow-up to #18263, as requested by @EdDev in [review](https://github.com/kubevirt/kubevirt/pull/18263#pullrequestreview-4587109493).

### Why we need it and why it was done in this way

New contributors can't easily tell which interface construction API to use. The `// Deprecated:` marker is the standard Go way to signal this — IDEs and linters will flag usage of the old functions.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

/kind cleanup

```release-note
NONE
```