### PR TITLE
virt-handler: decouple k8s kv client

### DIFF
--- a/cmd/virt-handler/BUILD.bazel
+++ b/cmd/virt-handler/BUILD.bazel
@@ -58,6 +58,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/fields:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/scheme:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/typed/core/v1:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",

--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -41,6 +41,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	k8coresv1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/cache"
@@ -166,8 +167,9 @@ type virtHandlerApp struct {
 	migrationKeyFilePath    string
 	externallyManaged       bool
 
-	virtCli   kubecli.KubevirtClient
-	namespace string
+	virtClient kubecli.KubevirtClient
+	k8sClient  kubernetes.Interface
+	namespace  string
 
 	migrationServerTLSConfig    *tls.Config
 	serverTLSConfig             *tls.Config
@@ -202,7 +204,7 @@ func (app *virtHandlerApp) prepareCertManager() (err error) {
 
 func (app *virtHandlerApp) markNodeAsUnschedulable(logger *log.FilteredLogger) {
 	data := []byte(fmt.Sprintf(`{"metadata": { "labels": {"%s": "false"}}}`, v1.NodeSchedulable))
-	_, err := app.virtCli.CoreV1().Nodes().Patch(context.Background(), app.HostOverride, types.StrategicMergePatchType, data, metav1.PatchOptions{})
+	_, err := app.k8sClient.CoreV1().Nodes().Patch(context.Background(), app.HostOverride, types.StrategicMergePatchType, data, metav1.PatchOptions{})
 	if err != nil {
 		logger.Reason(err).Error("Unable to mark node as unschedulable")
 	}
@@ -233,7 +235,11 @@ func (app *virtHandlerApp) Run() {
 		panic(err)
 	}
 	clientConfig.RateLimiter = app.reloadableRateLimiter
-	app.virtCli, err = kubecli.GetKubevirtClientFromRESTConfig(clientConfig)
+	app.virtClient, err = kubecli.GetKubevirtClientFromRESTConfig(clientConfig)
+	if err != nil {
+		panic(err)
+	}
+	app.k8sClient, err = kubecli.GetK8sClientFromRESTConfig(clientConfig)
 	if err != nil {
 		panic(err)
 	}
@@ -259,12 +265,12 @@ func (app *virtHandlerApp) Run() {
 
 	// Create event recorder
 	broadcaster := record.NewBroadcaster()
-	broadcaster.StartRecordingToSink(&k8coresv1.EventSinkImpl{Interface: app.virtCli.CoreV1().Events(k8sv1.NamespaceAll)})
+	broadcaster.StartRecordingToSink(&k8coresv1.EventSinkImpl{Interface: app.k8sClient.CoreV1().Events(k8sv1.NamespaceAll)})
 	// Scheme is used to create an ObjectReference from an Object (e.g. VirtualMachineInstance) during Event creation
 	recorder := broadcaster.NewRecorder(scheme.Scheme, k8sv1.EventSource{Component: "virt-handler", Host: app.HostOverride})
 
 	// Wire VirtualMachineInstance controller
-	factory := controller.NewKubeInformerFactory(app.virtCli.RestClient(), app.virtCli, app.virtCli, nil, app.namespace)
+	factory := controller.NewKubeInformerFactory(app.virtClient.RestClient(), app.virtClient, app.k8sClient, nil, app.namespace)
 
 	vmiInformer := factory.VMI()
 	vmiSourceInformer := factory.VMISourceHost(app.HostOverride)
@@ -327,7 +333,7 @@ func (app *virtHandlerApp) Run() {
 
 	// Create a ListWatch filtered to only the local node
 	listWatch := cache.NewListWatchFromClient(
-		app.virtCli.CoreV1().RESTClient(),
+		app.k8sClient.CoreV1().RESTClient(),
 		"nodes",
 		metav1.NamespaceAll,
 		fields.OneTermEqualSelector("metadata.name", app.HostOverride),
@@ -335,7 +341,7 @@ func (app *virtHandlerApp) Run() {
 
 	nodeInformer := cache.NewSharedInformer(listWatch, &k8sv1.Node{}, controller.ResyncPeriod(12*time.Hour))
 
-	ksmHandler := ksm.NewHandler(app.HostOverride, app.virtCli.CoreV1(), nodeInformer.GetStore(), app.clusterConfig)
+	ksmHandler := ksm.NewHandler(app.HostOverride, app.k8sClient.CoreV1(), nodeInformer.GetStore(), app.clusterConfig)
 
 	var capabilities libvirtxml.Caps
 	var hostCpuModel string
@@ -353,7 +359,7 @@ func (app *virtHandlerApp) Run() {
 
 	nodeLabellerrecorder := broadcaster.NewRecorder(scheme.Scheme, k8sv1.EventSource{Component: "node-labeller", Host: app.HostOverride})
 	nodeLabellerController, err := nodelabeller.NewNodeLabeller(app.clusterConfig,
-		app.virtCli.CoreV1().Nodes(),
+		app.k8sClient.CoreV1().Nodes(),
 		nodeInformer.GetStore(),
 		app.HostOverride,
 		nodeLabellerrecorder,
@@ -409,7 +415,7 @@ func (app *virtHandlerApp) Run() {
 
 	migrationSourceController, err := virthandler.NewMigrationSourceController(
 		recorder,
-		app.virtCli,
+		app.virtClient,
 		app.HostOverride,
 		launcherClientsManager,
 		vmiSourceInformer,
@@ -429,7 +435,7 @@ func (app *virtHandlerApp) Run() {
 
 	migrationTargetController, err := virthandler.NewMigrationTargetController(
 		recorder,
-		app.virtCli,
+		app.virtClient,
 		app.HostOverride,
 		app.VirtPrivateDir,
 		app.KubeletPodsDir,
@@ -453,11 +459,12 @@ func (app *virtHandlerApp) Run() {
 		panic(err)
 	}
 
-	cbtHandler := virthandler.NewCBTHandler(app.virtCli, backupTrackerInformer)
+	cbtHandler := virthandler.NewCBTHandler(app.virtClient, backupTrackerInformer)
 
 	vmController, err := virthandler.NewVirtualMachineController(
 		recorder,
-		app.virtCli,
+		app.virtClient,
+		app.k8sClient,
 		nodeInformer.GetStore(),
 		app.HostOverride,
 		app.VirtPrivateDir,

--- a/pkg/virt-handler/BUILD.bazel
+++ b/pkg/virt-handler/BUILD.bazel
@@ -76,6 +76,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/client-go/tools/record:go_default_library",
         "//vendor/k8s.io/client-go/util/workqueue:go_default_library",

--- a/pkg/virt-handler/cbt.go
+++ b/pkg/virt-handler/cbt.go
@@ -36,16 +36,16 @@ import (
 )
 
 type CBTHandler struct {
-	clientset       kubecli.KubevirtClient
+	virtClient      kubecli.KubevirtClient
 	trackerInformer cache.SharedIndexInformer
 }
 
 func NewCBTHandler(
-	clientset kubecli.KubevirtClient,
+	virtClient kubecli.KubevirtClient,
 	trackerInformer cache.SharedIndexInformer,
 ) *CBTHandler {
 	return &CBTHandler{
-		clientset:       clientset,
+		virtClient:      virtClient,
 		trackerInformer: trackerInformer,
 	}
 }
@@ -117,8 +117,8 @@ func (h *CBTHandler) backupTrackersForVMI(vmi *v1.VirtualMachineInstance) []*bac
 }
 
 func (h *CBTHandler) markTrackersForRedefinition(vmi *v1.VirtualMachineInstance) error {
-	if h.trackerInformer == nil || h.clientset == nil {
-		return fmt.Errorf("tracker informer or clientset is nil")
+	if h.trackerInformer == nil || h.virtClient == nil {
+		return fmt.Errorf("tracker informer or virtClient is nil")
 	}
 
 	trackers := h.backupTrackersForVMI(vmi)
@@ -132,7 +132,7 @@ func (h *CBTHandler) markTrackersForRedefinition(vmi *v1.VirtualMachineInstance)
 		}
 
 		patch := []byte(`{"status":{"checkpointRedefinitionRequired":true}}`)
-		_, err := h.clientset.VirtualMachineBackupTracker(tracker.Namespace).Patch(
+		_, err := h.virtClient.VirtualMachineBackupTracker(tracker.Namespace).Patch(
 			context.Background(),
 			tracker.Name,
 			types.MergePatchType,

--- a/pkg/virt-handler/cbt_test.go
+++ b/pkg/virt-handler/cbt_test.go
@@ -192,15 +192,15 @@ var _ = Describe("CBTHandler", func() {
 			vmi.Status.ChangedBlockTracking = &v1.ChangedBlockTrackingStatus{State: v1.ChangedBlockTrackingInitializing}
 			err := handler.markTrackersForRedefinition(vmi)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("tracker informer or clientset is nil"))
+			Expect(err.Error()).To(ContainSubstring("tracker informer or virtClient is nil"))
 		})
 
-		It("should return error when clientset is nil", func() {
+		It("should return error when virtClient is nil", func() {
 			handler := NewCBTHandler(nil, trackerInformer)
 			vmi.Status.ChangedBlockTracking = &v1.ChangedBlockTrackingStatus{State: v1.ChangedBlockTrackingInitializing}
 			err := handler.markTrackersForRedefinition(vmi)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("tracker informer or clientset is nil"))
+			Expect(err.Error()).To(ContainSubstring("tracker informer or virtClient is nil"))
 		})
 
 		DescribeTable("should skip trackers that don't need redefinition",

--- a/pkg/virt-handler/controller.go
+++ b/pkg/virt-handler/controller.go
@@ -102,7 +102,7 @@ type netconf interface {
 type BaseController struct {
 	logger                      *log.FilteredLogger
 	host                        string
-	clientset                   kubecli.KubevirtClient
+	virtClient                  kubecli.KubevirtClient
 	queue                       workqueue.TypedRateLimitingInterface[string]
 	vmiStore                    cache.Store
 	domainStore                 cache.Store
@@ -124,7 +124,7 @@ func NewBaseController(
 	logger *log.FilteredLogger,
 	host string,
 	recorder record.EventRecorder,
-	clientset kubecli.KubevirtClient,
+	virtClient kubecli.KubevirtClient,
 	queue workqueue.TypedRateLimitingInterface[string],
 	vmiInformer cache.SharedIndexInformer,
 	domainInformer cache.SharedInformer,
@@ -143,7 +143,7 @@ func NewBaseController(
 		logger:                      logger,
 		host:                        host,
 		recorder:                    recorder,
-		clientset:                   clientset,
+		virtClient:                  virtClient,
 		queue:                       queue,
 		vmiStore:                    vmiInformer.GetStore(),
 		domainStore:                 domainInformer.GetStore(),

--- a/pkg/virt-handler/migration-source.go
+++ b/pkg/virt-handler/migration-source.go
@@ -70,7 +70,7 @@ type MigrationSourceController struct {
 
 func NewMigrationSourceController(
 	recorder record.EventRecorder,
-	clientset kubecli.KubevirtClient,
+	virtClient kubecli.KubevirtClient,
 	host string,
 	launcherClients launcherclients.LauncherClientsManager,
 	vmiInformer cache.SharedIndexInformer,
@@ -97,7 +97,7 @@ func NewMigrationSourceController(
 		logger,
 		host,
 		recorder,
-		clientset,
+		virtClient,
 		queue,
 		vmiInformer,
 		domainInformer,
@@ -372,7 +372,7 @@ func (c *MigrationSourceController) sync(vmi *v1.VirtualMachineInstance, domain 
 	if !equality.Semantic.DeepEqual(*oldStatus, vmi.Status) {
 		key := controller.VirtualMachineInstanceKey(vmi)
 		c.vmiExpectations.SetExpectations(key, 1, 0)
-		_, err := c.clientset.VirtualMachineInstance(vmi.ObjectMeta.Namespace).Update(context.Background(), vmi, metav1.UpdateOptions{})
+		_, err := c.virtClient.VirtualMachineInstance(vmi.ObjectMeta.Namespace).Update(context.Background(), vmi, metav1.UpdateOptions{})
 		if err != nil {
 			c.vmiExpectations.SetExpectations(key, 0, 0)
 			return err

--- a/pkg/virt-handler/migration-source_test.go
+++ b/pkg/virt-handler/migration-source_test.go
@@ -39,7 +39,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 
@@ -160,9 +159,7 @@ var _ = Describe("VirtualMachineInstance migration target", func() {
 
 		virtfakeClient = kubevirtfake.NewSimpleClientset()
 		ctrl := gomock.NewController(GinkgoT())
-		k8sfakeClient := fake.NewSimpleClientset()
 		virtClient = kubecli.NewMockKubevirtClient(ctrl)
-		virtClient.EXPECT().CoreV1().Return(k8sfakeClient.CoreV1()).AnyTimes()
 		virtClient.EXPECT().VirtualMachineInstance(metav1.NamespaceDefault).Return(virtfakeClient.KubevirtV1().VirtualMachineInstances(metav1.NamespaceDefault)).AnyTimes()
 		kv := &v1.KubeVirtConfiguration{
 			DeveloperConfiguration: &v1.DeveloperConfiguration{

--- a/pkg/virt-handler/migration-target.go
+++ b/pkg/virt-handler/migration-target.go
@@ -94,7 +94,7 @@ type MigrationTargetController struct {
 
 func NewMigrationTargetController(
 	recorder record.EventRecorder,
-	clientset kubecli.KubevirtClient,
+	virtClient kubecli.KubevirtClient,
 	host string,
 	virtPrivateDir string,
 	kubeletPodsDir string,
@@ -126,7 +126,7 @@ func NewMigrationTargetController(
 		logger,
 		host,
 		recorder,
-		clientset,
+		virtClient,
 		queue,
 		vmiInformer,
 		domainInformer,
@@ -502,7 +502,7 @@ func (c *MigrationTargetController) updateVMI(vmi *v1.VirtualMachineInstance, ol
 		if shouldExpect {
 			c.vmiExpectations.SetExpectations(key, 1, 0)
 		}
-		_, err := c.clientset.VirtualMachineInstance(vmi.ObjectMeta.Namespace).Update(context.Background(), vmi, metav1.UpdateOptions{})
+		_, err := c.virtClient.VirtualMachineInstance(vmi.ObjectMeta.Namespace).Update(context.Background(), vmi, metav1.UpdateOptions{})
 		if err != nil {
 			if shouldExpect {
 				c.vmiExpectations.SetExpectations(key, 0, 0)

--- a/pkg/virt-handler/migration-target_test.go
+++ b/pkg/virt-handler/migration-target_test.go
@@ -42,7 +42,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/uuid"
 	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	v1 "kubevirt.io/api/core/v1"
@@ -185,11 +184,9 @@ var _ = Describe("VirtualMachineInstance migration target", func() {
 		recorder = record.NewFakeRecorder(100)
 		recorder.IncludeObject = true
 
-		k8sfakeClient := fake.NewSimpleClientset()
 		virtfakeClient = kubevirtfake.NewSimpleClientset()
 		ctrl := gomock.NewController(GinkgoT())
 		virtClient = kubecli.NewMockKubevirtClient(ctrl)
-		virtClient.EXPECT().CoreV1().Return(k8sfakeClient.CoreV1()).AnyTimes()
 		virtClient.EXPECT().VirtualMachineInstance(metav1.NamespaceDefault).Return(virtfakeClient.KubevirtV1().VirtualMachineInstances(metav1.NamespaceDefault)).AnyTimes()
 		kv := &v1.KubeVirtConfiguration{
 			DeveloperConfiguration: &v1.DeveloperConfiguration{

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -43,6 +43,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
@@ -105,7 +106,7 @@ type downwardMetricsManager interface {
 type VirtualMachineController struct {
 	*BaseController
 	capabilities             *libvirtxml.Caps
-	clientset                kubecli.KubevirtClient
+	virtClient               kubecli.KubevirtClient
 	containerDiskMounter     containerdisk.Mounter
 	downwardMetricsManager   downwardMetricsManager
 	hotplugVolumeMounter     hotplugvolume.VolumeMounter
@@ -130,7 +131,8 @@ var getCgroupManager = func(vmi *v1.VirtualMachineInstance, host string, hypervi
 
 func NewVirtualMachineController(
 	recorder record.EventRecorder,
-	clientset kubecli.KubevirtClient,
+	virtClient kubecli.KubevirtClient,
+	k8sClient kubernetes.Interface,
 	nodeStore cache.Store,
 	host string,
 	virtPrivateDir string,
@@ -165,7 +167,7 @@ func NewVirtualMachineController(
 		logger,
 		host,
 		recorder,
-		clientset,
+		virtClient,
 		queue,
 		vmiInformer,
 		domainInformer,
@@ -196,7 +198,7 @@ func NewVirtualMachineController(
 	c := &VirtualMachineController{
 		BaseController:           baseCtrl,
 		capabilities:             capabilities,
-		clientset:                clientset,
+		virtClient:               virtClient,
 		containerDiskMounter:     containerdisk.NewMounter(podIsolationDetector, containerDiskState, clusterConfig),
 		downwardMetricsManager:   downwardMetricsManager,
 		hotplugVolumeMounter:     hotplugvolume.NewVolumeMounter(hotplugState, kubeletPodsDir, host),
@@ -249,7 +251,7 @@ func NewVirtualMachineController(
 		deviceManager.PermanentHostDevicePlugins(c.hypervisorNodeInfo.GetHypervisorDevice(), maxDevices, permissions),
 		clusterConfig,
 		nodeStore)
-	c.heartBeat = heartbeat.NewHeartBeat(clientset.CoreV1(), c.deviceManagerController, clusterConfig, host)
+	c.heartBeat = heartbeat.NewHeartBeat(k8sClient.CoreV1(), c.deviceManagerController, clusterConfig, host)
 
 	return c, nil
 }
@@ -1136,7 +1138,7 @@ func (c *VirtualMachineController) updateVMIStatus(oldStatus *v1.VirtualMachineI
 	if !equality.Semantic.DeepEqual(*oldStatus, vmi.Status) {
 		key := controller.VirtualMachineInstanceKey(vmi)
 		c.vmiExpectations.SetExpectations(key, 1, 0)
-		_, err := c.clientset.VirtualMachineInstance(vmi.ObjectMeta.Namespace).Update(context.Background(), vmi, metav1.UpdateOptions{})
+		_, err := c.virtClient.VirtualMachineInstance(vmi.ObjectMeta.Namespace).Update(context.Background(), vmi, metav1.UpdateOptions{})
 		if err != nil {
 			c.vmiExpectations.SetExpectations(key, 0, 0)
 			return err

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -159,7 +159,6 @@ var _ = Describe("VirtualMachineInstance", func() {
 		virtfakeClient = kubevirtfake.NewSimpleClientset()
 		ctrl := gomock.NewController(GinkgoT())
 		virtClient = kubecli.NewMockKubevirtClient(ctrl)
-		virtClient.EXPECT().CoreV1().Return(k8sfakeClient.CoreV1()).AnyTimes()
 		virtClient.EXPECT().VirtualMachineInstance(metav1.NamespaceDefault).Return(virtfakeClient.KubevirtV1().VirtualMachineInstances(metav1.NamespaceDefault)).AnyTimes()
 		kv := &v1.KubeVirtConfiguration{}
 		kv.NetworkConfiguration = &v1.NetworkConfiguration{Binding: map[string]v1.InterfaceBindingPlugin{
@@ -198,6 +197,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 		controller, _ = NewVirtualMachineController(
 			recorder,
 			virtClient,
+			k8sfakeClient,
 			fakeNodeStore,
 			host,
 			privateDir,
@@ -718,19 +718,6 @@ var _ = Describe("VirtualMachineInstance", func() {
 			domain.Status.Status = api.Running
 
 			addVMI(vmi, domain)
-
-			node := &k8sv1.Node{
-				Status: k8sv1.NodeStatus{
-					Addresses: []k8sv1.NodeAddress{
-						{
-							Type:    k8sv1.NodeInternalIP,
-							Address: "127.0.0.1",
-						},
-					},
-				},
-			}
-			fakeClient := fake.NewSimpleClientset(node).CoreV1()
-			virtClient.EXPECT().CoreV1().Return(fakeClient).AnyTimes()
 
 			sanityExecute()
 
@@ -1975,9 +1962,6 @@ var _ = Describe("VirtualMachineInstance", func() {
 		var testBlockPvc *k8sv1.PersistentVolumeClaim
 
 		BeforeEach(func() {
-			kubeClient := fake.NewSimpleClientset()
-			virtClient.EXPECT().CoreV1().Return(kubeClient.CoreV1()).AnyTimes()
-
 			// create a test block pvc
 			mode := k8sv1.PersistentVolumeBlock
 			testBlockPvc = &k8sv1.PersistentVolumeClaim{

--- a/staging/src/kubevirt.io/client-go/kubecli/kubecli.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kubecli.go
@@ -470,6 +470,8 @@ func GetK8sClientFromRESTConfig(config *rest.Config) (kubernetes.Interface, erro
 	shallowCopy.NegotiatedSerializer = serializer.WithoutConversionCodecFactory{CodecFactory: Codecs}
 	shallowCopy.ContentType = runtime.ContentTypeJSON
 
+	executeRestConfigHooks(&shallowCopy)
+
 	k8sClient, err := kubernetes.NewForConfig(&shallowCopy)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
### What this PR does
#### Before this PR:
In `pkg/virt-handler` and `cmd/virt-handler`, a single `kubecli.KubevirtClient` was used for both standard Kubernetes API calls (CoreV1, etc.) and KubeVirt-specific API calls (VirtualMachineInstance, VirtualMachineBackupTracker). Tests required mock bridging expectations like `virtClient.EXPECT().CoreV1().Return(...)` to wire KubeVirt mocks to fake K8s clients.

#### After this PR:
The KubeVirt clientset is decoupled from the Kubernetes clientset. A dedicated `kubernetes.Interface` (`k8sClient`) handles standard K8s API calls, while `kubecli.KubevirtClient` (`virtClient`) handles KubeVirt-specific calls. Tests pass the fake K8s client directly, eliminating mock bridging.

### References

- Partially addresses #16916

### Why we need it and why it was done in this way
The following tradeoffs were made:
- Constructors that only use KubeVirt-specific calls (MigrationSourceController, MigrationTargetController, CBTHandler) only receive `virtClient`, not `k8sClient`, since they don't need it.
- `VirtualMachineController` receives both because its constructor passes `k8sClient.CoreV1()` to the heartbeat subsystem.

The following alternatives were considered:
- Using narrower interfaces (e.g. `CoreV1Interface`) instead of `kubernetes.Interface` — this was not done to stay consistent with the pattern established in #16106.

Links to places where the discussion took place:
- PR #16106 (same effort for pkg/virt-operator)

### Special notes for your reviewer
Follows the exact same pattern as #16106 which did this for `pkg/virt-operator`. The `heartbeat.HeartBeat`, `ksm.Handler`, and `nodelabeller.NodeLabeller` already accepted narrow K8s interfaces — no changes needed there.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Testing: Existing unit tests updated and passing (234/234)
- [x] AI Contributions: The PR abides by the KubeVirt AI Contribution Policy.

### Release note
```release-note
NONE
```