### PR TITLE
unit-test,virt-operator: Cache install strategy between test runs

### DIFF
--- a/pkg/virt-operator/kubevirt_test.go
+++ b/pkg/virt-operator/kubevirt_test.go
@@ -121,6 +121,11 @@ var (
 		components.NewVirtualMachineBackupTrackerCrd, components.NewPluginCrd,
 	}
 	numCRDs = len(crdFunctions) + numVirtTemplateCRDs
+
+	// installStrategyConfigMapCache caches the encoded install-strategy configmap by deployment ID.
+	// NewInstallStrategyConfigMap is expensive (gzip+base64 encoding of all manifests), and many
+	// tests call addInstallStrategy with the same config, so we reuse the result across test runs.
+	installStrategyConfigMapCache = map[string]*k8sv1.ConfigMap{}
 )
 
 type KubeVirtTestData struct {
@@ -1683,10 +1688,16 @@ func (k *KubeVirtTestData) addValidatingWebhook(wh *admissionregistrationv1.Vali
 }
 
 func (k *KubeVirtTestData) addInstallStrategy(config *util.KubeVirtDeploymentConfig) {
-	// install strategy config
-	resource, err := install.NewInstallStrategyConfigMap(config, "openshift-monitoring", NAMESPACE)
-	Expect(err).ToNot(HaveOccurred())
+	cached, ok := installStrategyConfigMapCache[config.GetDeploymentID()]
+	if !ok {
+		var err error
+		cached, err = install.NewInstallStrategyConfigMap(config, "openshift-monitoring", NAMESPACE)
+		Expect(err).ToNot(HaveOccurred())
+		installStrategyConfigMapCache[config.GetDeploymentID()] = cached
+	}
 
+	// Each test needs a unique copy
+	resource := cached.DeepCopy()
 	resource.Name = fmt.Sprintf("%s-%s", resource.Name, rand.String(10))
 
 	injectMetadata(&resource.ObjectMeta, config)


### PR DESCRIPTION
Compressing and encoding the config each time is expensive. To save time cache the results between test runs.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
The `virt-operator` testsuite would occasionally run into the timeout of 15m during unit-tests on s390x
#### After this PR:
The testsuite runs about 5min faster on s390x, about 3min on x86_64 (my laptop, running with go-test).

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
Partially addresses https://github.com/kubevirt/project-infra/issues/5180
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:
The map is not thread safe, so tests need to ensure it is accessed sequentially.
The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

