### PR TITLE
virt-launcher: guard RamFB.Enabled nil in the DRA and legacy mdev host-device builders

### DIFF
--- a/pkg/virt-launcher/virtwrap/device/hostdevice/dra/gpu_hostdev.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/dra/gpu_hostdev.go
@@ -106,7 +106,7 @@ func createHostDeviceForGPU(gpu v1.GPU, basePath string, resourceClaims []v1.Vir
 			displayEnabled := gpu.VirtualGPUOptions.Display.Enabled
 			if displayEnabled == nil || *displayEnabled {
 				hostDevice.Display = "on"
-				if gpu.VirtualGPUOptions.Display.RamFB == nil || *gpu.VirtualGPUOptions.Display.RamFB.Enabled {
+				if gpu.VirtualGPUOptions.Display.RamFB == nil || gpu.VirtualGPUOptions.Display.RamFB.Enabled == nil || *gpu.VirtualGPUOptions.Display.RamFB.Enabled {
 					hostDevice.RamFB = "on"
 				}
 			}

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/dra/gpu_hostdev.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/dra/gpu_hostdev.go
@@ -106,7 +106,8 @@ func createHostDeviceForGPU(gpu v1.GPU, basePath string, resourceClaims []v1.Vir
 			displayEnabled := gpu.VirtualGPUOptions.Display.Enabled
 			if displayEnabled == nil || *displayEnabled {
 				hostDevice.Display = "on"
-				if gpu.VirtualGPUOptions.Display.RamFB == nil || *gpu.VirtualGPUOptions.Display.RamFB.Enabled {
+				ramFB := gpu.VirtualGPUOptions.Display.RamFB
+				if ramFB == nil || ramFB.Enabled == nil || *ramFB.Enabled {
 					hostDevice.RamFB = "on"
 				}
 			}

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/dra/gpu_hostdev_test.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/dra/gpu_hostdev_test.go
@@ -50,6 +50,53 @@ var _ = Describe("CreateDRAGPUHostDevices", func() {
 		Expect(os.WriteFile(filepath.Join(dir, driver+"-metadata.json"), data, 0644)).To(Succeed())
 	}
 
+	// writeMDevClaim writes metadata for a single mdev (vGPU) device under
+	// claim1/req1, keyed by the given mdev UUID.
+	writeMDevClaim := func(uuid string) {
+		createMetadataFile("claim1", "req1", "gpu.example.com", &metadata.DeviceMetadata{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "DeviceMetadata",
+				APIVersion: metadata.APIVersionV1Alpha1,
+			},
+			ObjectMeta: metav1.ObjectMeta{Name: "claim1"},
+			Requests: []metadata.DeviceMetadataRequest{{
+				Name: "req1",
+				Devices: []metadata.Device{{
+					Driver: "gpu.example.com",
+					Pool:   "gpu-pool",
+					Name:   "device1",
+					Attributes: map[resourcev1.QualifiedName]resourcev1.DeviceAttribute{
+						metadata.MDevUUIDAttribute: {StringValue: &uuid},
+					},
+				}},
+			}},
+		})
+	}
+
+	// vgpuVMI builds a VMI with a single vGPU bound to claim1/req1. A nil display
+	// leaves VirtualGPUOptions unset; otherwise the given display options are used.
+	vgpuVMI := func(display *v1.VGPUDisplayOptions) *v1.VirtualMachineInstance {
+		gpu := v1.GPU{
+			Name:         "vgpu1",
+			ClaimRequest: &v1.ClaimRequest{ClaimName: "claim1", RequestName: "req1"},
+		}
+		if display != nil {
+			gpu.VirtualGPUOptions = &v1.VGPUOptions{Display: display}
+		}
+		return &v1.VirtualMachineInstance{
+			ObjectMeta: metav1.ObjectMeta{Name: "testvmi", Namespace: "default"},
+			Spec: v1.VirtualMachineInstanceSpec{
+				ResourceClaims: []v1.VirtualMachineInstanceResourceClaim{{
+					Name:              "claim1",
+					ResourceClaimName: ptr.To("claim1"),
+				}},
+				Domain: v1.DomainSpec{
+					Devices: v1.Devices{GPUs: []v1.GPU{gpu}},
+				},
+			},
+		}
+	}
+
 	Context("when the VMI has no GPUs with DRA", func() {
 		It("should return an empty slice without error", func() {
 			vmi := &v1.VirtualMachineInstance{
@@ -134,51 +181,9 @@ var _ = Describe("CreateDRAGPUHostDevices", func() {
 	Context("when the VMI has a virtual GPU (mdev) allocated through DRA", func() {
 		It("should create exactly one mdev host device with display enabled", func() {
 			uuid := "123e4567-e89b-12d3-a456-426614174000"
+			writeMDevClaim(uuid)
 
-			createMetadataFile("claim1", "req1", "gpu.example.com", &metadata.DeviceMetadata{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "DeviceMetadata",
-					APIVersion: metadata.APIVersionV1Alpha1,
-				},
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "claim1",
-				},
-				Requests: []metadata.DeviceMetadataRequest{{
-					Name: "req1",
-					Devices: []metadata.Device{{
-						Driver: "gpu.example.com",
-						Pool:   "gpu-pool",
-						Name:   "device1",
-						Attributes: map[resourcev1.QualifiedName]resourcev1.DeviceAttribute{
-							metadata.MDevUUIDAttribute: {StringValue: &uuid},
-						},
-					}},
-				}},
-			})
-
-			vmi := &v1.VirtualMachineInstance{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "testvmi",
-					Namespace: "default",
-				},
-				Spec: v1.VirtualMachineInstanceSpec{
-					ResourceClaims: []v1.VirtualMachineInstanceResourceClaim{{
-						Name:              "claim1",
-						ResourceClaimName: ptr.To("claim1"),
-					}},
-					Domain: v1.DomainSpec{
-						Devices: v1.Devices{
-							GPUs: []v1.GPU{{
-								Name: "vgpu1",
-								ClaimRequest: &v1.ClaimRequest{
-									ClaimName:   "claim1",
-									RequestName: "req1",
-								},
-							}},
-						},
-					},
-				},
-			}
+			vmi := vgpuVMI(nil)
 
 			hostDevices, err := CreateDRAGPUHostDevices(vmi, tempDir)
 			Expect(err).ToNot(HaveOccurred())
@@ -194,50 +199,42 @@ var _ = Describe("CreateDRAGPUHostDevices", func() {
 		})
 
 		It("should not panic and should keep ramfb on when RamFB is present with Enabled unset", func() {
-			uuid := "223e4567-e89b-12d3-a456-426614174000"
+			writeMDevClaim("223e4567-e89b-12d3-a456-426614174000")
 
-			createMetadataFile("claim1", "req1", "gpu.example.com", &metadata.DeviceMetadata{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "DeviceMetadata",
-					APIVersion: metadata.APIVersionV1Alpha1,
-				},
-				ObjectMeta: metav1.ObjectMeta{Name: "claim1"},
-				Requests: []metadata.DeviceMetadataRequest{{
-					Name: "req1",
-					Devices: []metadata.Device{{
-						Driver: "gpu.example.com",
-						Pool:   "gpu-pool",
-						Name:   "device1",
-						Attributes: map[resourcev1.QualifiedName]resourcev1.DeviceAttribute{
-							metadata.MDevUUIDAttribute: {StringValue: &uuid},
-						},
-					}},
-				}},
+			vmi := vgpuVMI(&v1.VGPUDisplayOptions{
+				Enabled: ptr.To(true),
+				RamFB:   &v1.FeatureState{Enabled: nil}, // present but unset: used to panic
 			})
 
-			vmi := &v1.VirtualMachineInstance{
-				ObjectMeta: metav1.ObjectMeta{Name: "testvmi", Namespace: "default"},
-				Spec: v1.VirtualMachineInstanceSpec{
-					ResourceClaims: []v1.VirtualMachineInstanceResourceClaim{{
-						Name:              "claim1",
-						ResourceClaimName: ptr.To("claim1"),
-					}},
-					Domain: v1.DomainSpec{
-						Devices: v1.Devices{
-							GPUs: []v1.GPU{{
-								Name:         "vgpu1",
-								ClaimRequest: &v1.ClaimRequest{ClaimName: "claim1", RequestName: "req1"},
-								VirtualGPUOptions: &v1.VGPUOptions{
-									Display: &v1.VGPUDisplayOptions{
-										Enabled: ptr.To(true),
-										RamFB:   &v1.FeatureState{Enabled: nil}, // present but unset: used to panic
-									},
-								},
-							}},
-						},
-					},
-				},
-			}
+			hostDevices, err := CreateDRAGPUHostDevices(vmi, tempDir)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(hostDevices).To(HaveLen(1))
+			Expect(hostDevices[0].Display).To(Equal("on"))
+			Expect(hostDevices[0].RamFB).To(Equal("on"))
+		})
+
+		It("should keep ramfb off when RamFB.Enabled is false and display is enabled", func() {
+			writeMDevClaim("323e4567-e89b-12d3-a456-426614174000")
+
+			vmi := vgpuVMI(&v1.VGPUDisplayOptions{
+				Enabled: ptr.To(true),
+				RamFB:   &v1.FeatureState{Enabled: ptr.To(false)},
+			})
+
+			hostDevices, err := CreateDRAGPUHostDevices(vmi, tempDir)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(hostDevices).To(HaveLen(1))
+			Expect(hostDevices[0].Display).To(Equal("on"))
+			Expect(hostDevices[0].RamFB).To(BeEmpty())
+		})
+
+		It("should default display and ramfb to on when both Enabled fields are unset", func() {
+			writeMDevClaim("423e4567-e89b-12d3-a456-426614174000")
+
+			vmi := vgpuVMI(&v1.VGPUDisplayOptions{
+				// Enabled unset (nil)
+				RamFB: &v1.FeatureState{}, // Enabled unset (nil)
+			})
 
 			hostDevices, err := CreateDRAGPUHostDevices(vmi, tempDir)
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/dra/gpu_hostdev_test.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/dra/gpu_hostdev_test.go
@@ -192,6 +192,59 @@ var _ = Describe("CreateDRAGPUHostDevices", func() {
 			Expect(dev.Source.Address).ToNot(BeNil())
 			Expect(dev.Source.Address.UUID).To(Equal(uuid))
 		})
+
+		It("should not panic and should keep ramfb on when RamFB is present with Enabled unset", func() {
+			uuid := "223e4567-e89b-12d3-a456-426614174000"
+
+			createMetadataFile("claim1", "req1", "gpu.example.com", &metadata.DeviceMetadata{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "DeviceMetadata",
+					APIVersion: metadata.APIVersionV1Alpha1,
+				},
+				ObjectMeta: metav1.ObjectMeta{Name: "claim1"},
+				Requests: []metadata.DeviceMetadataRequest{{
+					Name: "req1",
+					Devices: []metadata.Device{{
+						Driver: "gpu.example.com",
+						Pool:   "gpu-pool",
+						Name:   "device1",
+						Attributes: map[resourcev1.QualifiedName]resourcev1.DeviceAttribute{
+							metadata.MDevUUIDAttribute: {StringValue: &uuid},
+						},
+					}},
+				}},
+			})
+
+			vmi := &v1.VirtualMachineInstance{
+				ObjectMeta: metav1.ObjectMeta{Name: "testvmi", Namespace: "default"},
+				Spec: v1.VirtualMachineInstanceSpec{
+					ResourceClaims: []v1.VirtualMachineInstanceResourceClaim{{
+						Name:              "claim1",
+						ResourceClaimName: ptr.To("claim1"),
+					}},
+					Domain: v1.DomainSpec{
+						Devices: v1.Devices{
+							GPUs: []v1.GPU{{
+								Name:         "vgpu1",
+								ClaimRequest: &v1.ClaimRequest{ClaimName: "claim1", RequestName: "req1"},
+								VirtualGPUOptions: &v1.VGPUOptions{
+									Display: &v1.VGPUDisplayOptions{
+										Enabled: ptr.To(true),
+										RamFB:   &v1.FeatureState{Enabled: nil}, // present but unset: used to panic
+									},
+								},
+							}},
+						},
+					},
+				},
+			}
+
+			hostDevices, err := CreateDRAGPUHostDevices(vmi, tempDir)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(hostDevices).To(HaveLen(1))
+			Expect(hostDevices[0].Display).To(Equal("on"))
+			Expect(hostDevices[0].RamFB).To(Equal("on"))
+		})
 	})
 
 	Context("when the device has both pciBusID and mdevUUID", func() {

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/hostdev.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/hostdev.go
@@ -170,7 +170,7 @@ func createMDEVHostDeviceWithDisplay(hostDeviceData HostDeviceMetaData, mdevUUID
 			displayEnabled := hostDeviceData.VirtualGPUOptions.Display.Enabled
 			if displayEnabled == nil || *displayEnabled {
 				mdev.Display = "on"
-				if hostDeviceData.VirtualGPUOptions.Display.RamFB == nil || *hostDeviceData.VirtualGPUOptions.Display.RamFB.Enabled {
+				if hostDeviceData.VirtualGPUOptions.Display.RamFB == nil || hostDeviceData.VirtualGPUOptions.Display.RamFB.Enabled == nil || *hostDeviceData.VirtualGPUOptions.Display.RamFB.Enabled {
 					mdev.RamFB = "on"
 				}
 			}

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/hostdev.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/hostdev.go
@@ -169,7 +169,7 @@ func createMDEVHostDeviceWithDisplay(hostDeviceData HostDeviceMetaData, mdevUUID
 			displayEnabled := hostDeviceData.VirtualGPUOptions.Display.Enabled
 			if displayEnabled == nil || *displayEnabled {
 				mdev.Display = "on"
-				if hostDeviceData.VirtualGPUOptions.Display.RamFB == nil || *hostDeviceData.VirtualGPUOptions.Display.RamFB.Enabled {
+				if isRamFBSet(hostDeviceData) {
 					mdev.RamFB = "on"
 				}
 			}

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/hostdev_test.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/hostdev_test.go
@@ -333,6 +333,25 @@ var _ = Describe("HostDevice", func() {
 			Expect(hostDevices, err).To(Equal([]api.HostDevice{expectHostDevice1}))
 		})
 
+		It("makes sure that an unset RamFB.Enabled keeps display and ramfb on", func() {
+			hostDevicesMetaData := []hostdevice.HostDeviceMetaData{
+				{AliasPrefix: aliasPrefix, Name: devName0, ResourceName: resourceName0,
+					VirtualGPUOptions: &v1.VGPUOptions{
+						Display: &v1.VGPUDisplayOptions{
+							Enabled: pointer.P(true),
+							RamFB:   &v1.FeatureState{}, // Enabled unset (nil): must not be dereferenced
+						},
+					}},
+			}
+			pool.AddResource(resourceName0, uuid0, uuid1)
+
+			hostDevices, err := hostdevice.CreateMDEVHostDevices(hostDevicesMetaData, pool, true)
+			expectHostDevice1.Display = "on"
+			expectHostDevice1.RamFB = "on"
+
+			Expect(hostDevices, err).To(Equal([]api.HostDevice{expectHostDevice1}))
+		})
+
 		It("makes sure that only one ramfb is configured with 2 vGPU devices", func() {
 			hostDevicesMetaData := []hostdevice.HostDeviceMetaData{
 				{AliasPrefix: aliasPrefix, Name: devName0, ResourceName: resourceName0},

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/hostdev_test.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/hostdev_test.go
@@ -335,6 +335,25 @@ var _ = Describe("HostDevice", func() {
 			Expect(hostDevices, err).To(Equal([]api.HostDevice{expectHostDevice1}))
 		})
 
+		It("makes sure that an unset RamFB.Enabled keeps display and ramfb on", func() {
+			hostDevicesMetaData := []hostdevice.HostDeviceMetaData{{
+				AliasPrefix: aliasPrefix, Name: devName0, ResourceName: resourceName0,
+				VirtualGPUOptions: &v1.VGPUOptions{
+					Display: &v1.VGPUDisplayOptions{
+						Enabled: pointer.P(true),
+						RamFB:   &v1.FeatureState{}, // nil Enabled is the case that panicked
+					},
+				},
+			}}
+			pool.AddResource(resourceName0, uuid0, uuid1)
+
+			hostDevices, err := hostdevice.CreateMDEVHostDevices(hostDevicesMetaData, pool, true)
+			expectHostDevice1.Display = "on"
+			expectHostDevice1.RamFB = "on"
+
+			Expect(hostDevices, err).To(Equal([]api.HostDevice{expectHostDevice1}))
+		})
+
 		It("makes sure that only one ramfb is configured with 2 vGPU devices", func() {
 			hostDevicesMetaData := []hostdevice.HostDeviceMetaData{
 				{AliasPrefix: aliasPrefix, Name: devName0, ResourceName: resourceName0},


### PR DESCRIPTION
### What this PR does
#### Before this PR:
Two mdev builders dereferenced `Display.RamFB.Enabled` after checking only `RamFB == nil`, so an object carrying `ramFB` with `enabled` unset crashed them: `createHostDeviceForGPU` in `pkg/virt-launcher/virtwrap/device/hostdevice/dra/gpu_hostdev.go` (DRA mdev path) and `createMDEVHostDeviceWithDisplay` in `pkg/virt-launcher/virtwrap/device/hostdevice/hostdev.go` (legacy mdev path).

virt-launcher should not be handed that object in practice. The VMI mutating webhook is registered for create and update and runs the generated defaulter, which fills `RamFB.Enabled` through `SetDefaults_FeatureState`, so this is defense in depth in the builders rather than a fix for something expressible through the API. The reproduction in #18430 is a direct call into `CreateDRAGPUHostDevices`.

#### After this PR:
Neither builder reads the field before checking it, and both treat an unset `enabled` as enabled. That is what the API documents, since `VGPUDisplayOptions.Enabled` and `RamFB` are both marked "Defaults to true", and what the defaulter would have filled in. The legacy builder calls the existing `isRamFBSet` helper instead of repeating the condition, and the DRA builder reads the pointer into a local first, matching the `displayEnabled` line above it.

### References
- Fixes #18430

### Why we need it and why it was done in this way
#18536 moved `isRamFBSet` to enabled-when-unset for the PCI display path, and #18542 did the same for `countConfiguredMDEVRamFBs` in the create admitter. Those two left the mdev builders behind, so this finishes them rather than introducing a third rule.

### Special notes for your reviewer
Both sites have regression coverage and each one discriminates: reverting the DRA guard reddens only the `dra` package, reverting the legacy guard reddens only `hostdevice`, and breaking `isRamFBSet` itself reddens the legacy test, so the helper reuse is load-bearing rather than cosmetic. The legacy false-enabled and omitted-`ramFB` cases are already covered in `pkg/virt-launcher/virtwrap/device/hostdevice/gpu/hostdev_test.go`, so I did not duplicate them.

I set the release note to NONE to match #18536, which made the same semantic change for the PCI path, since nothing a user can express through the API behaves differently. Happy to write one if you would rather have it recorded.

### Release note
```release-note
NONE
```
