### PR TITLE
Drop redundant e2e tests, which have good-enough unit-test coverage

### DIFF
--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -916,19 +916,6 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 		})
 	})
 
-	Context("with a custom scheduler", decorators.WgS390x, func() {
-		It("[test_id:4631]should set the custom scheduler on the pod", func() {
-			vmi := libvmi.New(
-				libvmi.WithMemoryRequest(enoughMemForSafeBiosEmulation),
-				WithSchedulerName("my-custom-scheduler"),
-			)
-			runningVMI := libvmops.RunVMIAndExpectScheduling(vmi, 30)
-			launcherPod, err := libpod.GetPodByVirtualMachineInstance(runningVMI, testsuite.GetTestNamespace(vmi))
-			Expect(err).ToNot(HaveOccurred())
-			Expect(launcherPod.Spec.SchedulerName).To(Equal("my-custom-scheduler"))
-		})
-	})
-
 	Context("using automatic resource limits", decorators.WgS390x, func() {
 
 		When("there is no ResourceQuota with memory and cpu limits associated with the creation namespace", func() {
@@ -1759,12 +1746,6 @@ func machineTypeForArch() (machineType, expectedSubstring string, emulatedMachin
 		return "s390-ccw-virtio", "s390-ccw-virtio", []string{"s390-ccw-virtio*"}
 	}
 	return "pc", "pc-i440", []string{"pc"}
-}
-
-func WithSchedulerName(schedulerName string) libvmi.Option {
-	return func(vmi *v1.VirtualMachineInstance) {
-		vmi.Spec.SchedulerName = schedulerName
-	}
 }
 
 func withSerialBIOS() libvmi.Option {

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -862,45 +862,6 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				}, 60*time.Second, 1*time.Second).Should(Equal(k8sv1.PodReasonUnschedulable), "VMI should be unchedulable")
 			})
 
-			It("[test_id:3202]the vmi with cpu.features matching nfd labels on a node should be scheduled", decorators.WgS390x, func() {
-
-				By("adding a node-feature-discovery CPU model label to a node")
-				vmi := libvmifact.NewGuestless()
-				var featureToDisable string
-				// Use a different feature to disable, as  s390x and
-				//other archs do not have common cpu features
-
-				switch libnode.GetArch() {
-				case "s390x":
-					featureToDisable = "zpci"
-				case "amd64":
-					featureToDisable = "fpu"
-
-				}
-
-				featureToRequire := supportedFeatures[0]
-
-				if featureToRequire == featureToDisable {
-					// Picking another feature since this one is going to be disabled
-					featureToRequire = supportedFeatures[1]
-				}
-
-				vmi.Spec.Domain.CPU = &v1.CPU{
-					Cores: 1,
-					Features: []v1.CPUFeature{
-						{
-							Name:   featureToRequire,
-							Policy: "require",
-						},
-						{
-							Name:   featureToDisable,
-							Policy: "disable",
-						},
-					},
-				}
-				libvmops.RunVMIAndExpectLaunch(vmi, startupTimeout)
-			})
-
 			It("[test_id:3203]the vmi with cpu.features that cannot match nfd labels on a node should not be scheduled", func() {
 				var featureDenyList = map[string]struct{}{
 					"svm": {},

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -51,7 +51,6 @@ import (
 	"kubevirt.io/kubevirt/pkg/hypervisor"
 	"kubevirt.io/kubevirt/pkg/libvmi"
 	"kubevirt.io/kubevirt/pkg/pointer"
-	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"
 	device_manager "kubevirt.io/kubevirt/pkg/virt-handler/device-manager"
 	"kubevirt.io/kubevirt/tests/console"
@@ -828,7 +827,6 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			var supportedCPUs []string
 			var supportedFeatures []string
 			var nodes *k8sv1.NodeList
-			var supportedKVMInfoFeature []string
 
 			BeforeEach(func() {
 				nodes = libnode.GetAllSchedulableNodes(kubevirt.Client())
@@ -842,18 +840,6 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 
 				supportedFeatures = libnode.GetSupportedCPUFeatures(*nodes)
 				Expect(len(supportedFeatures)).To(BeNumerically(">=", 2), "There should be at least 2 supported cpu features")
-
-				for key := range node.Labels {
-					if strings.Contains(key, v1.HypervLabel) &&
-						!strings.Contains(key, "tlbflush") &&
-						!strings.Contains(key, "ipi") &&
-						!strings.Contains(key, "synictimer") {
-						supportedKVMInfoFeature = append(supportedKVMInfoFeature, strings.TrimPrefix(key, v1.HypervLabel))
-					}
-
-				}
-
-				kvconfig.EnableFeatureGate(featuregate.HypervStrictCheckGate)
 			})
 
 			It("[test_id:1639]the vmi with cpu.model matching a nfd label on a node should be scheduled", func() {

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -823,8 +823,6 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 
 		Context("with node feature discovery", Serial, decorators.CPUModel, decorators.RequiresAMD64, func() {
 			var node *k8sv1.Node
-			var supportedCPU string
-			var supportedCPUs []string
 			var supportedFeatures []string
 			var nodes *k8sv1.NodeList
 
@@ -833,29 +831,9 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				Expect(nodes.Items).ToNot(BeEmpty(), "There should be some compute node")
 
 				node = &nodes.Items[0]
-				supportedCPUs = libnode.GetSupportedCPUModels(*nodes)
-				Expect(supportedCPUs).ToNot(BeEmpty(), "There should be some supported cpu models")
-
-				supportedCPU = supportedCPUs[0]
 
 				supportedFeatures = libnode.GetSupportedCPUFeatures(*nodes)
 				Expect(len(supportedFeatures)).To(BeNumerically(">=", 2), "There should be at least 2 supported cpu features")
-			})
-
-			It("[test_id:1639]the vmi with cpu.model matching a nfd label on a node should be scheduled", func() {
-				vmi := libvmifact.NewGuestless()
-				vmi.Spec.Domain.CPU = &v1.CPU{
-					Cores: 1,
-					Model: supportedCPU,
-				}
-				vmi = libvmops.RunVMIAndExpectLaunch(vmi, startupTimeout)
-
-				By("Verifying VirtualMachineInstance's status is Succeeded")
-				Eventually(func() v1.VirtualMachineInstancePhase {
-					currVMI, err := kubevirt.Client().VirtualMachineInstance(vmi.Namespace).Get(context.Background(), vmi.Name, metav1.GetOptions{})
-					Expect(err).ToNot(HaveOccurred(), "Should get VMI")
-					return currVMI.Status.Phase
-				}, 120, 0.5).Should(Equal(v1.Running), "VMI should be succeeded")
 			})
 
 			It("[test_id:1640]the vmi with cpu.model that cannot match an nfd label on node should not be scheduled", decorators.WgS390x, func() {


### PR DESCRIPTION
Remove three e2e tests with little to no value.
Drop dead code that has been left over by PR #18262.

/kind cleanup

```release-note
NONE
```

