### PR TITLE
tests: wait for all workers schedulable instead of cpumanager=true

### DIFF
--- a/tests/testsuite/fixture.go
+++ b/tests/testsuite/fixture.go
@@ -128,6 +128,7 @@ func SynchronizedBeforeTestSetup() []byte {
 	EnsureHypervisorPresent()
 	AdjustKubeVirtResource()
 	EnsureKubevirtReady()
+	WaitForWorkerNodesSchedulable()
 
 	return nil
 }

--- a/tests/testsuite/kubevirtresource.go
+++ b/tests/testsuite/kubevirtresource.go
@@ -37,7 +37,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/strategicpatch"
 	v1 "kubevirt.io/api/core/v1"
-	"kubevirt.io/client-go/log"
+	"kubevirt.io/client-go/kubecli"
 
 	"kubevirt.io/kubevirt/pkg/pointer"
 	"kubevirt.io/kubevirt/pkg/storage/cbt"
@@ -52,6 +52,7 @@ import (
 var (
 	KubeVirtDefaultConfig v1.KubeVirtConfiguration
 	originalKV            *v1.KubeVirt
+	appliedE2EConfig      bool
 )
 
 func AdjustKubeVirtResource() {
@@ -65,6 +66,8 @@ func AdjustKubeVirtResource() {
 	if !flags.ApplyDefaulte2eConfiguration {
 		return
 	}
+
+	appliedE2EConfig = true
 
 	// Rotate very often during the tests to ensure that things are working
 	kv.Spec.CertificateRotationStrategy = v1.KubeVirtCertificateRotateStrategy{SelfSigned: &v1.KubeVirtSelfSignConfiguration{
@@ -152,27 +155,60 @@ func AdjustKubeVirtResource() {
 	adjustedKV, err := virtClient.KubeVirt(kv.Namespace).Patch(context.Background(), kv.Name, types.JSONPatchType, []byte(patchData), metav1.PatchOptions{})
 	Expect(err).ToNot(HaveOccurred())
 	KubeVirtDefaultConfig = adjustedKV.Spec.Configuration
-	if checks.HasFeature(featuregate.CPUManager) {
-		// CPUManager is typically not enabled in the control-plane node(s)
-		nodes, err := virtClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{LabelSelector: "!node-role.kubernetes.io/control-plane"})
-		Expect(err).NotTo(HaveOccurred())
-		// This case could happen in the case of single node clusters (like OpenShift SNO)
-		if len(nodes.Items) == 0 {
-			log.Log.Info("No non-control-plane nodes found. This shouldn't happen unless this is a single-node cluster. Falling back to listing nodes labeled as `worker`.")
-			nodes, err = virtClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{LabelSelector: "node-role.kubernetes.io/worker"})
-			Expect(err).NotTo(HaveOccurred())
-		}
-		waitForSchedulableNodesWithCPUManager(len(nodes.Items))
-	}
 }
 
-func waitForSchedulableNodesWithCPUManager(n int) {
+func workerNodes(virtClient kubecli.KubevirtClient) []string {
+	// Fall back to all nodes for single-node clusters (SNO / kubevirtci / kubeadm).
+	nodes, err := virtClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{
+		LabelSelector: "!node-role.kubernetes.io/control-plane",
+	})
+	Expect(err).ToNot(HaveOccurred())
+	if len(nodes.Items) == 0 {
+		nodes, err = virtClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{})
+		Expect(err).ToNot(HaveOccurred())
+	}
+	Expect(nodes.Items).ToNot(BeEmpty(), "expected at least one worker node")
+
+	names := make([]string, len(nodes.Items))
+	for i := range nodes.Items {
+		names[i] = nodes.Items[i].Name
+	}
+	return names
+}
+
+func WaitForWorkerNodesSchedulable() {
 	virtClient := kubevirt.Client()
-	Eventually(func() bool {
-		nodes, err := virtClient.CoreV1().Nodes().List(context.Background(), metav1.ListOptions{LabelSelector: v1.NodeSchedulable + "=" + "true," + v1.CPUManager + "=true"})
-		Expect(err).ToNot(HaveOccurred(), "Should list compute nodes")
-		return len(nodes.Items) == n
-	}, 360, 1*time.Second).Should(BeTrue())
+	workerNames := workerNodes(virtClient)
+
+	// Baseline at wait start (after EnsureKubevirtReady). A later heartbeat means
+	// schedulable + cpumanager were rewritten under suite config (same patch).
+	var heartbeatTimestamps map[string]string
+	if appliedE2EConfig {
+		heartbeatTimestamps = make(map[string]string, len(workerNames))
+		for _, name := range workerNames {
+			node, err := virtClient.CoreV1().Nodes().Get(context.Background(), name, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			heartbeatTimestamps[name] = node.Annotations[v1.VirtHandlerHeartbeat]
+		}
+	}
+
+	Eventually(func(g Gomega) {
+		for _, name := range workerNames {
+			node, err := virtClient.CoreV1().Nodes().Get(context.Background(), name, metav1.GetOptions{})
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(node.Labels[v1.NodeSchedulable]).To(Equal("true"),
+				"node %s is not kubevirt.io/schedulable=true", name)
+			if !appliedE2EConfig {
+				continue
+			}
+			heartbeat := node.Annotations[v1.VirtHandlerHeartbeat]
+			g.Expect(heartbeat).ToNot(BeEmpty(),
+				"node %s is missing kubevirt.io/heartbeat", name)
+			g.Expect(heartbeat).ToNot(Equal(heartbeatTimestamps[name]),
+				"node %s has not heartbeated since suite config was applied", name)
+		}
+	}, 360*time.Second, time.Second).Should(Succeed(),
+		"timed out waiting for worker nodes to become schedulable")
 }
 
 func RestoreKubeVirtResource() {


### PR DESCRIPTION
### What this PR does

**TL;DR:** Suite setup hung for ~360s on clusters without static CPU manager policy, because it waited for `kubevirt.io/cpumanager=true`. That conflated handler readiness with kubelet policy. Wait for handler readiness instead (`schedulable=true`, plus a post-ready heartbeat when default e2e config was applied).

> **Invariant:** suite setup means every worker has been heartbeated by virt-handler under the (optional) suite config — not that every worker has static CPU manager policy.

#### Before

E2E suite setup (inside `AdjustKubeVirtResource`, gated on the CPUManager feature gate) waited until every counted worker had `kubevirt.io/schedulable=true,kubevirt.io/cpumanager=true`.

On non-static clusters (external / kubeadm / many single-node setups), virt-handler correctly sets `cpumanager=false`, so setup hangs (~360s). That showed up after #16781 tightened single-node worker selection ([comment](https://github.com/kubevirt/kubevirt/pull/16781#issuecomment-4462165261)).

On kubevirt CI (static policy + `-apply-default-e2e-configuration` enables the Alpha `CPUManager` gate), waiting for `=true` happened to also mean “all workers heartbeated under suite config,” which is why #11092 used that predicate for migration flakes. Convenient on CI, not portable.

#### After

Suite setup waits **after** `EnsureKubevirtReady` for all selected workers to be `kubevirt.io/schedulable=true`.

- If default e2e config was applied: also require a `kubevirt.io/heartbeat` newer than a baseline taken **at wait start**, so labels were rewritten under the suite CR. virt-handler writes `schedulable` and `cpumanager` (`true`/`false`) in the same heartbeat patch and does **not** heartbeat on config change — so a post-ready heartbeat is the earliest portable “labels reflect suite config” signal.
- If default e2e config was skipped (e.g. KWOK/perf): only `schedulable=true` (no heartbeat wait).

Worker selection prefers non-control-plane nodes, then falls back to all nodes for single-node layouts. Names are captured once so membership cannot change mid-poll.

Unblocks suite setup only. Dedicated-CPU / CPU-manager tests still need `cpumanager=true` (static policy) via decorators / lane filters / `KUBEVIRT_E2E_SKIP`. If CI has static policy and handlers have heartbeated under suite config but the label is still `false`, that is a cluster-up/kubelet bug — not something suite setup should paper over.

### References

- Fixes [suite hang on #16781](https://github.com/kubevirt/kubevirt/pull/16781#issuecomment-4462165261)
- Preserves the readiness intent of [#11092](https://github.com/kubevirt/kubevirt/pull/11092) without requiring `cpumanager=true`
- Supersedes decorator-only hang fix [#18242](https://github.com/kubevirt/kubevirt/pull/18242)

### Why this way

**Cost:** up to ~one heartbeat period (1–2 minutes) after `EnsureKubevirtReady` when a fresh heartbeat is still needed. Preferable to a 360s hang or a #11092-class flake.

**Why not simpler alternatives:**

- Keep `cpumanager=true` (#11092) — hangs when the label is correctly `false` (wrong layer: asserts kubelet policy in suite setup).
- Existence-only `cpumanager` ([ce8856f](https://github.com/kubevirt/kubevirt/commit/ce8856f88349e1e7813441ed7030c47776e6afe4)) — key is already `false` before the suite enables the FG; wait can return before a post-FG heartbeat.
- `schedulable=true` only — same early-return window if nodes were already schedulable.
- Decorator-driven waits only (#18242) — held over coverage risk; no single suite readiness bar.
- kubevirtci cluster-up only — does not cover external clusters.

### Special notes for your reviewer

- Does **not** make dedicated-CPU tests pass without static policy.
- Please close or retarget #18242 once this lands.
- On s390x, default e2e config still skips enabling `CPUManager`; with default config applied we still wait for a post-ready heartbeat (and `schedulable`).
- Heartbeat period is ~1–2 minutes; wait is bounded by the existing 360s timeout.
- Optional follow-up: make heartbeat interval configurable (default stays 1m) and shorten it in kubevirtci/e2e to cut post-ready latency.

### Checklist
- [x] Design: A [VEP](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
NONE
```