### PR TITLE
converter/compute: Refactor CPUDomainConfigurator

### DIFF
--- a/pkg/virt-launcher/virtwrap/converter/compute/cpu.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/cpu.go
@@ -35,13 +35,16 @@ type CPUDomainConfigurator struct {
 	isMemfdSupported         bool
 }
 
-func NewCPUDomainConfigurator(isHotplugSupported, requiresMPXCPUValidation, crossArchEmulation, isMemfdSupported bool) CPUDomainConfigurator {
-	return CPUDomainConfigurator{
-		isHotplugSupported:       isHotplugSupported,
-		requiresMPXCPUValidation: requiresMPXCPUValidation,
-		crossArchEmulation:       crossArchEmulation,
-		isMemfdSupported:         isMemfdSupported,
+type cpuOption func(*CPUDomainConfigurator)
+
+func NewCPUDomainConfigurator(options ...cpuOption) CPUDomainConfigurator {
+	var configurator CPUDomainConfigurator
+
+	for _, f := range options {
+		f(&configurator)
 	}
+
+	return configurator
 }
 
 func (c CPUDomainConfigurator) Configure(vmi *v1.VirtualMachineInstance, domain *api.Domain) error {
@@ -167,5 +170,29 @@ func domainVCPUTopologyForHotplug(vmi *v1.VirtualMachineInstance, domain *api.Do
 	domain.Spec.VCPU = &api.VCPU{
 		Placement: "static",
 		CPUs:      cpuCount,
+	}
+}
+
+func CPUWithHotplugSupported(isHotplugSupported bool) cpuOption {
+	return func(c *CPUDomainConfigurator) {
+		c.isHotplugSupported = isHotplugSupported
+	}
+}
+
+func CPUWithMPXCPUValidation(requiresMPXCPUValidation bool) cpuOption {
+	return func(c *CPUDomainConfigurator) {
+		c.requiresMPXCPUValidation = requiresMPXCPUValidation
+	}
+}
+
+func CPUWithCrossArchEmulation(crossArchEmulation bool) cpuOption {
+	return func(c *CPUDomainConfigurator) {
+		c.crossArchEmulation = crossArchEmulation
+	}
+}
+
+func CPUWithMemfdSupported(isMemfdSupported bool) cpuOption {
+	return func(c *CPUDomainConfigurator) {
+		c.isMemfdSupported = isMemfdSupported
 	}
 }

--- a/pkg/virt-launcher/virtwrap/converter/compute/cpu.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/cpu.go
@@ -50,41 +50,7 @@ func NewCPUDomainConfigurator(options ...cpuOption) CPUDomainConfigurator {
 func (c CPUDomainConfigurator) Configure(vmi *v1.VirtualMachineInstance, domain *api.Domain) error {
 	c.configureCPUTopology(vmi, domain)
 	c.configureCPUModel(vmi, domain)
-
-	if vmi.Spec.Domain.CPU != nil {
-		// Set VM CPU features
-		existingFeatures := make(map[string]struct{})
-		if vmi.Spec.Domain.CPU.Features != nil {
-			for _, feature := range vmi.Spec.Domain.CPU.Features {
-				existingFeatures[feature.Name] = struct{}{}
-				domain.Spec.CPU.Features = append(domain.Spec.CPU.Features, api.CPUFeature{
-					Name:   feature.Name,
-					Policy: feature.Policy,
-				})
-			}
-		}
-
-		/*
-						Libvirt validation fails when a CPU model is usable
-						by QEMU but lacks features listed in
-						`/usr/share/libvirt/cpu_map/[CPU Model].xml` on a node
-						To avoid the validation error mentioned above we can disable
-						deprecated features in the `/usr/share/libvirt/cpu_map/[CPU Model].xml` files.
-						Examples of validation error:
-			    		https://bugzilla.redhat.com/show_bug.cgi?id=2122283 - resolve by obsolete Opteron_G2
-						https://gitlab.com/libvirt/libvirt/-/issues/304 - resolve by disabling mpx which is deprecated
-						Issue in Libvirt: https://gitlab.com/libvirt/libvirt/-/issues/608
-						once the issue is resolved we can remove mpx disablement
-		*/
-
-		_, exists := existingFeatures["mpx"]
-		if c.requiresMPXCPUValidation && !exists && vmi.Spec.Domain.CPU.Model != v1.CPUModeHostModel && vmi.Spec.Domain.CPU.Model != v1.CPUModeHostPassthrough {
-			domain.Spec.CPU.Features = append(domain.Spec.CPU.Features, api.CPUFeature{
-				Name:   "mpx",
-				Policy: "disable",
-			})
-		}
-	}
+	c.configureCPUFeatures(vmi, domain)
 
 	if c.isMemfdSupported && isMemfdRequired(vmi) && (vmi.Spec.Domain.CPU == nil || vmi.Spec.Domain.CPU.NUMA == nil) {
 		memKiB := uint64(vcpu.GetVirtualMemory(vmi).Value() / int64(1024))
@@ -155,6 +121,42 @@ func (c CPUDomainConfigurator) configureCPUModel(vmi *v1.VirtualMachineInstance,
 		domain.Spec.CPU.Model = "max"
 	} else {
 		domain.Spec.CPU.Mode = v1.CPUModeHostModel
+	}
+}
+
+func (c CPUDomainConfigurator) configureCPUFeatures(vmi *v1.VirtualMachineInstance, domain *api.Domain) {
+	if vmi.Spec.Domain.CPU == nil {
+		return
+	}
+
+	existingFeatures := make(map[string]struct{})
+	for _, feature := range vmi.Spec.Domain.CPU.Features {
+		existingFeatures[feature.Name] = struct{}{}
+		domain.Spec.CPU.Features = append(domain.Spec.CPU.Features, api.CPUFeature{
+			Name:   feature.Name,
+			Policy: feature.Policy,
+		})
+	}
+
+	/*
+					Libvirt validation fails when a CPU model is usable
+					by QEMU but lacks features listed in
+					`/usr/share/libvirt/cpu_map/[CPU Model].xml` on a node
+					To avoid the validation error mentioned above we can disable
+					deprecated features in the `/usr/share/libvirt/cpu_map/[CPU Model].xml` files.
+					Examples of validation error:
+		    		https://bugzilla.redhat.com/show_bug.cgi?id=2122283 - resolve by obsolete Opteron_G2
+					https://gitlab.com/libvirt/libvirt/-/issues/304 - resolve by disabling mpx which is deprecated
+					Issue in Libvirt: https://gitlab.com/libvirt/libvirt/-/issues/608
+					once the issue is resolved we can remove mpx disablement
+	*/
+
+	_, exists := existingFeatures["mpx"]
+	if c.requiresMPXCPUValidation && !exists && vmi.Spec.Domain.CPU.Model != v1.CPUModeHostModel && vmi.Spec.Domain.CPU.Model != v1.CPUModeHostPassthrough {
+		domain.Spec.CPU.Features = append(domain.Spec.CPU.Features, api.CPUFeature{
+			Name:   "mpx",
+			Policy: "disable",
+		})
 	}
 }
 

--- a/pkg/virt-launcher/virtwrap/converter/compute/cpu.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/cpu.go
@@ -51,20 +51,7 @@ func (c CPUDomainConfigurator) Configure(vmi *v1.VirtualMachineInstance, domain 
 	c.configureCPUTopology(vmi, domain)
 	c.configureCPUModel(vmi, domain)
 	c.configureCPUFeatures(vmi, domain)
-
-	if c.isMemfdSupported && isMemfdRequired(vmi) && (vmi.Spec.Domain.CPU == nil || vmi.Spec.Domain.CPU.NUMA == nil) {
-		memKiB := uint64(vcpu.GetVirtualMemory(vmi).Value() / int64(1024))
-		domain.Spec.CPU.NUMA = &api.NUMA{
-			Cells: []api.NUMACell{
-				{
-					ID:     "0",
-					CPUs:   fmt.Sprintf("0-%d", domain.Spec.VCPU.CPUs-1),
-					Memory: &memKiB,
-					Unit:   "KiB",
-				},
-			},
-		}
-	}
+	c.configureSyntheticNUMA(vmi, domain)
 
 	return nil
 }
@@ -157,6 +144,27 @@ func (c CPUDomainConfigurator) configureCPUFeatures(vmi *v1.VirtualMachineInstan
 			Name:   "mpx",
 			Policy: "disable",
 		})
+	}
+}
+
+func (c CPUDomainConfigurator) configureSyntheticNUMA(vmi *v1.VirtualMachineInstance, domain *api.Domain) {
+	if !c.isMemfdSupported || !isMemfdRequired(vmi) {
+		return
+	}
+	if vmi.Spec.Domain.CPU != nil && vmi.Spec.Domain.CPU.NUMA != nil {
+		return
+	}
+
+	memKiB := uint64(vcpu.GetVirtualMemory(vmi).Value() / int64(1024))
+	domain.Spec.CPU.NUMA = &api.NUMA{
+		Cells: []api.NUMACell{
+			{
+				ID:     "0",
+				CPUs:   fmt.Sprintf("0-%d", domain.Spec.VCPU.CPUs-1),
+				Memory: &memKiB,
+				Unit:   "KiB",
+			},
+		},
 	}
 }
 

--- a/pkg/virt-launcher/virtwrap/converter/compute/cpu.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/cpu.go
@@ -48,22 +48,7 @@ func NewCPUDomainConfigurator(options ...cpuOption) CPUDomainConfigurator {
 }
 
 func (c CPUDomainConfigurator) Configure(vmi *v1.VirtualMachineInstance, domain *api.Domain) error {
-	// Set VM CPU cores
-	// CPU topology will be created everytime, because user can specify
-	// number of cores in vmi.Spec.Domain.Resources.Requests/Limits, not only
-	// in vmi.Spec.Domain.CPU
-	cpuTopology := vcpu.GetCPUTopology(vmi)
-	cpuCount := vcpu.CalculateRequestedVCPUs(cpuTopology)
-
-	domain.Spec.CPU.Topology = cpuTopology
-	domain.Spec.VCPU = &api.VCPU{
-		Placement: "static",
-		CPUs:      cpuCount,
-	}
-	// set the maximum number of sockets here to allow hot-plug CPUs
-	if vmiCPU := vmi.Spec.Domain.CPU; vmiCPU != nil && vmiCPU.MaxSockets != 0 && c.isHotplugSupported {
-		domainVCPUTopologyForHotplug(vmi, domain)
-	}
+	c.configureCPUTopology(vmi, domain)
 
 	if vmi.Spec.Domain.CPU != nil {
 		// Set VM CPU model and vendor
@@ -140,6 +125,21 @@ func (c CPUDomainConfigurator) Configure(vmi *v1.VirtualMachineInstance, domain 
 	}
 
 	return nil
+}
+
+func (c CPUDomainConfigurator) configureCPUTopology(vmi *v1.VirtualMachineInstance, domain *api.Domain) {
+	cpuTopology := vcpu.GetCPUTopology(vmi)
+	cpuCount := vcpu.CalculateRequestedVCPUs(cpuTopology)
+
+	domain.Spec.CPU.Topology = cpuTopology
+	domain.Spec.VCPU = &api.VCPU{
+		Placement: "static",
+		CPUs:      cpuCount,
+	}
+
+	if vmiCPU := vmi.Spec.Domain.CPU; vmiCPU != nil && vmiCPU.MaxSockets != 0 && c.isHotplugSupported {
+		domainVCPUTopologyForHotplug(vmi, domain)
+	}
 }
 
 func domainVCPUTopologyForHotplug(vmi *v1.VirtualMachineInstance, domain *api.Domain) {

--- a/pkg/virt-launcher/virtwrap/converter/compute/cpu.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/cpu.go
@@ -131,41 +131,25 @@ func (c CPUDomainConfigurator) configureCPUTopology(vmi *v1.VirtualMachineInstan
 	cpuTopology := vcpu.GetCPUTopology(vmi)
 	cpuCount := vcpu.CalculateRequestedVCPUs(cpuTopology)
 
-	domain.Spec.CPU.Topology = cpuTopology
-	domain.Spec.VCPU = &api.VCPU{
-		Placement: "static",
-		CPUs:      cpuCount,
-	}
-
 	if vmiCPU := vmi.Spec.Domain.CPU; vmiCPU != nil && vmiCPU.MaxSockets != 0 && c.isHotplugSupported {
-		domainVCPUTopologyForHotplug(vmi, domain)
-	}
-}
+		minEnabledCpuCount := cpuTopology.Cores * cpuTopology.Threads
+		enabledCpuCount := cpuCount
+		cpuTopology.Sockets = vmiCPU.MaxSockets
+		cpuCount = vcpu.CalculateRequestedVCPUs(cpuTopology)
 
-func domainVCPUTopologyForHotplug(vmi *v1.VirtualMachineInstance, domain *api.Domain) {
-	cpuTopology := vcpu.GetCPUTopology(vmi)
-	cpuCount := vcpu.CalculateRequestedVCPUs(cpuTopology)
-	// Always allow to hotplug to minimum of 1 socket
-	minEnabledCpuCount := cpuTopology.Cores * cpuTopology.Threads
-	// Total vCPU count
-	enabledCpuCount := cpuCount
-	cpuTopology.Sockets = vmi.Spec.Domain.CPU.MaxSockets
-	cpuCount = vcpu.CalculateRequestedVCPUs(cpuTopology)
-	VCPUs := &api.VCPUs{}
-	for id := uint32(0); id < cpuCount; id++ {
-		// Enable all requestd vCPUs
-		isEnabled := id < enabledCpuCount
-		// There should not be fewer vCPU than cores and threads within a single socket
-		isHotpluggable := id >= minEnabledCpuCount
-		vcpu := api.VCPUsVCPU{
-			ID:           id,
-			Enabled:      boolToYesNo(&isEnabled, true),
-			Hotpluggable: boolToYesNo(&isHotpluggable, false),
+		VCPUs := &api.VCPUs{}
+		for id := uint32(0); id < cpuCount; id++ {
+			isEnabled := id < enabledCpuCount
+			isHotpluggable := id >= minEnabledCpuCount
+			VCPUs.VCPU = append(VCPUs.VCPU, api.VCPUsVCPU{
+				ID:           id,
+				Enabled:      boolToYesNo(&isEnabled, true),
+				Hotpluggable: boolToYesNo(&isHotpluggable, false),
+			})
 		}
-		VCPUs.VCPU = append(VCPUs.VCPU, vcpu)
+		domain.Spec.VCPUs = VCPUs
 	}
 
-	domain.Spec.VCPUs = VCPUs
 	domain.Spec.CPU.Topology = cpuTopology
 	domain.Spec.VCPU = &api.VCPU{
 		Placement: "static",

--- a/pkg/virt-launcher/virtwrap/converter/compute/cpu.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/cpu.go
@@ -49,24 +49,9 @@ func NewCPUDomainConfigurator(options ...cpuOption) CPUDomainConfigurator {
 
 func (c CPUDomainConfigurator) Configure(vmi *v1.VirtualMachineInstance, domain *api.Domain) error {
 	c.configureCPUTopology(vmi, domain)
+	c.configureCPUModel(vmi, domain)
 
 	if vmi.Spec.Domain.CPU != nil {
-		// Set VM CPU model and vendor
-		if vmi.Spec.Domain.CPU.Model != "" {
-			isHostCPUMode := vmi.Spec.Domain.CPU.Model == v1.CPUModeHostModel || vmi.Spec.Domain.CPU.Model == v1.CPUModeHostPassthrough
-			if c.crossArchEmulation && isHostCPUMode {
-				// host-passthrough and host-model are incompatible with cross-architecture
-				// TCG emulation. Use "max" which exposes all features QEMU can emulate.
-				domain.Spec.CPU.Mode = "custom"
-				domain.Spec.CPU.Model = "max"
-			} else if isHostCPUMode {
-				domain.Spec.CPU.Mode = vmi.Spec.Domain.CPU.Model
-			} else {
-				domain.Spec.CPU.Mode = "custom"
-				domain.Spec.CPU.Model = vmi.Spec.Domain.CPU.Model
-			}
-		}
-
 		// Set VM CPU features
 		existingFeatures := make(map[string]struct{})
 		if vmi.Spec.Domain.CPU.Features != nil {
@@ -98,15 +83,6 @@ func (c CPUDomainConfigurator) Configure(vmi *v1.VirtualMachineInstance, domain 
 				Name:   "mpx",
 				Policy: "disable",
 			})
-		}
-	}
-
-	if vmi.Spec.Domain.CPU == nil || vmi.Spec.Domain.CPU.Model == "" {
-		if c.crossArchEmulation {
-			domain.Spec.CPU.Mode = "custom"
-			domain.Spec.CPU.Model = "max"
-		} else {
-			domain.Spec.CPU.Mode = v1.CPUModeHostModel
 		}
 	}
 
@@ -154,6 +130,31 @@ func (c CPUDomainConfigurator) configureCPUTopology(vmi *v1.VirtualMachineInstan
 	domain.Spec.VCPU = &api.VCPU{
 		Placement: "static",
 		CPUs:      cpuCount,
+	}
+}
+
+func (c CPUDomainConfigurator) configureCPUModel(vmi *v1.VirtualMachineInstance, domain *api.Domain) {
+	if vmi.Spec.Domain.CPU != nil && vmi.Spec.Domain.CPU.Model != "" {
+		isHostCPUMode := vmi.Spec.Domain.CPU.Model == v1.CPUModeHostModel || vmi.Spec.Domain.CPU.Model == v1.CPUModeHostPassthrough
+		if c.crossArchEmulation && isHostCPUMode {
+			// host-passthrough and host-model are incompatible with cross-architecture
+			// TCG emulation. Use "max" which exposes all features QEMU can emulate.
+			domain.Spec.CPU.Mode = "custom"
+			domain.Spec.CPU.Model = "max"
+		} else if isHostCPUMode {
+			domain.Spec.CPU.Mode = vmi.Spec.Domain.CPU.Model
+		} else {
+			domain.Spec.CPU.Mode = "custom"
+			domain.Spec.CPU.Model = vmi.Spec.Domain.CPU.Model
+		}
+		return
+	}
+
+	if c.crossArchEmulation {
+		domain.Spec.CPU.Mode = "custom"
+		domain.Spec.CPU.Model = "max"
+	} else {
+		domain.Spec.CPU.Mode = v1.CPUModeHostModel
 	}
 }
 

--- a/pkg/virt-launcher/virtwrap/converter/compute/cpu_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/cpu_test.go
@@ -33,18 +33,17 @@ import (
 )
 
 var _ = Describe("CPU Domain Configurator", func() {
-	const (
-		hotplugSupported         = true
-		requiresMPXCPUValidation = true
-		memfdSupported           = true
-	)
-
 	Context("CPU topology", func() {
 		DescribeTable("should set topology and VCPU count from VMI CPU spec",
 			func(vmi *v1.VirtualMachineInstance, expectedDomain api.Domain) {
 				var domain api.Domain
 
-				configurator := compute.NewCPUDomainConfigurator(!hotplugSupported, !requiresMPXCPUValidation, false, memfdSupported)
+				configurator := compute.NewCPUDomainConfigurator(
+					compute.CPUWithHotplugSupported(false),
+					compute.CPUWithMPXCPUValidation(false),
+					compute.CPUWithCrossArchEmulation(false),
+					compute.CPUWithMemfdSupported(true),
+				)
 				Expect(configurator.Configure(vmi, &domain)).To(Succeed())
 
 				Expect(domain).To(Equal(expectedDomain))
@@ -85,7 +84,12 @@ var _ = Describe("CPU Domain Configurator", func() {
 			func(vmi *v1.VirtualMachineInstance, expectedDomain api.Domain) {
 				var domain api.Domain
 
-				configurator := compute.NewCPUDomainConfigurator(!hotplugSupported, !requiresMPXCPUValidation, false, memfdSupported)
+				configurator := compute.NewCPUDomainConfigurator(
+					compute.CPUWithHotplugSupported(false),
+					compute.CPUWithMPXCPUValidation(false),
+					compute.CPUWithCrossArchEmulation(false),
+					compute.CPUWithMemfdSupported(true),
+				)
 				Expect(configurator.Configure(vmi, &domain)).To(Succeed())
 
 				Expect(domain).To(Equal(expectedDomain))
@@ -130,7 +134,12 @@ var _ = Describe("CPU Domain Configurator", func() {
 			)
 			var domain api.Domain
 
-			configurator := compute.NewCPUDomainConfigurator(!hotplugSupported, !requiresMPXCPUValidation, false, memfdSupported)
+			configurator := compute.NewCPUDomainConfigurator(
+				compute.CPUWithHotplugSupported(false),
+				compute.CPUWithMPXCPUValidation(false),
+				compute.CPUWithCrossArchEmulation(false),
+				compute.CPUWithMemfdSupported(true),
+			)
 			Expect(configurator.Configure(vmi, &domain)).To(Succeed())
 
 			expectedDomain := api.Domain{Spec: api.DomainSpec{
@@ -154,14 +163,19 @@ var _ = Describe("CPU Domain Configurator", func() {
 			func(vmi *v1.VirtualMachineInstance, requiresMPX bool, expectedDomain api.Domain) {
 				var domain api.Domain
 
-				configurator := compute.NewCPUDomainConfigurator(!hotplugSupported, requiresMPX, false, memfdSupported)
+				configurator := compute.NewCPUDomainConfigurator(
+					compute.CPUWithHotplugSupported(false),
+					compute.CPUWithMPXCPUValidation(requiresMPX),
+					compute.CPUWithCrossArchEmulation(false),
+					compute.CPUWithMemfdSupported(true),
+				)
 				Expect(configurator.Configure(vmi, &domain)).To(Succeed())
 
 				Expect(domain).To(Equal(expectedDomain))
 			},
 			Entry("adds mpx disable for custom model when MPX validation is required",
 				libvmi.New(libvmi.WithCPUModel("Skylake-Server")),
-				requiresMPXCPUValidation,
+				true,
 				api.Domain{Spec: api.DomainSpec{
 					CPU: api.CPU{
 						Mode:     "custom",
@@ -174,7 +188,7 @@ var _ = Describe("CPU Domain Configurator", func() {
 			),
 			Entry("does not add mpx for host-model",
 				libvmi.New(libvmi.WithCPUModel(v1.CPUModeHostModel)),
-				requiresMPXCPUValidation,
+				true,
 				api.Domain{Spec: api.DomainSpec{
 					CPU:  api.CPU{Mode: v1.CPUModeHostModel, Topology: &api.CPUTopology{Sockets: 1, Cores: 1, Threads: 1}},
 					VCPU: &api.VCPU{Placement: "static", CPUs: 1},
@@ -182,7 +196,7 @@ var _ = Describe("CPU Domain Configurator", func() {
 			),
 			Entry("does not add mpx for host-passthrough",
 				libvmi.New(libvmi.WithCPUModel(v1.CPUModeHostPassthrough)),
-				requiresMPXCPUValidation,
+				true,
 				api.Domain{Spec: api.DomainSpec{
 					CPU:  api.CPU{Mode: v1.CPUModeHostPassthrough, Topology: &api.CPUTopology{Sockets: 1, Cores: 1, Threads: 1}},
 					VCPU: &api.VCPU{Placement: "static", CPUs: 1},
@@ -193,7 +207,7 @@ var _ = Describe("CPU Domain Configurator", func() {
 					libvmi.WithCPUModel("Skylake-Server"),
 					libvmi.WithCPUFeature("mpx", "require"),
 				),
-				requiresMPXCPUValidation,
+				true,
 				api.Domain{Spec: api.DomainSpec{
 					CPU: api.CPU{
 						Mode:     "custom",
@@ -208,13 +222,16 @@ var _ = Describe("CPU Domain Configurator", func() {
 	})
 
 	Context("Cross-architecture emulation", func() {
-		const crossArchEmulation = true
-
 		DescribeTable("should use CPU model max for cross-arch emulation",
 			func(vmi *v1.VirtualMachineInstance, expectedDomain api.Domain) {
 				var domain api.Domain
 
-				configurator := compute.NewCPUDomainConfigurator(!hotplugSupported, !requiresMPXCPUValidation, crossArchEmulation, memfdSupported)
+				configurator := compute.NewCPUDomainConfigurator(
+					compute.CPUWithHotplugSupported(false),
+					compute.CPUWithMPXCPUValidation(false),
+					compute.CPUWithCrossArchEmulation(true),
+					compute.CPUWithMemfdSupported(true),
+				)
 				Expect(configurator.Configure(vmi, &domain)).To(Succeed())
 
 				Expect(domain).To(Equal(expectedDomain))
@@ -255,7 +272,12 @@ var _ = Describe("CPU Domain Configurator", func() {
 			func(vmi *v1.VirtualMachineInstance, topology *api.CPUTopology, expectedNUMA *api.NUMA) {
 				var domain api.Domain
 
-				configurator := compute.NewCPUDomainConfigurator(!hotplugSupported, !requiresMPXCPUValidation, false, memfdSupported)
+				configurator := compute.NewCPUDomainConfigurator(
+					compute.CPUWithHotplugSupported(false),
+					compute.CPUWithMPXCPUValidation(false),
+					compute.CPUWithCrossArchEmulation(false),
+					compute.CPUWithMemfdSupported(true),
+				)
 				Expect(configurator.Configure(vmi, &domain)).To(Succeed())
 
 				cpuCount := topology.Sockets * topology.Cores * topology.Threads
@@ -332,7 +354,12 @@ var _ = Describe("CPU Domain Configurator", func() {
 			)
 			var domain api.Domain
 
-			configurator := compute.NewCPUDomainConfigurator(hotplugSupported, !requiresMPXCPUValidation, false, memfdSupported)
+			configurator := compute.NewCPUDomainConfigurator(
+				compute.CPUWithHotplugSupported(true),
+				compute.CPUWithMPXCPUValidation(false),
+				compute.CPUWithCrossArchEmulation(false),
+				compute.CPUWithMemfdSupported(true),
+			)
 			Expect(configurator.Configure(vmi, &domain)).To(Succeed())
 
 			expectedDomain := api.Domain{Spec: api.DomainSpec{
@@ -359,7 +386,12 @@ var _ = Describe("CPU Domain Configurator", func() {
 			)
 			var domain api.Domain
 
-			configurator := compute.NewCPUDomainConfigurator(!hotplugSupported, !requiresMPXCPUValidation, false, !memfdSupported)
+			configurator := compute.NewCPUDomainConfigurator(
+				compute.CPUWithHotplugSupported(false),
+				compute.CPUWithMPXCPUValidation(false),
+				compute.CPUWithCrossArchEmulation(false),
+				compute.CPUWithMemfdSupported(false),
+			)
 			Expect(configurator.Configure(vmi, &domain)).To(Succeed())
 
 			expectedDomain := api.Domain{Spec: api.DomainSpec{
@@ -378,7 +410,12 @@ var _ = Describe("CPU Domain Configurator", func() {
 			)
 			var domain api.Domain
 
-			configurator := compute.NewCPUDomainConfigurator(hotplugSupported, !requiresMPXCPUValidation, false, memfdSupported)
+			configurator := compute.NewCPUDomainConfigurator(
+				compute.CPUWithHotplugSupported(true),
+				compute.CPUWithMPXCPUValidation(false),
+				compute.CPUWithCrossArchEmulation(false),
+				compute.CPUWithMemfdSupported(true),
+			)
 			Expect(configurator.Configure(vmi, &domain)).To(Succeed())
 
 			expectedDomain := api.Domain{Spec: api.DomainSpec{
@@ -401,7 +438,12 @@ var _ = Describe("CPU Domain Configurator", func() {
 			)
 			var domain api.Domain
 
-			configurator := compute.NewCPUDomainConfigurator(!hotplugSupported, !requiresMPXCPUValidation, false, memfdSupported)
+			configurator := compute.NewCPUDomainConfigurator(
+				compute.CPUWithHotplugSupported(false),
+				compute.CPUWithMPXCPUValidation(false),
+				compute.CPUWithCrossArchEmulation(false),
+				compute.CPUWithMemfdSupported(true),
+			)
 			Expect(configurator.Configure(vmi, &domain)).To(Succeed())
 
 			expectedDomain := api.Domain{Spec: api.DomainSpec{
@@ -415,7 +457,12 @@ var _ = Describe("CPU Domain Configurator", func() {
 			vmi := libvmi.New(libvmi.WithCPUCount(1, 1, 2))
 			var domain api.Domain
 
-			configurator := compute.NewCPUDomainConfigurator(hotplugSupported, !requiresMPXCPUValidation, false, memfdSupported)
+			configurator := compute.NewCPUDomainConfigurator(
+				compute.CPUWithHotplugSupported(true),
+				compute.CPUWithMPXCPUValidation(false),
+				compute.CPUWithCrossArchEmulation(false),
+				compute.CPUWithMemfdSupported(true),
+			)
 			Expect(configurator.Configure(vmi, &domain)).To(Succeed())
 
 			expectedDomain := api.Domain{Spec: api.DomainSpec{
@@ -432,7 +479,12 @@ var _ = Describe("CPU Domain Configurator", func() {
 			)
 			var domain api.Domain
 
-			configurator := compute.NewCPUDomainConfigurator(hotplugSupported, !requiresMPXCPUValidation, false, memfdSupported)
+			configurator := compute.NewCPUDomainConfigurator(
+				compute.CPUWithHotplugSupported(true),
+				compute.CPUWithMPXCPUValidation(false),
+				compute.CPUWithCrossArchEmulation(false),
+				compute.CPUWithMemfdSupported(true),
+			)
 			Expect(configurator.Configure(vmi, &domain)).To(Succeed())
 
 			expectedDomain := api.Domain{Spec: api.DomainSpec{

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -1040,7 +1040,12 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 			compute.ControllersWithVirtioSerialModel(virtioModel),
 		),
 		compute.NewQemuCmdDomainConfigurator(c.Architecture.ShouldVerboseLogsBeEnabled()),
-		compute.NewCPUDomainConfigurator(c.Architecture.SupportCPUHotplug(), c.Architecture.RequiresMPXCPUValidation(), c.AllowCrossArchEmulation, c.Architecture.IsMemfdSupported()),
+		compute.NewCPUDomainConfigurator(
+			compute.CPUWithHotplugSupported(c.Architecture.SupportCPUHotplug()),
+			compute.CPUWithMPXCPUValidation(c.Architecture.RequiresMPXCPUValidation()),
+			compute.CPUWithCrossArchEmulation(c.AllowCrossArchEmulation),
+			compute.CPUWithMemfdSupported(c.Architecture.IsMemfdSupported()),
+		),
 		compute.NewIOThreadsDomainConfigurator(uint(ioThreadCount)),
 		compute.MemoryConfigurator{},
 		compute.NewMemoryBackingConfigurator(c.Architecture.IsMemfdSupported()),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
`CPUDomainConfigurator.Configure` has a cyclomatic complexity of 23, too high for the gocognit linter. 
In preparation for covering the `compute` package with the linter:
  - Replace the four positional bool parameters with option functions to prevent silent parameter swaps
  - Break Configure into four focused helpers - configureCPUTopology, configureCPUModel, configureCPUFeatures, and configureSyntheticNUMA - bringing the maximum per-function complexity down to 8

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

