### PR TITLE
Dequarantine virt-template TLS configuration test

### DIFF
--- a/pkg/virt-operator/kubevirt_test.go
+++ b/pkg/virt-operator/kubevirt_test.go
@@ -1551,16 +1551,27 @@ func (k *KubeVirtTestData) shouldExpectInstallStrategyDeletion() {
 	})
 }
 
-func (k *KubeVirtTestData) makeDeploymentsReady(kv *v1.KubeVirt) {
+func (k *KubeVirtTestData) makeDeploymentsReady(config *util.KubeVirtDeploymentConfig, kv *v1.KubeVirt) {
 	makeDeploymentReady := func(item interface{}) {
 		depl, _ := item.(*appsv1.Deployment)
 		deplNew := depl.DeepCopy()
-		var replicas int32 = 1
-		if depl.Spec.Replicas != nil {
-			replicas = *depl.Spec.Replicas
+		if deplNew.Annotations == nil {
+			deplNew.Annotations = map[string]string{}
 		}
-		deplNew.Status.Replicas = replicas
-		deplNew.Status.ReadyReplicas = replicas
+		deplNew.Annotations[v1.InstallStrategyVersionAnnotation] = config.GetKubeVirtVersion()
+		deplNew.Annotations[v1.InstallStrategyRegistryAnnotation] = config.GetImageRegistry()
+		deplNew.Annotations[v1.InstallStrategyIdentifierAnnotation] = config.GetDeploymentID()
+		deplNew.Status.Conditions = []appsv1.DeploymentCondition{
+			{
+				Type:   appsv1.DeploymentProgressing,
+				Status: k8sv1.ConditionTrue,
+				Reason: "NewReplicaSetAvailable",
+			},
+			{
+				Type:   appsv1.DeploymentAvailable,
+				Status: k8sv1.ConditionTrue,
+			},
+		}
 		k.controller.stores.DeploymentCache.Update(deplNew)
 		key, err := kubecontroller.KeyFunc(deplNew)
 		Expect(err).To(Not(HaveOccurred()))
@@ -1908,7 +1919,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			kvTestData.addInstallStrategy(kvTestData.defaultConfig)
 			kvTestData.addAll(kvTestData.defaultConfig, kv)
 			kvTestData.addPodsAndPodDisruptionBudgets(kvTestData.defaultConfig, kv)
-			kvTestData.makeDeploymentsReady(kv)
+			kvTestData.makeDeploymentsReady(kvTestData.defaultConfig, kv)
 			kvTestData.makeHandlerReady()
 			kvTestData.shouldExpectPatchesAndUpdates(kv)
 
@@ -1985,7 +1996,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			kvTestData.addInstallStrategy(customConfig)
 			kvTestData.addPodsAndPodDisruptionBudgets(customConfig, kv)
 
-			kvTestData.makeDeploymentsReady(kv)
+			kvTestData.makeDeploymentsReady(customConfig, kv)
 			kvTestData.makeHandlerReady()
 
 			kvTestData.shouldExpectKubeVirtUpdateStatusVersion(1, customConfig)
@@ -2027,7 +2038,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			kvTestData.addInstallStrategy(kvTestData.defaultConfig)
 			kvTestData.addAll(kvTestData.defaultConfig, kv)
 			kvTestData.addPodsAndPodDisruptionBudgets(kvTestData.defaultConfig, kv)
-			kvTestData.makeDeploymentsReady(kv)
+			kvTestData.makeDeploymentsReady(kvTestData.defaultConfig, kv)
 			kvTestData.makeHandlerReady()
 
 			kvTestData.shouldExpectDeletions()
@@ -2099,7 +2110,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			kvTestData.addInstallStrategy(kvTestData.defaultConfig)
 			kvTestData.addAll(kvTestData.defaultConfig, kv)
 			kvTestData.addPodsAndPodDisruptionBudgets(kvTestData.defaultConfig, kv)
-			kvTestData.makeDeploymentsReady(kv)
+			kvTestData.makeDeploymentsReady(kvTestData.defaultConfig, kv)
 			kvTestData.makeHandlerReady()
 
 			kvTestData.shouldExpectDeletions()
@@ -2141,7 +2152,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			kvTestData.addInstallStrategy(kvTestData.defaultConfig)
 			kvTestData.addAll(kvTestData.defaultConfig, kv)
 			kvTestData.addPodsAndPodDisruptionBudgets(kvTestData.defaultConfig, kv)
-			kvTestData.makeDeploymentsReady(kv)
+			kvTestData.makeDeploymentsReady(kvTestData.defaultConfig, kv)
 			kvTestData.makeHandlerReady()
 
 			kvTestData.fakeNamespaceModificationEvent()
@@ -2202,7 +2213,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			kvTestData.addInstallStrategy(newConfig)
 			kvTestData.addAll(newConfig, kv)
 			kvTestData.addPodsWithOptionalPodDisruptionBudgets(newConfig, true, kvNoTemplate)
-			kvTestData.makeDeploymentsReady(kvNoTemplate)
+			kvTestData.makeDeploymentsReady(newConfig, kvNoTemplate)
 			kvTestData.makeHandlerReady()
 
 			kvTestData.fakeNamespaceModificationEvent()
@@ -2232,7 +2243,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			}
 			kvTestData.addKubeVirt(kv)
 			kvTestData.addPodsWithOptionalPodDisruptionBudgets(newConfig, true, kv)
-			kvTestData.makeDeploymentsReady(kv)
+			kvTestData.makeDeploymentsReady(newConfig, kv)
 			kvTestData.shouldExpectPatchesAndUpdates(kv)
 			kvTestData.shouldExpectKubeVirtUpdateStatus(1)
 
@@ -2277,7 +2288,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			kvTestData.addInstallStrategy(kvTestData.defaultConfig)
 			kvTestData.addAll(kvTestData.defaultConfig, kv)
 			kvTestData.addPodsAndPodDisruptionBudgets(kvTestData.defaultConfig, kv)
-			kvTestData.makeDeploymentsReady(kv)
+			kvTestData.makeDeploymentsReady(kvTestData.defaultConfig, kv)
 			kvTestData.makeHandlerReady()
 			kvTestData.makeHandlerComplete()
 
@@ -2341,7 +2352,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			numResources := kvTestData.generateRandomResources()
 			kvTestData.addPodsAndPodDisruptionBudgets(kvTestData.defaultConfig, kv)
 
-			kvTestData.makeDeploymentsReady(kv)
+			kvTestData.makeDeploymentsReady(kvTestData.defaultConfig, kv)
 			kvTestData.makeHandlerReady()
 
 			kvTestData.shouldExpectDeletions()
@@ -2861,7 +2872,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			kvTestData.addAll(kvTestData.defaultConfig, kv)
 			kvTestData.addPodsAndPodDisruptionBudgets(kvTestData.defaultConfig, kv)
 
-			kvTestData.makeDeploymentsReady(kv)
+			kvTestData.makeDeploymentsReady(kvTestData.defaultConfig, kv)
 			kvTestData.makeHandlerReady()
 
 			kvTestData.addToCache = false
@@ -2932,7 +2943,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			kvTestData.addAll(kvTestData.defaultConfig, kv)
 			kvTestData.addPodsAndPodDisruptionBudgets(kvTestData.defaultConfig, kv)
 
-			kvTestData.makeDeploymentsReady(kv)
+			kvTestData.makeDeploymentsReady(kvTestData.defaultConfig, kv)
 			kvTestData.makeHandlerReady()
 
 			kvTestData.addToCache = false
@@ -3008,7 +3019,7 @@ var _ = Describe("KubeVirt Operator", func() {
 
 			kvTestData.addPodsWithIndividualConfigs(kvTestData.defaultConfig, kvTestData.defaultConfig, kvTestData.defaultConfig, updatedConfig, true, kv)
 
-			kvTestData.makeDeploymentsReady(kv)
+			kvTestData.makeDeploymentsReady(kvTestData.defaultConfig, kv)
 			kvTestData.makeHandlerReady()
 
 			kvTestData.addToCache = false
@@ -3283,7 +3294,7 @@ var _ = Describe("KubeVirt Operator", func() {
 				kvTestData.addDeployment(exportProxyDeployment, kv)
 				kvTestData.addDaemonset(handlerDaemonset, kv)
 				kvTestData.addPodsAndPodDisruptionBudgets(customConfig, kv)
-				kvTestData.makeDeploymentsReady(kv)
+				kvTestData.makeDeploymentsReady(customConfig, kv)
 				kvTestData.makeHandlerReady()
 
 				var apiDeploy, ctrlDeploy, tplApiDeploy, tplCtrlDeploy, exportproxyDeploy *appsv1.Deployment
@@ -3450,7 +3461,7 @@ var _ = Describe("KubeVirt Operator", func() {
 				kvTestData.addDeployment(exportProxyDeployment, kv)
 				kvTestData.addDaemonset(handlerDaemonset, kv)
 				kvTestData.addPodsAndPodDisruptionBudgets(customConfig, kv)
-				kvTestData.makeDeploymentsReady(kv)
+				kvTestData.makeDeploymentsReady(customConfig, kv)
 				kvTestData.makeHandlerReady()
 
 				kvTestData.daemonSetPatchReactionFunc = func(action testing.Action) (handled bool, obj runtime.Object, err error) {
@@ -3529,7 +3540,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			kvTestData.addVirtHandler(updatedConfig, kv)
 			kvTestData.addPodsWithOptionalPodDisruptionBudgets(updatedConfig, false, kv)
 
-			kvTestData.makeDeploymentsReady(kv)
+			kvTestData.makeDeploymentsReady(updatedConfig, kv)
 			kvTestData.makeHandlerReady()
 
 			kvTestData.shouldExpectPatchesAndUpdates(kv)
@@ -3600,7 +3611,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			// all resources.
 			kvTestData.addPodsWithOptionalPodDisruptionBudgets(updatedConfig, false, kv)
 
-			kvTestData.makeDeploymentsReady(kv)
+			kvTestData.makeDeploymentsReady(updatedConfig, kv)
 			kvTestData.makeHandlerReady()
 
 			kvTestData.shouldExpectPatchesAndUpdates(kv)
@@ -3685,7 +3696,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			// all resources.
 			kvTestData.addPodsWithOptionalPodDisruptionBudgets(updatedConfig, false, kv)
 
-			kvTestData.makeDeploymentsReady(kv)
+			kvTestData.makeDeploymentsReady(updatedConfig, kv)
 			kvTestData.makeHandlerReady()
 
 			kvTestData.shouldExpectPatchesAndUpdates(kv)
@@ -3919,7 +3930,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			// Add updated Pods for new config
 			kvTestData.addPodsAndPodDisruptionBudgets(newConfig, newKv)
 			kvTestData.addVirtHandler(newConfig, newKv)
-			kvTestData.makeDeploymentsReady(kv)
+			kvTestData.makeDeploymentsReady(newConfig, newKv)
 			kvTestData.makeHandlerReady()
 
 			kvTestData.shouldExpectDeletions()
@@ -3980,7 +3991,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			// Add updated Pods for new config
 			kvTestData.addPodsAndPodDisruptionBudgets(newConfig, newKv)
 			kvTestData.addVirtHandler(newConfig, newKv)
-			kvTestData.makeDeploymentsReady(kv)
+			kvTestData.makeDeploymentsReady(newConfig, kv)
 			kvTestData.makeHandlerReady()
 
 			kvTestData.deleteFromCache = false
@@ -4069,7 +4080,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			// Add updated Pods for new config
 			kvTestData.addPodsAndPodDisruptionBudgets(newConfig, newKv)
 			kvTestData.addVirtHandler(newConfig, newKv)
-			kvTestData.makeDeploymentsReady(kv)
+			kvTestData.makeDeploymentsReady(newConfig, newKv)
 			kvTestData.makeHandlerReady()
 
 			kvTestData.shouldExpectDeletions()
@@ -4114,7 +4125,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			// Add updated Pods for new config
 			kvTestData.addPodsAndPodDisruptionBudgets(newConfig, newKv)
 			kvTestData.addVirtHandler(newConfig, newKv)
-			kvTestData.makeDeploymentsReady(kv)
+			kvTestData.makeDeploymentsReady(newConfig, newKv)
 			kvTestData.makeHandlerReady()
 
 			kvTestData.shouldExpectCreations()

--- a/pkg/virt-operator/kubevirt_test.go
+++ b/pkg/virt-operator/kubevirt_test.go
@@ -1561,6 +1561,7 @@ func (k *KubeVirtTestData) makeDeploymentsReady(config *util.KubeVirtDeploymentC
 		deplNew.Annotations[v1.InstallStrategyVersionAnnotation] = config.GetKubeVirtVersion()
 		deplNew.Annotations[v1.InstallStrategyRegistryAnnotation] = config.GetImageRegistry()
 		deplNew.Annotations[v1.InstallStrategyIdentifierAnnotation] = config.GetDeploymentID()
+		deplNew.Status.ObservedGeneration = deplNew.Generation
 		deplNew.Status.Conditions = []appsv1.DeploymentCondition{
 			{
 				Type:   appsv1.DeploymentProgressing,
@@ -1634,6 +1635,7 @@ func (k *KubeVirtTestData) makeHandlerReady() {
 			handlerNew.Status.NumberReady = 1
 			handlerNew.Status.NumberAvailable = 1
 			handlerNew.Status.UpdatedNumberScheduled = 1
+			handlerNew.Status.ObservedGeneration = handlerNew.Generation
 			maxUnavailable := intstr.FromInt(1)
 			handlerNew.Spec.UpdateStrategy.RollingUpdate = &appsv1.RollingUpdateDaemonSet{
 				MaxUnavailable: &maxUnavailable,

--- a/pkg/virt-operator/util/BUILD.bazel
+++ b/pkg/virt-operator/util/BUILD.bazel
@@ -35,6 +35,7 @@ go_test(
     srcs = [
         "client_test.go",
         "config_test.go",
+        "readycheck_test.go",
         "util_suite_test.go",
     ],
     embed = [":go_default_library"],
@@ -44,8 +45,10 @@ go_test(
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/api/apps/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/rand:go_default_library",
+        "//vendor/k8s.io/client-go/tools/cache:go_default_library",
     ],
 )

--- a/pkg/virt-operator/util/readycheck.go
+++ b/pkg/virt-operator/util/readycheck.go
@@ -20,8 +20,6 @@
 package util
 
 import (
-	"strings"
-
 	appsv1 "k8s.io/api/apps/v1"
 	k8sv1 "k8s.io/api/core/v1"
 
@@ -30,54 +28,33 @@ import (
 )
 
 func DaemonsetIsReady(kv *v1.KubeVirt, daemonset *appsv1.DaemonSet, stores Stores) bool {
-
-	// ensure we're looking at the latest daemonset from cache
 	obj, exists, _ := stores.DaemonSetCache.Get(daemonset)
-	if exists {
-		daemonset = obj.(*appsv1.DaemonSet)
-	} else {
-		// not in cache yet
+	if !exists {
+		return false
+	}
+	daemonset = obj.(*appsv1.DaemonSet)
+
+	if !DaemonSetIsUpToDate(kv, daemonset) {
+		log.Log.V(4).Infof("DaemonSet %v not at target version yet", daemonset.Name)
 		return false
 	}
 
-	if daemonset.Status.DesiredNumberScheduled == 0 ||
-		daemonset.Status.DesiredNumberScheduled != daemonset.Status.NumberReady {
+	// Status fields are only reliable once the controller has observed the current spec.
+	if daemonset.Status.ObservedGeneration < daemonset.Generation {
+		log.Log.V(4).Infof("DaemonSet %v controller has not observed current spec", daemonset.Name)
+		return false
+	}
 
+	// NumberReady and UpdatedNumberScheduled both exclude misscheduled pods (k8s API guarantee),
+	// so == is safe even when there are extra pods running on tainted nodes.
+	if daemonset.Status.DesiredNumberScheduled == 0 ||
+		daemonset.Status.UpdatedNumberScheduled != daemonset.Status.DesiredNumberScheduled ||
+		daemonset.Status.NumberReady != daemonset.Status.DesiredNumberScheduled {
 		log.Log.V(4).Infof("DaemonSet %v not ready yet", daemonset.Name)
 		return false
 	}
 
-	// cross check that we have 'daemonset.Status.NumberReady' pods with
-	// the desired version tag. This ensures we wait for rolling update to complete
-	// before marking the infrastructure as 100% ready.
-	var podsReady int32
-	for _, obj := range stores.InfrastructurePodCache.List() {
-		if pod, ok := obj.(*k8sv1.Pod); ok {
-			if !podIsRunning(pod) {
-				continue
-			} else if !podHasNamePrefix(pod, daemonset.Name) {
-				continue
-			}
-
-			if !PodIsUpToDate(pod, kv) {
-				log.Log.Infof("DaemonSet %v waiting for out of date pods to terminate.", daemonset.Name)
-				return false
-			}
-
-			if PodIsReady(pod) {
-				podsReady++
-			}
-		}
-	}
-
-	if podsReady == 0 {
-		log.Log.Infof("DaemonSet %v not ready yet. Waiting for all pods to be ready", daemonset.Name)
-		return false
-	}
-
-	// Misscheduled but up to date daemonset pods will not be evicted unless manually deleted or the daemonset gets updated.
-	// Don't force the Available condition to false or block the upgrade on up-to-date misscheduled pods.
-	return podsReady >= daemonset.Status.DesiredNumberScheduled
+	return true
 }
 
 // deploymentProgressingReasonComplete is the Reason the k8s deployment controller
@@ -137,14 +114,6 @@ func DaemonSetIsUpToDate(kv *v1.KubeVirt, daemonSet *appsv1.DaemonSet) bool {
 	return daemonSet.Annotations[v1.InstallStrategyVersionAnnotation] == version &&
 		daemonSet.Annotations[v1.InstallStrategyRegistryAnnotation] == registry &&
 		daemonSet.Annotations[v1.InstallStrategyIdentifierAnnotation] == id
-}
-
-func podIsRunning(pod *k8sv1.Pod) bool {
-	return pod.Status.Phase == k8sv1.PodRunning
-}
-
-func podHasNamePrefix(pod *k8sv1.Pod, namePrefix string) bool {
-	return strings.Contains(pod.Name, namePrefix)
 }
 
 func PodIsUpToDate(pod *k8sv1.Pod, kv *v1.KubeVirt) bool {

--- a/pkg/virt-operator/util/readycheck.go
+++ b/pkg/virt-operator/util/readycheck.go
@@ -80,46 +80,50 @@ func DaemonsetIsReady(kv *v1.KubeVirt, daemonset *appsv1.DaemonSet, stores Store
 	return podsReady >= daemonset.Status.DesiredNumberScheduled
 }
 
+// deploymentProgressingReasonComplete is the Reason the k8s deployment controller
+// sets on the Progressing condition when a rollout has reached its desired replica count.
+// It is not exported as a typed constant in k8s.io/api/apps/v1.
+const deploymentProgressingReasonComplete = "NewReplicaSetAvailable"
+
 func DeploymentIsReady(kv *v1.KubeVirt, deployment *appsv1.Deployment, stores Stores) bool {
-	// ensure we're looking at the latest deployment from cache
 	obj, exists, _ := stores.DeploymentCache.Get(deployment)
-	if exists {
-		deployment = obj.(*appsv1.Deployment)
-	} else {
-		// not in cache yet
+	if !exists {
+		return false
+	}
+	deployment = obj.(*appsv1.Deployment)
+
+	// Conditions in Status reflect the state as of ObservedGeneration. If the spec
+	// has been updated (Generation incremented) but the controller hasn't reconciled
+	// yet, conditions are stale and must not be trusted.
+	if deployment.Status.ObservedGeneration < deployment.Generation {
+		log.Log.V(4).Infof("Deployment %v conditions are stale (generation mismatch)", deployment.Name)
 		return false
 	}
 
-	if deployment.Status.Replicas == 0 || deployment.Status.ReadyReplicas == 0 {
-		log.Log.V(4).Infof("Deployment %v not ready yet", deployment.Name)
+	if deployment.Annotations[v1.InstallStrategyVersionAnnotation] != kv.Status.TargetKubeVirtVersion ||
+		deployment.Annotations[v1.InstallStrategyRegistryAnnotation] != kv.Status.TargetKubeVirtRegistry ||
+		deployment.Annotations[v1.InstallStrategyIdentifierAnnotation] != kv.Status.TargetDeploymentID {
+		log.Log.V(4).Infof("Deployment %v not at target version yet", deployment.Name)
 		return false
 	}
 
-	// cross check that we have 'deployment.Status.ReadyReplicas' pods with
-	// the desired version tag. This ensures we wait for rolling update to complete
-	// before marking the infrastructure as 100% ready.
-	var podsReady int32
-	for _, obj := range stores.InfrastructurePodCache.List() {
-		if pod, ok := obj.(*k8sv1.Pod); ok {
-			if !podIsRunning(pod) {
-				continue
-			} else if !podHasNamePrefix(pod, deployment.Name) {
-				continue
-			}
-
-			if !PodIsUpToDate(pod, kv) {
-				log.Log.Infof("Deployment %v waiting for out of date pods to terminate.", deployment.Name)
-				return false
-			}
-
-			if PodIsReady(pod) {
-				podsReady++
-			}
+	// Require both rollout completion and current availability. Progressing=True/NewReplicaSetAvailable
+	// is set once when the rollout finishes and never resets if pods subsequently crash-loop.
+	// Available=True confirms pods are currently healthy.
+	var rolloutComplete, currentlyAvailable bool
+	for _, c := range deployment.Status.Conditions {
+		switch {
+		case c.Type == appsv1.DeploymentProgressing &&
+			c.Status == k8sv1.ConditionTrue &&
+			c.Reason == deploymentProgressingReasonComplete:
+			rolloutComplete = true
+		case c.Type == appsv1.DeploymentAvailable &&
+			c.Status == k8sv1.ConditionTrue:
+			currentlyAvailable = true
 		}
 	}
-
-	if podsReady == 0 {
-		log.Log.Infof("Deployment %v not ready yet. Waiting for at least one pod to become ready", deployment.Name)
+	if !rolloutComplete || !currentlyAvailable {
+		log.Log.V(4).Infof("Deployment %v not ready yet", deployment.Name)
 		return false
 	}
 	return true

--- a/pkg/virt-operator/util/readycheck_test.go
+++ b/pkg/virt-operator/util/readycheck_test.go
@@ -31,6 +31,98 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 )
 
+var _ = Describe("DaemonsetIsReady", func() {
+	const (
+		targetVersion  = "1.0.0"
+		targetRegistry = "registry.example.com"
+		targetID       = "abc123"
+	)
+
+	var (
+		kv        *v1.KubeVirt
+		daemonset *appsv1.DaemonSet
+	)
+
+	targetAnnotations := map[string]string{
+		v1.InstallStrategyVersionAnnotation:    targetVersion,
+		v1.InstallStrategyRegistryAnnotation:   targetRegistry,
+		v1.InstallStrategyIdentifierAnnotation: targetID,
+	}
+
+	BeforeEach(func() {
+		kv = &v1.KubeVirt{
+			Status: v1.KubeVirtStatus{
+				TargetKubeVirtVersion:  targetVersion,
+				TargetKubeVirtRegistry: targetRegistry,
+				TargetDeploymentID:     targetID,
+			},
+		}
+		daemonset = &appsv1.DaemonSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "virt-handler",
+				Namespace:   "kubevirt",
+				Annotations: targetAnnotations,
+			},
+			Status: appsv1.DaemonSetStatus{
+				DesiredNumberScheduled: 3,
+				UpdatedNumberScheduled: 3,
+				NumberReady:            3,
+			},
+		}
+	})
+
+	storeWith := func(obj interface{}) cache.Store {
+		s := cache.NewStore(cache.MetaNamespaceKeyFunc)
+		if obj != nil {
+			Expect(s.Add(obj)).To(Succeed())
+		}
+		return s
+	}
+
+	stores := func(ds *appsv1.DaemonSet) Stores {
+		return Stores{DaemonSetCache: storeWith(ds)}
+	}
+
+	DescribeTable("status and version checks",
+		func(mutate func(*appsv1.DaemonSet), expectedReady bool) {
+			if mutate != nil {
+				mutate(daemonset)
+			}
+			Expect(DaemonsetIsReady(kv, daemonset, stores(daemonset))).To(Equal(expectedReady))
+		},
+		Entry("all conditions met",
+			nil, true),
+		Entry("annotations behind target version",
+			func(ds *appsv1.DaemonSet) {
+				ds.Annotations[v1.InstallStrategyVersionAnnotation] = "0.9.9"
+			}, false),
+		Entry("ObservedGeneration behind Generation (controller not yet reconciled)",
+			func(ds *appsv1.DaemonSet) {
+				ds.Generation = 5
+				ds.Status.ObservedGeneration = 4
+			}, false),
+		Entry("DesiredNumberScheduled is zero (no schedulable nodes)",
+			func(ds *appsv1.DaemonSet) {
+				ds.Status.DesiredNumberScheduled = 0
+				ds.Status.UpdatedNumberScheduled = 0
+				ds.Status.NumberReady = 0
+			}, false),
+		Entry("UpdatedNumberScheduled behind (rollout in progress)",
+			func(ds *appsv1.DaemonSet) {
+				ds.Status.UpdatedNumberScheduled = 2
+			}, false),
+		Entry("NumberReady behind (pods not yet ready)",
+			func(ds *appsv1.DaemonSet) {
+				ds.Status.NumberReady = 2
+			}, false),
+	)
+
+	It("returns false when DaemonSet is not in cache", func() {
+		emptyStore := cache.NewStore(cache.MetaNamespaceKeyFunc)
+		Expect(DaemonsetIsReady(kv, daemonset, Stores{DaemonSetCache: emptyStore})).To(BeFalse())
+	})
+})
+
 var _ = Describe("DeploymentIsReady", func() {
 	const (
 		targetVersion  = "1.0.0"

--- a/pkg/virt-operator/util/readycheck_test.go
+++ b/pkg/virt-operator/util/readycheck_test.go
@@ -1,0 +1,146 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package util
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/cache"
+
+	v1 "kubevirt.io/api/core/v1"
+)
+
+var _ = Describe("DeploymentIsReady", func() {
+	const (
+		targetVersion  = "1.0.0"
+		targetRegistry = "registry.example.com"
+		targetID       = "abc123"
+	)
+
+	var (
+		kv         *v1.KubeVirt
+		deployment *appsv1.Deployment
+	)
+
+	BeforeEach(func() {
+		kv = &v1.KubeVirt{
+			Status: v1.KubeVirtStatus{
+				TargetKubeVirtVersion:  targetVersion,
+				TargetKubeVirtRegistry: targetRegistry,
+				TargetDeploymentID:     targetID,
+			},
+		}
+		deployment = &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "virt-api",
+				Namespace: "kubevirt",
+				Annotations: map[string]string{
+					v1.InstallStrategyVersionAnnotation:    targetVersion,
+					v1.InstallStrategyRegistryAnnotation:   targetRegistry,
+					v1.InstallStrategyIdentifierAnnotation: targetID,
+				},
+			},
+		}
+	})
+
+	storeWith := func(obj interface{}) cache.Store {
+		s := cache.NewStore(cache.MetaNamespaceKeyFunc)
+		if obj != nil {
+			Expect(s.Add(obj)).To(Succeed())
+		}
+		return s
+	}
+
+	progressingCondition := func(status corev1.ConditionStatus, reason string) appsv1.DeploymentCondition {
+		return appsv1.DeploymentCondition{
+			Type:   appsv1.DeploymentProgressing,
+			Status: status,
+			Reason: reason,
+		}
+	}
+
+	availableCondition := func(status corev1.ConditionStatus) appsv1.DeploymentCondition {
+		return appsv1.DeploymentCondition{
+			Type:   appsv1.DeploymentAvailable,
+			Status: status,
+		}
+	}
+
+	readyConditions := []appsv1.DeploymentCondition{
+		progressingCondition(corev1.ConditionTrue, "NewReplicaSetAvailable"),
+		availableCondition(corev1.ConditionTrue),
+	}
+
+	DescribeTable("condition and version checks",
+		func(conditions []appsv1.DeploymentCondition, annotations map[string]string, inCache bool, expectedReady bool) {
+			deployment.Status.Conditions = conditions
+			if annotations != nil {
+				deployment.Annotations = annotations
+			}
+			var store cache.Store
+			if inCache {
+				store = storeWith(deployment)
+			} else {
+				store = storeWith(nil)
+			}
+			stores := Stores{DeploymentCache: store}
+			Expect(DeploymentIsReady(kv, deployment, stores)).To(Equal(expectedReady))
+		},
+		Entry("not in cache",
+			nil, nil, false, false),
+		Entry("no conditions",
+			nil, nil, true, false),
+		Entry("Progressing=False/ProgressDeadlineExceeded",
+			[]appsv1.DeploymentCondition{progressingCondition(corev1.ConditionFalse, "ProgressDeadlineExceeded")}, nil, true, false),
+		Entry("Progressing=True/ReplicaSetUpdated (rollout in progress)",
+			[]appsv1.DeploymentCondition{progressingCondition(corev1.ConditionTrue, "ReplicaSetUpdated")}, nil, true, false),
+		Entry("rollout complete and available",
+			readyConditions, nil, true, true),
+		Entry("rollout complete but pods crash-looping (Available=False)",
+			[]appsv1.DeploymentCondition{
+				progressingCondition(corev1.ConditionTrue, "NewReplicaSetAvailable"),
+				availableCondition(corev1.ConditionFalse),
+			}, nil, true, false),
+		Entry("rollout complete but Available condition absent",
+			[]appsv1.DeploymentCondition{progressingCondition(corev1.ConditionTrue, "NewReplicaSetAvailable")}, nil, true, false),
+		Entry("Available=True but no Progressing condition",
+			[]appsv1.DeploymentCondition{availableCondition(corev1.ConditionTrue)}, nil, true, false),
+		Entry("rollout complete but deployment at wrong version",
+			readyConditions,
+			map[string]string{
+				v1.InstallStrategyVersionAnnotation:    "0.9.9",
+				v1.InstallStrategyRegistryAnnotation:   targetRegistry,
+				v1.InstallStrategyIdentifierAnnotation: targetID,
+			},
+			true, false),
+	)
+
+	It("returns false when conditions are stale (ObservedGeneration < Generation)", func() {
+		deployment.Generation = 2
+		deployment.Status.ObservedGeneration = 1
+		deployment.Status.Conditions = readyConditions
+		store := storeWith(deployment)
+		Expect(DeploymentIsReady(kv, deployment, Stores{DeploymentCache: store})).To(BeFalse())
+	})
+})

--- a/tests/infrastructure/tls-configuration.go
+++ b/tests/infrastructure/tls-configuration.go
@@ -90,8 +90,15 @@ func listPods(labelSelectors ...string) []k8sv1.Pod {
 		})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(podList.Items).ToNot(BeEmpty())
-		pods = append(pods, podList.Items...)
+		for _, pod := range podList.Items {
+			// virt-template pods roll out on TLS config changes; skip
+			// terminating pods that haven't finished graceful shutdown yet.
+			if pod.DeletionTimestamp == nil {
+				pods = append(pods, pod)
+			}
+		}
 	}
+	Expect(pods).ToNot(BeEmpty())
 	return pods
 }
 

--- a/tests/infrastructure/tls-configuration.go
+++ b/tests/infrastructure/tls-configuration.go
@@ -70,7 +70,7 @@ var _ = Describe(SIGSerial("tls configuration", func() {
 			verifyTLSEnforcement(podsToTest, kubevirtPodTLSPort, cipher)
 		})
 
-	It("[QUARANTINE]should enforce TLS configuration on virt-template components", decorators.Quarantine, func() {
+	It("should enforce TLS configuration on virt-template components", func() {
 		podsToTest := listPods(
 			"app.kubernetes.io/name=virt-template,control-plane=apiserver",
 			"app.kubernetes.io/name=virt-template,control-plane=controller-manager",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
The rebase over https://github.com/kubevirt/kubevirt/pull/18429 together with filtering for terminating pods allows us to remove the test from quarantine.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

