### PR TITLE
virt-exportproxy: fix backend connection FD leak and inherit backend TLS config from kubevirt CR

### DIFF
--- a/cmd/virt-exportproxy/BUILD.bazel
+++ b/cmd/virt-exportproxy/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
 load("@rules_oci//oci:defs.bzl", "oci_image")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
 load("//staging/src/kubevirt.io/client-go/version:def.bzl", "version_x_defs")
@@ -61,4 +61,27 @@ oci_image(
     ],
     user = "1001",
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "virt-exportproxy_suite_test.go",
+        "virt-exportproxy_test.go",
+    ],
+    embed = [":go_default_library"],
+    race = "on",
+    deps = [
+        "//pkg/certificates/triple:go_default_library",
+        "//pkg/certificates/triple/cert:go_default_library",
+        "//pkg/testutils:go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/api/export/v1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/github.com/onsi/gomega/types:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+        "//vendor/k8s.io/client-go/tools/cache:go_default_library",
+    ],
 )

--- a/cmd/virt-exportproxy/virt-exportproxy.go
+++ b/cmd/virt-exportproxy/virt-exportproxy.go
@@ -207,6 +207,7 @@ func (app *exportProxyApp) dialBackendTLS(ctx context.Context, network, addr str
 		VerifyConnection:   app.verifyBackendConnection,
 		ServerName:         serverName,
 	}
