### PR TITLE
tests/network: migrate to NewInterface builder pattern

### DIFF
--- a/tests/network/bindingplugin.go
+++ b/tests/network/bindingplugin.go
@@ -75,7 +75,11 @@ var _ = Describe(SIG("network binding plugin", Serial, decorators.NetCustomBindi
 			const (
 				macAddress = "02:00:00:00:00:02"
 			)
-			passtIface := libvmi.InterfaceWithMac(libvmi.InterfaceWithPasstBindingPlugin(), macAddress)
+			passtIface := libvmi.NewInterface(
+				v1.DefaultPodNetwork().Name,
+				libvmi.WithBindingPlugin(v1.PluginBinding{Name: "passt"}),
+				libvmi.WithMac(macAddress),
+			)
 			vmi := libvmifact.NewAlpineWithTestTooling(
 				libvmi.WithInterface(passtIface),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
@@ -131,12 +135,12 @@ var _ = Describe(SIG("network binding plugin", Serial, decorators.NetCustomBindi
 			chosenMAC = chosenMACHW.String()
 
 			ifaceName := "macvtapIface"
-			macvtapIface := libvmi.InterfaceWithBindingPlugin(
-				ifaceName, v1.PluginBinding{Name: macvtapBindingName},
-			)
 			vmi = libvmifact.NewAlpineWithTestTooling(
-				libvmi.WithInterface(
-					libvmi.InterfaceWithMac(macvtapIface, chosenMAC)),
+				libvmi.WithInterface(libvmi.NewInterface(
+					ifaceName,
+					libvmi.WithBindingPlugin(v1.PluginBinding{Name: macvtapBindingName}),
+					libvmi.WithMac(chosenMAC),
+				)),
 				libvmi.WithNetwork(libvmi.MultusNetwork(ifaceName, macvtapNetworkName)))
 
 			namespace := testsuite.GetTestNamespace(nil)
@@ -170,8 +174,9 @@ var _ = Describe(SIG("network binding plugin", Serial, decorators.NetCustomBindi
 		It("can run a virtual machine with one primary managed-tap interface", func() {
 			var vmi *v1.VirtualMachineInstance
 
-			primaryIface := libvmi.InterfaceWithBindingPlugin(
-				networkName, v1.PluginBinding{Name: bindingName},
+			primaryIface := libvmi.NewInterface(
+				networkName,
+				libvmi.WithBindingPlugin(v1.PluginBinding{Name: bindingName}),
 			)
 			vmi = libvmifact.NewAlpineWithTestTooling(
 				libvmi.WithInterface(primaryIface),
@@ -212,9 +217,6 @@ var _ = Describe(SIG("network binding plugin", Serial, decorators.NetCustomBindi
 			_, err := libnet.CreateNetAttachDef(context.Background(), namespace, netAttachDef)
 			Expect(err).ToNot(HaveOccurred())
 
-			primaryIface := libvmi.InterfaceWithBindingPlugin(
-				"mynet1", v1.PluginBinding{Name: bindingName},
-			)
 			primaryNetwork := v1.Network{
 				Name: "mynet1",
 				NetworkSource: v1.NetworkSource{
@@ -225,12 +227,20 @@ var _ = Describe(SIG("network binding plugin", Serial, decorators.NetCustomBindi
 				},
 			}
 			serverVMI := libvmifact.NewAlpineWithTestTooling(
-				libvmi.WithInterface(libvmi.InterfaceWithMac(primaryIface, "de:ad:00:00:be:af")),
+				libvmi.WithInterface(libvmi.NewInterface(
+					"mynet1",
+					libvmi.WithBindingPlugin(v1.PluginBinding{Name: bindingName}),
+					libvmi.WithMac("de:ad:00:00:be:af"),
+				)),
 				libvmi.WithNetwork(&primaryNetwork),
 				libvmi.WithNodeAffinityFor(nodeName),
 			)
 			clientVMI := libvmifact.NewAlpineWithTestTooling(
-				libvmi.WithInterface(libvmi.InterfaceWithMac(primaryIface, "de:ad:00:00:be:aa")),
+				libvmi.WithInterface(libvmi.NewInterface(
+					"mynet1",
+					libvmi.WithBindingPlugin(v1.PluginBinding{Name: bindingName}),
+					libvmi.WithMac("de:ad:00:00:be:aa"),
+				)),
 				libvmi.WithNetwork(&primaryNetwork),
 				libvmi.WithNodeAffinityFor(nodeName),
 			)

--- a/tests/network/bindingplugin_macvtap.go
+++ b/tests/network/bindingplugin_macvtap.go
@@ -90,7 +90,10 @@ var _ = Describe(SIG("VirtualMachineInstance with macvtap network binding plugin
 		nodeName := nodeList.Items[0].Name
 
 		opts := []libvmi.Option{
-			libvmi.WithInterface(libvmi.InterfaceWithMacvtapBindingPlugin(macvtapNetworkName)),
+			libvmi.WithInterface(libvmi.NewInterface(
+				macvtapNetworkName,
+				libvmi.WithBindingPlugin(v1.PluginBinding{Name: "macvtap"}),
+			)),
 			libvmi.WithNetwork(libvmi.MultusNetwork(macvtapNetworkName, macvtapNetworkName)),
 			libvmi.WithNodeAffinityFor(nodeName),
 		}
@@ -118,8 +121,11 @@ var _ = Describe(SIG("VirtualMachineInstance with macvtap network binding plugin
 
 		BeforeEach(func() {
 			clientVMI = libvmifact.NewAlpineWithTestTooling(
-				libvmi.WithInterface(libvmi.InterfaceWithMac(
-					libvmi.InterfaceWithMacvtapBindingPlugin("test"), clientMAC)),
+				libvmi.WithInterface(libvmi.NewInterface(
+					"test",
+					libvmi.WithBindingPlugin(v1.PluginBinding{Name: "macvtap"}),
+					libvmi.WithMac(clientMAC),
+				)),
 				libvmi.WithNetwork(libvmi.MultusNetwork("test", macvtapNetworkName)),
 			)
 			var err error
@@ -148,9 +154,13 @@ var _ = Describe(SIG("VirtualMachineInstance with macvtap network binding plugin
 
 			BeforeEach(func() {
 				serverVMI = libvmifact.NewFedora(
-					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
-					libvmi.WithInterface(libvmi.InterfaceWithMac(
-						libvmi.InterfaceWithMacvtapBindingPlugin(macvtapNetworkName), serverMAC)),
+					libvmi.WithInterface(libvmi.NewInterface(
+						v1.DefaultPodNetwork().Name, libvmi.WithMasqueradeBinding())),
+					libvmi.WithInterface(libvmi.NewInterface(
+						macvtapNetworkName,
+						libvmi.WithBindingPlugin(v1.PluginBinding{Name: "macvtap"}),
+						libvmi.WithMac(serverMAC),
+					)),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					libvmi.WithNetwork(libvmi.MultusNetwork(macvtapNetworkName, macvtapNetworkName)),
 				)

--- a/tests/network/hotplug_sriov.go
+++ b/tests/network/hotplug_sriov.go
@@ -165,29 +165,14 @@ func createSRIOVNetworkAttachmentDefinition(namespace, networkName, sriovResourc
 	return err
 }
 
-func newSRIOVNetworkInterface(name, netAttachDefName string) (v1.Network, v1.Interface) {
-	network := v1.Network{
-		Name: name,
-		NetworkSource: v1.NetworkSource{
-			Multus: &v1.MultusNetwork{
-				NetworkName: netAttachDefName,
-			},
-		},
-	}
-	iface := v1.Interface{
-		Name:                   name,
-		InterfaceBindingMethod: v1.InterfaceBindingMethod{SRIOV: &v1.InterfaceSRIOV{}},
-	}
-	return network, iface
-}
-
 func addSRIOVInterface(vm *v1.VirtualMachine, name, netAttachDefName string) error {
-	newNetwork, newIface := newSRIOVNetworkInterface(name, netAttachDefName)
 	mac, err := libnet.GenerateRandomMac()
 	if err != nil {
 		return err
 	}
-	return libnet.PatchVMWithNewInterface(vm, newNetwork, libvmi.InterfaceWithMac(newIface, mac.String()))
+	newNetwork := *libvmi.MultusNetwork(name, netAttachDefName)
+	newIface := libvmi.NewInterface(name, libvmi.WithSRIOVBinding(), libvmi.WithMac(mac.String()))
+	return libnet.PatchVMWithNewInterface(vm, newNetwork, newIface)
 }
 
 func verifySriovDynamicInterfaceChange(vmi *v1.VirtualMachineInstance) *v1.VirtualMachineInstance {

--- a/tests/network/multiqueue.go
+++ b/tests/network/multiqueue.go
@@ -50,7 +50,11 @@ var _ = Describe(SIG("MultiQueue VMI", func() {
 			)
 
 			vmi := libvmifact.NewFedora(
-				libvmi.WithInterface(libvmi.InterfaceWithModel(libvmi.InterfaceDeviceWithMasqueradeBinding(), interfaceModel)),
+				libvmi.WithInterface(libvmi.NewInterface(
+					v1.DefaultPodNetwork().Name,
+					libvmi.WithMasqueradeBinding(),
+					libvmi.WithModel(interfaceModel),
+				)),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 				libvmi.WithNetworkInterfaceMultiQueue(true),
 				libvmi.WithCPUCount(numCpus, 1, 1),

--- a/tests/network/nad_live_update.go
+++ b/tests/network/nad_live_update.go
@@ -236,7 +236,7 @@ func newVMIWithAffinity(name, nad, ip, node string) (*v1.VirtualMachineInstance,
 	}
 	vmi := libvmifact.NewAlpineWithTestTooling(
 		libvmi.WithName(name),
-		libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(ifaceName)),
+		libvmi.WithInterface(libvmi.NewInterface(ifaceName, libvmi.WithBridgeBinding())),
 		libvmi.WithNetwork(libvmi.MultusNetwork(ifaceName, nad)),
 		libvmi.WithNodeAffinityFor(node),
 		libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(networkData1)),

--- a/tests/network/port_forward.go
+++ b/tests/network/port_forward.go
@@ -167,7 +167,11 @@ func killPortForwardCommand(portForwardCmd *exec.Cmd) error {
 func createAlpineVMIWithPortsAndBlockUntilReady(virtClient kubecli.KubevirtClient, ports []v1.Port) *v1.VirtualMachineInstance {
 	vmi := libvmifact.NewAlpineWithTestTooling(
 		libvmi.WithNetwork(v1.DefaultPodNetwork()),
-		libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding(ports...)),
+		libvmi.WithInterface(libvmi.NewInterface(
+			v1.DefaultPodNetwork().Name,
+			libvmi.WithMasqueradeBinding(),
+			libvmi.WithPorts(ports...),
+		)),
 	)
 
 	vmi, err := virtClient.VirtualMachineInstance(testsuite.NamespaceTestDefault).Create(context.Background(), vmi, metav1.CreateOptions{})

--- a/tests/network/primary_pod_network.go
+++ b/tests/network/primary_pod_network.go
@@ -71,7 +71,7 @@ var _ = Describe(SIG("Primary Pod Network", func() {
 					libnet.SkipWhenClusterNotSupportIpv4()
 					var err error
 
-					vmi, err = newFedoraWithGuestAgentAndDefaultInterface(libvmi.InterfaceDeviceWithBridgeBinding(v1.DefaultPodNetwork().Name))
+					vmi, err = newFedoraWithGuestAgentAndDefaultInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithBridgeBinding()))
 					Expect(err).NotTo(HaveOccurred())
 
 					vmi, err = virtClient.VirtualMachineInstance(testsuite.NamespaceTestDefault).Create(context.Background(), vmi, metav1.CreateOptions{})
@@ -100,7 +100,8 @@ var _ = Describe(SIG("Primary Pod Network", func() {
 				var vmi *v1.VirtualMachineInstance
 
 				BeforeEach(func() {
-					tmpVmi, err := newFedoraWithGuestAgentAndDefaultInterface(libvmi.InterfaceDeviceWithMasqueradeBinding())
+					tmpVmi, err := newFedoraWithGuestAgentAndDefaultInterface(
+						libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithMasqueradeBinding()))
 					Expect(err).NotTo(HaveOccurred())
 
 					tmpVmi, err = virtClient.VirtualMachineInstance(testsuite.NamespaceTestDefault).Create(context.Background(), tmpVmi, metav1.CreateOptions{})

--- a/tests/network/services.go
+++ b/tests/network/services.go
@@ -73,7 +73,7 @@ var _ = Describe(SIG("Services", func() {
 			libnet.SkipWhenClusterNotSupportIpv4()
 
 			inboundVMI = libvmifact.NewAlpineWithTestTooling(
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(v1.DefaultPodNetwork().Name)),
+				libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithBridgeBinding())),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 				libvmi.WithLabel(selectorLabelKey, selectorLabelValue),
 				libvmi.WithSubdomain("vmi"),

--- a/tests/network/sriov.go
+++ b/tests/network/sriov.go
@@ -118,9 +118,11 @@ var _ = Describe(SIG("SRIOV", Serial, decorators.SRIOV, func() {
 				libvmi.WithCloudInitConfigDrive(libvmici.WithConfigDriveNetworkData(defaultCloudInitNetworkData())),
 				libvmi.WithCPUCount(4, 0, 0),
 				libvmi.WithDedicatedCPUPlacement(),
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+				libvmi.WithInterface(libvmi.NewInterface(
+					v1.DefaultPodNetwork().Name, libvmi.WithMasqueradeBinding())),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
-				libvmi.WithInterface(libvmi.InterfaceWithTag(libvmi.InterfaceDeviceWithSRIOVBinding(sriovnet1), "specialNet")),
+				libvmi.WithInterface(libvmi.NewInterface(
+					sriovnet1, libvmi.WithSRIOVBinding(), libvmi.WithTag("specialNet"))),
 				libvmi.WithNetwork(libvmi.MultusNetwork(sriovnet1, sriovnet1)),
 			)
 			vmi, err := createVMIAndWait(vmi)
@@ -353,7 +355,8 @@ var _ = Describe(SIG("SRIOV", Serial, decorators.SRIOV, func() {
 				)
 				vmi := libvmifact.NewAlpineWithTestTooling(
 					libvmi.WithGuestMemory(initialGuestMemory),
-					libvmi.WithInterface(libvmi.InterfaceWithMac(libvmi.InterfaceDeviceWithSRIOVBinding(sriovNetworkLogicalName), mac)),
+					libvmi.WithInterface(libvmi.NewInterface(
+						sriovNetworkLogicalName, libvmi.WithSRIOVBinding(), libvmi.WithMac(mac))),
 					libvmi.WithNetwork(libvmi.MultusNetwork(sriovNetworkLogicalName, sriovnet1)),
 				)
 				vmi.Spec.Domain.Resources.Requests = nil
@@ -426,11 +429,14 @@ var _ = Describe(SIG("SRIOV", Serial, decorators.SRIOV, func() {
 		It("[test_id:1755]should create a virtual machine with two sriov interfaces referring the same resource", func() {
 			vmi := libvmifact.NewFedora(
 				libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(defaultCloudInitNetworkData())),
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+				libvmi.WithInterface(libvmi.NewInterface(
+					v1.DefaultPodNetwork().Name, libvmi.WithMasqueradeBinding())),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
-				libvmi.WithInterface(libvmi.InterfaceWithPciAddress(libvmi.InterfaceDeviceWithSRIOVBinding(sriovnet1), "0000:06:00.0")),
+				libvmi.WithInterface(libvmi.NewInterface(
+					sriovnet1, libvmi.WithSRIOVBinding(), libvmi.WithPciAddress("0000:06:00.0"))),
 				libvmi.WithNetwork(libvmi.MultusNetwork(sriovnet1, sriovnet1)),
-				libvmi.WithInterface(libvmi.InterfaceWithPciAddress(libvmi.InterfaceDeviceWithSRIOVBinding(sriovnet2), "0000:07:00.0")),
+				libvmi.WithInterface(libvmi.NewInterface(
+					sriovnet2, libvmi.WithSRIOVBinding(), libvmi.WithPciAddress("0000:07:00.0"))),
 				libvmi.WithNetwork(libvmi.MultusNetwork(sriovnet2, sriovnet2)),
 			)
 
@@ -682,13 +688,14 @@ func findIfaceByMAC(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMachineIns
 
 func newSRIOVVmi(networks []string, opts ...libvmi.Option) *v1.VirtualMachineInstance {
 	options := []libvmi.Option{
-		libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+		libvmi.WithInterface(libvmi.NewInterface(
+			v1.DefaultPodNetwork().Name, libvmi.WithMasqueradeBinding())),
 		libvmi.WithNetwork(v1.DefaultPodNetwork()),
 	}
 
 	for _, name := range networks {
 		options = append(options,
-			libvmi.WithInterface(libvmi.InterfaceDeviceWithSRIOVBinding(name)),
+			libvmi.WithInterface(libvmi.NewInterface(name, libvmi.WithSRIOVBinding())),
 			libvmi.WithNetwork(libvmi.MultusNetwork(name, name)),
 		)
 	}

--- a/tests/network/vmi_infosource.go
+++ b/tests/network/vmi_infosource.go
@@ -80,14 +80,23 @@ var _ = Describe(SIG("Infosource", func() {
 			_, err := libnet.CreateNetAttachDef(context.Background(), testsuite.NamespaceTestDefault, netAttachDef)
 			Expect(err).NotTo(HaveOccurred())
 
-			defaultBridgeInterface := libvmi.InterfaceDeviceWithBridgeBinding(primaryNetwork)
-			secondaryLinuxBridgeInterface1 := libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetwork1.Name)
-			secondaryLinuxBridgeInterface2 := libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetwork2.Name)
 			vmiSpec := libvmifact.NewFedora(
-				libvmi.WithInterface(libvmi.InterfaceWithMac(defaultBridgeInterface, primaryInterfaceMac)),
+				libvmi.WithInterface(libvmi.NewInterface(
+					primaryNetwork,
+					libvmi.WithBridgeBinding(),
+					libvmi.WithMac(primaryInterfaceMac),
+				)),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
-				libvmi.WithInterface(libvmi.InterfaceWithMac(secondaryLinuxBridgeInterface1, secondaryInterface1Mac)),
-				libvmi.WithInterface(libvmi.InterfaceWithMac(secondaryLinuxBridgeInterface2, secondaryInterface2Mac)),
+				libvmi.WithInterface(libvmi.NewInterface(
+					secondaryNetwork1.Name,
+					libvmi.WithBridgeBinding(),
+					libvmi.WithMac(secondaryInterface1Mac),
+				)),
+				libvmi.WithInterface(libvmi.NewInterface(
+					secondaryNetwork2.Name,
+					libvmi.WithBridgeBinding(),
+					libvmi.WithMac(secondaryInterface2Mac),
+				)),
 				libvmi.WithNetwork(secondaryNetwork1),
 				libvmi.WithNetwork(secondaryNetwork2),
 				libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudUserData(manipulateGuestLinksScript(primaryInterfaceNewMac, dummyInterfaceMac))))

--- a/tests/network/vmi_istio.go
+++ b/tests/network/vmi_istio.go
@@ -204,7 +204,8 @@ var istioTests = func(vmType VmType) {
 
 				bastionVMI = libvmifact.NewCirros(
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
-					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding([]v1.Port{}...)),
+					libvmi.WithInterface(libvmi.NewInterface(
+						v1.DefaultPodNetwork().Name, libvmi.WithMasqueradeBinding())),
 				)
 
 				bastionVMI, err = virtClient.VirtualMachineInstance(namespace).Create(context.Background(), bastionVMI, metav1.CreateOptions{})
@@ -333,7 +334,8 @@ var istioTests = func(vmType VmType) {
 
 				serverVMI = libvmifact.NewAlpineWithTestTooling(
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
-					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding([]v1.Port{}...)),
+					libvmi.WithInterface(libvmi.NewInterface(
+						v1.DefaultPodNetwork().Name, libvmi.WithMasqueradeBinding())),
 					libvmi.WithLabel("version", "v1"),
 					libvmi.WithLabel(vmiAppSelectorKey, vmiServerAppSelectorValue),
 					libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(networkData)),
@@ -472,7 +474,11 @@ func createMasqueradeVm(ports []v1.Port) *v1.VirtualMachineInstance {
 	networkData := cloudinit.CreateDefaultCloudInitNetworkData()
 	vmi := libvmifact.NewAlpineWithTestTooling(
 		libvmi.WithNetwork(v1.DefaultPodNetwork()),
-		libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding(ports...)),
+		libvmi.WithInterface(libvmi.NewInterface(
+			v1.DefaultPodNetwork().Name,
+			libvmi.WithMasqueradeBinding(),
+			libvmi.WithPorts(ports...),
+		)),
 		libvmi.WithLabel(vmiAppSelectorKey, vmiAppSelectorValue),
 		libvmi.WithAnnotation(istio.InjectSidecarAnnotation, "true"),
 		libvmi.WithCloudInitNoCloud(
@@ -484,8 +490,8 @@ func createMasqueradeVm(ports []v1.Port) *v1.VirtualMachineInstance {
 }
 
 func createPasstVm(ports []v1.Port) *v1.VirtualMachineInstance {
-	passtIface := libvmi.InterfaceDeviceWithPasstBinding(v1.DefaultPodNetwork().Name)
-	passtIface.Ports = ports
+	passtIface := libvmi.NewInterface(
+		v1.DefaultPodNetwork().Name, libvmi.WithPasstBinding(), libvmi.WithPorts(ports...))
 	vmi := libvmifact.NewAlpineWithTestTooling(
 		libvmi.WithNetwork(v1.DefaultPodNetwork()),
 		libvmi.WithInterface(passtIface),

--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -104,8 +104,8 @@ var _ = Describe(SIG("Multus", Serial, decorators.Multus, func() {
 
 	var nodes *k8sv1.NodeList
 
-	linuxBridgeInterface := libvmi.InterfaceDeviceWithBridgeBinding(linuxBridgeIfaceName)
-	linuxBridgeInterfaceWithIPAM := libvmi.InterfaceDeviceWithBridgeBinding(linuxBridgeWithIPAMIfaceName)
+	linuxBridgeInterface := libvmi.NewInterface(linuxBridgeIfaceName, libvmi.WithBridgeBinding())
+	linuxBridgeInterfaceWithIPAM := libvmi.NewInterface(linuxBridgeWithIPAMIfaceName, libvmi.WithBridgeBinding())
 
 	linuxBridgeNetwork := v1.Network{
 		Name: linuxBridgeIfaceName,
@@ -167,7 +167,7 @@ var _ = Describe(SIG("Multus", Serial, decorators.Multus, func() {
 				By("checking virtual machine instance can ping using ptp cni plugin")
 				detachedVMI := libvmifact.NewAlpineWithTestTooling(
 					libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(networkData)),
-					libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding("ptp")),
+					libvmi.WithInterface(libvmi.NewInterface("ptp", libvmi.WithBridgeBinding())),
 					libvmi.WithNetwork(libvmi.MultusNetwork("ptp", fmt.Sprintf("%s/%s", testsuite.NamespaceTestAlternative, ptpConf2))),
 				)
 
@@ -182,8 +182,9 @@ var _ = Describe(SIG("Multus", Serial, decorators.Multus, func() {
 				By("checking virtual machine instance can ping using ptp cni plugin")
 				const secondaryNetName = "ptp"
 				detachedVMI := libvmifact.NewAlpineWithTestTooling(
-					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
-					libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetName)),
+					libvmi.WithInterface(libvmi.NewInterface(
+						v1.DefaultPodNetwork().Name, libvmi.WithMasqueradeBinding())),
+					libvmi.WithInterface(libvmi.NewInterface(secondaryNetName, libvmi.WithBridgeBinding())),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					libvmi.WithNetwork(libvmi.MultusNetwork(secondaryNetName, ptpConf1)),
 				)
@@ -223,7 +224,7 @@ var _ = Describe(SIG("Multus", Serial, decorators.Multus, func() {
 				Expect(err).NotTo(HaveOccurred())
 				detachedVMI := libvmifact.NewAlpineWithTestTooling(
 					libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(networkData)),
-					libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding("ptp")),
+					libvmi.WithInterface(libvmi.NewInterface("ptp", libvmi.WithBridgeBinding())),
 					libvmi.WithNetwork(&v1.Network{
 						Name: "ptp",
 						NetworkSource: v1.NetworkSource{
@@ -373,7 +374,8 @@ var _ = Describe(SIG("Multus", Serial, decorators.Multus, func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				vmiTwo := libvmifact.NewFedora(
-					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+					libvmi.WithInterface(libvmi.NewInterface(
+						v1.DefaultPodNetwork().Name, libvmi.WithMasqueradeBinding())),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					libvmi.WithInterface(linuxBridgeInterface),
 					libvmi.WithNetwork(&linuxBridgeNetwork),
@@ -387,7 +389,8 @@ var _ = Describe(SIG("Multus", Serial, decorators.Multus, func() {
 
 			It("[test_id:676]should configure valid custom MAC address on Linux bridge CNI interface.", decorators.WgS390x, func() {
 				By("Creating another VM with custom MAC address on its Linux bridge CNI interface.")
-				linuxBridgeInterfaceWithCustomMac := libvmi.InterfaceWithMac(linuxBridgeInterface, customMacAddress)
+				linuxBridgeInterfaceWithCustomMac := libvmi.NewInterface(
+					linuxBridgeIfaceName, libvmi.WithBridgeBinding(), libvmi.WithMac(customMacAddress))
 
 				networkData, err := cloudinit.NewNetworkData(
 					cloudinit.WithEthernet("eth1",
@@ -398,7 +401,8 @@ var _ = Describe(SIG("Multus", Serial, decorators.Multus, func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				vmi := libvmifact.NewFedora(
-					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+					libvmi.WithInterface(libvmi.NewInterface(
+						v1.DefaultPodNetwork().Name, libvmi.WithMasqueradeBinding())),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					libvmi.WithInterface(linuxBridgeInterfaceWithCustomMac),
 					libvmi.WithNetwork(&linuxBridgeNetwork),
@@ -539,10 +543,9 @@ var _ = Describe(SIG("Multus", Serial, decorators.Multus, func() {
 					Expect(err).NotTo(HaveOccurred())
 					spoofedMacAddressStr := spoofedMacAddress.String()
 
-					linuxBridgeInterfaceWithMACSpoofCheck := libvmi.InterfaceDeviceWithBridgeBinding(linuxBridgeWithMACSpoofCheckNetwork)
-
 					By("Creating a VM with custom MAC address on its Linux bridge CNI interface.")
-					linuxBridgeInterfaceWithCustomMac := libvmi.InterfaceWithMac(linuxBridgeInterfaceWithMACSpoofCheck, initialMacAddressStr)
+					linuxBridgeInterfaceWithCustomMac := libvmi.NewInterface(
+						linuxBridgeWithMACSpoofCheckNetwork, libvmi.WithBridgeBinding(), libvmi.WithMac(initialMacAddressStr))
 
 					networkData, err := cloudinit.NewNetworkData(
 						cloudinit.WithEthernet(linuxBridgeInterfaceWithCustomMac.Name,
@@ -570,7 +573,8 @@ var _ = Describe(SIG("Multus", Serial, decorators.Multus, func() {
 					Expect(err).NotTo(HaveOccurred())
 
 					targetVmi := libvmifact.NewFedora(
-						libvmi.WithInterface(linuxBridgeInterfaceWithMACSpoofCheck),
+						libvmi.WithInterface(libvmi.NewInterface(
+							linuxBridgeWithMACSpoofCheckNetwork, libvmi.WithBridgeBinding())),
 						libvmi.WithNetwork(libvmi.MultusNetwork(linuxBridgeWithMACSpoofCheckNetwork, linuxBridgeWithMACSpoofCheckNetwork)),
 						libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(targetNetworkData)),
 						libvmi.WithNodeAffinityFor(nodes.Items[0].Name),

--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -209,16 +209,20 @@ var _ = Describe(SIG("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:
 
 		It("[test_id:1770]should expose the right device type to the guest", func() {
 			By("checking the device vendor in /sys/class")
-			e1000ModelIface := libvmi.InterfaceWithModel(libvmi.InterfaceDeviceWithMasqueradeBinding(), "e1000")
-			e1000ModelIface.PciAddress = "0000:02:01.0"
-
-			const secondaryNetName = "secondary-net"
-			defaultModelIface := libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetName)
-			defaultModelIface.PciAddress = "0000:03:00.0"
+			const (
+				secondaryNetName  = "secondary-net"
+				e1000PciAddress   = "0000:02:01.0"
+				defaultPciAddress = "0000:03:00.0"
+			)
 			vmi := libvmifact.NewAlpine(
-				libvmi.WithInterface(e1000ModelIface),
+				libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name,
+					libvmi.WithMasqueradeBinding(), libvmi.WithModel("e1000"),
+					libvmi.WithPciAddress(e1000PciAddress),
+				)),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
-				libvmi.WithInterface(defaultModelIface),
+				libvmi.WithInterface(libvmi.NewInterface(secondaryNetName,
+					libvmi.WithBridgeBinding(), libvmi.WithPciAddress(defaultPciAddress),
+				)),
 				libvmi.WithNetwork(libvmi.MultusNetwork(secondaryNetName, nadName)),
 			)
 
@@ -239,9 +243,9 @@ var _ = Describe(SIG("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:
 			err = console.SafeExpectBatch(vmi, []expect.Batcher{
 				&expect.BSnd{S: "\n"},
 				&expect.BExp{R: ""},
-				&expect.BSnd{S: fmt.Sprintf(vendorCmd, e1000ModelIface.PciAddress)},
+				&expect.BSnd{S: fmt.Sprintf(vendorCmd, e1000PciAddress)},
 				&expect.BExp{R: intelVendorID},
-				&expect.BSnd{S: fmt.Sprintf(vendorCmd, defaultModelIface.PciAddress)},
+				&expect.BSnd{S: fmt.Sprintf(vendorCmd, defaultPciAddress)},
 				&expect.BExp{R: redhatVendorID},
 			}, 40)
 			Expect(err).ToNot(HaveOccurred())
@@ -401,7 +405,11 @@ var _ = Describe(SIG("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:
 				net.NetworkSource.Pod.VMNetworkCIDR = ipv4NetworkCIDR
 			}
 			return libvmifact.NewAlpineWithTestTooling(
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding(ports...)),
+				libvmi.WithInterface(libvmi.NewInterface(
+					v1.DefaultPodNetwork().Name,
+					libvmi.WithMasqueradeBinding(),
+					libvmi.WithPorts(ports...),
+				)),
 				libvmi.WithNetwork(net),
 			)
 		}
@@ -705,7 +713,8 @@ var _ = Describe(SIG("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:
 				Expect(err).ToNot(HaveOccurred())
 
 				vmi = libvmifact.NewFedora(
-					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+					libvmi.WithInterface(libvmi.NewInterface(
+						v1.DefaultPodNetwork().Name, libvmi.WithMasqueradeBinding())),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(networkData)),
 				)
@@ -796,7 +805,11 @@ func newFedoraMasqueradeIPv6VMI(ports []v1.Port, ipv6NetworkCIDR string) (*v1.Vi
 	net := v1.DefaultPodNetwork()
 	net.Pod.VMIPv6NetworkCIDR = ipv6NetworkCIDR
 	vmi := libvmifact.NewFedora(
-		libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding(ports...)),
+		libvmi.WithInterface(libvmi.NewInterface(
+			v1.DefaultPodNetwork().Name,
+			libvmi.WithMasqueradeBinding(),
+			libvmi.WithPorts(ports...),
+		)),
 		libvmi.WithNetwork(net),
 		libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(networkData)),
 	)
@@ -855,7 +868,8 @@ func runVMI(vmi *v1.VirtualMachineInstance) *v1.VirtualMachineInstance {
 
 func vmiWithCustomMacAddress(mac string) *v1.VirtualMachineInstance {
 	return libvmifact.NewAlpineWithTestTooling(
-		libvmi.WithInterface(libvmi.InterfaceWithMac(*v1.DefaultBridgeNetworkInterface(), mac)),
+		libvmi.WithInterface(libvmi.NewInterface(
+			v1.DefaultPodNetwork().Name, libvmi.WithBridgeBinding(), libvmi.WithMac(mac))),
 		libvmi.WithNetwork(v1.DefaultPodNetwork()))
 }
 

--- a/tests/network/vmi_subdomain.go
+++ b/tests/network/vmi_subdomain.go
@@ -163,14 +163,14 @@ var _ = Describe(SIG("Subdomain", func() {
 
 func fedoraMasqueradeVMI(opts ...libvmi.Option) *v1.VirtualMachineInstance {
 	return libvmifact.NewFedora(append([]libvmi.Option{
-		libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+		libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithMasqueradeBinding())),
 		libvmi.WithNetwork(v1.DefaultPodNetwork()),
 	}, opts...)...)
 }
 
 func fedoraBridgeBindingVMI(opts ...libvmi.Option) *v1.VirtualMachineInstance {
 	return libvmifact.NewFedora(append([]libvmi.Option{
-		libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(v1.DefaultPodNetwork().Name)),
+		libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithBridgeBinding())),
 		libvmi.WithNetwork(v1.DefaultPodNetwork()),
 	}, opts...)...)
 }


### PR DESCRIPTION
### What this PR does
#### Before this PR:
Test files in `tests/network/` use legacy interface builders (`InterfaceDeviceWith*`, `InterfaceWith*`) to construct interfaces.

#### After this PR:
All 14 remaining test files in `tests/network/` use `NewInterface` with option functions (`WithMasqueradeBinding`, `WithBridgeBinding`, `WithMac`, etc.) introduced in #18263.

This is the first in a series of migration PRs — scoped to `tests/network/` to keep it reviewable and avoid conflicts with other areas.

### References

Follow-up to #18263 as requested by @EdDev.

### Why we need it and why it was done in this way

Migrating callers to the new builder pattern is a prerequisite for eventually deprecating the legacy functions. Splitting by directory keeps PRs small and reduces merge conflict risk.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

/kind cleanup

```release-note
NONE
```