### PR TITLE
tests: add RequiresFeatureGate labels to alpha/beta FG tests

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -617,7 +617,7 @@ if [[ -z ${KUBEVIRT_E2E_FOCUS} && -z ${KUBEVIRT_E2E_SKIP} && -z ${label_filter} 
   fi
 
   if [[ $KUBEVIRT_PROVIDER =~ k8s-1\.3[1-4] ]]; then
-    add_to_label_filter "(!ImageVolume)" "&&"
+    add_to_label_filter "(!RequiresImageVolume)" "&&"
   fi
 
   rwofs_sc=$(jq -er .storageRWOFileSystem "${kubevirt_test_config}")

--- a/tests/clone_test.go
+++ b/tests/clone_test.go
@@ -49,7 +49,7 @@ const (
 	vmAPIGroup = "kubevirt.io"
 )
 
-var _ = Describe("VirtualMachineClone Tests", func() {
+var _ = Describe("VirtualMachineClone Tests", decorators.RequiresFeatureGate(featuregate.SnapshotGate), func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 

--- a/tests/compute/vm_lifecycle.go
+++ b/tests/compute/vm_lifecycle.go
@@ -33,6 +33,7 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
 	"kubevirt.io/kubevirt/pkg/pointer"
+	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/framework/matcher"
@@ -119,7 +120,7 @@ var _ = Describe(SIG("[rfe_id:1177][crit:medium] VirtualMachine", func() {
 		Entry("with unresponsive empty-disk VMI", libvmifact.NewGuestless),
 	)
 
-	Context("with reboot policy", func() {
+	Context("with reboot policy", decorators.RequiresFeatureGate(featuregate.RebootPolicy), func() {
 		It("should recreate VMI on guest reboot with runStrategy Always", decorators.RebootPolicy, func() {
 			By("Creating a VM with runStrategy Always and rebootPolicy Terminate")
 			vm := libvmi.NewVirtualMachine(libvmifact.NewFedora(

--- a/tests/compute/vmi_memory_overhead.go
+++ b/tests/compute/vmi_memory_overhead.go
@@ -46,7 +46,7 @@ import (
 )
 
 // TODO: remove the Serial once VmiMemoryOverheadReport is enabled by default
-var _ = Describe(SIG("VMI Memory Overhead Reporting", decorators.RequiresTwoSchedulableNodes, Serial, func() {
+var _ = Describe(SIG("VMI Memory Overhead Reporting", decorators.RequiresTwoSchedulableNodes, decorators.RequiresFeatureGate(featuregate.VmiMemoryOverheadReport), Serial, func() {
 	var virtClient kubecli.KubevirtClient
 
 	BeforeEach(func() {

--- a/tests/container_disk_test.go
+++ b/tests/container_disk_test.go
@@ -210,7 +210,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 		})
 	})
 
-	Describe("Simulate an upgrade from a version where ImageVolume was disabled to a version where it is enabled", Serial, decorators.ImageVolume, decorators.NoFlakeCheck, func() {
+	Describe("Simulate an upgrade from a version where ImageVolume was disabled to a version where it is enabled", Serial, decorators.NoFlakeCheck, decorators.RequiresFeatureGate(featuregate.ImageVolume), func() {
 		BeforeEach(func() {
 			v, err := checks.GetKubernetesVersion()
 			Expect(err).ToNot(HaveOccurred())

--- a/tests/cross_arch_emulation_test.go
+++ b/tests/cross_arch_emulation_test.go
@@ -41,7 +41,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libvmops"
 )
 
-var _ = Describe("[sig-compute]Cross-architecture software emulation", Serial, decorators.SigCompute, decorators.RequiresCrossArchEmulation, func() {
+var _ = Describe("[sig-compute]Cross-architecture software emulation", Serial, decorators.SigCompute, decorators.RequiresCrossArchEmulation, decorators.RequiresFeatureGate(featuregate.CrossArchitectureVirtualization), func() {
 
 	BeforeEach(func() {
 		config.EnableFeatureGate(featuregate.CrossArchitectureVirtualization)

--- a/tests/decorators/decorators.go
+++ b/tests/decorators/decorators.go
@@ -100,8 +100,6 @@ var (
 	StorageCritical = Label("StorageCritical")
 	// RequiresVolumeExpansion requires a storage class with volume expansion support
 	RequiresVolumeExpansion = Label("RequiresVolumeExpansion")
-	// RequiresDecentralizedLiveMigration request the feature gate is enabled
-	RequiresDecentralizedLiveMigration = Label("RequiresDecentralizedLiveMigration")
 
 	/* Provisioner */
 
@@ -159,3 +157,7 @@ var (
 	// (e.g., tests requiring SecurityContextConstraints, Routes)
 	OpenShift = Label("OpenShift")
 )
+
+func RequiresFeatureGate(gate string) Labels {
+	return Label("Requires" + gate)
+}

--- a/tests/decorators/decorators.go
+++ b/tests/decorators/decorators.go
@@ -72,7 +72,6 @@ var (
 	RequiresHugepages2Mi                 = Label("requireHugepages2Mi")
 	RequiresHugepages1Gi                 = Label("requireHugepages1Gi")
 	GuestAgentProbes                     = Label("guest-agent-probes")
-	ImageVolume                          = Label("ImageVolume")
 	RebootPolicy                         = Label("RebootPolicy")
 
 	/* Storage classes */

--- a/tests/dryrun_test.go
+++ b/tests/dryrun_test.go
@@ -530,7 +530,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", decorators.SigCompute, decorat
 		})
 	})
 
-	Context("VM Snapshots", func() {
+	Context("VM Snapshots", decorators.RequiresFeatureGate(featuregate.SnapshotGate), func() {
 		var snap *snapshotv1.VirtualMachineSnapshot
 
 		BeforeEach(func() {
@@ -609,7 +609,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", decorators.SigCompute, decorat
 		})
 	})
 
-	Context("VM Restores", func() {
+	Context("VM Restores", decorators.RequiresFeatureGate(featuregate.SnapshotGate), func() {
 		var restore *snapshotv1.VirtualMachineRestore
 
 		BeforeEach(func() {

--- a/tests/hotplug/BUILD.bazel
+++ b/tests/hotplug/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//pkg/apimachinery/patch:go_default_library",
         "//pkg/libvmi:go_default_library",
         "//pkg/pointer:go_default_library",
+        "//pkg/virt-config/featuregate:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/api/instancetype/v1beta1:go_default_library",
         "//staging/src/kubevirt.io/api/migrations/v1alpha1:go_default_library",

--- a/tests/hotplug/cpu.go
+++ b/tests/hotplug/cpu.go
@@ -20,6 +20,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
 	"kubevirt.io/kubevirt/pkg/libvmi"
 	"kubevirt.io/kubevirt/pkg/pointer"
+	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/checks"
@@ -208,7 +209,7 @@ var _ = Describe("[sig-compute]CPU Hotplug", decorators.SigCompute, decorators.S
 			Eventually(ThisVM(vm), 4*time.Minute, 2*time.Second).Should(HaveConditionMissingOrFalse(v1.VirtualMachineRestartRequired))
 		})
 
-		It("[test_id:10822]should successfully plug guaranteed vCPUs", decorators.RequiresTwoWorkerNodesWithCPUManager, func() {
+		It("[test_id:10822]should successfully plug guaranteed vCPUs", decorators.RequiresTwoWorkerNodesWithCPUManager, decorators.RequiresFeatureGate(featuregate.CPUManager), func() {
 			checks.ExpectAtLeastTwoWorkerNodesWithCPUManager(virtClient)
 			const maxSockets uint32 = 3
 

--- a/tests/infrastructure/downward-metrics.go
+++ b/tests/infrastructure/downward-metrics.go
@@ -30,6 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
+	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
@@ -38,7 +39,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libvmops"
 )
 
-var _ = Describe(SIG("downwardMetrics", func() {
+var _ = Describe(SIG("downwardMetrics", decorators.RequiresFeatureGate(featuregate.DownwardMetricsFeatureGate), func() {
 	const vmiStartTimeout = libvmops.StartupTimeoutSecondsXLarge
 
 	DescribeTable("should start a vmi and get the metrics", func(via libvmi.Option, metricsGetter libinfra.MetricsGetter) {

--- a/tests/infrastructure/security.go
+++ b/tests/infrastructure/security.go
@@ -42,66 +42,69 @@ import (
 	"kubevirt.io/kubevirt/tests/libvmops"
 )
 
-var _ = Describe(SIGSerial("Node Restriction", decorators.RequiresTwoSchedulableNodes, func() {
-	var virtClient kubecli.KubevirtClient
-	const minNodesWithVirtHandler = 2
+var _ = Describe(SIGSerial("Node Restriction",
+	decorators.RequiresTwoSchedulableNodes,
+	decorators.RequiresFeatureGate(featuregate.NodeRestrictionGate),
+	func() {
+		var virtClient kubecli.KubevirtClient
+		const minNodesWithVirtHandler = 2
 
-	BeforeEach(func() {
-		virtClient = kubevirt.Client()
-		config.EnableFeatureGate(featuregate.NodeRestrictionGate)
-	})
-
-	It("Should disallow to modify VMs on different node", func() {
-		nodes := libnode.GetAllSchedulableNodes(virtClient).Items
-		if len(nodes) < minNodesWithVirtHandler {
-			Fail("Requires multiple nodes with virt-handler running")
-		}
-
-		vmi := libvmifact.NewGuestless()
-		vmi = libvmops.RunVMIAndExpectLaunch(vmi, libvmops.StartupTimeoutSecondsSmall)
-
-		node := vmi.Status.NodeName
-
-		differentNode := ""
-		for _, n := range nodes {
-			if node != n.Name {
-				differentNode = n.Name
-				break
-			}
-		}
-		pod, err := libnode.GetVirtHandlerPod(virtClient, differentNode)
-		Expect(err).ToNot(HaveOccurred())
-
-		token, err := exec.ExecuteCommandOnPod(
-			pod,
-			"virt-handler",
-			[]string{
-				"cat",
-				"/var/run/secrets/kubernetes.io/serviceaccount/token",
-			},
-		)
-		Expect(err).ToNot(HaveOccurred())
-
-		handlerClient, err := kubecli.GetKubevirtClientFromRESTConfig(&rest.Config{
-			Host: virtClient.Config().Host,
-			TLSClientConfig: rest.TLSClientConfig{
-				Insecure: true,
-			},
-			BearerToken: token,
+		BeforeEach(func() {
+			virtClient = kubevirt.Client()
+			config.EnableFeatureGate(featuregate.NodeRestrictionGate)
 		})
-		Expect(err).ToNot(HaveOccurred())
 
-		// We cannot use patch as handler doesn't have RBAC
-		// Therefore we need to use Eventually with Update
-		Eventually(func(g Gomega) error {
-			vmiScoped, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.TODO(), vmi.Name, metav1.GetOptions{})
-			g.Expect(err).ToNot(HaveOccurred())
+		It("Should disallow to modify VMs on different node", func() {
+			nodes := libnode.GetAllSchedulableNodes(virtClient).Items
+			if len(nodes) < minNodesWithVirtHandler {
+				Fail("Requires multiple nodes with virt-handler running")
+			}
 
-			vmiScoped.Labels["allowed.io"] = "value"
-			_, err = handlerClient.VirtualMachineInstance(vmi.Namespace).Update(context.TODO(), vmiScoped, metav1.UpdateOptions{})
-			return err
-		}, 10*time.Second, time.Second).Should(MatchError(
-			ContainSubstring("Node restriction, virt-handler is only allowed to modify VMIs it owns"),
-		))
-	})
-}))
+			vmi := libvmifact.NewGuestless()
+			vmi = libvmops.RunVMIAndExpectLaunch(vmi, libvmops.StartupTimeoutSecondsSmall)
+
+			node := vmi.Status.NodeName
+
+			differentNode := ""
+			for _, n := range nodes {
+				if node != n.Name {
+					differentNode = n.Name
+					break
+				}
+			}
+			pod, err := libnode.GetVirtHandlerPod(virtClient, differentNode)
+			Expect(err).ToNot(HaveOccurred())
+
+			token, err := exec.ExecuteCommandOnPod(
+				pod,
+				"virt-handler",
+				[]string{
+					"cat",
+					"/var/run/secrets/kubernetes.io/serviceaccount/token",
+				},
+			)
+			Expect(err).ToNot(HaveOccurred())
+
+			handlerClient, err := kubecli.GetKubevirtClientFromRESTConfig(&rest.Config{
+				Host: virtClient.Config().Host,
+				TLSClientConfig: rest.TLSClientConfig{
+					Insecure: true,
+				},
+				BearerToken: token,
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+			// We cannot use patch as handler doesn't have RBAC
+			// Therefore we need to use Eventually with Update
+			Eventually(func(g Gomega) error {
+				vmiScoped, err := virtClient.VirtualMachineInstance(vmi.Namespace).Get(context.TODO(), vmi.Name, metav1.GetOptions{})
+				g.Expect(err).ToNot(HaveOccurred())
+
+				vmiScoped.Labels["allowed.io"] = "value"
+				_, err = handlerClient.VirtualMachineInstance(vmi.Namespace).Update(context.TODO(), vmiScoped, metav1.UpdateOptions{})
+				return err
+			}, 10*time.Second, time.Second).Should(MatchError(
+				ContainSubstring("Node restriction, virt-handler is only allowed to modify VMIs it owns"),
+			))
+		})
+	}))

--- a/tests/instancetype/BUILD.bazel
+++ b/tests/instancetype/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//pkg/libvmi:go_default_library",
         "//pkg/pointer:go_default_library",
         "//pkg/util:go_default_library",
+        "//pkg/virt-config/featuregate:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/api/instancetype:go_default_library",
         "//staging/src/kubevirt.io/api/instancetype/v1beta1:go_default_library",

--- a/tests/instancetype/instancetype.go
+++ b/tests/instancetype/instancetype.go
@@ -16,6 +16,7 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
 	"kubevirt.io/kubevirt/pkg/pointer"
+	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/framework/matcher"
@@ -300,7 +301,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 		})
 	})
 
-	Context("instance type with dedicatedCPUPlacement enabled", decorators.RequiresNodeWithCPUManager, func() {
+	Context("instance type with dedicatedCPUPlacement enabled", decorators.RequiresNodeWithCPUManager, decorators.RequiresFeatureGate(featuregate.CPUManager), func() {
 		It("should be accepted and result in running VirtualMachineInstance", func() {
 			vmi := libvmifact.NewGuestless()
 

--- a/tests/launchsecurity/sev.go
+++ b/tests/launchsecurity/sev.go
@@ -47,384 +47,387 @@ import (
 	"kubevirt.io/kubevirt/tests/libwait"
 )
 
-var _ = Describe("[sig-compute]AMD Secure Encrypted Virtualization (SEV)", decorators.SEV, decorators.SigCompute, func() {
-	const (
-		diskSecret = "qwerty123"
-	)
-
-	newSEVFedora := func(withES, withSNP bool, opts ...libvmi.Option) *v1.VirtualMachineInstance {
-		const secureBoot = false
-		sevOptions := []libvmi.Option{
-			libvmi.WithUefi(secureBoot),
-			libvmi.WithSEV(withES, withSNP),
-			libvmi.WithCPUModel("EPYC-v4"),
-		}
-		opts = append(sevOptions, opts...)
-		return libvmifact.NewFedora(opts...)
-	}
-
-	// As per section 6.5 LAUNCH_MEASURE of the AMD SEV specification the launch
-	// measurement is calculated as:
-	//   HMAC(0x04 || API_MAJOR || API_MINOR || BUILD ||
-	//        GCTX.POLICY || GCTX.LD || MNONCE; GCTX.TIK)
-	// The implementation is based on
-	//   https://blog.hansenpartnership.com/wp-uploads/2020/12/sevsecret.txt
-	verifyMeasurement := func(sevMeasurementInfo *v1.SEVMeasurementInfo, tikBase64 string) []byte {
-		By("Verifying launch measurement")
-		tik, err := base64.StdEncoding.DecodeString(tikBase64)
-		ExpectWithOffset(1, err).ToNot(HaveOccurred())
-		h := hmac.New(sha256.New, tik)
-		const sevLaunchMeasurementPrefix = 0x04
-		err = binary.Write(h, binary.LittleEndian, uint8(sevLaunchMeasurementPrefix))
-		ExpectWithOffset(1, err).ToNot(HaveOccurred())
-		err = binary.Write(h, binary.LittleEndian, uint8(sevMeasurementInfo.APIMajor))
-		ExpectWithOffset(1, err).ToNot(HaveOccurred())
-		err = binary.Write(h, binary.LittleEndian, uint8(sevMeasurementInfo.APIMinor))
-		ExpectWithOffset(1, err).ToNot(HaveOccurred())
-		err = binary.Write(h, binary.LittleEndian, uint8(sevMeasurementInfo.BuildID))
-		ExpectWithOffset(1, err).ToNot(HaveOccurred())
-		err = binary.Write(h, binary.LittleEndian, uint32(sevMeasurementInfo.Policy))
-		ExpectWithOffset(1, err).ToNot(HaveOccurred())
-		loaderSHA, err := hex.DecodeString(sevMeasurementInfo.LoaderSHA)
-		ExpectWithOffset(1, err).ToNot(HaveOccurred())
-		h.Write(loaderSHA)
-		m, err := base64.StdEncoding.DecodeString(sevMeasurementInfo.Measurement)
-		ExpectWithOffset(1, err).ToNot(HaveOccurred())
-		nonce := m[32:48]
-		h.Write(nonce)
-		measure := m[0:32]
-		ExpectWithOffset(1, hex.EncodeToString(h.Sum(nil))).To(Equal(hex.EncodeToString(measure)))
-		return measure
-	}
-
-	// The implementation is based on
-	//   https://blog.hansenpartnership.com/wp-uploads/2020/12/sevsecret.txt
-	encryptSecret := func(diskSecret string, measure []byte, tikBase64, tekBase64 string) *v1.SEVSecretOptions {
-		By("Encrypting launch secret")
-		tik, err := base64.StdEncoding.DecodeString(tikBase64)
-		ExpectWithOffset(1, err).ToNot(HaveOccurred())
-		tek, err := base64.StdEncoding.DecodeString(tekBase64)
-		ExpectWithOffset(1, err).ToNot(HaveOccurred())
-
-		// AMD SEV specification, section 4.6 Endianness: all integral values
-		// passed between the firmware and the CPU driver are little-endian
-		// formatted. Applies to UUIDs as well.
-		writeUUID := func(w io.Writer, uuid uuid.UUID) {
-			var writeErr error
-			writeErr = binary.Write(w, binary.LittleEndian, binary.BigEndian.Uint32(uuid[0:4]))
-			ExpectWithOffset(2, writeErr).ToNot(HaveOccurred())
-			writeErr = binary.Write(w, binary.LittleEndian, binary.BigEndian.Uint16(uuid[4:6]))
-			ExpectWithOffset(2, writeErr).ToNot(HaveOccurred())
-			writeErr = binary.Write(w, binary.LittleEndian, binary.BigEndian.Uint16(uuid[6:8]))
-			ExpectWithOffset(2, writeErr).ToNot(HaveOccurred())
-			_, writeErr = w.Write(uuid[8:])
-			ExpectWithOffset(2, writeErr).ToNot(HaveOccurred())
-		}
-
+var _ = Describe("[sig-compute]AMD Secure Encrypted Virtualization (SEV)",
+	decorators.SEV, decorators.SigCompute,
+	decorators.RequiresFeatureGate(featuregate.WorkloadEncryptionSEV),
+	func() {
 		const (
-			uuidLen = 16
-			sizeLen = 4
+			diskSecret = "qwerty123"
 		)
 
-		// total length of table: header plus one entry with trailing \0
-		l := (uuidLen + sizeLen) + (uuidLen + sizeLen) + len(diskSecret) + 1
-		// SEV-ES requires rounding to 16
-		l = (l + 15) & ^15
-
-		secret := bytes.NewBuffer(make([]byte, 0, l))
-		// 0:16
-		writeUUID(secret, uuid.MustParse("{1e74f542-71dd-4d66-963e-ef4287ff173b}"))
-		// 16:20
-		err = binary.Write(secret, binary.LittleEndian, uint32(l))
-		ExpectWithOffset(1, err).ToNot(HaveOccurred())
-		// 20:36
-		writeUUID(secret, uuid.MustParse("{736869e5-84f0-4973-92ec-06879ce3da0b}"))
-		// 36:40
-		err = binary.Write(secret, binary.LittleEndian, uint32(uuidLen+sizeLen+len(diskSecret)+1))
-		ExpectWithOffset(1, err).ToNot(HaveOccurred())
-		// 40:40+len(diskSecret)+1
-		secret.WriteString(diskSecret)
-		// write zeroes
-		secret.Write(make([]byte, l-secret.Len()))
-		ExpectWithOffset(1, secret.Len()).To(Equal(l))
-
-		// The data protection scheme utilizes AES-128 CTR mode:
-		//   C = AES-128-CTR(M; K, IV)
-		const aesBlockSize = 16
-		iv := make([]byte, aesBlockSize)
-		_, err = rand.Read(iv)
-		ExpectWithOffset(1, err).ToNot(HaveOccurred())
-		aes, err := aes.NewCipher(tek)
-		ExpectWithOffset(1, err).ToNot(HaveOccurred())
-		ctr := cipher.NewCTR(aes, iv)
-		encryptedSecret := make([]byte, secret.Len())
-		ctr.XORKeyStream(encryptedSecret, secret.Bytes())
-
-		// AMD SEV specification, section 6.6 LAUNCH_SECRET:
-		//   Header: FLAGS + IV + HMAC
-		const sevSecretHeaderSize = 52
-		header := bytes.NewBuffer(make([]byte, 0, sevSecretHeaderSize))
-		// 0:4 FLAGS.COMPRESSED
-		err = binary.Write(header, binary.LittleEndian, uint32(0))
-		ExpectWithOffset(1, err).ToNot(HaveOccurred())
-		// 4:20 IV
-		header.Write(iv)
-		// HMAC(0x01 || FLAGS || IV || GUEST_LENGTH ||
-		//      TRANS_LENGTH || DATA || MEASURE; GCTX.TIK)
-		h := hmac.New(sha256.New, tik)
-		const sevLaunchSecretPrefix = 0x01
-		err = binary.Write(h, binary.LittleEndian, uint8(sevLaunchSecretPrefix))
-		ExpectWithOffset(1, err).ToNot(HaveOccurred())
-		h.Write(header.Bytes()[0:20]) // FLAGS || IV
-		err = binary.Write(h, binary.LittleEndian, uint32(l))
-		ExpectWithOffset(1, err).ToNot(HaveOccurred())
-		err = binary.Write(h, binary.LittleEndian, uint32(l))
-		ExpectWithOffset(1, err).ToNot(HaveOccurred())
-		h.Write(encryptedSecret)
-		h.Write(measure)
-		// 20:52 HMAC
-		header.Write(h.Sum(nil))
-
-		return &v1.SEVSecretOptions{
-			Secret: base64.StdEncoding.EncodeToString(encryptedSecret),
-			Header: base64.StdEncoding.EncodeToString(header.Bytes()),
-		}
-	}
-
-	parseVirshInfo := func(info string, expectedKeys []string) map[string]string {
-		entries := make(map[string]string)
-		scanner := bufio.NewScanner(strings.NewReader(info))
-		for scanner.Scan() {
-			line := strings.TrimSpace(scanner.Text())
-			if line == "" {
-				continue
+		newSEVFedora := func(withES, withSNP bool, opts ...libvmi.Option) *v1.VirtualMachineInstance {
+			const secureBoot = false
+			sevOptions := []libvmi.Option{
+				libvmi.WithUefi(secureBoot),
+				libvmi.WithSEV(withES, withSNP),
+				libvmi.WithCPUModel("EPYC-v4"),
 			}
-			const expectedFieldCount = 2
-			data := strings.Split(line, ":")
-			ExpectWithOffset(1, data).To(HaveLen(expectedFieldCount))
-			entries[strings.TrimSpace(data[0])] = strings.TrimSpace(data[1])
-		}
-		for _, key := range expectedKeys {
-			ExpectWithOffset(1, entries).To(HaveKeyWithValue(key, Not(BeEmpty())))
-		}
-		return entries
-	}
-
-	toUint := func(s string) uint {
-		val, err := strconv.Atoi(s)
-		ExpectWithOffset(1, err).ToNot(HaveOccurred())
-		ExpectWithOffset(1, val).To(BeNumerically(">=", 0))
-		return uint(val)
-	}
-
-	prepareSession := func(virtClient kubecli.KubevirtClient, nodeName, pdh string) (*v1.SEVSessionOptions, string, string) {
-		helperPod := libpod.RenderPrivilegedPod("sev-helper", []string{"sleep"}, []string{"infinity"})
-		helperPod.Spec.NodeName = nodeName
-
-		var err error
-		helperPod, err = virtClient.CoreV1().Pods(testsuite.GetTestNamespace(helperPod)).Create(
-			context.Background(), helperPod, k8smetav1.CreateOptions{})
-		Expect(err).ToNot(HaveOccurred())
-		defer func() {
-			deleteErr := virtClient.CoreV1().Pods(helperPod.Namespace).Delete(context.Background(), helperPod.Name, k8smetav1.DeleteOptions{})
-			ExpectWithOffset(1, deleteErr).ToNot(HaveOccurred())
-		}()
-		EventuallyWithOffset(1, matcher.ThisPod(helperPod), 30).Should(matcher.BeInPhase(k8sv1.PodRunning))
-
-		execOnHelperPod := func(command string) (string, error) {
-			execStdout, execErr := exec.ExecuteCommandOnPod(
-				helperPod,
-				helperPod.Spec.Containers[0].Name,
-				[]string{"/bin/bash", "-c", command})
-			return strings.TrimSpace(execStdout), execErr
+			opts = append(sevOptions, opts...)
+			return libvmifact.NewFedora(opts...)
 		}
 
-		_, err = execOnHelperPod(fmt.Sprintf("echo %s | base64 --decode > pdh.bin", pdh))
-		ExpectWithOffset(1, err).ToNot(HaveOccurred())
-		_, err = execOnHelperPod("sevctl session pdh.bin 1")
-		ExpectWithOffset(1, err).ToNot(HaveOccurred())
-		godh, err := execOnHelperPod("cat vm_godh.b64")
-		ExpectWithOffset(1, err).ToNot(HaveOccurred())
-		session, err := execOnHelperPod("cat vm_session.b64")
-		ExpectWithOffset(1, err).ToNot(HaveOccurred())
-		tikBase64, err := execOnHelperPod("base64 vm_tik.bin")
-		ExpectWithOffset(1, err).ToNot(HaveOccurred())
-		tekBase64, err := execOnHelperPod("base64 vm_tek.bin")
-		ExpectWithOffset(1, err).ToNot(HaveOccurred())
+		// As per section 6.5 LAUNCH_MEASURE of the AMD SEV specification the launch
+		// measurement is calculated as:
+		//   HMAC(0x04 || API_MAJOR || API_MINOR || BUILD ||
+		//        GCTX.POLICY || GCTX.LD || MNONCE; GCTX.TIK)
+		// The implementation is based on
+		//   https://blog.hansenpartnership.com/wp-uploads/2020/12/sevsecret.txt
+		verifyMeasurement := func(sevMeasurementInfo *v1.SEVMeasurementInfo, tikBase64 string) []byte {
+			By("Verifying launch measurement")
+			tik, err := base64.StdEncoding.DecodeString(tikBase64)
+			ExpectWithOffset(1, err).ToNot(HaveOccurred())
+			h := hmac.New(sha256.New, tik)
+			const sevLaunchMeasurementPrefix = 0x04
+			err = binary.Write(h, binary.LittleEndian, uint8(sevLaunchMeasurementPrefix))
+			ExpectWithOffset(1, err).ToNot(HaveOccurred())
+			err = binary.Write(h, binary.LittleEndian, uint8(sevMeasurementInfo.APIMajor))
+			ExpectWithOffset(1, err).ToNot(HaveOccurred())
+			err = binary.Write(h, binary.LittleEndian, uint8(sevMeasurementInfo.APIMinor))
+			ExpectWithOffset(1, err).ToNot(HaveOccurred())
+			err = binary.Write(h, binary.LittleEndian, uint8(sevMeasurementInfo.BuildID))
+			ExpectWithOffset(1, err).ToNot(HaveOccurred())
+			err = binary.Write(h, binary.LittleEndian, uint32(sevMeasurementInfo.Policy))
+			ExpectWithOffset(1, err).ToNot(HaveOccurred())
+			loaderSHA, err := hex.DecodeString(sevMeasurementInfo.LoaderSHA)
+			ExpectWithOffset(1, err).ToNot(HaveOccurred())
+			h.Write(loaderSHA)
+			m, err := base64.StdEncoding.DecodeString(sevMeasurementInfo.Measurement)
+			ExpectWithOffset(1, err).ToNot(HaveOccurred())
+			nonce := m[32:48]
+			h.Write(nonce)
+			measure := m[0:32]
+			ExpectWithOffset(1, hex.EncodeToString(h.Sum(nil))).To(Equal(hex.EncodeToString(measure)))
+			return measure
+		}
 
-		return &v1.SEVSessionOptions{
-			DHCert:  godh,
-			Session: session,
-		}, tikBase64, tekBase64
-	}
+		// The implementation is based on
+		//   https://blog.hansenpartnership.com/wp-uploads/2020/12/sevsecret.txt
+		encryptSecret := func(diskSecret string, measure []byte, tikBase64, tekBase64 string) *v1.SEVSecretOptions {
+			By("Encrypting launch secret")
+			tik, err := base64.StdEncoding.DecodeString(tikBase64)
+			ExpectWithOffset(1, err).ToNot(HaveOccurred())
+			tek, err := base64.StdEncoding.DecodeString(tekBase64)
+			ExpectWithOffset(1, err).ToNot(HaveOccurred())
 
-	Context("device management", Serial, func() {
-		const (
-			sevResourceName = "devices.kubevirt.io/sev"
-			sevDevicePath   = "/proc/1/root/dev/sev"
-		)
-
-		var (
-			virtClient      kubecli.KubevirtClient
-			nodeName        string
-			isDevicePresent bool
-			err             error
-		)
-
-		BeforeEach(func() {
-			virtClient = kubevirt.Client()
-
-			nodeName = libnode.GetNodeNameWithHandler()
-			Expect(nodeName).ToNot(BeEmpty())
-
-			checkCmd := []string{"ls", sevDevicePath}
-			_, err = libnode.ExecuteCommandInVirtHandlerPod(nodeName, checkCmd)
-			isDevicePresent = err == nil
-
-			if !isDevicePresent {
-				By(fmt.Sprintf("Creating a fake SEV device on %s", nodeName))
-				mknodCmd := []string{"mknod", sevDevicePath, "c", "10", "124"}
-				_, err = libnode.ExecuteCommandInVirtHandlerPod(nodeName, mknodCmd)
-				Expect(err).ToNot(HaveOccurred())
+			// AMD SEV specification, section 4.6 Endianness: all integral values
+			// passed between the firmware and the CPU driver are little-endian
+			// formatted. Applies to UUIDs as well.
+			writeUUID := func(w io.Writer, uuid uuid.UUID) {
+				var writeErr error
+				writeErr = binary.Write(w, binary.LittleEndian, binary.BigEndian.Uint32(uuid[0:4]))
+				ExpectWithOffset(2, writeErr).ToNot(HaveOccurred())
+				writeErr = binary.Write(w, binary.LittleEndian, binary.BigEndian.Uint16(uuid[4:6]))
+				ExpectWithOffset(2, writeErr).ToNot(HaveOccurred())
+				writeErr = binary.Write(w, binary.LittleEndian, binary.BigEndian.Uint16(uuid[6:8]))
+				ExpectWithOffset(2, writeErr).ToNot(HaveOccurred())
+				_, writeErr = w.Write(uuid[8:])
+				ExpectWithOffset(2, writeErr).ToNot(HaveOccurred())
 			}
 
-			Eventually(func() bool {
-				allocatableNode, nodeErr := virtClient.CoreV1().Nodes().Get(context.Background(), nodeName, k8smetav1.GetOptions{})
-				Expect(nodeErr).ToNot(HaveOccurred())
-				val, ok := allocatableNode.Status.Allocatable[sevResourceName]
-				return ok && !val.IsZero()
-			}, 180*time.Second, 1*time.Second).Should(BeTrue(), fmt.Sprintf("Allocatable SEV should not be zero on %s", nodeName))
-		})
-
-		AfterEach(func() {
-			if !isDevicePresent {
-				By(fmt.Sprintf("Removing the fake SEV device from %s", nodeName))
-				rmCmd := []string{"rm", "-f", sevDevicePath}
-				_, err = libnode.ExecuteCommandInVirtHandlerPod(nodeName, rmCmd)
-				Expect(err).ToNot(HaveOccurred())
-			}
-		})
-
-		It("should reset SEV allocatable devices when the feature gate is disabled", func() {
-			By(fmt.Sprintf("Disabling %s feature gate", featuregate.WorkloadEncryptionSEV))
-			config.DisableFeatureGate(featuregate.WorkloadEncryptionSEV)
-			Eventually(func() bool {
-				node, err := virtClient.CoreV1().Nodes().Get(context.Background(), nodeName, k8smetav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				val, ok := node.Status.Allocatable[sevResourceName]
-				return !ok || val.IsZero()
-			}, 180*time.Second, 1*time.Second).Should(BeTrue(), fmt.Sprintf("Allocatable SEV should be zero on %s", nodeName))
-		})
-	})
-
-	Context("lifecycle", func() {
-		DescribeTable("should start a SEV or SEV-ES VM",
-			func(withES, withSNP bool, sevstr string) {
-				vmi := newSEVFedora(withES, withSNP)
-				vmi = libvmops.RunVMIAndExpectLaunch(vmi, libvmops.StartupTimeoutSecondsXHuge)
-
-				By("Expecting the VirtualMachineInstance console")
-				Expect(console.LoginToFedora(vmi)).To(Succeed())
-
-				By("Verifying that SEV is enabled in the guest")
-				const consoleTimeout = 60
-				err := console.SafeExpectBatch(vmi, []expect.Batcher{
-					&expect.BSnd{S: "\n"},
-					&expect.BExp{R: ""},
-					&expect.BSnd{S: "dmesg | grep --color=never SEV\n"},
-					&expect.BExp{R: "Memory Encryption Features active: AMD " + sevstr},
-					&expect.BSnd{S: "\n"},
-					&expect.BExp{R: ""},
-				}, consoleTimeout)
-				Expect(err).ToNot(HaveOccurred())
-			},
-			// SEV-ES disabled, SEV enabled
-			Entry("It should launch with base SEV features enabled", false, false, "SEV"),
-			// SEV-ES enabled
-			Entry("It should launch with SEV-ES features enabled", decorators.SEVES, true, false, "SEV SEV-ES"),
-			// SEV-SNP enabled
-			Entry("It should launch with SEV-SNP features enabled", decorators.SEVSNP, false, true, "SEV SEV-ES SEV-SNP"),
-		)
-
-		It("[QUARANTINE] should run guest attestation", decorators.Quarantine, func() {
-			var (
-				expectedSEVPlatformInfo    v1.SEVPlatformInfo
-				expectedSEVMeasurementInfo v1.SEVMeasurementInfo
+			const (
+				uuidLen = 16
+				sizeLen = 4
 			)
 
-			virtClient, err := kubecli.GetKubevirtClient()
-			Expect(err).ToNot(HaveOccurred())
+			// total length of table: header plus one entry with trailing \0
+			l := (uuidLen + sizeLen) + (uuidLen + sizeLen) + len(diskSecret) + 1
+			// SEV-ES requires rounding to 16
+			l = (l + 15) & ^15
 
-			vmi := newSEVFedora(false, false, libvmi.WithSEVAttestation())
-			vmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(
-				context.Background(), vmi, k8smetav1.CreateOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			Eventually(matcher.ThisVMI(vmi), 60).Should(matcher.BeInPhase(v1.Scheduled))
+			secret := bytes.NewBuffer(make([]byte, 0, l))
+			// 0:16
+			writeUUID(secret, uuid.MustParse("{1e74f542-71dd-4d66-963e-ef4287ff173b}"))
+			// 16:20
+			err = binary.Write(secret, binary.LittleEndian, uint32(l))
+			ExpectWithOffset(1, err).ToNot(HaveOccurred())
+			// 20:36
+			writeUUID(secret, uuid.MustParse("{736869e5-84f0-4973-92ec-06879ce3da0b}"))
+			// 36:40
+			err = binary.Write(secret, binary.LittleEndian, uint32(uuidLen+sizeLen+len(diskSecret)+1))
+			ExpectWithOffset(1, err).ToNot(HaveOccurred())
+			// 40:40+len(diskSecret)+1
+			secret.WriteString(diskSecret)
+			// write zeroes
+			secret.Write(make([]byte, l-secret.Len()))
+			ExpectWithOffset(1, secret.Len()).To(Equal(l))
 
-			By("Querying virsh nodesevinfo")
-			nodeSevInfo := libpod.RunCommandOnVmiPod(vmi, []string{"virsh", "nodesevinfo"})
-			Expect(nodeSevInfo).ToNot(BeEmpty())
-			entries := parseVirshInfo(nodeSevInfo, []string{"pdh", "cert-chain"})
-			expectedSEVPlatformInfo.PDH = entries["pdh"]
-			expectedSEVPlatformInfo.CertChain = entries["cert-chain"]
+			// The data protection scheme utilizes AES-128 CTR mode:
+			//   C = AES-128-CTR(M; K, IV)
+			const aesBlockSize = 16
+			iv := make([]byte, aesBlockSize)
+			_, err = rand.Read(iv)
+			ExpectWithOffset(1, err).ToNot(HaveOccurred())
+			aes, err := aes.NewCipher(tek)
+			ExpectWithOffset(1, err).ToNot(HaveOccurred())
+			ctr := cipher.NewCTR(aes, iv)
+			encryptedSecret := make([]byte, secret.Len())
+			ctr.XORKeyStream(encryptedSecret, secret.Bytes())
 
-			By("Fetching platform certificates")
-			sevPlatformInfo, err := virtClient.VirtualMachineInstance(vmi.Namespace).SEVFetchCertChain(context.Background(), vmi.Name)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(sevPlatformInfo).To(Equal(expectedSEVPlatformInfo))
+			// AMD SEV specification, section 6.6 LAUNCH_SECRET:
+			//   Header: FLAGS + IV + HMAC
+			const sevSecretHeaderSize = 52
+			header := bytes.NewBuffer(make([]byte, 0, sevSecretHeaderSize))
+			// 0:4 FLAGS.COMPRESSED
+			err = binary.Write(header, binary.LittleEndian, uint32(0))
+			ExpectWithOffset(1, err).ToNot(HaveOccurred())
+			// 4:20 IV
+			header.Write(iv)
+			// HMAC(0x01 || FLAGS || IV || GUEST_LENGTH ||
+			//      TRANS_LENGTH || DATA || MEASURE; GCTX.TIK)
+			h := hmac.New(sha256.New, tik)
+			const sevLaunchSecretPrefix = 0x01
+			err = binary.Write(h, binary.LittleEndian, uint8(sevLaunchSecretPrefix))
+			ExpectWithOffset(1, err).ToNot(HaveOccurred())
+			h.Write(header.Bytes()[0:20]) // FLAGS || IV
+			err = binary.Write(h, binary.LittleEndian, uint32(l))
+			ExpectWithOffset(1, err).ToNot(HaveOccurred())
+			err = binary.Write(h, binary.LittleEndian, uint32(l))
+			ExpectWithOffset(1, err).ToNot(HaveOccurred())
+			h.Write(encryptedSecret)
+			h.Write(measure)
+			// 20:52 HMAC
+			header.Write(h.Sum(nil))
 
-			By("Setting up session parameters")
-			vmi, err = matcher.ThisVMI(vmi)()
-			Expect(err).ToNot(HaveOccurred())
-			sevSessionOptions, tikBase64, tekBase64 := prepareSession(virtClient, vmi.Status.NodeName, sevPlatformInfo.PDH)
-			err = virtClient.VirtualMachineInstance(vmi.Namespace).SEVSetupSession(context.Background(), vmi.Name, sevSessionOptions)
-			Expect(err).ToNot(HaveOccurred())
-			Eventually(matcher.ThisVMI(vmi), 60).Should(And(matcher.BeRunning(), matcher.HaveConditionTrue(v1.VirtualMachineInstancePaused)))
+			return &v1.SEVSecretOptions{
+				Secret: base64.StdEncoding.EncodeToString(encryptedSecret),
+				Header: base64.StdEncoding.EncodeToString(header.Bytes()),
+			}
+		}
 
-			By("Querying virsh domlaunchsecinfo 1")
-			domLaunchSecInfo := libpod.RunCommandOnVmiPod(vmi, []string{"virsh", "domlaunchsecinfo", "1"})
-			Expect(domLaunchSecInfo).ToNot(BeEmpty())
-			entries = parseVirshInfo(domLaunchSecInfo, []string{
-				"sev-measurement", "sev-api-major", "sev-api-minor", "sev-build-id", "sev-policy",
+		parseVirshInfo := func(info string, expectedKeys []string) map[string]string {
+			entries := make(map[string]string)
+			scanner := bufio.NewScanner(strings.NewReader(info))
+			for scanner.Scan() {
+				line := strings.TrimSpace(scanner.Text())
+				if line == "" {
+					continue
+				}
+				const expectedFieldCount = 2
+				data := strings.Split(line, ":")
+				ExpectWithOffset(1, data).To(HaveLen(expectedFieldCount))
+				entries[strings.TrimSpace(data[0])] = strings.TrimSpace(data[1])
+			}
+			for _, key := range expectedKeys {
+				ExpectWithOffset(1, entries).To(HaveKeyWithValue(key, Not(BeEmpty())))
+			}
+			return entries
+		}
+
+		toUint := func(s string) uint {
+			val, err := strconv.Atoi(s)
+			ExpectWithOffset(1, err).ToNot(HaveOccurred())
+			ExpectWithOffset(1, val).To(BeNumerically(">=", 0))
+			return uint(val)
+		}
+
+		prepareSession := func(virtClient kubecli.KubevirtClient, nodeName, pdh string) (*v1.SEVSessionOptions, string, string) {
+			helperPod := libpod.RenderPrivilegedPod("sev-helper", []string{"sleep"}, []string{"infinity"})
+			helperPod.Spec.NodeName = nodeName
+
+			var err error
+			helperPod, err = virtClient.CoreV1().Pods(testsuite.GetTestNamespace(helperPod)).Create(
+				context.Background(), helperPod, k8smetav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			defer func() {
+				deleteErr := virtClient.CoreV1().Pods(helperPod.Namespace).Delete(context.Background(), helperPod.Name, k8smetav1.DeleteOptions{})
+				ExpectWithOffset(1, deleteErr).ToNot(HaveOccurred())
+			}()
+			EventuallyWithOffset(1, matcher.ThisPod(helperPod), 30).Should(matcher.BeInPhase(k8sv1.PodRunning))
+
+			execOnHelperPod := func(command string) (string, error) {
+				execStdout, execErr := exec.ExecuteCommandOnPod(
+					helperPod,
+					helperPod.Spec.Containers[0].Name,
+					[]string{"/bin/bash", "-c", command})
+				return strings.TrimSpace(execStdout), execErr
+			}
+
+			_, err = execOnHelperPod(fmt.Sprintf("echo %s | base64 --decode > pdh.bin", pdh))
+			ExpectWithOffset(1, err).ToNot(HaveOccurred())
+			_, err = execOnHelperPod("sevctl session pdh.bin 1")
+			ExpectWithOffset(1, err).ToNot(HaveOccurred())
+			godh, err := execOnHelperPod("cat vm_godh.b64")
+			ExpectWithOffset(1, err).ToNot(HaveOccurred())
+			session, err := execOnHelperPod("cat vm_session.b64")
+			ExpectWithOffset(1, err).ToNot(HaveOccurred())
+			tikBase64, err := execOnHelperPod("base64 vm_tik.bin")
+			ExpectWithOffset(1, err).ToNot(HaveOccurred())
+			tekBase64, err := execOnHelperPod("base64 vm_tek.bin")
+			ExpectWithOffset(1, err).ToNot(HaveOccurred())
+
+			return &v1.SEVSessionOptions{
+				DHCert:  godh,
+				Session: session,
+			}, tikBase64, tekBase64
+		}
+
+		Context("device management", Serial, func() {
+			const (
+				sevResourceName = "devices.kubevirt.io/sev"
+				sevDevicePath   = "/proc/1/root/dev/sev"
+			)
+
+			var (
+				virtClient      kubecli.KubevirtClient
+				nodeName        string
+				isDevicePresent bool
+				err             error
+			)
+
+			BeforeEach(func() {
+				virtClient = kubevirt.Client()
+
+				nodeName = libnode.GetNodeNameWithHandler()
+				Expect(nodeName).ToNot(BeEmpty())
+
+				checkCmd := []string{"ls", sevDevicePath}
+				_, err = libnode.ExecuteCommandInVirtHandlerPod(nodeName, checkCmd)
+				isDevicePresent = err == nil
+
+				if !isDevicePresent {
+					By(fmt.Sprintf("Creating a fake SEV device on %s", nodeName))
+					mknodCmd := []string{"mknod", sevDevicePath, "c", "10", "124"}
+					_, err = libnode.ExecuteCommandInVirtHandlerPod(nodeName, mknodCmd)
+					Expect(err).ToNot(HaveOccurred())
+				}
+
+				Eventually(func() bool {
+					allocatableNode, nodeErr := virtClient.CoreV1().Nodes().Get(context.Background(), nodeName, k8smetav1.GetOptions{})
+					Expect(nodeErr).ToNot(HaveOccurred())
+					val, ok := allocatableNode.Status.Allocatable[sevResourceName]
+					return ok && !val.IsZero()
+				}, 180*time.Second, 1*time.Second).Should(BeTrue(), fmt.Sprintf("Allocatable SEV should not be zero on %s", nodeName))
 			})
-			expectedSEVMeasurementInfo.APIMajor = toUint(entries["sev-api-major"])
-			expectedSEVMeasurementInfo.APIMinor = toUint(entries["sev-api-minor"])
-			expectedSEVMeasurementInfo.BuildID = toUint(entries["sev-build-id"])
-			expectedSEVMeasurementInfo.Policy = toUint(entries["sev-policy"])
-			expectedSEVMeasurementInfo.Measurement = entries["sev-measurement"]
 
-			By("Querying the domain loader path")
-			domainSpec, err := libdomain.GetRunningVMIDomainSpec(vmi)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(domainSpec.OS.BootLoader).ToNot(BeNil())
-			Expect(domainSpec.OS.BootLoader.Path).ToNot(BeEmpty())
+			AfterEach(func() {
+				if !isDevicePresent {
+					By(fmt.Sprintf("Removing the fake SEV device from %s", nodeName))
+					rmCmd := []string{"rm", "-f", sevDevicePath}
+					_, err = libnode.ExecuteCommandInVirtHandlerPod(nodeName, rmCmd)
+					Expect(err).ToNot(HaveOccurred())
+				}
+			})
 
-			By(fmt.Sprintf("Computing sha256sum %s", domainSpec.OS.BootLoader.Path))
-			sha256sum := libpod.RunCommandOnVmiPod(vmi, []string{"sha256sum", domainSpec.OS.BootLoader.Path})
-			Expect(sha256sum).ToNot(BeEmpty())
-			const sha256HexLength = 64
-			expectedSEVMeasurementInfo.LoaderSHA = strings.TrimSpace(strings.Split(sha256sum, " ")[0])
-			Expect(expectedSEVMeasurementInfo.LoaderSHA).To(HaveLen(sha256HexLength))
+			It("should reset SEV allocatable devices when the feature gate is disabled", func() {
+				By(fmt.Sprintf("Disabling %s feature gate", featuregate.WorkloadEncryptionSEV))
+				config.DisableFeatureGate(featuregate.WorkloadEncryptionSEV)
+				Eventually(func() bool {
+					node, err := virtClient.CoreV1().Nodes().Get(context.Background(), nodeName, k8smetav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred())
+					val, ok := node.Status.Allocatable[sevResourceName]
+					return !ok || val.IsZero()
+				}, 180*time.Second, 1*time.Second).Should(BeTrue(), fmt.Sprintf("Allocatable SEV should be zero on %s", nodeName))
+			})
+		})
 
-			By("Querying launch measurement")
-			sevMeasurementInfo, err := virtClient.VirtualMachineInstance(vmi.Namespace).SEVQueryLaunchMeasurement(context.Background(), vmi.Name)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(sevMeasurementInfo).To(Equal(expectedSEVMeasurementInfo))
-			measure := verifyMeasurement(&sevMeasurementInfo, tikBase64)
-			sevSecretOptions := encryptSecret(diskSecret, measure, tikBase64, tekBase64)
+		Context("lifecycle", func() {
+			DescribeTable("should start a SEV or SEV-ES VM",
+				func(withES, withSNP bool, sevstr string) {
+					vmi := newSEVFedora(withES, withSNP)
+					vmi = libvmops.RunVMIAndExpectLaunch(vmi, libvmops.StartupTimeoutSecondsXHuge)
 
-			By("Injecting launch secret")
-			err = virtClient.VirtualMachineInstance(vmi.Namespace).SEVInjectLaunchSecret(context.Background(), vmi.Name, sevSecretOptions)
-			Expect(err).ToNot(HaveOccurred())
+					By("Expecting the VirtualMachineInstance console")
+					Expect(console.LoginToFedora(vmi)).To(Succeed())
 
-			By("Unpausing the VirtualMachineInstance")
-			err = virtClient.VirtualMachineInstance(vmi.Namespace).Unpause(context.Background(), vmi.Name, &v1.UnpauseOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			Eventually(matcher.ThisVMI(vmi), 30*time.Second, time.Second).Should(
-				matcher.HaveConditionMissingOrFalse(v1.VirtualMachineInstancePaused))
+					By("Verifying that SEV is enabled in the guest")
+					const consoleTimeout = 60
+					err := console.SafeExpectBatch(vmi, []expect.Batcher{
+						&expect.BSnd{S: "\n"},
+						&expect.BExp{R: ""},
+						&expect.BSnd{S: "dmesg | grep --color=never SEV\n"},
+						&expect.BExp{R: "Memory Encryption Features active: AMD " + sevstr},
+						&expect.BSnd{S: "\n"},
+						&expect.BExp{R: ""},
+					}, consoleTimeout)
+					Expect(err).ToNot(HaveOccurred())
+				},
+				// SEV-ES disabled, SEV enabled
+				Entry("It should launch with base SEV features enabled", false, false, "SEV"),
+				// SEV-ES enabled
+				Entry("It should launch with SEV-ES features enabled", decorators.SEVES, true, false, "SEV SEV-ES"),
+				// SEV-SNP enabled
+				Entry("It should launch with SEV-SNP features enabled", decorators.SEVSNP, false, true, "SEV SEV-ES SEV-SNP"),
+			)
 
-			By("Waiting for the VirtualMachineInstance to become ready")
-			libwait.WaitUntilVMIReady(vmi, console.LoginToFedora)
+			It("[QUARANTINE] should run guest attestation", decorators.Quarantine, func() {
+				var (
+					expectedSEVPlatformInfo    v1.SEVPlatformInfo
+					expectedSEVMeasurementInfo v1.SEVMeasurementInfo
+				)
+
+				virtClient, err := kubecli.GetKubevirtClient()
+				Expect(err).ToNot(HaveOccurred())
+
+				vmi := newSEVFedora(false, false, libvmi.WithSEVAttestation())
+				vmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(
+					context.Background(), vmi, k8smetav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				Eventually(matcher.ThisVMI(vmi), 60).Should(matcher.BeInPhase(v1.Scheduled))
+
+				By("Querying virsh nodesevinfo")
+				nodeSevInfo := libpod.RunCommandOnVmiPod(vmi, []string{"virsh", "nodesevinfo"})
+				Expect(nodeSevInfo).ToNot(BeEmpty())
+				entries := parseVirshInfo(nodeSevInfo, []string{"pdh", "cert-chain"})
+				expectedSEVPlatformInfo.PDH = entries["pdh"]
+				expectedSEVPlatformInfo.CertChain = entries["cert-chain"]
+
+				By("Fetching platform certificates")
+				sevPlatformInfo, err := virtClient.VirtualMachineInstance(vmi.Namespace).SEVFetchCertChain(context.Background(), vmi.Name)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(sevPlatformInfo).To(Equal(expectedSEVPlatformInfo))
+
+				By("Setting up session parameters")
+				vmi, err = matcher.ThisVMI(vmi)()
+				Expect(err).ToNot(HaveOccurred())
+				sevSessionOptions, tikBase64, tekBase64 := prepareSession(virtClient, vmi.Status.NodeName, sevPlatformInfo.PDH)
+				err = virtClient.VirtualMachineInstance(vmi.Namespace).SEVSetupSession(context.Background(), vmi.Name, sevSessionOptions)
+				Expect(err).ToNot(HaveOccurred())
+				Eventually(matcher.ThisVMI(vmi), 60).Should(And(matcher.BeRunning(), matcher.HaveConditionTrue(v1.VirtualMachineInstancePaused)))
+
+				By("Querying virsh domlaunchsecinfo 1")
+				domLaunchSecInfo := libpod.RunCommandOnVmiPod(vmi, []string{"virsh", "domlaunchsecinfo", "1"})
+				Expect(domLaunchSecInfo).ToNot(BeEmpty())
+				entries = parseVirshInfo(domLaunchSecInfo, []string{
+					"sev-measurement", "sev-api-major", "sev-api-minor", "sev-build-id", "sev-policy",
+				})
+				expectedSEVMeasurementInfo.APIMajor = toUint(entries["sev-api-major"])
+				expectedSEVMeasurementInfo.APIMinor = toUint(entries["sev-api-minor"])
+				expectedSEVMeasurementInfo.BuildID = toUint(entries["sev-build-id"])
+				expectedSEVMeasurementInfo.Policy = toUint(entries["sev-policy"])
+				expectedSEVMeasurementInfo.Measurement = entries["sev-measurement"]
+
+				By("Querying the domain loader path")
+				domainSpec, err := libdomain.GetRunningVMIDomainSpec(vmi)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(domainSpec.OS.BootLoader).ToNot(BeNil())
+				Expect(domainSpec.OS.BootLoader.Path).ToNot(BeEmpty())
+
+				By(fmt.Sprintf("Computing sha256sum %s", domainSpec.OS.BootLoader.Path))
+				sha256sum := libpod.RunCommandOnVmiPod(vmi, []string{"sha256sum", domainSpec.OS.BootLoader.Path})
+				Expect(sha256sum).ToNot(BeEmpty())
+				const sha256HexLength = 64
+				expectedSEVMeasurementInfo.LoaderSHA = strings.TrimSpace(strings.Split(sha256sum, " ")[0])
+				Expect(expectedSEVMeasurementInfo.LoaderSHA).To(HaveLen(sha256HexLength))
+
+				By("Querying launch measurement")
+				sevMeasurementInfo, err := virtClient.VirtualMachineInstance(vmi.Namespace).SEVQueryLaunchMeasurement(context.Background(), vmi.Name)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(sevMeasurementInfo).To(Equal(expectedSEVMeasurementInfo))
+				measure := verifyMeasurement(&sevMeasurementInfo, tikBase64)
+				sevSecretOptions := encryptSecret(diskSecret, measure, tikBase64, tekBase64)
+
+				By("Injecting launch secret")
+				err = virtClient.VirtualMachineInstance(vmi.Namespace).SEVInjectLaunchSecret(context.Background(), vmi.Name, sevSecretOptions)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Unpausing the VirtualMachineInstance")
+				err = virtClient.VirtualMachineInstance(vmi.Namespace).Unpause(context.Background(), vmi.Name, &v1.UnpauseOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				Eventually(matcher.ThisVMI(vmi), 30*time.Second, time.Second).Should(
+					matcher.HaveConditionMissingOrFalse(v1.VirtualMachineInstancePaused))
+
+				By("Waiting for the VirtualMachineInstance to become ready")
+				libwait.WaitUntilVMIReady(vmi, console.LoginToFedora)
+			})
 		})
 	})
-})

--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -1114,7 +1114,7 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 			return dv
 		}
 
-		Context(" migration to nonroot", Serial, func() {
+		Context(" migration to nonroot", Serial, decorators.RequiresFeatureGate(featuregate.Root), func() {
 			var dv *cdiv1.DataVolume
 			size := "256Mi"
 			var clusterIsRoot bool
@@ -1198,7 +1198,7 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 				}, console.LoginToAlpine),
 			)
 		})
-		Context(" migration to root", Serial, func() {
+		Context(" migration to root", Serial, decorators.RequiresFeatureGate(featuregate.Root), func() {
 			var dv *cdiv1.DataVolume
 			var clusterIsRoot bool
 			size := "256Mi"

--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -414,7 +414,7 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 				Expect(vmi.Status.MigrationMethod).To(Equal(v1.LiveMigration), "migration method is expected to be Live Migration")
 			})
 
-			DescribeTable("should migrate with a downwardMetrics", func(via libvmi.Option, metricsGetter libinfra.MetricsGetter) {
+			DescribeTable("should migrate with a downwardMetrics", decorators.RequiresFeatureGate(featuregate.DownwardMetricsFeatureGate), func(via libvmi.Option, metricsGetter libinfra.MetricsGetter) {
 				vmi := libvmifact.NewFedora(
 					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
@@ -2413,7 +2413,7 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 		)
 	})
 
-	Context(" with CPU pinning and huge pages", Serial, decorators.RequiresTwoWorkerNodesWithCPUManager, decorators.RequiresHugepages2Mi, func() {
+	Context(" with CPU pinning and huge pages", Serial, decorators.RequiresTwoWorkerNodesWithCPUManager, decorators.RequiresHugepages2Mi, decorators.RequiresFeatureGate(featuregate.CPUManager), func() {
 		It("should not make migrations fail", func() {
 			var err error
 			cpuVMI := libvmifact.NewAlpine(
@@ -2458,7 +2458,7 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 		})
 	})
 
-	Context("with dedicated CPUs", decorators.RequiresTwoWorkerNodesWithCPUManager, func() {
+	Context("with dedicated CPUs", decorators.RequiresTwoWorkerNodesWithCPUManager, decorators.RequiresFeatureGate(featuregate.CPUManager), func() {
 		var (
 			nodes         []k8sv1.Node
 			pausePod      *k8sv1.Pod

--- a/tests/migration/namespace.go
+++ b/tests/migration/namespace.go
@@ -45,6 +45,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/libvmi"
 	libvmici "kubevirt.io/kubevirt/pkg/libvmi/cloudinit"
 	"kubevirt.io/kubevirt/pkg/pointer"
+	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 	"kubevirt.io/kubevirt/tests/decorators"
@@ -62,7 +63,7 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = Describe(SIG("Live Migration across namespaces", decorators.RequiresDecentralizedLiveMigration, func() {
+var _ = Describe(SIG("Live Migration across namespaces", decorators.RequiresFeatureGate(featuregate.DecentralizedLiveMigration), func() {
 	var (
 		virtClient    kubecli.KubevirtClient
 		connectionURL string
@@ -531,7 +532,7 @@ var _ = Describe(SIG("Live Migration across namespaces", decorators.RequiresDece
 
 			// TODO: Remove the RequiresRWOFsVMStateStorageClass once libvirt allows us to tell it to ignore the check
 			// for shared storage.
-			It("should decentralized migrate a VMI with persistent TPM+EFI enabled", decorators.RequiresDecentralizedLiveMigration, decorators.RequiresRWOFsVMStateStorageClass, Serial, func() {
+			It("should decentralized migrate a VMI with persistent TPM+EFI enabled", decorators.RequiresFeatureGate(featuregate.DecentralizedLiveMigration), decorators.RequiresRWOFsVMStateStorageClass, Serial, func() {
 				migrationID := fmt.Sprintf("mig-%s", rand.String(5))
 				By("Creating a VMI with TPM+EFI enabled")
 				sourceVMI := libvmifact.NewFedora(

--- a/tests/network/passt.go
+++ b/tests/network/passt.go
@@ -36,6 +36,7 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
 	libvmici "kubevirt.io/kubevirt/pkg/libvmi/cloudinit"
+	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/flags"
@@ -53,267 +54,268 @@ const (
 	vmiReadyTimeout = 180
 )
 
-var _ = Describe(SIG(" VirtualMachineInstance with passt network binding", func() {
-	var err error
+var _ = Describe(SIG(" VirtualMachineInstance with passt network binding",
+	decorators.RequiresFeatureGate(featuregate.PasstBinding), func() {
+		var err error
 
-	It("should apply the interface configuration", func() {
-		const testMACAddr = "02:02:02:02:02:02"
-		const testPCIAddr = "0000:01:00.0"
-		vmi := libvmifact.NewAlpineWithTestTooling(
-			libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name,
-				libvmi.WithPasstBinding(),
-				libvmi.WithMac(testMACAddr),
-				libvmi.WithPorts(v1.Port{Port: 1234, Protocol: "TCP"}),
-				libvmi.WithPciAddress(testPCIAddr),
-			)),
-			libvmi.WithNetwork(v1.DefaultPodNetwork()),
-		)
-
-		namespace := testsuite.GetTestNamespace(nil)
-		vmi, err = kubevirt.Client().VirtualMachineInstance(namespace).Create(
-			context.Background(), vmi, metav1.CreateOptions{})
-		Expect(err).ToNot(HaveOccurred())
-		waitUntilVMIsReady(console.LoginToAlpine, vmi)
-
-		Expect(vmi.Status.Interfaces).To(HaveLen(1))
-		Expect(vmi.Status.Interfaces[0].IPs).NotTo(BeEmpty())
-		Expect(vmi.Status.Interfaces[0].IP).NotTo(BeEmpty())
-		Expect(vmi.Status.Interfaces[0].MAC).To(Equal(testMACAddr))
-
-		guestIfaceName := vmi.Status.Interfaces[0].InterfaceName
-		cmd := fmt.Sprintf("ls /sys/bus/pci/devices/%s/virtio0/net/%s", testPCIAddr, guestIfaceName)
-		Expect(console.RunCommand(vmi, cmd, time.Second*5)).To(Succeed())
-	})
-
-	Context("TCP without port specification", Ordered, decorators.OncePerOrderedCleanup, func() {
-		var clientVMI *v1.VirtualMachineInstance
-		var serverVMI *v1.VirtualMachineInstance
-
-		const highTCPPort = 8080
-
-		BeforeAll(func() {
-			namespace := testsuite.GetTestNamespace(nil)
-
-			clientVMI = libvmifact.NewAlpineWithTestTooling(
-				withPasstInterfaceWithPort(),
-				libvmi.WithNetwork(v1.DefaultPodNetwork()),
-			)
-			clientVMI, err = kubevirt.Client().VirtualMachineInstance(namespace).Create(
-				context.Background(), clientVMI, metav1.CreateOptions{})
-			Expect(err).ToNot(HaveOccurred())
-
-			serverVMI = libvmifact.NewAlpineWithTestTooling(
-				libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithPasstBinding())),
-				libvmi.WithNetwork(v1.DefaultPodNetwork()),
-			)
-			serverVMI, err = kubevirt.Client().VirtualMachineInstance(namespace).Create(
-				context.Background(), serverVMI, metav1.CreateOptions{})
-			Expect(err).ToNot(HaveOccurred())
-
-			waitUntilVMIsReady(console.LoginToAlpine, clientVMI, serverVMI)
-
-			vmnetserver.StartTCPServer(serverVMI, highTCPPort, console.LoginToAlpine)
-		})
-		DescribeTable("connectivity", func(ipFamily k8sv1.IPFamily) {
-			libnet.SkipWhenClusterNotSupportIPFamily(ipFamily)
-
-			serverIP := libnet.GetVmiPrimaryIPByFamily(serverVMI, ipFamily)
-			Expect(libnet.PingFromVMConsole(clientVMI, serverIP)).To(Succeed())
-			Expect(console.RunCommand(clientVMI, connectToServerCmd(serverIP, highTCPPort), 30*time.Second)).To(Succeed())
-		},
-			Entry("[IPv4]", k8sv1.IPv4Protocol),
-			Entry("[IPv6]", k8sv1.IPv6Protocol),
-		)
-	})
-
-	Context("TCP with port specification", Ordered, decorators.OncePerOrderedCleanup, func() {
-		const highTCPPort = 8080
-		const lowTCPPort = 80
-
-		DescribeTable("connectivity",
-			func(tcpPort int, ipFamily k8sv1.IPFamily) {
-				clientVMI, serverVMI, createErr := createClientServerPasstVMIsWithTCPServer(tcpPort)
-				Expect(createErr).ToNot(HaveOccurred())
-
-				libnet.SkipWhenClusterNotSupportIPFamily(ipFamily)
-
-				serverIP := libnet.GetVmiPrimaryIPByFamily(serverVMI, ipFamily)
-				Expect(libnet.PingFromVMConsole(clientVMI, serverIP)).To(Succeed())
-
-				By("Connecting from the client VM")
-				Expect(console.RunCommand(clientVMI, connectToServerCmd(serverIP, tcpPort), 30*time.Second)).To(Succeed())
-
-				By("Connecting from the client VM to a port not specified on the VM spec")
-				Expect(console.RunCommand(clientVMI, connectToServerCmd(serverIP, tcpPort+1), 30)).NotTo(Succeed())
-			},
-			Entry("[IPv4] high port", highTCPPort, k8sv1.IPv4Protocol),
-			Entry("[IPv6] high port", highTCPPort, k8sv1.IPv6Protocol),
-			Entry("[IPv4] low port", lowTCPPort, k8sv1.IPv4Protocol),
-			Entry("[IPv6] low port", lowTCPPort, k8sv1.IPv6Protocol),
-		)
-	})
-
-	Context("UDP", Ordered, decorators.OncePerOrderedCleanup, func() {
-		var clientVMI *v1.VirtualMachineInstance
-		var serverVMI *v1.VirtualMachineInstance
-
-		const udpPortForIPv4 = 1700
-		const udpPortForIPv6 = 1701
-
-		BeforeAll(func() {
-			namespace := testsuite.GetTestNamespace(nil)
-
-			By("Starting server VMI")
-			serverVMI = libvmifact.NewAlpineWithTestTooling(
+		It("should apply the interface configuration", func() {
+			const testMACAddr = "02:02:02:02:02:02"
+			const testPCIAddr = "0000:01:00.0"
+			vmi := libvmifact.NewAlpineWithTestTooling(
 				libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name,
 					libvmi.WithPasstBinding(),
-					libvmi.WithPorts(
-						v1.Port{Port: udpPortForIPv4, Protocol: "UDP"},
-						v1.Port{Port: udpPortForIPv6, Protocol: "UDP"},
-					),
+					libvmi.WithMac(testMACAddr),
+					libvmi.WithPorts(v1.Port{Port: 1234, Protocol: "TCP"}),
+					libvmi.WithPciAddress(testPCIAddr),
 				)),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 			)
-			serverVMI, err = kubevirt.Client().VirtualMachineInstance(namespace).Create(
-				context.Background(), serverVMI, metav1.CreateOptions{})
-			Expect(err).ToNot(HaveOccurred())
 
-			By("Starting client VMI")
-			clientVMI = libvmifact.NewAlpineWithTestTooling(
-				libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithPasstBinding())),
-				libvmi.WithNetwork(v1.DefaultPodNetwork()),
-			)
-			clientVMI, err = kubevirt.Client().VirtualMachineInstance(namespace).Create(
-				context.Background(), clientVMI, metav1.CreateOptions{})
-			Expect(err).ToNot(HaveOccurred())
-
-			waitUntilVMIsReady(console.LoginToAlpine, serverVMI, clientVMI)
-		})
-
-		DescribeTable("connectivity", func(udpPort int, ipFamily k8sv1.IPFamily) {
-			libnet.SkipWhenClusterNotSupportIPFamily(ipFamily)
-
-			By("Starting a UDP server")
-			vmnetserver.StartPythonUDPServer(serverVMI, udpPort, ipFamily)
-
-			By("Starting and verifying UDP client")
-			// Due to a passt bug, at least one UDPv6 message has to be sent from a machine before it can receive UDPv6 messages
-			// Tracking bug - https://bugs.passt.top/show_bug.cgi?id=16
-			if ipFamily == k8sv1.IPv6Protocol {
-				clientIP := libnet.GetVmiPrimaryIPByFamily(clientVMI, ipFamily)
-				Expect(libnet.PingFromVMConsole(serverVMI, clientIP)).To(Succeed())
-			}
-			serverIP := libnet.GetVmiPrimaryIPByFamily(serverVMI, ipFamily)
-			Expect(startAndVerifyUDPClient(clientVMI, serverIP, udpPort, ipFamily)).To(Succeed())
-		},
-			Entry("[IPv4]", udpPortForIPv4, k8sv1.IPv4Protocol),
-			Entry("[IPv6]", udpPortForIPv6, k8sv1.IPv6Protocol),
-		)
-	})
-
-	Context("egress connectivity", Ordered, decorators.OncePerOrderedCleanup, func() {
-		var vmi *v1.VirtualMachineInstance
-
-		BeforeAll(func() {
-			vmi = libvmifact.NewAlpineWithTestTooling(
-				withPasstInterfaceWithPort(),
-				libvmi.WithNetwork(v1.DefaultPodNetwork()),
-			)
 			namespace := testsuite.GetTestNamespace(nil)
 			vmi, err = kubevirt.Client().VirtualMachineInstance(namespace).Create(
 				context.Background(), vmi, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
-
 			waitUntilVMIsReady(console.LoginToAlpine, vmi)
+
+			Expect(vmi.Status.Interfaces).To(HaveLen(1))
+			Expect(vmi.Status.Interfaces[0].IPs).NotTo(BeEmpty())
+			Expect(vmi.Status.Interfaces[0].IP).NotTo(BeEmpty())
+			Expect(vmi.Status.Interfaces[0].MAC).To(Equal(testMACAddr))
+
+			guestIfaceName := vmi.Status.Interfaces[0].InterfaceName
+			cmd := fmt.Sprintf("ls /sys/bus/pci/devices/%s/virtio0/net/%s", testPCIAddr, guestIfaceName)
+			Expect(console.RunCommand(vmi, cmd, time.Second*5)).To(Succeed())
 		})
 
-		It("should be able to reach the outside world [IPv4]", Label("RequiresOutsideConnectivity"), func() {
-			libnet.SkipWhenClusterNotSupportIpv4()
-			const externalIPv4Address = "8.8.8.8"
-			ipv4Address := externalIPv4Address
-			if flags.IPV4ConnectivityCheckAddress != "" {
-				ipv4Address = flags.IPV4ConnectivityCheckAddress
-			}
-			const externalDomain = "google.com"
-			dns := externalDomain
-			if flags.ConnectivityCheckDNS != "" {
-				dns = flags.ConnectivityCheckDNS
-			}
+		Context("TCP without port specification", Ordered, decorators.OncePerOrderedCleanup, func() {
+			var clientVMI *v1.VirtualMachineInstance
+			var serverVMI *v1.VirtualMachineInstance
 
-			By("Checking ping (IPv4)")
-			Expect(libnet.PingFromVMConsole(vmi, ipv4Address, "-c 5", "-w 15")).To(Succeed())
-			Expect(libnet.PingFromVMConsole(vmi, dns, "-c 5", "-w 15")).To(Succeed())
+			const highTCPPort = 8080
+
+			BeforeAll(func() {
+				namespace := testsuite.GetTestNamespace(nil)
+
+				clientVMI = libvmifact.NewAlpineWithTestTooling(
+					withPasstInterfaceWithPort(),
+					libvmi.WithNetwork(v1.DefaultPodNetwork()),
+				)
+				clientVMI, err = kubevirt.Client().VirtualMachineInstance(namespace).Create(
+					context.Background(), clientVMI, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				serverVMI = libvmifact.NewAlpineWithTestTooling(
+					libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithPasstBinding())),
+					libvmi.WithNetwork(v1.DefaultPodNetwork()),
+				)
+				serverVMI, err = kubevirt.Client().VirtualMachineInstance(namespace).Create(
+					context.Background(), serverVMI, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				waitUntilVMIsReady(console.LoginToAlpine, clientVMI, serverVMI)
+
+				vmnetserver.StartTCPServer(serverVMI, highTCPPort, console.LoginToAlpine)
+			})
+			DescribeTable("connectivity", func(ipFamily k8sv1.IPFamily) {
+				libnet.SkipWhenClusterNotSupportIPFamily(ipFamily)
+
+				serverIP := libnet.GetVmiPrimaryIPByFamily(serverVMI, ipFamily)
+				Expect(libnet.PingFromVMConsole(clientVMI, serverIP)).To(Succeed())
+				Expect(console.RunCommand(clientVMI, connectToServerCmd(serverIP, highTCPPort), 30*time.Second)).To(Succeed())
+			},
+				Entry("[IPv4]", k8sv1.IPv4Protocol),
+				Entry("[IPv6]", k8sv1.IPv6Protocol),
+			)
 		})
 
-		It("should be able to reach the outside world", Label("RequiresOutsideConnectivity", "IPv6"), func() {
-			libnet.SkipWhenClusterNotSupportIpv6()
-			// Cluster nodes subnet (docker network gateway)
-			// Docker network subnet cidr definition:
-			// https://github.com/kubevirt/project-infra/blob/master/github/ci/shared-deployments/files/docker-daemon-mirror.conf#L5
-			const externalIPv6Address = "2001:db8:1::1"
-			ipv6Address := externalIPv6Address
-			if flags.IPV6ConnectivityCheckAddress != "" {
-				ipv6Address = flags.IPV6ConnectivityCheckAddress
-			}
+		Context("TCP with port specification", Ordered, decorators.OncePerOrderedCleanup, func() {
+			const highTCPPort = 8080
+			const lowTCPPort = 80
 
-			By("Checking ping (IPv6) from VM to cluster nodes gateway")
-			Expect(libnet.PingFromVMConsole(vmi, ipv6Address)).To(Succeed())
-		})
-	})
+			DescribeTable("connectivity",
+				func(tcpPort int, ipFamily k8sv1.IPFamily) {
+					clientVMI, serverVMI, createErr := createClientServerPasstVMIsWithTCPServer(tcpPort)
+					Expect(createErr).ToNot(HaveOccurred())
 
-	Context("migration", Ordered, decorators.OncePerOrderedCleanup, func() {
-		var migrateVMI *v1.VirtualMachineInstance
-		var anotherVMI *v1.VirtualMachineInstance
+					libnet.SkipWhenClusterNotSupportIPFamily(ipFamily)
 
-		BeforeAll(func() {
-			By("Starting a VMI")
-			migrateVMI = startPasstVMI()
+					serverIP := libnet.GetVmiPrimaryIPByFamily(serverVMI, ipFamily)
+					Expect(libnet.PingFromVMConsole(clientVMI, serverIP)).To(Succeed())
 
-			By("Starting another VMI")
-			anotherVMI = startPasstVMI()
+					By("Connecting from the client VM")
+					Expect(console.RunCommand(clientVMI, connectToServerCmd(serverIP, tcpPort), 30*time.Second)).To(Succeed())
 
-			waitUntilVMIsReady(console.LoginToFedora, migrateVMI, anotherVMI)
+					By("Connecting from the client VM to a port not specified on the VM spec")
+					Expect(console.RunCommand(clientVMI, connectToServerCmd(serverIP, tcpPort+1), 30)).NotTo(Succeed())
+				},
+				Entry("[IPv4] high port", highTCPPort, k8sv1.IPv4Protocol),
+				Entry("[IPv6] high port", highTCPPort, k8sv1.IPv6Protocol),
+				Entry("[IPv4] low port", lowTCPPort, k8sv1.IPv4Protocol),
+				Entry("[IPv6] low port", lowTCPPort, k8sv1.IPv6Protocol),
+			)
 		})
 
-		It("connectivity should be preserved for ipv4", func() {
-			libnet.SkipWhenClusterNotSupportIPFamily(k8sv1.IPv4Protocol)
+		Context("UDP", Ordered, decorators.OncePerOrderedCleanup, func() {
+			var clientVMI *v1.VirtualMachineInstance
+			var serverVMI *v1.VirtualMachineInstance
 
-			By("Verify the VMIs can ping each other")
-			migrateVmiBeforeMigIP := libnet.GetVmiPrimaryIPByFamily(migrateVMI, k8sv1.IPv4Protocol)
-			anotherVmiIP := libnet.GetVmiPrimaryIPByFamily(anotherVMI, k8sv1.IPv4Protocol)
-			Expect(libnet.PingFromVMConsole(migrateVMI, anotherVmiIP)).To(Succeed())
-			Expect(libnet.PingFromVMConsole(anotherVMI, migrateVmiBeforeMigIP)).To(Succeed())
+			const udpPortForIPv4 = 1700
+			const udpPortForIPv6 = 1701
 
-			beforeMigNodeName := migrateVMI.Status.NodeName
+			BeforeAll(func() {
+				namespace := testsuite.GetTestNamespace(nil)
 
-			By("Perform migration")
-			migration := libmigration.New(migrateVMI.Name, migrateVMI.Namespace)
-			migrationUID := libmigration.RunMigrationAndExpectToCompleteWithDefaultTimeout(kubevirt.Client(), migration)
-			migrateVMI = libmigration.ConfirmVMIPostMigration(kubevirt.Client(), migrateVMI, migrationUID)
+				By("Starting server VMI")
+				serverVMI = libvmifact.NewAlpineWithTestTooling(
+					libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name,
+						libvmi.WithPasstBinding(),
+						libvmi.WithPorts(
+							v1.Port{Port: udpPortForIPv4, Protocol: "UDP"},
+							v1.Port{Port: udpPortForIPv6, Protocol: "UDP"},
+						),
+					)),
+					libvmi.WithNetwork(v1.DefaultPodNetwork()),
+				)
+				serverVMI, err = kubevirt.Client().VirtualMachineInstance(namespace).Create(
+					context.Background(), serverVMI, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
 
-			By("Verify all the containers in the source pod were terminated")
-			labelSelector := fmt.Sprintf("%s=%s", v1.CreatedByLabel, string(migrateVMI.GetUID()))
-			fieldSelector := fmt.Sprintf("spec.nodeName==%s", beforeMigNodeName)
+				By("Starting client VMI")
+				clientVMI = libvmifact.NewAlpineWithTestTooling(
+					libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithPasstBinding())),
+					libvmi.WithNetwork(v1.DefaultPodNetwork()),
+				)
+				clientVMI, err = kubevirt.Client().VirtualMachineInstance(namespace).Create(
+					context.Background(), clientVMI, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
 
-			assertSourcePodContainersTerminate(labelSelector, fieldSelector, migrateVMI)
+				waitUntilVMIsReady(console.LoginToAlpine, serverVMI, clientVMI)
+			})
 
-			By("Verify the VMI new IP is propagated to the status")
-			var migrateVmiAfterMigIP string
-			Eventually(func() string {
-				vmiClient := kubevirt.Client().VirtualMachineInstance(migrateVMI.Namespace)
-				migrateVMI, err = vmiClient.Get(
-					context.Background(), migrateVMI.Name, metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred(), "should have been able to retrieve the VMI instance")
-				migrateVmiAfterMigIP = libnet.GetVmiPrimaryIPByFamily(migrateVMI, k8sv1.IPv4Protocol)
-				return migrateVmiAfterMigIP
-			}, 30*time.Second).ShouldNot(Equal(migrateVmiBeforeMigIP), "the VMI status should get a new IP after migration")
+			DescribeTable("connectivity", func(udpPort int, ipFamily k8sv1.IPFamily) {
+				libnet.SkipWhenClusterNotSupportIPFamily(ipFamily)
 
-			By("Verify the VMIs can ping each other after migration")
-			Expect(libnet.PingFromVMConsole(migrateVMI, anotherVmiIP)).To(Succeed())
-			Expect(libnet.PingFromVMConsole(anotherVMI, migrateVmiAfterMigIP)).To(Succeed())
+				By("Starting a UDP server")
+				vmnetserver.StartPythonUDPServer(serverVMI, udpPort, ipFamily)
+
+				By("Starting and verifying UDP client")
+				// Due to a passt bug, at least one UDPv6 message has to be sent from a machine before it can receive UDPv6 messages
+				// Tracking bug - https://bugs.passt.top/show_bug.cgi?id=16
+				if ipFamily == k8sv1.IPv6Protocol {
+					clientIP := libnet.GetVmiPrimaryIPByFamily(clientVMI, ipFamily)
+					Expect(libnet.PingFromVMConsole(serverVMI, clientIP)).To(Succeed())
+				}
+				serverIP := libnet.GetVmiPrimaryIPByFamily(serverVMI, ipFamily)
+				Expect(startAndVerifyUDPClient(clientVMI, serverIP, udpPort, ipFamily)).To(Succeed())
+			},
+				Entry("[IPv4]", udpPortForIPv4, k8sv1.IPv4Protocol),
+				Entry("[IPv6]", udpPortForIPv6, k8sv1.IPv6Protocol),
+			)
 		})
-	})
-}),
+
+		Context("egress connectivity", Ordered, decorators.OncePerOrderedCleanup, func() {
+			var vmi *v1.VirtualMachineInstance
+
+			BeforeAll(func() {
+				vmi = libvmifact.NewAlpineWithTestTooling(
+					withPasstInterfaceWithPort(),
+					libvmi.WithNetwork(v1.DefaultPodNetwork()),
+				)
+				namespace := testsuite.GetTestNamespace(nil)
+				vmi, err = kubevirt.Client().VirtualMachineInstance(namespace).Create(
+					context.Background(), vmi, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				waitUntilVMIsReady(console.LoginToAlpine, vmi)
+			})
+
+			It("should be able to reach the outside world [IPv4]", Label("RequiresOutsideConnectivity"), func() {
+				libnet.SkipWhenClusterNotSupportIpv4()
+				const externalIPv4Address = "8.8.8.8"
+				ipv4Address := externalIPv4Address
+				if flags.IPV4ConnectivityCheckAddress != "" {
+					ipv4Address = flags.IPV4ConnectivityCheckAddress
+				}
+				const externalDomain = "google.com"
+				dns := externalDomain
+				if flags.ConnectivityCheckDNS != "" {
+					dns = flags.ConnectivityCheckDNS
+				}
+
+				By("Checking ping (IPv4)")
+				Expect(libnet.PingFromVMConsole(vmi, ipv4Address, "-c 5", "-w 15")).To(Succeed())
+				Expect(libnet.PingFromVMConsole(vmi, dns, "-c 5", "-w 15")).To(Succeed())
+			})
+
+			It("should be able to reach the outside world", Label("RequiresOutsideConnectivity", "IPv6"), func() {
+				libnet.SkipWhenClusterNotSupportIpv6()
+				// Cluster nodes subnet (docker network gateway)
+				// Docker network subnet cidr definition:
+				// https://github.com/kubevirt/project-infra/blob/master/github/ci/shared-deployments/files/docker-daemon-mirror.conf#L5
+				const externalIPv6Address = "2001:db8:1::1"
+				ipv6Address := externalIPv6Address
+				if flags.IPV6ConnectivityCheckAddress != "" {
+					ipv6Address = flags.IPV6ConnectivityCheckAddress
+				}
+
+				By("Checking ping (IPv6) from VM to cluster nodes gateway")
+				Expect(libnet.PingFromVMConsole(vmi, ipv6Address)).To(Succeed())
+			})
+		})
+
+		Context("migration", Ordered, decorators.OncePerOrderedCleanup, func() {
+			var migrateVMI *v1.VirtualMachineInstance
+			var anotherVMI *v1.VirtualMachineInstance
+
+			BeforeAll(func() {
+				By("Starting a VMI")
+				migrateVMI = startPasstVMI()
+
+				By("Starting another VMI")
+				anotherVMI = startPasstVMI()
+
+				waitUntilVMIsReady(console.LoginToFedora, migrateVMI, anotherVMI)
+			})
+
+			It("connectivity should be preserved for ipv4", func() {
+				libnet.SkipWhenClusterNotSupportIPFamily(k8sv1.IPv4Protocol)
+
+				By("Verify the VMIs can ping each other")
+				migrateVmiBeforeMigIP := libnet.GetVmiPrimaryIPByFamily(migrateVMI, k8sv1.IPv4Protocol)
+				anotherVmiIP := libnet.GetVmiPrimaryIPByFamily(anotherVMI, k8sv1.IPv4Protocol)
+				Expect(libnet.PingFromVMConsole(migrateVMI, anotherVmiIP)).To(Succeed())
+				Expect(libnet.PingFromVMConsole(anotherVMI, migrateVmiBeforeMigIP)).To(Succeed())
+
+				beforeMigNodeName := migrateVMI.Status.NodeName
+
+				By("Perform migration")
+				migration := libmigration.New(migrateVMI.Name, migrateVMI.Namespace)
+				migrationUID := libmigration.RunMigrationAndExpectToCompleteWithDefaultTimeout(kubevirt.Client(), migration)
+				migrateVMI = libmigration.ConfirmVMIPostMigration(kubevirt.Client(), migrateVMI, migrationUID)
+
+				By("Verify all the containers in the source pod were terminated")
+				labelSelector := fmt.Sprintf("%s=%s", v1.CreatedByLabel, string(migrateVMI.GetUID()))
+				fieldSelector := fmt.Sprintf("spec.nodeName==%s", beforeMigNodeName)
+
+				assertSourcePodContainersTerminate(labelSelector, fieldSelector, migrateVMI)
+
+				By("Verify the VMI new IP is propagated to the status")
+				var migrateVmiAfterMigIP string
+				Eventually(func() string {
+					vmiClient := kubevirt.Client().VirtualMachineInstance(migrateVMI.Namespace)
+					migrateVMI, err = vmiClient.Get(
+						context.Background(), migrateVMI.Name, metav1.GetOptions{})
+					Expect(err).ToNot(HaveOccurred(), "should have been able to retrieve the VMI instance")
+					migrateVmiAfterMigIP = libnet.GetVmiPrimaryIPByFamily(migrateVMI, k8sv1.IPv4Protocol)
+					return migrateVmiAfterMigIP
+				}, 30*time.Second).ShouldNot(Equal(migrateVmiBeforeMigIP), "the VMI status should get a new IP after migration")
+
+				By("Verify the VMIs can ping each other after migration")
+				Expect(libnet.PingFromVMConsole(migrateVMI, anotherVmiIP)).To(Succeed())
+				Expect(libnet.PingFromVMConsole(anotherVMI, migrateVmiAfterMigIP)).To(Succeed())
+			})
+		})
+	}),
 )
 
 func withPasstInterfaceWithPort() libvmi.Option {

--- a/tests/network/sriov.go
+++ b/tests/network/sriov.go
@@ -91,7 +91,7 @@ const (
 
 var pciAddressRegex = regexp.MustCompile(hardware.PCI_ADDRESS_PATTERN)
 
-var _ = Describe(SIG("SRIOV", Serial, decorators.SRIOV, func() {
+var _ = Describe(SIG("SRIOV", Serial, decorators.SRIOV, decorators.RequiresFeatureGate(featuregate.ExternalNetResourceInjection), func() {
 	var virtClient kubecli.KubevirtClient
 
 	sriovResourceName := readSRIOVResourceName()

--- a/tests/network/sriov.go
+++ b/tests/network/sriov.go
@@ -113,7 +113,7 @@ var _ = Describe(SIG("SRIOV", Serial, decorators.SRIOV, decorators.RequiresFeatu
 			Expect(err).NotTo(HaveOccurred(), shouldCreateNetwork)
 		})
 
-		It("should have cloud-init meta_data with tagged interface and aligned cpus to sriov interface numa node for VMIs with dedicatedCPUs", decorators.RequiresNodeWithCPUManager, func() {
+		It("should have cloud-init meta_data with tagged interface and aligned cpus to sriov interface numa node for VMIs with dedicatedCPUs", decorators.RequiresNodeWithCPUManager, decorators.RequiresFeatureGate(featuregate.CPUManager), func() {
 			vmi := libvmifact.NewFedora(
 				libvmi.WithCloudInitConfigDrive(libvmici.WithConfigDriveNetworkData(defaultCloudInitNetworkData())),
 				libvmi.WithCPUCount(4, 0, 0),
@@ -216,7 +216,7 @@ var _ = Describe(SIG("SRIOV", Serial, decorators.SRIOV, decorators.RequiresFeatu
 			}
 		})
 
-		It("[test_id:3959]should create a virtual machine with sriov interface and dedicatedCPUs", decorators.RequiresNodeWithCPUManager, func() {
+		It("[test_id:3959]should create a virtual machine with sriov interface and dedicatedCPUs", decorators.RequiresNodeWithCPUManager, decorators.RequiresFeatureGate(featuregate.CPUManager), func() {
 			// In addition to verifying that we can start a VMI with CPU pinning
 			// this also tests if we've correctly calculated the overhead for VFIO devices.
 			vmi := newSRIOVVmi([]string{sriovnet1},

--- a/tests/network/vmi_istio.go
+++ b/tests/network/vmi_istio.go
@@ -40,6 +40,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/libvmi"
 	libvmici "kubevirt.io/kubevirt/pkg/libvmi/cloudinit"
 	"kubevirt.io/kubevirt/pkg/network/istio"
+	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
@@ -454,7 +455,7 @@ var istioTestsWithPasstBinding = func() {
 
 var _ = Describe(SIG(" Istio with masquerade binding", decorators.Istio, Serial, istioTestsWithMasqueradeBinding))
 
-var _ = Describe(SIG(" Istio with passt binding", decorators.Istio, Serial, istioTestsWithPasstBinding))
+var _ = Describe(SIG(" Istio with passt binding", decorators.Istio, decorators.RequiresFeatureGate(featuregate.PasstBinding), Serial, istioTestsWithPasstBinding))
 
 func newVMIWithIstioSidecar(ports []v1.Port, vmType VmType) (*v1.VirtualMachineInstance, error) {
 	if vmType == Masquerade {

--- a/tests/numa/BUILD.bazel
+++ b/tests/numa/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/tests/numa",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/virt-config/featuregate:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//tests/console:go_default_library",

--- a/tests/numa/numa.go
+++ b/tests/numa/numa.go
@@ -19,6 +19,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 
+	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/exec"
@@ -37,7 +38,7 @@ var _ = Describe("[sig-compute]NUMA", Serial, decorators.SigCompute, func() {
 	})
 
 	It("[test_id:7299] topology should be mapped to the guest and hugepages should be allocated",
-		decorators.RequiresNodeWithCPUManager, decorators.RequiresHugepages2Mi, func() {
+		decorators.RequiresNodeWithCPUManager, decorators.RequiresHugepages2Mi, decorators.RequiresFeatureGate(featuregate.CPUManager), func() {
 			var err error
 			cpuVMI := libvmifact.NewAlpine()
 			cpuVMI.Spec.Domain.Resources.Requests[k8sv1.ResourceMemory] = resource.MustParse("128Mi")

--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -1894,7 +1894,7 @@ var _ = Describe("[sig-operator]Operator", Serial, decorators.SigOperator, func(
 		})
 	})
 
-	Context("with ContainerPathVolumes feature gate toggled", func() {
+	Context("with ContainerPathVolumes feature gate toggled", decorators.RequiresFeatureGate(featuregate.ContainerPathVolumesGate), func() {
 
 		AfterEach(func() {
 			kvconfig.EnableFeatureGate(featuregate.ContainerPathVolumesGate)
@@ -1930,7 +1930,7 @@ var _ = Describe("[sig-operator]Operator", Serial, decorators.SigOperator, func(
 		})
 	})
 
-	Context(" Seccomp configuration", Serial, func() {
+	Context(" Seccomp configuration", Serial, decorators.RequiresFeatureGate(featuregate.KubevirtSeccompProfile), func() {
 
 		Context("Kubevirt profile", func() {
 			var nodeName string
@@ -2349,7 +2349,7 @@ var _ = Describe("[sig-operator]Operator", Serial, decorators.SigOperator, func(
 		})
 	})
 
-	Context("virt-template deployment", func() {
+	Context("virt-template deployment", decorators.RequiresFeatureGate(featuregate.Template), func() {
 		var fgDisabled bool
 
 		BeforeEach(func() {
@@ -2547,7 +2547,7 @@ var _ = Describe("[sig-operator]Operator", Serial, decorators.SigOperator, func(
 		})
 	})
 
-	Context("RoleAggregationStrategy", func() {
+	Context("RoleAggregationStrategy", decorators.RequiresFeatureGate(featuregate.OptOutRoleAggregation), func() {
 		It("should disable aggregate labels when set to Manual and restore them when set to AggregateToDefault", func() {
 			By("Verifying aggregate labels are present by default")
 			verifyAggregateLabels(kubevirt.Client(), "true")

--- a/tests/performance/BUILD.bazel
+++ b/tests/performance/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
     deps = [
         "//pkg/libvmi:go_default_library",
         "//pkg/libvmi/cloudinit:go_default_library",
+        "//pkg/virt-config/featuregate:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/api/instancetype/v1beta1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",

--- a/tests/performance/realtime.go
+++ b/tests/performance/realtime.go
@@ -18,6 +18,7 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
 	libvmici "kubevirt.io/kubevirt/pkg/libvmi/cloudinit"
+	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
@@ -42,7 +43,7 @@ func byStartingTheVMI(vmi *v1.VirtualMachineInstance, virtClient kubecli.Kubevir
 	libwait.WaitForSuccessfulVMIStart(vmi)
 }
 
-var _ = Describe(SIG("CPU latency tests for measuring realtime VMs performance", decorators.RequiresTwoWorkerNodesWithCPUManager, decorators.RequiresHugepages2Mi, func() {
+var _ = Describe(SIG("CPU latency tests for measuring realtime VMs performance", decorators.RequiresTwoWorkerNodesWithCPUManager, decorators.RequiresHugepages2Mi, decorators.RequiresFeatureGate(featuregate.CPUManager), func() {
 
 	var (
 		vmi        *v1.VirtualMachineInstance

--- a/tests/plugin_test.go
+++ b/tests/plugin_test.go
@@ -59,7 +59,7 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = Describe("[sig-compute]Plugin domain hooks", Serial, decorators.SigCompute, func() {
+var _ = Describe("[sig-compute]Plugin domain hooks", Serial, decorators.SigCompute, decorators.RequiresFeatureGate(featuregate.PluginsGate), func() {
 
 	BeforeEach(func() {
 		config.EnableFeatureGate(featuregate.PluginsGate)
@@ -489,7 +489,7 @@ const (
 	pluginMarkerDir  = "/var/run/kubevirt/plugin-test-markers"
 )
 
-var _ = Describe("[sig-compute]Plugin node hooks", Serial, decorators.SigCompute, func() {
+var _ = Describe("[sig-compute]Plugin node hooks", Serial, decorators.SigCompute, decorators.RequiresFeatureGate(featuregate.PluginsGate), func() {
 	var virtClient kubecli.KubevirtClient
 
 	BeforeEach(func() {

--- a/tests/storage/BUILD.bazel
+++ b/tests/storage/BUILD.bazel
@@ -124,6 +124,7 @@ go_test(
     deps = [
         "//pkg/libdv:go_default_library",
         "//pkg/libvmi:go_default_library",
+        "//pkg/virt-config/featuregate:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//tests/containerdisk:go_default_library",

--- a/tests/storage/backup.go
+++ b/tests/storage/backup.go
@@ -57,6 +57,7 @@ import (
 	exportServer "kubevirt.io/kubevirt/pkg/storage/export/virt-exportserver"
 	"kubevirt.io/kubevirt/pkg/storage/velero"
 	"kubevirt.io/kubevirt/pkg/util/net/dns"
+	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
@@ -73,7 +74,7 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = Describe(SIG("Backup", func() {
+var _ = Describe(SIG("Backup", decorators.RequiresFeatureGate(featuregate.IncrementalBackupGate), func() {
 	var (
 		err        error
 		virtClient kubecli.KubevirtClient
@@ -1232,7 +1233,7 @@ func getPodByVMI(vmi *v1.VirtualMachineInstance) *corev1.Pod {
 	return pod
 }
 
-var _ = Describe("Backup with migration", func() {
+var _ = Describe("Backup with migration", decorators.RequiresFeatureGate(featuregate.IncrementalBackupGate), func() {
 	var (
 		err        error
 		virtClient kubecli.KubevirtClient

--- a/tests/storage/export.go
+++ b/tests/storage/export.go
@@ -2360,7 +2360,7 @@ var _ = Describe(SIG("Export", func() {
 		})
 	})
 
-	Context("OCI export", Serial, Ordered, decorators.OncePerOrderedCleanup, func() {
+	Context("OCI export", Serial, Ordered, decorators.OncePerOrderedCleanup, decorators.RequiresFeatureGate(featuregate.OCIExport), func() {
 		const (
 			reasonDigestsComputed = "DigestsComputed"
 		)
@@ -2485,7 +2485,7 @@ var _ = Describe(SIG("Export", func() {
 			Expect(ociUrl).To(BeEmpty(), "OCI manifest URL should not be present when feature gate is disabled")
 		})
 
-		It("should export VirtualMachineTemplate as OCI artifact", func() {
+		It("should export VirtualMachineTemplate as OCI artifact", decorators.RequiresFeatureGate(featuregate.Template), func() {
 			if !checks.HasFeature(featuregate.Template) {
 				kvconfig.EnableFeatureGate(featuregate.Template)
 				defer kvconfig.DisableFeatureGate(featuregate.Template)

--- a/tests/storage/hotplug.go
+++ b/tests/storage/hotplug.go
@@ -887,7 +887,7 @@ var _ = Describe(SIG("Hotplug", func() {
 				return sc
 			}
 
-			Context("with legacy hotplug", Serial, func() {
+			Context("with legacy hotplug", Serial, decorators.RequiresFeatureGate(featuregate.HotplugVolumesGate), func() {
 				BeforeEach(func() {
 					kvconfig.DisableFeatureGate(featuregate.DeclarativeHotplugVolumesGate)
 					kvconfig.EnableFeatureGate(featuregate.HotplugVolumesGate)
@@ -2084,7 +2084,7 @@ var _ = Describe(SIG("Hotplug", func() {
 	})
 
 	// Regression test for https://github.com/kubevirt/kubevirt/issues/17124
-	Context("with PCI HostDevices", Serial, func() {
+	Context("with PCI HostDevices", Serial, decorators.RequiresFeatureGate(featuregate.HostDevicesGate), func() {
 		const deviceName = "example.org/soundcard"
 
 		BeforeEach(func() {

--- a/tests/storage/hotplug.go
+++ b/tests/storage/hotplug.go
@@ -909,7 +909,7 @@ var _ = Describe(SIG("Hotplug", func() {
 				)
 			})
 
-			Context("with declarative hotplug", func() {
+			Context("with declarative hotplug", decorators.RequiresFeatureGate(featuregate.DeclarativeHotplugVolumesGate), func() {
 				DescribeTable("should add/remove volume", decorators.StorageCritical, func(addVolumeFunc addVolumeFunction, removeVolumeFunc removeVolumeFunction, volumeMode k8sv1.PersistentVolumeMode, waitToStart bool) {
 					verifyAttachDetachVolume(vm, addVolumeFunc, removeVolumeFunc, scForVolumeMode(volumeMode), volumeMode, v1.DiskBusSCSI, waitToStart)
 				},

--- a/tests/storage/migration.go
+++ b/tests/storage/migration.go
@@ -939,7 +939,7 @@ var _ = Describe(SIG("Volumes update with migration", decorators.RequiresTwoSche
 		})
 	})
 
-	Context("Hotplug volumes", func() {
+	Context("Hotplug volumes", decorators.RequiresFeatureGate(featuregate.HotplugVolumesGate), func() {
 
 		enableLegacyHotplug := func() {
 			// even if DeclarativeHotplugVolumesGate is enabled this takes precedence

--- a/tests/storage/objectgraph_test.go
+++ b/tests/storage/objectgraph_test.go
@@ -35,6 +35,7 @@ import (
 
 	libdv "kubevirt.io/kubevirt/pkg/libdv"
 	"kubevirt.io/kubevirt/pkg/libvmi"
+	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
@@ -45,7 +46,7 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = Describe("[sig-storage]ObjectGraph", decorators.SigStorage, func() {
+var _ = Describe("[sig-storage]ObjectGraph", decorators.SigStorage, decorators.RequiresFeatureGate(featuregate.ObjectGraph), func() {
 	var (
 		virtClient kubecli.KubevirtClient
 	)

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -505,7 +505,7 @@ var _ = Describe(SIG("Storage", func() {
 			})
 		})
 
-		Context("[rfe_id:2298][crit:medium][vendor:cnv-qe@redhat.com][level:component] With HostDisk and PVC initialization", func() {
+		Context("[rfe_id:2298][crit:medium][vendor:cnv-qe@redhat.com][level:component] With HostDisk and PVC initialization", decorators.RequiresFeatureGate(featuregate.HostDiskGate), func() {
 
 			BeforeEach(func() {
 				if !checks.HasFeature(featuregate.HostDiskGate) {

--- a/tests/storage/utility-volumes.go
+++ b/tests/storage/utility-volumes.go
@@ -39,6 +39,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
 	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/libvmi"
+	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/events"
 	"kubevirt.io/kubevirt/tests/flags"
@@ -66,7 +67,7 @@ func getKubevirtControllerClient(virtCli kubecli.KubevirtClient, namespace strin
 	return client
 }
 
-var _ = Describe(SIG("Utility Volumes", func() {
+var _ = Describe(SIG("Utility Volumes", decorators.RequiresFeatureGate(featuregate.UtilityVolumesGate), func() {
 	var (
 		virtClient        kubecli.KubevirtClient
 		controllerClient  kubecli.KubevirtClient

--- a/tests/usb/usb.go
+++ b/tests/usb/usb.go
@@ -33,7 +33,7 @@ const (
 )
 
 var _ = Describe("[sig-compute][USB] [QUARANTINE] host USB Passthrough", Serial,
-	decorators.Quarantine, decorators.SigCompute, decorators.USB, func() {
+	decorators.Quarantine, decorators.SigCompute, decorators.USB, decorators.RequiresFeatureGate(featuregate.HostDevicesGate), func() {
 		var virtClient kubecli.KubevirtClient
 		var config v1.KubeVirtConfiguration
 		var vmi *v1.VirtualMachineInstance

--- a/tests/virtiofs/datavolume.go
+++ b/tests/virtiofs/datavolume.go
@@ -65,7 +65,7 @@ const (
 	checkingVMInstanceConsoleOut = "Checking that the VirtualMachineInstance console has expected output"
 )
 
-var _ = Describe("[sig-storage] virtiofs", decorators.SigStorage, decorators.StorageVolumesVirtiofs, func() {
+var _ = Describe("[sig-storage] virtiofs", decorators.SigStorage, decorators.StorageVolumesVirtiofs, decorators.RequiresFeatureGate(featuregate.VirtIOFSStorageVolumeGate), func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 	var vmi *virtv1.VirtualMachineInstance

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -507,7 +507,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			),
 		)
 
-		It("[test_id:6869]should report an error status when image pull error occurs", Serial, decorators.Conformance, decorators.WgS390x, func() {
+		It("[test_id:6869]should report an error status when image pull error occurs", Serial, decorators.Conformance, decorators.WgS390x, decorators.RequiresFeatureGate(featuregate.ImageVolume), func() {
 			if checks.HasFeature(featuregate.ImageVolume) {
 				config.DisableFeatureGate(featuregate.ImageVolume)
 				DeferCleanup(config.EnableFeatureGate, featuregate.ImageVolume)

--- a/tests/vmi_cloudinit_hook_sidecar_test.go
+++ b/tests/vmi_cloudinit_hook_sidecar_test.go
@@ -36,6 +36,7 @@ import (
 	"kubevirt.io/client-go/kubecli"
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
+	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
@@ -48,7 +49,7 @@ import (
 
 const cloudinitHookSidecarImage = "example-cloudinit-hook-sidecar"
 
-var _ = Describe("[sig-compute]CloudInitHookSidecars", decorators.SigCompute, func() {
+var _ = Describe("[sig-compute]CloudInitHookSidecars", decorators.SigCompute, decorators.RequiresFeatureGate(featuregate.SidecarGate), func() {
 
 	var err error
 	var virtClient kubecli.KubevirtClient

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -1080,7 +1080,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 			Expect(vmiCondition.Reason).To(Equal("Synchronizing with the Domain failed."))
 		})
 	})
-	Describe("[rfe_id:897][crit:medium][vendor:cnv-qe@redhat.com][level:component]VirtualMachineInstance with CPU pinning", decorators.WgArm64, decorators.RequiresTwoWorkerNodesWithCPUManager, func() {
+	Describe("[rfe_id:897][crit:medium][vendor:cnv-qe@redhat.com][level:component]VirtualMachineInstance with CPU pinning", decorators.WgArm64, decorators.RequiresTwoWorkerNodesWithCPUManager, decorators.RequiresFeatureGate(featuregate.CPUManager), func() {
 		isNodeHasCPUManagerLabel := func(nodeName string) bool {
 
 			nodeObject, err := virtClient.CoreV1().Nodes().Get(context.Background(), nodeName, metav1.GetOptions{})

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -348,7 +348,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 		},
 			Entry("[test_id:1668]should use EFI without secure boot", Serial, false, "SecureBoot disabled", false),
 			Entry("[test_id:4437]should enable EFI secure boot", Serial, true, "SecureBoot enabled", false),
-			Entry("should enable EFI secure boot with firmware auto-selection", Serial, true, "SecureBoot enabled", true),
+			Entry("should enable EFI secure boot with firmware auto-selection", Serial, decorators.RequiresFeatureGate(featuregate.FirmwareAutoSelection), true, "SecureBoot enabled", true),
 		)
 
 		Context("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:component]Support memory over commitment test", func() {

--- a/tests/vmi_hook_sidecar_test.go
+++ b/tests/vmi_hook_sidecar_test.go
@@ -41,6 +41,7 @@ import (
 	hooksv1alpha2 "kubevirt.io/kubevirt/pkg/hooks/v1alpha2"
 	hooksv1alpha3 "kubevirt.io/kubevirt/pkg/hooks/v1alpha3"
 	"kubevirt.io/kubevirt/pkg/libvmi"
+	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/decorators"
@@ -66,7 +67,7 @@ const (
 //go:embed testdata/sidecar-hook-configmap.sh
 var configMapData string
 
-var _ = Describe("[sig-compute]HookSidecars", decorators.SigCompute, func() {
+var _ = Describe("[sig-compute]HookSidecars", decorators.SigCompute, decorators.RequiresFeatureGate(featuregate.SidecarGate), func() {
 
 	var (
 		err        error

--- a/tests/vmi_hostdev_test.go
+++ b/tests/vmi_hostdev_test.go
@@ -34,7 +34,7 @@ const (
 	failedDeleteVMI = "Failed to delete VMI"
 )
 
-var _ = Describe("[sig-compute]HostDevices", Serial, decorators.SigCompute, func() {
+var _ = Describe("[sig-compute]HostDevices", Serial, decorators.SigCompute, decorators.RequiresFeatureGate(featuregate.HostDevicesGate), func() {
 	var (
 		virtClient kubecli.KubevirtClient
 		config     v1.KubeVirtConfiguration

--- a/tests/vmi_ignition_test.go
+++ b/tests/vmi_ignition_test.go
@@ -32,12 +32,13 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
+	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/libvmifact"
 )
 
-var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:component][sig-compute]IgnitionData", decorators.SigCompute, func() {
+var _ = Describe("[rfe_id:151][crit:high][vendor:cnv-qe@redhat.com][level:component][sig-compute]IgnitionData", decorators.SigCompute, decorators.RequiresFeatureGate(featuregate.IgnitionGate), func() {
 
 	BeforeEach(func() {
 		if !checks.HasFeature("ExperimentalIgnitionSupport") {

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -822,7 +822,7 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			})
 		})
 
-		Context("with node feature discovery", Serial, decorators.CPUModel, decorators.RequiresAMD64, func() {
+		Context("with node feature discovery", Serial, decorators.CPUModel, decorators.RequiresAMD64, decorators.RequiresFeatureGate(featuregate.HypervStrictCheckGate), func() {
 			var node *k8sv1.Node
 			var supportedCPU string
 			var supportedCPUs []string

--- a/tests/vmi_vsock_test.go
+++ b/tests/vmi_vsock_test.go
@@ -53,7 +53,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libvmops"
 )
 
-var _ = Describe("[sig-compute]VSOCK", Serial, decorators.SigCompute, decorators.VSOCK, func() {
+var _ = Describe("[sig-compute]VSOCK", Serial, decorators.SigCompute, decorators.VSOCK, decorators.RequiresFeatureGate(featuregate.VSOCKGate), func() {
 	var virtClient kubecli.KubevirtClient
 	var err error
 


### PR DESCRIPTION
### What this PR does
#### Before this PR:

There is no consistent way to identify which functional tests depend on specific alpha or beta feature gates. The only feature-gate-related label is `RequiresDecentralizedLiveMigration`, defined as a static decorator constant. PR #18383 removes explicit beta FG enablement from tests (since beta gates are now enabled by default), which is correct upstream but removes the only signal downstream consumers had to identify which tests need which gates.

#### After this PR:

- Introduces a `RequiresFeatureGate(gate string)` helper in `tests/decorators/` that generates `Requires${FeatureGateName}` Ginkgo labels (e.g. `RequiresVSOCK`, `RequiresSnapshot`, `RequiresPlugins`)
- Applies these labels to all functional test nodes that explicitly enable or require alpha/beta feature gates (~25 files)
- Migrates the static `RequiresDecentralizedLiveMigration` decorator to use the new helper (same label string, backward compatible)
- Migrates the standalone `ImageVolume` decorator to `RequiresImageVolume` via `RequiresFeatureGate` and updates `automation/test.sh` accordingly

### References

- Partially addresses the downstream impact of #18383

### Why we need it and why it was done in this way

Downstream environments provisioned by HCO do not always enable all beta (or alpha) feature gates. After #18383 removes explicit beta FG enablement from tests, there is no mechanism for downstream to identify which tests depend on which gates and dynamically build `--ginkgo.label-filter` expressions to exclude them.

The `RequiresFeatureGate(gate)` function approach was chosen over static per-gate decorator constants because:
- It is self-maintaining: new gates don't require adding new constants
- It produces consistent label names derived from the gate string
- It matches the existing `RequiresDecentralizedLiveMigration` pattern exactly

The following alternatives were considered:
- Static decorator constants per gate: higher maintenance burden, easy to forget
- A runtime skip mechanism: doesn't allow CI-level filtering before test execution

### Special notes for your reviewer

- The label string format is `Requires` + the feature gate name string (e.g. `RequiresVSOCK`, `RequiresSnapshot`). This matches the existing `RequiresDecentralizedLiveMigration` label exactly.
- Only tests that **explicitly** reference feature gates (via `EnableFeatureGate`, `FailTestIfNoFeatureGate`, or `HasFeature`) are labeled in this PR. Tests that implicitly depend on suite-level gates without referencing them are out of scope for a follow-up.
- No upstream CI behavior changes — the new labels are additive and invisible until explicitly used in filter expressions.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] AI Contributions: The PR abides by the KubeVirt AI Contribution Policy.

### Release note
```release-note
NONE
```