### PR TITLE
plugin VAP: use objectSelector instead of matchConditions for label filtering

### DIFF
--- a/pkg/virt-operator/resource/generate/components/validatingadmissionpolicies/BUILD.bazel
+++ b/pkg/virt-operator/resource/generate/components/validatingadmissionpolicies/BUILD.bazel
@@ -28,6 +28,7 @@ go_test(
     race = "on",
     deps = [
         ":go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/api/plugin/v1alpha1:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/google/cel-go/cel:go_default_library",

--- a/pkg/virt-operator/resource/generate/components/validatingadmissionpolicies/validatingadmissionpolicy_sidecar.go
+++ b/pkg/virt-operator/resource/generate/components/validatingadmissionpolicies/validatingadmissionpolicy_sidecar.go
@@ -50,6 +50,11 @@ func NewSidecarSubPathValidatingAdmissionPolicy() *admissionregistrationv1.Valid
 		Spec: admissionregistrationv1.ValidatingAdmissionPolicySpec{
 			FailurePolicy: pointer.P(admissionregistrationv1.Fail),
 			MatchConstraints: &admissionregistrationv1.MatchResources{
+				ObjectSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						v1.AppLabel: "virt-launcher",
+					},
+				},
 				ResourceRules: []admissionregistrationv1.NamedRuleWithOperations{
 					{
 						RuleWithOperations: admissionregistrationv1.RuleWithOperations{
@@ -64,12 +69,6 @@ func NewSidecarSubPathValidatingAdmissionPolicy() *admissionregistrationv1.Valid
 							},
 						},
 					},
-				},
-			},
-			MatchConditions: []admissionregistrationv1.MatchCondition{
-				{
-					Name:       "is-virt-launcher-pod",
-					Expression: `has(object.metadata.labels) && "kubevirt.io" in object.metadata.labels && object.metadata.labels["kubevirt.io"] == "virt-launcher"`,
 				},
 			},
 			Variables: []admissionregistrationv1.Variable{

--- a/pkg/virt-operator/resource/generate/components/validatingadmissionpolicies/validatingadmissionpolicy_sidecar_test.go
+++ b/pkg/virt-operator/resource/generate/components/validatingadmissionpolicies/validatingadmissionpolicy_sidecar_test.go
@@ -29,6 +29,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	v1 "kubevirt.io/api/core/v1"
 	pluginv1alpha1 "kubevirt.io/api/plugin/v1alpha1"
 
 	vap "kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/components/validatingadmissionpolicies"
@@ -71,6 +72,14 @@ func pluginVolumeMount(subPath string) corev1.VolumeMount {
 
 var _ = Describe("Sidecar ValidatingAdmissionPolicies", func() {
 	Context("SidecarSubPath policy", func() {
+		It("should use objectSelector to match virt-launcher pods", func() {
+			policy := vap.NewSidecarSubPathValidatingAdmissionPolicy()
+			Expect(policy.Spec.MatchConstraints).ToNot(BeNil())
+			Expect(policy.Spec.MatchConstraints.ObjectSelector).ToNot(BeNil())
+			Expect(policy.Spec.MatchConstraints.ObjectSelector.MatchLabels).To(HaveKeyWithValue(v1.AppLabel, "virt-launcher"))
+			Expect(policy.Spec.MatchConditions).To(BeEmpty())
+		})
+
 		It("should allow compute container without subPath", func() {
 			pod := launcherPod(corev1.Container{
 				Name:         "compute",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
The sidecar subpath VAP was using a matchConditions CEL expression to
filter for virt-launcher pods, which causes unnecessary CEL evaluation
on every pod create/update. Replace with an objectSelector on
matchConstraints so non-matching pods are filtered at the API server
match stage before any CEL runs.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
https://redhat.atlassian.net/browse/CNV-92373
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: Importer pod rejected by ValidatingAdmissionPolicy 'kubevirt-plugin-sidecar-subpath-policy'
```

