### PR TITLE
Add CodeRabbit AI code review configuration

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,1 @@
+hack/reviewcfg/.coderabbit.yaml

--- a/hack/reviewcfg/.coderabbit.yaml
+++ b/hack/reviewcfg/.coderabbit.yaml
@@ -1,0 +1,44 @@
+language: en-US
+
+reviews:
+  profile: chill
+  request_changes_workflow: false
+  auto_review:
+    enabled: false
+  path_filters:
+    - "!vendor/**"
+  path_instructions:
+    - path: "{pkg,cmd,staging,tests}/**/*.go"
+      instructions: >
+        See docs/coding-conventions.md, docs/reviewer-guide.md, docs/architecture.md,
+        docs/gosec.md, and docs/deprecation.md.
+    - path: "tests/**"
+      instructions: >
+        See tests/README.md, docs/conformance.md, and docs/quarantine.md.
+    - path: "pkg/libvmi/**"
+      instructions: "Follow the rules in pkg/libvmi/README.md."
+    - path: "tests/libvmifact/**"
+      instructions: "Follow the rules in tests/libvmifact/README.md."
+    - path: "pkg/network/**"
+      instructions: "See docs/network/network-binding-mechanisms.md."
+    - path: "pkg/monitoring/**"
+      instructions: "See docs/observability/monitoring-guidelines.md."
+  tools:
+    trufflehog:
+      enabled: true
+
+knowledge_base:
+  opt_out: true
+  code_guidelines:
+    enabled: true
+    filePatterns:
+      - CONTRIBUTING.md
+      - docs/commit-message-guidelines.md
+  linked_repositories:
+    - repository: "kubevirt/enhancements"
+      instructions: >
+        Contains VEP design documents and feature gate lifecycle rules
+        (docs/feature-lifecycle.md). When a PR references a VEP number, locate
+        the corresponding vep.md and verify the implementation aligns with the stated
+        API shape, phasing plan, and non-goals. For changes touching feature gates,
+        apply the lifecycle rules from docs/feature-lifecycle.md.

--- a/hack/reviewcfg/OWNERS
+++ b/hack/reviewcfg/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+approvers:
+  - EdDev
+  - iholder101


### PR DESCRIPTION
### What this PR does

Introduces the evaluation baseline CodeRabbit configuration for kubevirt/kubevirt,
implementing [VEP #297](https://github.com/kubevirt/enhancements/tree/main/veps/meta-VEPs/297-coderabbit-adoption).

CodeRabbit is a documentation-aware AI code reviewer. It ingests project knowledge —
contribution guidelines, architectural rules, package-level conventions — and applies
them when reviewing a PR diff. It can reason about whether a change aligns with
documented project intent, not just whether it compiles or passes linting. This
addresses the core gap in Sourcery: it has no mechanism to ingest or act on project
documentation.

**What was added:**

- `hack/reviewcfg/.coderabbit.yaml` — the configuration file
- `hack/reviewcfg/OWNERS` — explicit ownership; additional approvers can be added here
- `.coderabbit.yaml` — symlink to the above, following the `.golangci.yml → hack/linter/` convention

**Configuration decisions:**

- **Advisory only**: `profile: chill`, `request_changes_workflow: false`. CodeRabbit
  comments are purely informational and have no interaction with Prow, Tide, `/lgtm`,
  or `/approve`.
- **Manual trigger only**: `auto_review.enabled: false`. CodeRabbit will not fire on
  every PR. To request a review, post a comment on the PR:

  ```
  @coderabbitai review
  ```

- **No long-term learning**: `knowledge_base.opt_out: true`. No state is retained
  across reviews; CodeRabbit does not train on submitted code.
- **Documentation-driven context**: path instructions point CodeRabbit at existing
  project docs — coding conventions, reviewer guide, architecture, gosec rules,
  deprecation policy, test rules, and package-level READMEs — rather than duplicating
  rules in the config itself. The config stays small; the knowledge lives in the repo's
  own documentation where it is maintained for human readers too.
- **Cross-repo context**: linked to `kubevirt/enhancements` so CodeRabbit can verify
  that implementation PRs align with the API shape, phasing plan, and non-goals of a
  referenced VEP.
- **Secret scanning**: TruffleHog enabled to catch accidentally committed credentials
  in the diff.

### References

- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/297

### Why we need it and why it was done in this way

The following tradeoffs were made:

- Auto-review is disabled deliberately to start small and avoid noise fatigue during
  evaluation. Once signal-to-noise ratio is assessed as acceptable, it can be enabled
  for specific base branches or label filters.
- `knowledge_base.opt_out: true` fully disables learning. The alternative (`scope: local`)
  still accumulates cross-PR state within the repo, which contradicts the evaluation
  intent of observing baseline behavior without model drift.
- The config is kept intentionally minimal. Path instructions reference existing docs
  rather than embedding rules, so improvements to project documentation automatically
  improve review quality without touching the CodeRabbit config.
- Configuration lives under `hack/reviewcfg/` rather than the repo root so that
  ownership is explicit (via OWNERS) and future review tools can sit alongside it.

The following alternatives were considered:

- Keeping Sourcery: evaluated and found insufficient on Go language depth,
  cross-file analysis, and documentation ingestion. See VEP #297 appendix.
- Enabling auto-review from day one: rejected; evaluation period with manual
  trigger gives contributors and reviewers time to calibrate expectations.

### Special notes for your reviewer

After the GitHub App is installed on the kubevirt org scoped to this repository,
open any PR and post `@coderabbitai review` to validate the configuration is active
and producing useful output.

### Checklist

- [x] Design: VEP #297 is present and accepted
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: N/A — configuration files only
- [x] Refactor: N/A
- [x] Upgrade: No upgrade impact; removing the GitHub App or deleting `.coderabbit.yaml` stops all activity immediately
- [x] Testing: Validated by opening a PR and posting `@coderabbitai review` (requires GitHub App installation)
- [x] Documentation: No user-guide update required; this is a developer tooling change
- [x] Community: Announcement to kubevirt-dev to be sent after merge
- [x] AI Contributions: This PR abides by the KubeVirt AI Contribution Policy

### Release note

```release-note
NONE
```