### PR TITLE
hypervisor: bump QemuOverhead from 30Mi to 50Mi

### DIFF
--- a/pkg/hypervisor/kvm/hypervisorbackend.go
+++ b/pkg/hypervisor/kvm/hypervisorbackend.go
@@ -39,7 +39,7 @@ const (
 	VirtLauncherOverhead        = "100Mi" // The `ps` RSS for the virt-launcher process
 	VirtlogdOverhead            = "25Mi"  // The `ps` RSS for virtlogd
 	VirtqemudOverhead           = "40Mi"  // The `ps` RSS for virtqemud
-	QemuOverhead                = "30Mi"  // The `ps` RSS for qemu, minus the RAM of its (stressed) guest, minus the virtual page table
+	QemuOverhead                = "50Mi"  // The `ps` RSS for qemu, minus the RAM of its (stressed) guest, minus the virtual page table
 
 	kvmHypervisorDevice = "kvm"
 	kvmVirtType         = "kvm"

--- a/pkg/hypervisor/kvm/hypervisorbackend_test.go
+++ b/pkg/hypervisor/kvm/hypervisorbackend_test.go
@@ -40,7 +40,7 @@ import (
 
 var _ = Describe("GetMemoryOverhead calculation", func() {
 	// VirtLauncherMonitorOverhead + VirtLauncherOverhead + VirtlogdOverhead + VirtqemudOverhead + QemuOverhead + IothreadsOverhead
-	const staticOverheadString = "223Mi"
+	const staticOverheadString = "243Mi"
 	var (
 		vmi                     *v1.VirtualMachineInstance
 		staticOverhead          *resource.Quantity

--- a/pkg/hypervisor/mshv/hypervisorbackend.go
+++ b/pkg/hypervisor/mshv/hypervisorbackend.go
@@ -39,7 +39,7 @@ const (
 	VirtLauncherOverhead        = "100Mi" // The `ps` RSS for the virt-launcher process
 	VirtlogdOverhead            = "25Mi"  // The `ps` RSS for virtlogd
 	VirtqemudOverhead           = "40Mi"  // The `ps` RSS for virtqemud
-	QemuOverhead                = "30Mi"  // The `ps` RSS for qemu, minus the RAM of its (stressed) guest, minus the virtual page table
+	QemuOverhead                = "50Mi"  // The `ps` RSS for qemu, minus the RAM of its (stressed) guest, minus the virtual page table
 
 	mshvHypervisorDevice = "mshv"
 	mshvVirtType         = "hyperv"

--- a/pkg/hypervisor/mshv/hypervisorbackend_test.go
+++ b/pkg/hypervisor/mshv/hypervisorbackend_test.go
@@ -40,7 +40,7 @@ import (
 
 var _ = Describe("MSHV GetMemoryOverhead calculation", func() {
 	// VirtLauncherMonitorOverhead + VirtLauncherOverhead + VirtlogdOverhead + VirtqemudOverhead + QemuOverhead + IothreadsOverhead
-	const staticOverheadString = "223Mi"
+	const staticOverheadString = "243Mi"
 	var (
 		vmi                     *v1.VirtualMachineInstance
 		staticOverhead          *resource.Quantity

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -2225,8 +2225,8 @@ var _ = Describe("Template", func() {
 				Expect(pod.Spec.Containers[0].Resources.Requests.Memory().String()).To(Equal(requestMemory))
 				Expect(pod.Spec.Containers[0].Resources.Limits.Memory().String()).To(Equal(limitMemory))
 			},
-				Entry("on amd64", "amd64", "1282971493", "2282971493"),
-				Entry("on arm64", "arm64", "1417189221", "2417189221"),
+				Entry("on amd64", "amd64", "1303943013", "2303943013"),
+				Entry("on arm64", "arm64", "1438160741", "2438160741"),
 			)
 			DescribeTable("should overcommit guest overhead if selected, by only adding the overhead to memory limits", func(arch string, limitMemory string) {
 				config, kvStore, svc = configFactory(arch)
@@ -2262,8 +2262,8 @@ var _ = Describe("Template", func() {
 				Expect(pod.Spec.Containers[0].Resources.Requests.Memory().String()).To(Equal("1G"))
 				Expect(pod.Spec.Containers[0].Resources.Limits.Memory().String()).To(Equal(limitMemory))
 			},
-				Entry("on amd64", "amd64", "2282971493"),
-				Entry("on arm64", "arm64", "2417189221"),
+				Entry("on amd64", "amd64", "2303943013"),
+				Entry("on arm64", "arm64", "2438160741"),
 			)
 			DescribeTable("should not add unset resources", func(arch string, requestMemory int) {
 				config, kvStore, svc = configFactory(arch)
@@ -2301,8 +2301,8 @@ var _ = Describe("Template", func() {
 				// Limits for KVM and TUN devices should be requested.
 				Expect(pod.Spec.Containers[0].Resources.Limits).ToNot(BeNil())
 			},
-				Entry("on amd64", "amd64", 362),
-				Entry("on arm64", "arm64", 497),
+				Entry("on amd64", "amd64", 383),
+				Entry("on arm64", "arm64", 518),
 			)
 
 			DescribeTable("should check autoattachGraphicsDevicse", func(arch string, autoAttach *bool, memory int) {
@@ -2338,12 +2338,12 @@ var _ = Describe("Template", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(pod.Spec.Containers[0].Resources.Requests.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(memory)))
 			},
-				Entry("and consider graphics overhead if it is not set on amd64", "amd64", nil, 362),
-				Entry("and consider graphics overhead if it is set to true on amd64", "amd64", pointer.P(true), 362),
-				Entry("and not consider graphics overhead if it is set to false on amd64", "amd64", pointer.P(false), 329),
-				Entry("and consider graphics overhead if it is not set on arm64", "arm64", nil, 497),
-				Entry("and consider graphics overhead if it is set to true on arm64", "arm64", pointer.P(true), 497),
-				Entry("and not consider graphics overhead if it is set to false on arm64", "arm64", pointer.P(false), 463),
+				Entry("and consider graphics overhead if it is not set on amd64", "amd64", nil, 383),
+				Entry("and consider graphics overhead if it is set to true on amd64", "amd64", pointer.P(true), 383),
+				Entry("and not consider graphics overhead if it is set to false on amd64", "amd64", pointer.P(false), 350),
+				Entry("and consider graphics overhead if it is not set on arm64", "arm64", nil, 518),
+				Entry("and consider graphics overhead if it is set to true on arm64", "arm64", pointer.P(true), 518),
+				Entry("and not consider graphics overhead if it is set to false on arm64", "arm64", pointer.P(false), 484),
 			)
 			It("should calculate vcpus overhead based on guest toplogy", func() {
 				config, kvStore, svc = configFactory(defaultArch)
@@ -2653,10 +2653,10 @@ var _ = Describe("Template", func() {
 						},
 					))
 			},
-				Entry("hugepages-2Mi on amd64", "amd64", "2Mi", 282),
-				Entry("hugepages-1Gi on amd64", "amd64", "1Gi", 282),
-				Entry("hugepages-2Mi on arm64", "arm64", "2Mi", 416),
-				Entry("hugepages-1Gi on arm64", "arm64", "1Gi", 416),
+				Entry("hugepages-2Mi on amd64", "amd64", "2Mi", 303),
+				Entry("hugepages-1Gi on amd64", "amd64", "1Gi", 303),
+				Entry("hugepages-2Mi on arm64", "arm64", "2Mi", 437),
+				Entry("hugepages-1Gi on arm64", "arm64", "1Gi", 437),
 			)
 			DescribeTable("should account for difference between guest and container requested memory ", func(arch string, memorySize int) {
 				config, kvStore, svc = configFactory(arch)
@@ -2733,8 +2733,8 @@ var _ = Describe("Template", func() {
 						},
 					))
 			},
-				Entry("on amd64", "amd64", 282),
-				Entry("on arm64", "arm64", 416),
+				Entry("on amd64", "amd64", 303),
+				Entry("on arm64", "arm64", 437),
 			)
 		})
 

--- a/tests/compute/cpu.go
+++ b/tests/compute/cpu.go
@@ -96,7 +96,7 @@ var _ = Describe(SIG("CPU", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			computeContainer := libpod.LookupComputeContainer(readyPod)
-			Expect(computeContainer.Resources.Requests.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(399)))
+			Expect(computeContainer.Resources.Requests.Memory().ToDec().ScaledValue(resource.Mega)).To(Equal(int64(420)))
 		})
 
 		It("[test_id:1660]should report 3 sockets under guest OS", func() {


### PR DESCRIPTION
### What this PR does

Bumps the `QemuOverhead` constant from 30Mi to 50Mi in both KVM and MSHV hypervisor backends. This constant represents the expected QEMU process RSS overhead beyond guest memory, used both for pod memory request sizing and for the e2e memory usage test assertion at `tests/vmi_configuration_test.go:1711`.

The test `[sig-compute] Configurations virt-launcher processes memory usage should be lower than allocated size` is **flaking in CI** - it was the second most frequent failure in the [sig-compute failure report](https://storage.googleapis.com/kubevirt-prow/reports/sig-failure-reports/sig-compute-failure-report.html) with 4 failures across k8s-1.34, k8s-1.35, and k8s-1.36 lanes.

#### Before this PR:

- `QemuOverhead` is 30Mi, making the e2e test limit `30Mi + 544Mi (FedoraMemory) = 574Mi`
- QEMU RSS regularly exceeds 574Mi in CI, with the following observed failures:

| Prow Run | Job | Date | QEMU RSS | Over limit |
|----------|-----|------|----------|------------|
| [2074454089755791360](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/18329/pull-kubevirt-e2e-k8s-1.35-sig-compute/2074454089755791360) | sig-compute k8s-1.35 | 2026-07-07 | 587,796Ki (574.0Mi) | 0.02Mi |
| [2072677024140365824](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/18316/pull-kubevirt-e2e-k8s-1.35-sig-compute/2072677024140365824) | sig-compute k8s-1.35 | 2026-07-02 | 592,420Ki (578.5Mi) | 4.5Mi |
| [2072735340602331136](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/17936/pull-kubevirt-e2e-k8s-1.34-sig-compute/2072735340602331136) | sig-compute k8s-1.34 | 2026-07-02 | ~587Mi | ~0Mi |
| [2072732664082731008](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/18329/pull-kubevirt-e2e-k8s-1.36-sig-compute/2072732664082731008) | sig-compute k8s-1.36 | 2026-07-02 | ~587Mi | ~0Mi |

- Additionally, an overhead of ~39.6Mi was [observed](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/17480/pull-kubevirt-e2e-k8s-1.36-sig-compute/2074764999997263872) in an unrelated PR's CI run, confirming that even 40Mi would provide only a thin margin
- The actual QEMU overhead (RSS minus guest memory) ranges from 30Mi to 39.6Mi, varying because Linux demand-pages guest memory and QEMU's own allocations (virtio buffers, VGA framebuffer, device state) fluctuate between runs

#### After this PR:

- `QemuOverhead` is 50Mi, making the test limit `50Mi + 544Mi = 594Mi`
- This gives solid headroom over all observed cases including the 39.6Mi worst case
- Each VMI pod memory request increases by 20Mi

### Context

The constant has not been updated since 2022. Two things have changed since:
1. `FedoraMemory` was bumped from 512Mi to 544Mi for Fedora 44 (commit 9bd698130), increasing the guest memory footprint
2. Newer QEMU versions have slightly larger base RSS due to additional virtio features and device state

Issue #13633 tracked this same flake but was auto-closed by the stale bot without a fix.

### References

- Issue #13633 - same flake, auto-closed without fix
- PR #8247 - precedent: bumped VirtqemudOverhead from 30Mi to 40Mi
- Commit 9bd698130 - bumped FedoraMemory from 512Mi to 544Mi
- [CI search for this failure](https://search.ci.kubevirt.io/?search=the+qemu+process+is+taking+too+much+RAM&maxAge=336h&context=1&type=junit)

### Release note
```release-note
Bumped QEMU process memory overhead from 30Mi to 50Mi, increasing VMI pod memory requests by 20Mi to reflect actual QEMU RSS requirements with current QEMU versions.
```