### PR TITLE
Add a failing MatchAttribute test case for DRA

### DIFF
--- a/tests/compute/dra.go
+++ b/tests/compute/dra.go
@@ -215,6 +215,28 @@ var _ = Describe("[sig-compute]DRA", Serial, decorators.SigCompute, decorators.D
 		By("Waiting for the VMI to reach Running")
 		waitForVMIToBeRunning(createdVMI)
 	})
+
+	It("should fail when the matchattribute has different values", func() {
+		By("creating the ResourceClaimTemplate with matchAttribute on pciBusID across two requests")
+		createVFIOGPUResourceClaimTemplate(
+			WithVfioGPUMultipleRequests(draVfioMatchAttributeRequestCount),
+			WithVfioGPURequestMatchAttribute(
+				"resource.kubernetes.io/pciBusID",
+				vfioGPUIndexedRequestName(0),
+				vfioGPUIndexedRequestName(1),
+			),
+		)
+
+		By("creating the VMI with two GPUs backed by the matched requests")
+		vmi := createVFIOGPUVMI(
+			WithVfioGPUResourceClaimTemplate(draVfioClaimTemplateName),
+			WithVfioGPUMultipleGPUs(draVfioMatchAttributeRequestCount),
+		)
+
+		Eventually(matcher.ThisVMI(vmi), 30*time.Second, pollingInterval).Should(matcher.BeInPhase(v1.Scheduling))
+		Consistently(matcher.ThisVMI(vmi), 30*time.Second, pollingInterval).Should(matcher.BeInPhase(v1.Scheduling))
+		verifyVMIPodUnschedulable(vmi.Name, ContainSubstring("cannot allocate all claims"))
+	})
 })
 
 func createVFIOGPUResourceClaimTemplate(opts ...vfioGPUResourceClaimTemplateOption) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
There is no testcase for MatchAttribute with different values. 

As this cannot be covered in unit tests and is required during scheduling because matchattribute constraint is enforced by the K8s DRA scheduler, there is no code in kubevirt that evaluates that constraint. Adding it as a separate failing testcase in E2E tests.

#### After this PR:

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