+	kvtls.ApplyTLSConfigurationFromKubeVirtStore(cfg, app.kubeVirtStore)
 
 	tlsConn := tls.Client(conn, cfg)
 	if err := tlsConn.HandshakeContext(ctx); err != nil {

--- a/cmd/virt-exportproxy/virt-exportproxy.go
+++ b/cmd/virt-exportproxy/virt-exportproxy.go
@@ -20,13 +20,17 @@ package main
  */
 
 import (
+	"context"
 	"crypto/tls"
+	"crypto/x509"
 	"flag"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httputil"
 	"regexp"
+	"time"
 
 	kvtls "kubevirt.io/kubevirt/pkg/util/tls"
 
@@ -52,6 +56,13 @@ const (
 	apiGroup           = "export.kubevirt.io"
 	apiVersions        = "v1beta1|v1"
 	exportResourceName = "virtualmachineexports"
+
+	backendIdleConnTimeout       = 30 * time.Second
+	backendDialTimeout           = 10 * time.Second
+	backendDialKeepAlive         = 30 * time.Second
+	backendResponseHeaderTimeout = 30 * time.Second
+	serverIdleTimeout            = 60 * time.Second
+	serverReadHeaderTimeout      = 10 * time.Second
 )
 
 type exportProxyApp struct {
@@ -62,6 +73,9 @@ type exportProxyApp struct {
 	caManager       kvtls.ClientCAManager
 	exportStore     cache.Store
 	kubeVirtStore   cache.Store
+	// reverseProxy is a shared template; proxyHandler takes a shallow copy per
+	// request and sets a per-request Rewrite closure on the copy.
+	reverseProxy *httputil.ReverseProxy
 }
 
 func NewExportProxyApp() service.Service {
@@ -81,10 +95,14 @@ func (app *exportProxyApp) AddFlags() {
 func (app *exportProxyApp) Run() {
 	stopChan := make(chan struct{}, 1)
 	defer close(stopChan)
-	app.prepareInformers(stopChan)
+	if err := app.prepareInformers(stopChan); err != nil {
+		panic(err)
+	}
 
 	app.prepareCertManager()
 	go app.certManager.Start()
+
+	app.initReverseProxy()
 
 	appTLSConfig := kvtls.SetupExportProxyTLS(app.certManager, app.kubeVirtStore)
 	mux := http.NewServeMux()
@@ -93,9 +111,11 @@ func (app *exportProxyApp) Run() {
 	mux.Handle("/metrics", promhttp.Handler())
 
 	server := &http.Server{
-		Addr:      app.Address(),
-		Handler:   mux,
-		TLSConfig: appTLSConfig,
+		Addr:              app.Address(),
+		Handler:           mux,
+		TLSConfig:         appTLSConfig,
+		ReadHeaderTimeout: serverReadHeaderTimeout,
+		IdleTimeout:       serverIdleTimeout,
 		// Disable HTTP/2
 		// See CVE-2023-44487
 		TLSNextProto: map[string]func(*http.Server, *tls.Conn, http.Handler){},
@@ -132,54 +152,116 @@ func (app *exportProxyApp) proxyHandler(w http.ResponseWriter, r *http.Request) 
 	}
 
 	export := obj.(*exportv1.VirtualMachineExport)
-	if export.Status.Phase != exportv1.Ready {
+	if export.Status == nil || export.Status.Phase != exportv1.Ready {
 		w.WriteHeader(http.StatusServiceUnavailable)
 		return
 	}
 
-	host := fmt.Sprintf("%s.%s.svc:443", export.Status.ServiceName, match[2])
-	targetPath := "/" + match[4]
+	backendHost := fmt.Sprintf("%s.%s.svc:443", export.Status.ServiceName, match[2])
+	backendPath := "/" + match[4]
+	log.Log.V(4).Infof("Proxying to https://%s%s", backendHost, backendPath)
+	proxy := *app.reverseProxy
+	proxy.Rewrite = func(pr *httputil.ProxyRequest) {
+		// Route via Out (not SetURL) so the inbound path is not joined onto the target.
+		pr.Out.URL.Scheme = "https"
+		pr.Out.URL.Host = backendHost
+		pr.Out.URL.Path = backendPath
+		pr.Out.URL.RawPath = ""
+		pr.Out.Host = ""
+	}
+	proxy.ServeHTTP(w, r)
+}
+
+func (app *exportProxyApp) initReverseProxy() {
+	transport := &http.Transport{
+		DialTLSContext:        app.dialBackendTLS,
+		MaxIdleConns:          100,
+		MaxIdleConnsPerHost:   20,
+		IdleConnTimeout:       backendIdleConnTimeout,
+		ResponseHeaderTimeout: backendResponseHeaderTimeout,
+	}
+	app.reverseProxy = &httputil.ReverseProxy{
+		Transport:     transport,
+		FlushInterval: -1, // flush immediately; avoids proxy-side buffering of large export streams
+	}
+}
+
+func (app *exportProxyApp) dialBackendTLS(ctx context.Context, network, addr string) (net.Conn, error) {
+	dialer := net.Dialer{
+		Timeout:   backendDialTimeout,
+		KeepAlive: backendDialKeepAlive,
+	}
+	conn, err := dialer.DialContext(ctx, network, addr)
+	if err != nil {
+		return nil, err
+	}
+
+	serverName, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		_ = conn.Close()
+		return nil, fmt.Errorf("could not parse backend address %q: %w", addr, err)
+	}
+	cfg := &tls.Config{
+		// Neither the client nor the server should validate anything itself; VerifyConnection is still executed.
+		InsecureSkipVerify: true, // #nosec G402 -- VerifyConnection performs certificate verification
+		VerifyConnection:   app.verifyBackendConnection,
+		ServerName:         serverName,
+	}
+
+	tlsConn := tls.Client(conn, cfg)
+	if err := tlsConn.HandshakeContext(ctx); err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+	return tlsConn, nil
+}
+
+func (app *exportProxyApp) verifyBackendConnection(cs tls.ConnectionState) error {
+	if len(cs.PeerCertificates) == 0 {
+		return fmt.Errorf("backend presented no certificate")
+	}
+	if cs.ServerName == "" {
+		return fmt.Errorf("backend TLS ServerName is required")
+	}
 
 	certPool, err := app.caManager.GetCurrent()
 	if err != nil {
-		w.WriteHeader(http.StatusInternalServerError)
-		return
+		return err
 	}
 
-	p := &httputil.ReverseProxy{
-		Director: func(req *http.Request) {
-			req.URL.Scheme = "https"
-			req.URL.Host = host
-			req.URL.Path = targetPath
-			log.Log.Infof("Proxying to %s", req.URL.String())
-			if _, ok := req.Header["User-Agent"]; !ok {
-				// explicitly disable User-Agent so it's not set to default value
-				req.Header.Set("User-Agent", "")
-			}
-		},
-		Transport: &http.Transport{
-			TLSClientConfig: &tls.Config{
-				RootCAs: certPool,
-			},
-		},
+	peer := cs.PeerCertificates[0]
+	intermediates := x509.NewCertPool()
+	for _, intermediate := range cs.PeerCertificates[1:] {
+		intermediates.AddCert(intermediate)
 	}
 
-	p.ServeHTTP(w, r)
+	opts := x509.VerifyOptions{
+		Roots:         certPool,
+		Intermediates: intermediates,
+		KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSName:       cs.ServerName,
+	}
+
+	_, err = peer.Verify(opts)
+	if err != nil {
+		return fmt.Errorf("could not verify backend certificate: %w", err)
+	}
+	return nil
 }
 
-func (app *exportProxyApp) prepareInformers(stopChan <-chan struct{}) {
+func (app *exportProxyApp) prepareInformers(stopChan <-chan struct{}) error {
 	namespace, err := clientutil.GetNamespace()
 	if err != nil {
-		panic(err)
+		return fmt.Errorf("failed to get namespace: %w", err)
 	}
 
 	clientConfig, err := kubecli.GetKubevirtClientConfig()
 	if err != nil {
-		panic(err)
+		return fmt.Errorf("failed to get kubevirt client config: %w", err)
 	}
 	virtCli, err := kubecli.GetKubevirtClientFromRESTConfig(clientConfig)
 	if err != nil {
-		panic(err)
+		return fmt.Errorf("failed to create kubevirt client: %w", err)
 	}
 	aggregatorClient := aggregatorclient.NewForConfigOrDie(clientConfig)
 
@@ -191,6 +273,7 @@ func (app *exportProxyApp) prepareInformers(stopChan <-chan struct{}) {
 	kubeInformerFactory.WaitForCacheSync(stopChan)
 
 	app.caManager = kvtls.NewCAManager(caInformer.GetStore(), namespace, "kubevirt-export-ca")
+	return nil
 }
 
 func (app *exportProxyApp) prepareCertManager() {

--- a/cmd/virt-exportproxy/virt-exportproxy_suite_test.go
+++ b/cmd/virt-exportproxy/virt-exportproxy_suite_test.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"testing"
+
+	"kubevirt.io/client-go/testutils"
+)
+
+func TestVirtExportProxy(t *testing.T) {
+	testutils.KubeVirtTestSuiteSetup(t)
+}

--- a/cmd/virt-exportproxy/virt-exportproxy_test.go
+++ b/cmd/virt-exportproxy/virt-exportproxy_test.go
@@ -1,0 +1,423 @@
+package main
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"errors"
+	"fmt"
+	"io"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+
+	v1 "kubevirt.io/api/core/v1"
+	exportv1 "kubevirt.io/api/export/v1"
+
+	"kubevirt.io/kubevirt/pkg/certificates/triple"
+	certutil "kubevirt.io/kubevirt/pkg/certificates/triple/cert"
+	"kubevirt.io/kubevirt/pkg/testutils"
+)
+
+const (
+	testExportService = "virt-export"
+	testNamespace     = "default"
+	testBackendHost   = testExportService + "." + testNamespace + ".svc"
+)
+
+type mockClientCAManager struct {
+	pool *x509.CertPool
+	err  error
+}
+
+func (m *mockClientCAManager) GetCurrent() (*x509.CertPool, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return m.pool, nil
+}
+
+func (m *mockClientCAManager) GetCurrentRaw() ([]byte, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+func newTestExportProxyApp(caManager *mockClientCAManager) *exportProxyApp {
+	return &exportProxyApp{
+		caManager: caManager,
+	}
+}
+
+func newExportBackendCertChain(ca *triple.KeyPair, svcName, namespace string) (*x509.Certificate, *x509.Certificate) {
+	intermediateKey, err := certutil.NewECDSAPrivateKey()
+	Expect(err).NotTo(HaveOccurred())
+	now := time.Now()
+	intermediateTemplate := x509.Certificate{
+		SerialNumber:          big.NewInt(now.UnixNano()),
+		Subject:               pkix.Name{CommonName: fmt.Sprintf("intermediate@%d", now.Unix())},
+		NotBefore:             now.UTC(),
+		NotAfter:              now.Add(time.Hour).UTC(),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	intermediateDER, err := x509.CreateCertificate(rand.Reader, &intermediateTemplate, ca.Cert, intermediateKey.Public(), ca.Key)
+	Expect(err).NotTo(HaveOccurred())
+	intermediateCert, err := x509.ParseCertificate(intermediateDER)
+	Expect(err).NotTo(HaveOccurred())
+
+	namespacedName := fmt.Sprintf("%s.%s", svcName, namespace)
+	leafKey, err := certutil.NewECDSAPrivateKey()
+	Expect(err).NotTo(HaveOccurred())
+	leafConfig := certutil.Config{
+		CommonName: "export-server",
+		AltNames: certutil.AltNames{
+			DNSNames: []string{
+				svcName,
+				namespacedName,
+				fmt.Sprintf("%s.svc", namespacedName),
+			},
+		},
+		Usages: []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+	}
+	leafCert, err := certutil.NewSignedCert(leafConfig, leafKey, intermediateCert, intermediateKey, time.Hour)
+	Expect(err).NotTo(HaveOccurred())
+	return leafCert, intermediateCert
+}
+
+func newExportBackendCertPair(ca *triple.KeyPair, svcName, namespace string) *triple.KeyPair {
+	serverKP, err := triple.NewServerKeyPair(ca, "export-server", svcName, namespace, "cluster.local", nil, nil, time.Hour)
+	Expect(err).NotTo(HaveOccurred())
+	return serverKP
+}
+
+func certPoolFromCA(ca *triple.KeyPair) *x509.CertPool {
+	pool := x509.NewCertPool()
+	pool.AddCert(ca.Cert)
+	return pool
+}
+
+func connectionState(serverName string, certs ...*x509.Certificate) tls.ConnectionState {
+	return tls.ConnectionState{
+		ServerName:       serverName,
+		PeerCertificates: certs,
+	}
+}
+
+var _ = Describe("verifyBackendConnection", func() {
+	It("returns an error when no peer certificate is presented", func() {
+		app := newTestExportProxyApp(&mockClientCAManager{pool: x509.NewCertPool()})
+
+		err := app.verifyBackendConnection(tls.ConnectionState{})
+
+		Expect(err).To(MatchError("backend presented no certificate"))
+	})
+
+	It("propagates errors from caManager.GetCurrent", func() {
+		caErr := errors.New("ca unavailable")
+		app := newTestExportProxyApp(&mockClientCAManager{err: caErr})
+
+		err := app.verifyBackendConnection(connectionState(testBackendHost, &x509.Certificate{}))
+
+		Expect(err).To(MatchError(caErr))
+	})
+
+	DescribeTable("should", func(
+		setup func() (*exportProxyApp, tls.ConnectionState),
+		expectErr bool,
+		errMatcher types.GomegaMatcher,
+	) {
+		app, cs := setup()
+		err := app.verifyBackendConnection(cs)
+		if expectErr {
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(errMatcher)
+			return
+		}
+		Expect(err).NotTo(HaveOccurred())
+	},
+		Entry("reject a certificate that does not chain to the export CA",
+			func() (*exportProxyApp, tls.ConnectionState) {
+				trustedCA, err := triple.NewCA("trusted", time.Hour)
+				Expect(err).NotTo(HaveOccurred())
+				untrustedCA, err := triple.NewCA("untrusted", time.Hour)
+				Expect(err).NotTo(HaveOccurred())
+				serverKP := newExportBackendCertPair(untrustedCA, testExportService, testNamespace)
+				app := newTestExportProxyApp(&mockClientCAManager{pool: certPoolFromCA(trustedCA)})
+				return app, connectionState(testBackendHost, serverKP.Cert)
+			},
+			true,
+			MatchError(ContainSubstring("could not verify backend certificate")),
+		),
+		Entry("reject verification when ServerName is empty",
+			func() (*exportProxyApp, tls.ConnectionState) {
+				ca, err := triple.NewCA("trusted", time.Hour)
+				Expect(err).NotTo(HaveOccurred())
+				serverKP := newExportBackendCertPair(ca, testExportService, testNamespace)
+				app := newTestExportProxyApp(&mockClientCAManager{pool: certPoolFromCA(ca)})
+				return app, connectionState("", serverKP.Cert)
+			},
+			true,
+			MatchError("backend TLS ServerName is required"),
+		),
+		Entry("reject a valid chain when the hostname does not match",
+			func() (*exportProxyApp, tls.ConnectionState) {
+				ca, err := triple.NewCA("trusted", time.Hour)
+				Expect(err).NotTo(HaveOccurred())
+				serverKP := newExportBackendCertPair(ca, testExportService, testNamespace)
+				app := newTestExportProxyApp(&mockClientCAManager{pool: certPoolFromCA(ca)})
+				return app, connectionState("other."+testNamespace+".svc", serverKP.Cert)
+			},
+			true,
+			MatchError(ContainSubstring("could not verify backend certificate")),
+		),
+		Entry("accept a valid certificate chain and hostname",
+			func() (*exportProxyApp, tls.ConnectionState) {
+				ca, err := triple.NewCA("trusted", time.Hour)
+				Expect(err).NotTo(HaveOccurred())
+				serverKP := newExportBackendCertPair(ca, testExportService, testNamespace)
+				app := newTestExportProxyApp(&mockClientCAManager{pool: certPoolFromCA(ca)})
+				return app, connectionState(testBackendHost, serverKP.Cert)
+			},
+			false,
+			nil,
+		),
+		Entry("accept a valid certificate chain with an intermediate",
+			func() (*exportProxyApp, tls.ConnectionState) {
+				ca, err := triple.NewCA("trusted", time.Hour)
+				Expect(err).NotTo(HaveOccurred())
+				leafCert, intermediateCert := newExportBackendCertChain(ca, testExportService, testNamespace)
+				app := newTestExportProxyApp(&mockClientCAManager{pool: certPoolFromCA(ca)})
+				return app, connectionState(testBackendHost, leafCert, intermediateCert)
+			},
+			false,
+			nil,
+		),
+	)
+})
+
+func tlsCertificateFromKeyPair(kp *triple.KeyPair) tls.Certificate {
+	return tls.Certificate{
+		Certificate: [][]byte{kp.Cert.Raw},
+		PrivateKey:  kp.Key,
+		Leaf:        kp.Cert,
+	}
+}
+
+func newLocalBackendKeyPair(ca *triple.KeyPair) *triple.KeyPair {
+	serverKP, err := triple.NewServerKeyPair(
+		ca,
+		"export-server",
+		testExportService,
+		testNamespace,
+		"cluster.local",
+		[]string{"127.0.0.1"},
+		[]string{"localhost"},
+		time.Hour,
+	)
+	Expect(err).NotTo(HaveOccurred())
+	return serverKP
+}
+
+func startTLSBackend(serverCert tls.Certificate, minVersion uint16) (addr string) {
+	ln, err := tls.Listen("tcp4", "127.0.0.1:0", &tls.Config{
+		Certificates: []tls.Certificate{serverCert},
+		MinVersion:   minVersion,
+		MaxVersion:   minVersion,
+	})
+	Expect(err).NotTo(HaveOccurred())
+	DeferCleanup(func() {
+		_ = ln.Close()
+	})
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				_, _ = io.Copy(io.Discard, c)
+			}(conn)
+		}
+	}()
+
+	// Dial via localhost so TLS ServerName/SNI is a hostname (IPs are stripped from SNI).
+	_, port, err := net.SplitHostPort(ln.Addr().String())
+	Expect(err).NotTo(HaveOccurred())
+	return net.JoinHostPort("localhost", port)
+}
+
+func newDialTestApp(caManager *mockClientCAManager, kv *v1.KubeVirt) *exportProxyApp {
+	if kv == nil {
+		kv = &v1.KubeVirt{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "kubevirt",
+				Namespace: "kubevirt",
+			},
+			Spec: v1.KubeVirtSpec{
+				Configuration: v1.KubeVirtConfiguration{},
+			},
+		}
+	}
+	_, _, store := testutils.NewFakeClusterConfigUsingKV(kv)
+	return &exportProxyApp{
+		caManager:     caManager,
+		kubeVirtStore: store,
+	}
+}
+
+var _ = Describe("dialBackendTLS", func() {
+	It("establishes a TLS connection to a trusted backend", func() {
+		ca, err := triple.NewCA("trusted", time.Hour)
+		Expect(err).NotTo(HaveOccurred())
+		serverKP := newLocalBackendKeyPair(ca)
+		addr := startTLSBackend(tlsCertificateFromKeyPair(serverKP), tls.VersionTLS12)
+
+		app := newDialTestApp(&mockClientCAManager{pool: certPoolFromCA(ca)}, nil)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		DeferCleanup(cancel)
+
+		conn, err := app.dialBackendTLS(ctx, "tcp4", addr)
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() {
+			_ = conn.Close()
+		})
+
+		tlsConn, ok := conn.(*tls.Conn)
+		Expect(ok).To(BeTrue())
+		Expect(tlsConn.ConnectionState().HandshakeComplete).To(BeTrue())
+		Expect(tlsConn.ConnectionState().PeerCertificates).NotTo(BeEmpty())
+	})
+
+	It("fails when the backend certificate is not trusted", func() {
+		trustedCA, err := triple.NewCA("trusted", time.Hour)
+		Expect(err).NotTo(HaveOccurred())
+		untrustedCA, err := triple.NewCA("untrusted", time.Hour)
+		Expect(err).NotTo(HaveOccurred())
+		serverKP := newLocalBackendKeyPair(untrustedCA)
+		addr := startTLSBackend(tlsCertificateFromKeyPair(serverKP), tls.VersionTLS12)
+
+		app := newDialTestApp(&mockClientCAManager{pool: certPoolFromCA(trustedCA)}, nil)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		DeferCleanup(cancel)
+
+		conn, err := app.dialBackendTLS(ctx, "tcp4", addr)
+		Expect(err).To(HaveOccurred())
+		Expect(conn).To(BeNil())
+	})
+
+	It("fails when the dial cannot connect", func() {
+		app := newDialTestApp(&mockClientCAManager{pool: x509.NewCertPool()}, nil)
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		DeferCleanup(cancel)
+
+		conn, err := app.dialBackendTLS(ctx, "tcp4", "127.0.0.1:1")
+		Expect(err).To(HaveOccurred())
+		Expect(conn).To(BeNil())
+	})
+
+})
+
+type captureTransport struct {
+	lastReq *http.Request
+}
+
+func (t *captureTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	t.lastReq = req
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader("ok")),
+		Header:     make(http.Header),
+		Request:    req,
+	}, nil
+}
+
+func newReadyExport(namespace, name, serviceName string) *exportv1.VirtualMachineExport {
+	return &exportv1.VirtualMachineExport{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+		},
+		Status: &exportv1.VirtualMachineExportStatus{
+			Phase:       exportv1.Ready,
+			ServiceName: serviceName,
+		},
+	}
+}
+
+var _ = Describe("proxyHandler", func() {
+	var (
+		kvStore cache.Store
+		app     *exportProxyApp
+		capture *captureTransport
+	)
+
+	BeforeEach(func() {
+		kv := &v1.KubeVirt{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "kubevirt",
+				Namespace: "kubevirt",
+			},
+			Spec: v1.KubeVirtSpec{
+				Configuration: v1.KubeVirtConfiguration{},
+			},
+		}
+		_, _, kvStore = testutils.NewFakeClusterConfigUsingKV(kv)
+		capture = &captureTransport{}
+		app = &exportProxyApp{
+			kubeVirtStore: kvStore,
+			exportStore:   cache.NewStore(cache.MetaNamespaceKeyFunc),
+		}
+		app.initReverseProxy()
+		app.reverseProxy.Transport = capture
+	})
+
+	It("rewrites the outbound request URL and clears Host for the backend", func() {
+		Expect(app.exportStore.Add(newReadyExport(testNamespace, "my-export", testExportService))).To(Succeed())
+
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/api/export.kubevirt.io/v1/namespaces/default/virtualmachineexports/my-export/volumes/disk.img", nil)
+		req.Host = "virt-exportproxy.kubevirt.svc:443"
+		app.proxyHandler(rec, req)
+
+		Expect(rec.Code).To(Equal(http.StatusOK))
+		Expect(capture.lastReq.URL.Scheme).To(Equal("https"))
+		Expect(capture.lastReq.URL.Host).To(Equal(testBackendHost + ":443"))
+		Expect(capture.lastReq.URL.Path).To(Equal("/volumes/disk.img"))
+		Expect(capture.lastReq.Host).To(Equal(""))
+	})
+
+	It("returns 404 when the export does not exist", func() {
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/api/export.kubevirt.io/v1/namespaces/default/virtualmachineexports/missing/volumes/disk.img", nil)
+		app.proxyHandler(rec, req)
+
+		Expect(rec.Code).To(Equal(http.StatusNotFound))
+		Expect(capture.lastReq).To(BeNil())
+	})
+
+	It("returns 503 when the export is not Ready", func() {
+		export := newReadyExport(testNamespace, "my-export", testExportService)
+		export.Status.Phase = exportv1.Pending
+		Expect(app.exportStore.Add(export)).To(Succeed())
+
+		rec := httptest.NewRecorder()
+		req := httptest.NewRequest(http.MethodGet, "/api/export.kubevirt.io/v1/namespaces/default/virtualmachineexports/my-export/volumes/disk.img", nil)
+		app.proxyHandler(rec, req)
+
+		Expect(rec.Code).To(Equal(http.StatusServiceUnavailable))
+		Expect(capture.lastReq).To(BeNil())
+	})
+})

--- a/cmd/virt-exportproxy/virt-exportproxy_test.go
+++ b/cmd/virt-exportproxy/virt-exportproxy_test.go
@@ -328,6 +328,34 @@ var _ = Describe("dialBackendTLS", func() {
 		Expect(conn).To(BeNil())
 	})
 
+	It("applies MinTLSVersion from the KubeVirt store", func() {
+		ca, err := triple.NewCA("trusted", time.Hour)
+		Expect(err).NotTo(HaveOccurred())
+		serverKP := newLocalBackendKeyPair(ca)
+		// Backend only speaks TLS 1.2.
+		addr := startTLSBackend(tlsCertificateFromKeyPair(serverKP), tls.VersionTLS12)
+
+		kv := &v1.KubeVirt{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "kubevirt",
+				Namespace: "kubevirt",
+			},
+			Spec: v1.KubeVirtSpec{
+				Configuration: v1.KubeVirtConfiguration{
+					TLSConfiguration: &v1.TLSConfiguration{
+						MinTLSVersion: v1.VersionTLS13,
+					},
+				},
+			},
+		}
+		app := newDialTestApp(&mockClientCAManager{pool: certPoolFromCA(ca)}, kv)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		DeferCleanup(cancel)
+
+		conn, err := app.dialBackendTLS(ctx, "tcp4", addr)
+		Expect(err).To(HaveOccurred())
+		Expect(conn).To(BeNil())
+	})
 })
 
 type captureTransport struct {

--- a/pkg/util/tls/tls.go
+++ b/pkg/util/tls/tls.go
@@ -297,6 +297,23 @@ func getTLSConfiguration(kubevirt *v1.KubeVirt) *v1.TLSConfiguration {
 	return tlsConfiguration
 }
 
+func resolveTLSConfiguration(kubevirt *v1.KubeVirt) (minVersion uint16, cipherSuites []uint16) {
+	tlsConfig := getTLSConfiguration(kubevirt)
+	return TLSVersion(tlsConfig.MinTLSVersion), CipherSuiteIds(tlsConfig.Ciphers)
+}
+
+// ApplyTLSConfigurationFromKubeVirtStore applies the resolved TLS configuration from the
+// KubeVirt CR to the provided tls.Config.
+func ApplyTLSConfigurationFromKubeVirtStore(config *tls.Config, kubeVirtStore cache.Store) {
+	minVersion, cipherSuites := resolveTLSConfiguration(getKubevirt(kubeVirtStore))
+	config.MinVersion = minVersion
+	if len(cipherSuites) > 0 {
+		config.CipherSuites = cipherSuites
+	} else {
+		config.CipherSuites = nil
+	}
+}
+
 func CipherSuiteIds(names []string) []uint16 {
 	var idByName = CipherSuiteNameMap()
 	var ids []uint16

--- a/pkg/util/tls/tls_test.go
+++ b/pkg/util/tls/tls_test.go
@@ -480,4 +480,30 @@ var _ = Describe("TLS", func() {
 				To(MatchError(ContainSubstring("not found in deployment")))
 		})
 	})
