### PR TITLE
Handle volumeMounts when absent

### DIFF
--- a/pkg/virt-operator/resource/generate/components/validatingadmissionpolicies/validatingadmissionpolicy_sidecar.go
+++ b/pkg/virt-operator/resource/generate/components/validatingadmissionpolicies/validatingadmissionpolicy_sidecar.go
@@ -76,6 +76,7 @@ func NewSidecarSubPathValidatingAdmissionPolicy() *admissionregistrationv1.Valid
 					Name: "containersHaveSubPath",
 					Expression: `object.spec.containers.all(c,
     c.name == "compute" ||
+    !has(c.volumeMounts) ||
     !c.volumeMounts.exists(vm, vm.name == "kubevirt-plugin-sockets") ||
     c.volumeMounts.filter(vm, vm.name == "kubevirt-plugin-sockets")
         .all(vm, has(vm.subPath) && vm.subPath != ""))`,
@@ -84,6 +85,7 @@ func NewSidecarSubPathValidatingAdmissionPolicy() *admissionregistrationv1.Valid
 					Name: "initContainersHaveSubPath",
 					Expression: `!has(object.spec.initContainers) ||
     object.spec.initContainers.all(c,
+        !has(c.volumeMounts) ||
         !c.volumeMounts.exists(vm, vm.name == "kubevirt-plugin-sockets") ||
         c.volumeMounts.filter(vm, vm.name == "kubevirt-plugin-sockets")
             .all(vm, has(vm.subPath) && vm.subPath != ""))`,
@@ -92,6 +94,7 @@ func NewSidecarSubPathValidatingAdmissionPolicy() *admissionregistrationv1.Valid
 					Name: "ephemeralContainersHaveSubPath",
 					Expression: `!has(object.spec.ephemeralContainers) ||
     object.spec.ephemeralContainers.all(c,
+        !has(c.volumeMounts) ||
         !c.volumeMounts.exists(vm, vm.name == "kubevirt-plugin-sockets") ||
         c.volumeMounts.filter(vm, vm.name == "kubevirt-plugin-sockets")
             .all(vm, has(vm.subPath) && vm.subPath != ""))`,

--- a/pkg/virt-operator/resource/generate/components/validatingadmissionpolicies/validatingadmissionpolicy_sidecar_test.go
+++ b/pkg/virt-operator/resource/generate/components/validatingadmissionpolicies/validatingadmissionpolicy_sidecar_test.go
@@ -138,6 +138,32 @@ var _ = Describe("Sidecar ValidatingAdmissionPolicies", func() {
 			}}
 			Expect(admitSidecarSubPath(pod)).To(Succeed())
 		})
+
+		It("should allow containers without volumeMounts", func() {
+			pod := launcherPod(
+				corev1.Container{Name: "compute"},
+				corev1.Container{Name: "sidecar-no-mounts"},
+			)
+			Expect(admitSidecarSubPath(pod)).To(Succeed())
+		})
+
+		It("should allow initContainer without volumeMounts", func() {
+			pod := launcherPod(corev1.Container{Name: "compute"})
+			pod.Spec.InitContainers = []corev1.Container{{
+				Name: "volumedisk0",
+			}}
+			Expect(admitSidecarSubPath(pod)).To(Succeed())
+		})
+
+		It("should allow ephemeralContainer without volumeMounts", func() {
+			pod := launcherPod(corev1.Container{Name: "compute"})
+			pod.Spec.EphemeralContainers = []corev1.EphemeralContainer{{
+				EphemeralContainerCommon: corev1.EphemeralContainerCommon{
+					Name: "debug-no-mounts",
+				},
+			}}
+			Expect(admitSidecarSubPath(pod)).To(Succeed())
+		})
 	})
 
 	Context("PluginSocketPath policy", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
KWOK tests are failing to create virt-launcher pod with the following ValidatingAdmissionPolicy error:
 ` Warning  FailedCreate  13s (x4 over 31s)  virtualmachine-controller  (combined from similar events): Error creating pod: pods "virt-launcher-testvmi-txhzt-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxk45f7" is forbidden: ValidatingAdmissionPolicy 'kubevirt-plugin-sidecar-subpath-policy' with binding 'kubevirt-plugin-sidecar-subpath-binding' denied request: expression 'variables.containersHaveSubPath && variables.initContainersHaveSubPath && variables.ephemeralContainersHaveSubPath' resulted in error: composited variable "initContainersHaveSubPath" fails to evaluate: no such key: volumeMounts`
 
 https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.34-sig-performance-kwok&width=20

Currently the [policy](https://github.com/kubevirt/kubevirt/pull/18102/changes/d068e91247a9bccf053434453642dd875d0ae9fc#diff-5255f0b9e62745573e4bf8381647b176288d095a8c0a53e886f196c13b7c5fd3R75) assumes volumeMounts is always present. Since volumeMounts is an optional field in the Kubernetes API, Policy should handle the case where volumeMounts being absent.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

