### PR TITLE
test, namespace: Fix cleanup failures in env with  external ns labels 

### DIFF
--- a/tests/compute/BUILD.bazel
+++ b/tests/compute/BUILD.bazel
@@ -39,6 +39,7 @@ go_library(
         "//tests/libkubevirt:go_default_library",
         "//tests/libkubevirt/config:go_default_library",
         "//tests/libmigration:go_default_library",
+        "//tests/libnamespace:go_default_library",
         "//tests/libnet:go_default_library",
         "//tests/libnet/cloudinit:go_default_library",
         "//tests/libnode:go_default_library",

--- a/tests/compute/cpu.go
+++ b/tests/compute/cpu.go
@@ -32,7 +32,6 @@ import (
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 
 	"kubevirt.io/client-go/kubecli"
 
@@ -42,6 +41,7 @@ import (
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/libkubevirt"
 	kvconfig "kubevirt.io/kubevirt/tests/libkubevirt/config"
+	"kubevirt.io/kubevirt/tests/libnamespace"
 	"kubevirt.io/kubevirt/tests/libnode"
 	"kubevirt.io/kubevirt/tests/libpod"
 	"kubevirt.io/kubevirt/tests/libvmifact"
@@ -426,12 +426,7 @@ var _ = Describe(SIG("CPU", func() {
 			vmi := libvmifact.NewGuestless()
 
 			By("Adding the right label to VMI namespace")
-			namespace, err := virtClient.CoreV1().Namespaces().Get(context.Background(), testsuite.GetTestNamespace(vmi), metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-
-			patchData := []byte(fmt.Sprintf(`{"metadata": { "labels": {"%s": "true"}}}`, autoCPULimitLabel))
-			_, err = virtClient.CoreV1().Namespaces().Patch(context.Background(), namespace.Name, types.StrategicMergePatchType, patchData, metav1.PatchOptions{})
-			Expect(err).ToNot(HaveOccurred())
+			Expect(libnamespace.AddLabelToNamespace(virtClient, testsuite.GetTestNamespace(vmi), autoCPULimitLabel, "true")).To(Succeed())
 
 			By("Starting the VMI")
 			runningVMI := libvmops.RunVMIAndExpectScheduling(vmi, 30)

--- a/tests/libnamespace/BUILD.bazel
+++ b/tests/libnamespace/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",

--- a/tests/libnamespace/namespace.go
+++ b/tests/libnamespace/namespace.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"reflect"
 
+	. "github.com/onsi/ginkgo/v2"
+
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -14,6 +16,7 @@ import (
 )
 
 func AddLabelToNamespace(client kubecli.KubevirtClient, namespace, key, value string) error {
+	DeferCleanup(RemoveLabelFromNamespace, client, namespace, key)
 	return PatchNamespace(client, namespace, func(ns *v1.Namespace) {
 		if ns.Labels == nil {
 			ns.Labels = map[string]string{}

--- a/tests/testsuite/namespace.go
+++ b/tests/testsuite/namespace.go
@@ -394,17 +394,15 @@ func GetLabelsForNamespace(namespace string) map[string]string {
 
 func resetNamespaceLabelsToDefault(client kubecli.KubevirtClient, namespace string) error {
 	return libnamespace.PatchNamespace(client, namespace, func(ns *k8sv1.Namespace) {
-		if ns.Labels == nil {
-			return
+		for key, value := range GetLabelsForNamespace(namespace) {
+			ns.Labels[key] = value
 		}
-		ns.Labels = GetLabelsForNamespace(namespace)
 	})
 }
 
 func createNamespaces() {
 	virtCli := kubevirt.Client()
 
-	// Create a Test Namespaces
 	for _, namespace := range TestNamespaces {
 		ns := &k8sv1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
### What this PR does
The namespace cleanup in resetNamespaceLabelsToDefault replaces all
labels with a hardcoded default set. This fails in environments where
external systems add protected labels to namespaces that cannot
be removed.

Instead, AddLabelToNamespace automatically schedules removal of each 
label it adds via DeferCleanup. The namespace cleanup no longer 
replaces labels, only ensures defaults are present

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

