### PR TITLE
VEP 190: Node hooks to take plugin-level conditions into account

### DIFF
--- a/pkg/virt-handler/plugins/manager.go
+++ b/pkg/virt-handler/plugins/manager.go
@@ -84,6 +84,17 @@ func (m *nodeHookManager) CallNodeHooks(hookPoint pluginv1alpha1.NodeHookPoint, 
 			continue
 		}
 
+		if plugin.Spec.Condition != "" {
+			match, err := m.celEvaluator.EvaluateCondition(plugin.Spec.Condition, map[string]any{"vmi": vmi})
+			if err != nil {
+				return fmt.Errorf("CEL evaluation failed for plugin %s condition: %w", plugin.Name, err)
+			}
+			if !match {
+				log.Log.Object(vmi).V(3).Infof("Plugin %s condition not met, skipping all node hooks", plugin.Name)
+				continue
+			}
+		}
+
 		for _, nh := range plugin.Spec.NodeHooks {
 			if !slices.Contains(nh.PermittedHooks, hookPoint) {
 				log.Log.Object(vmi).V(4).Infof("Hook point %s not permitted for plugin %s, skipping", hookPoint, plugin.Name)

--- a/pkg/virt-handler/plugins/manager_test.go
+++ b/pkg/virt-handler/plugins/manager_test.go
@@ -113,6 +113,24 @@ var _ = Describe("NodeHookManager", func() {
 			Expect(err).To(HaveOccurred())
 		})
 
+		It("should skip plugin when plugin-level condition does not match", func() {
+			plugin := newPlugin("test-plugin", pluginv1alpha1.NodeHookPreVMStart)
+			plugin.Spec.Condition = "vmi.metadata.name == 'nonexistent'"
+			Expect(pluginStore.Add(plugin)).To(Succeed())
+
+			Expect(manager.CallNodeHooks(pluginv1alpha1.NodeHookPreVMStart, vmi, "test-node")).To(Succeed())
+		})
+
+		It("should attempt to call plugin when plugin-level condition matches", func() {
+			plugin := newPlugin("test-plugin", pluginv1alpha1.NodeHookPreVMStart)
+			plugin.Spec.Condition = "vmi.metadata.name == 'test-vmi'"
+			Expect(pluginStore.Add(plugin)).To(Succeed())
+
+			err := manager.CallNodeHooks(pluginv1alpha1.NodeHookPreVMStart, vmi, "test-node")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed to dial plugin"))
+		})
+
 		It("should process plugins in alphabetical order", func() {
 			pluginC := newPlugin("charlie", pluginv1alpha1.NodeHookPreVMStart)
 			pluginC.Spec.NodeHooks[0].FailureStrategy = pluginv1alpha1.FailureStrategyFail


### PR DESCRIPTION
### What this PR does
#### Before this PR:

`CallNodeHooks` only checked per-hook conditions (`NodeHook.Condition`) but did not evaluate the plugin-level `Spec.Condition`. Unlike the domain hook pipeline (in `pipeline.go`), which checks both, a plugin with a top-level condition would have it honored for domain hooks but silently ignored for node hooks.

#### After this PR:

A `Spec.Condition` evaluation is performed before iterating over `NodeHooks`, mirroring what `pipeline.go` does for domain hooks. If the plugin-level condition does not match, all node hooks for that plugin are skipped. Unit tests cover both matching and non-matching plugin-level conditions.

### References

- VEP: https://github.com/kubevirt/enhancements/issues/190

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] ~~Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required~~
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] ~~Upgrade: Impact of this change on upgrade flows was considered and addressed if required~~
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] ~~Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.~~
- [ ] ~~Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered~~
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
Fix CallNodeHooks to evaluate plugin-level Spec.Condition, ensuring consistent behavior between domain hooks and node hooks.
```