+
+	Describe("ApplyTLSConfigurationFromKubeVirtStore", func() {
+		It("should apply default TLS 1.2 when KubeVirt has no TLS config", func() {
+			config := &tls.Config{}
+			kvtls.ApplyTLSConfigurationFromKubeVirtStore(config, kubeVirtStore)
+
+			Expect(config.MinVersion).To(Equal(uint16(tls.VersionTLS12)))
+			Expect(config.CipherSuites).To(BeNil())
+		})
+
+		It("should apply custom TLS configuration from KubeVirt", func() {
+			kv := testutils.GetFakeKubeVirtClusterConfig(kubeVirtStore)
+			kvConfig := kv.DeepCopy()
+			kvConfig.Spec.Configuration.TLSConfiguration = &v1.TLSConfiguration{
+				MinTLSVersion: v1.VersionTLS13,
+				Ciphers:       []string{"TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384"},
+			}
+			testutils.UpdateFakeKubeVirtClusterConfig(kubeVirtStore, kvConfig)
+
+			config := &tls.Config{}
+			kvtls.ApplyTLSConfigurationFromKubeVirtStore(config, kubeVirtStore)
+
+			Expect(config.MinVersion).To(Equal(uint16(tls.VersionTLS13)))
+			Expect(config.CipherSuites).To(Equal(kvtls.CipherSuiteIds([]string{"TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384"})))
+		})
+	})
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Fixes a file descriptor leak in virt-exportproxy and adds backend TLS policy inheritance from the KubeVirt CR.

#### Before this PR:
The proxy created a new http.Transport and httputil.ReverseProxy on every request. Backend TLS connections were never pooled or reused, so file descriptors accumulated during export downloads and did not return to baseline after load drained. 

Backend TLS was verified against a hardcoded CA lookup per request with no connection keepalive, dial timeouts, or server idle timeouts.

#### After this PR:
- A single shared http.Transport is reused across requests with bounded idle connection pooling (MaxIdleConns: 100, IdleConnTimeout: 30s), backend dial and response-header timeouts, and server idle/read-header timeouts. 
- Backends are dialed via a custom DialTLSContext that builds a fresh tls.Config per connection, verifying the peer certificate chain and hostname against the export CA via VerifyConnection (fail closed if the backend presents no certificate or ServerName is missing). 
- The MinTLSVersion and CipherSuites are read live from the KubeVirt CR store on each dial, so backend connections follow the same cluster TLS policy as other components without requiring a restart or explicit connection flush.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [X] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [X] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: file descriptor leak in vmexport proxy
```

