### PR TITLE
tests, networkpolicy: Skip link-local IPv6 IPs in ping assertions

### DIFF
--- a/tests/network/networkpolicy.go
+++ b/tests/network/networkpolicy.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net"
+	"slices"
 	"strconv"
 	"time"
 
@@ -278,9 +279,19 @@ var _ = Describe(SIG("[rfe_id:150][crit:high][vendor:cnv-qe@redhat.com][level:co
 	})
 }))
 
+func filterOutLinkLocalAddresses(ips []string) []string {
+	return slices.DeleteFunc(slices.Clone(ips), func(ip string) bool {
+		addr := net.ParseIP(ip)
+		return addr != nil && addr.IsLinkLocalUnicast()
+	})
+}
+
 func assertPingSucceed(fromVmi, toVmi *v1.VirtualMachineInstance) {
+	ipAddressesToPing := filterOutLinkLocalAddresses(toVmi.Status.Interfaces[0].IPs)
+	Expect(ipAddressesToPing).NotTo(BeEmpty(), "no IPs left to ping after filtering link-local addresses")
+
 	ConsistentlyWithOffset(1, func() error {
-		for _, toIp := range toVmi.Status.Interfaces[0].IPs {
+		for _, toIp := range ipAddressesToPing {
 			if err := libnet.PingFromVMConsole(fromVmi, toIp); err != nil {
 				return err
 			}
@@ -290,9 +301,12 @@ func assertPingSucceed(fromVmi, toVmi *v1.VirtualMachineInstance) {
 }
 
 func assertPingFail(fromVmi, toVmi *v1.VirtualMachineInstance) {
+	ipAddressesToPing := filterOutLinkLocalAddresses(toVmi.Status.Interfaces[0].IPs)
+	Expect(ipAddressesToPing).NotTo(BeEmpty(), "no IPs left to ping after filtering link-local addresses")
+
 	EventuallyWithOffset(1, func() error {
 		var err error
-		for _, toIp := range toVmi.Status.Interfaces[0].IPs {
+		for _, toIp := range ipAddressesToPing {
 			if err = libnet.PingFromVMConsole(fromVmi, toIp); err == nil {
 				return nil
 			}
@@ -302,7 +316,7 @@ func assertPingFail(fromVmi, toVmi *v1.VirtualMachineInstance) {
 
 	ConsistentlyWithOffset(1, func() error {
 		var err error
-		for _, toIp := range toVmi.Status.Interfaces[0].IPs {
+		for _, toIp := range ipAddressesToPing {
 			if err = libnet.PingFromVMConsole(fromVmi, toIp); err == nil {
 				return nil
 			}


### PR DESCRIPTION
### What this PR does
The guest kernel generates link-local IPv6 addresses. KubeVirt
exposes them in the VMI status via QEMU Guest Agent. Since these
addresses are not assigned by the CNI, they are not guaranteed to be
reachable.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

Tested on a cluster where pod network is not the default network.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

