### PR TITLE
Pass network binding plugin name to sidecar containers

### DIFF
--- a/cmd/sidecars/network-passt-binding/domain/configurator.go
+++ b/cmd/sidecars/network-passt-binding/domain/configurator.go
@@ -47,8 +47,6 @@ type PasstNetworkConfigurator struct {
 }
 
 const (
-	// PasstPluginName passt binding plugin name should be registered to Kubevirt through Kubevirt CR
-	PasstPluginName = "passt"
 	//nolint:gosec
 	// PasstLogFilePath passt log file path Kubevirt consume and record
 	PasstLogFilePath = "/var/run/kubevirt/passt.log"
@@ -58,6 +56,7 @@ func NewPasstNetworkConfigurator(
 	ifaces []vmschema.Interface,
 	networks []vmschema.Network,
 	ifaceStatuses []vmschema.VirtualMachineInstanceNetworkInterface,
+	bindingPluginName string,
 	opts NetworkConfiguratorOptions,
 ) (*PasstNetworkConfigurator, error) {
 	network := vmispec.LookupPodNetwork(networks)
@@ -68,7 +67,7 @@ func NewPasstNetworkConfigurator(
 	if iface == nil {
 		return nil, fmt.Errorf("no interface found")
 	}
-	if iface.Binding == nil || iface.Binding != nil && iface.Binding.Name != PasstPluginName {
+	if iface.Binding == nil || iface.Binding.Name != bindingPluginName {
 		return nil, fmt.Errorf("interface %q is not set with Passt network binding plugin", network.Name)
 	}
 

--- a/cmd/sidecars/network-passt-binding/domain/configurator_test.go
+++ b/cmd/sidecars/network-passt-binding/domain/configurator_test.go
@@ -44,6 +44,7 @@ var _ = Describe("pod network configurator", func() {
 					ifaces,
 					networks,
 					ifaceStatuses,
+					"passt-plugin",
 					domain.NetworkConfiguratorOptions{},
 				)
 
@@ -55,7 +56,7 @@ var _ = Describe("pod network configurator", func() {
 				nil,
 			),
 			Entry("no corresponding iface",
-				[]vmschema.Interface{{Name: "not-default", Binding: &vmschema.PluginBinding{Name: "passt"}}},
+				[]vmschema.Interface{{Name: "not-default", Binding: &vmschema.PluginBinding{Name: "passt-plugin"}}},
 				[]vmschema.Network{*vmschema.DefaultPodNetwork()},
 				nil,
 			),
@@ -70,12 +71,12 @@ var _ = Describe("pod network configurator", func() {
 				[]vmschema.VirtualMachineInstanceNetworkInterface{{Name: "default", PodInterfaceName: defaultPrimaryPodIfaceName}},
 			),
 			Entry("Interface with no matching status entry",
-				[]vmschema.Interface{{Name: "default", Binding: &vmschema.PluginBinding{Name: "passt"}}},
+				[]vmschema.Interface{{Name: "default", Binding: &vmschema.PluginBinding{Name: "passt-plugin"}}},
 				[]vmschema.Network{*vmschema.DefaultPodNetwork()},
 				nil,
 			),
 			Entry("Interface with an empty PodInterfaceName",
-				[]vmschema.Interface{{Name: "default", Binding: &vmschema.PluginBinding{Name: "passt"}}},
+				[]vmschema.Interface{{Name: "default", Binding: &vmschema.PluginBinding{Name: "passt-plugin"}}},
 				[]vmschema.Network{*vmschema.DefaultPodNetwork()},
 				[]vmschema.VirtualMachineInstanceNetworkInterface{{Name: "default", PodInterfaceName: ""}},
 			),
@@ -83,7 +84,7 @@ var _ = Describe("pod network configurator", func() {
 
 		It("should fail given interface with invalid PCI address", func() {
 			ifaces := []vmschema.Interface{{
-				Name: "default", Binding: &vmschema.PluginBinding{Name: "passt"},
+				Name: "default", Binding: &vmschema.PluginBinding{Name: "passt-plugin"},
 				PciAddress: "invalid-pci-address",
 			}}
 			networks := []vmschema.Network{*vmschema.DefaultPodNetwork()}
@@ -93,6 +94,7 @@ var _ = Describe("pod network configurator", func() {
 				ifaces,
 				networks,
 				ifaceStatuses,
+				"passt-plugin",
 				domain.NetworkConfiguratorOptions{},
 			)
 			Expect(err).ToNot(HaveOccurred())
@@ -111,6 +113,7 @@ var _ = Describe("pod network configurator", func() {
 					ifaces,
 					networks,
 					ifaceStatuses,
+					"passt-plugin",
 					domain.NetworkConfiguratorOptions{},
 				)
 				Expect(err).ToNot(HaveOccurred())
@@ -120,7 +123,7 @@ var _ = Describe("pod network configurator", func() {
 				Expect(mutatedDomSpec.Devices.Interfaces).To(Equal([]domainschema.Interface{*expectedDomainIface}))
 			},
 			Entry("passt binding plugin",
-				&vmschema.Interface{Name: "default", Binding: &vmschema.PluginBinding{Name: "passt"}},
+				&vmschema.Interface{Name: "default", Binding: &vmschema.PluginBinding{Name: "passt-plugin"}},
 				&domainschema.Interface{
 					Alias:       domainschema.NewUserDefinedAlias("default"),
 					Type:        ifaceTypeVhostUser,
@@ -132,7 +135,7 @@ var _ = Describe("pod network configurator", func() {
 			),
 			Entry("PCI address",
 				&vmschema.Interface{
-					Name: "default", Binding: &vmschema.PluginBinding{Name: "passt"},
+					Name: "default", Binding: &vmschema.PluginBinding{Name: "passt-plugin"},
 					PciAddress: "0000:02:02.0",
 				},
 				&domainschema.Interface{
@@ -147,7 +150,7 @@ var _ = Describe("pod network configurator", func() {
 			),
 			Entry("MAC address",
 				&vmschema.Interface{
-					Name: "default", Binding: &vmschema.PluginBinding{Name: "passt"},
+					Name: "default", Binding: &vmschema.PluginBinding{Name: "passt-plugin"},
 					MacAddress: "02:02:02:02:02:02",
 				},
 				&domainschema.Interface{
@@ -162,7 +165,7 @@ var _ = Describe("pod network configurator", func() {
 			),
 			Entry("ACPI address",
 				&vmschema.Interface{
-					Name: "default", Binding: &vmschema.PluginBinding{Name: "passt"},
+					Name: "default", Binding: &vmschema.PluginBinding{Name: "passt-plugin"},
 					ACPIIndex: 2,
 				},
 				&domainschema.Interface{
@@ -177,7 +180,7 @@ var _ = Describe("pod network configurator", func() {
 			),
 			Entry("non virtio model",
 				&vmschema.Interface{
-					Name: "default", Binding: &vmschema.PluginBinding{Name: "passt"},
+					Name: "default", Binding: &vmschema.PluginBinding{Name: "passt-plugin"},
 					Model: "e1000",
 				},
 				&domainschema.Interface{
@@ -270,11 +273,11 @@ var _ = Describe("pod network configurator", func() {
 
 		DescribeTable("should add interface to domain spec given iface given the option",
 			func(opts *domain.NetworkConfiguratorOptions, expectedDomainIface *domainschema.Interface) {
-				ifaces := []vmschema.Interface{{Name: "default", Binding: &vmschema.PluginBinding{Name: "passt"}}}
+				ifaces := []vmschema.Interface{{Name: "default", Binding: &vmschema.PluginBinding{Name: "passt-plugin"}}}
 				networks := []vmschema.Network{*vmschema.DefaultPodNetwork()}
 				ifaceStatuses := []vmschema.VirtualMachineInstanceNetworkInterface{{Name: "default", PodInterfaceName: defaultPrimaryPodIfaceName}}
 
-				testMutator, err := domain.NewPasstNetworkConfigurator(ifaces, networks, ifaceStatuses, *opts)
+				testMutator, err := domain.NewPasstNetworkConfigurator(ifaces, networks, ifaceStatuses, "passt-plugin", *opts)
 				Expect(err).ToNot(HaveOccurred())
 
 				mutatedDomSpec, err := testMutator.Mutate(&domainschema.DomainSpec{})
@@ -324,7 +327,7 @@ var _ = Describe("pod network configurator", func() {
 				{Name: "secondary", NetworkSource: vmschema.NetworkSource{Multus: &vmschema.MultusNetwork{NetworkName: "sec"}}},
 			}
 			ifaces := []vmschema.Interface{
-				{Name: "default", Binding: &vmschema.PluginBinding{Name: "passt"}},
+				{Name: "default", Binding: &vmschema.PluginBinding{Name: "passt-plugin"}},
 				{Name: "secondary", InterfaceBindingMethod: vmschema.InterfaceBindingMethod{Bridge: &vmschema.InterfaceBridge{}}},
 			}
 
@@ -343,6 +346,7 @@ var _ = Describe("pod network configurator", func() {
 				ifaces,
 				networks,
 				ifaceStatuses,
+				"passt-plugin",
 				domain.NetworkConfiguratorOptions{},
 			)
 			Expect(err).ToNot(HaveOccurred())
@@ -361,7 +365,7 @@ var _ = Describe("pod network configurator", func() {
 
 		It("should set domain interface correctly when executed more than once", func() {
 			networks := []vmschema.Network{*vmschema.DefaultPodNetwork()}
-			ifaces := []vmschema.Interface{{Name: "default", Binding: &vmschema.PluginBinding{Name: "passt"}}}
+			ifaces := []vmschema.Interface{{Name: "default", Binding: &vmschema.PluginBinding{Name: "passt-plugin"}}}
 			ifaceStatuses := []vmschema.VirtualMachineInstanceNetworkInterface{{Name: "default", PodInterfaceName: defaultPrimaryPodIfaceName}}
 
 			expectedDomainIface := &domainschema.Interface{
@@ -377,6 +381,7 @@ var _ = Describe("pod network configurator", func() {
 				ifaces,
 				networks,
 				ifaceStatuses,
+				"passt-plugin",
 				domain.NetworkConfiguratorOptions{},
 			)
 			Expect(err).ToNot(HaveOccurred())
@@ -391,7 +396,7 @@ var _ = Describe("pod network configurator", func() {
 		})
 		It("should set domain interface source link to the optional one if exists", func() {
 			networks := []vmschema.Network{*vmschema.DefaultPodNetwork()}
-			ifaces := []vmschema.Interface{{Name: "default", Binding: &vmschema.PluginBinding{Name: "passt"}}}
+			ifaces := []vmschema.Interface{{Name: "default", Binding: &vmschema.PluginBinding{Name: "passt-plugin"}}}
 			ifaceStatuses := []vmschema.VirtualMachineInstanceNetworkInterface{{Name: "default", PodInterfaceName: "ovn-udn1"}}
 
 			expectedDomainIface := &domainschema.Interface{
@@ -406,6 +411,7 @@ var _ = Describe("pod network configurator", func() {
 				ifaces,
 				networks,
 				ifaceStatuses,
+				"passt-plugin",
 				domain.NetworkConfiguratorOptions{},
 			)
 			Expect(err).ToNot(HaveOccurred())
@@ -423,7 +429,7 @@ var _ = Describe("pod network configurator", func() {
 		var testMutator *domain.PasstNetworkConfigurator
 		BeforeEach(func() {
 			networks := []vmschema.Network{*vmschema.DefaultPodNetwork()}
-			ifaces := []vmschema.Interface{{Name: "default", Binding: &vmschema.PluginBinding{Name: "passt"}}}
+			ifaces := []vmschema.Interface{{Name: "default", Binding: &vmschema.PluginBinding{Name: "passt-plugin"}}}
 			ifaceStatuses := []vmschema.VirtualMachineInstanceNetworkInterface{{Name: "default", PodInterfaceName: defaultPrimaryPodIfaceName}}
 
 			var err error
@@ -431,6 +437,7 @@ var _ = Describe("pod network configurator", func() {
 				ifaces,
 				networks,
 				ifaceStatuses,
+				"passt-plugin",
 				domain.NetworkConfiguratorOptions{},
 			)
 			Expect(err).ToNot(HaveOccurred())
@@ -491,7 +498,7 @@ func newInterface(name string, options ...option) *vmschema.Interface {
 func withPasstBindingPlugin() option {
 	return func(iface *vmschema.Interface) {
 		iface.Binding = &vmschema.PluginBinding{
-			Name: "passt",
+			Name: "passt-plugin",
 		}
 	}
 }

--- a/cmd/sidecars/network-passt-binding/main.go
+++ b/cmd/sidecars/network-passt-binding/main.go
@@ -36,7 +36,10 @@ import (
 	srv "kubevirt.io/kubevirt/cmd/sidecars/network-passt-binding/server"
 )
 
-const hookSocket = "passt.sock"
+const (
+	hookSocket               = "passt.sock"
+	defaultBindingPluginName = "passt"
+)
 
 func main() {
 	socketPath := filepath.Join(hooks.HookSocketsSharedDirectory, hookSocket)
@@ -52,7 +55,11 @@ func main() {
 	hooksInfo.RegisterInfoServer(server, srv.InfoServer{Version: "v1alpha3"})
 
 	shutdownChan := make(chan struct{})
-	hooksV1alpha3.RegisterCallbacksServer(server, srv.V1alpha3Server{Done: shutdownChan})
+	bindingPluginName := os.Getenv(hooks.NetworkBindingPluginNameEnvVar)
+	if bindingPluginName == "" {
+		bindingPluginName = defaultBindingPluginName
+	}
+	hooksV1alpha3.RegisterCallbacksServer(server, srv.V1alpha3Server{Done: shutdownChan, BindingPluginName: bindingPluginName})
 	log.Log.Infof("passt sidecar is now exposing its services on socket %s using %q API version", socketPath, "v1alpha3")
 	srv.Serve(server, socket, shutdownChan)
 }

--- a/cmd/sidecars/network-passt-binding/server/server.go
+++ b/cmd/sidecars/network-passt-binding/server/server.go
@@ -66,7 +66,8 @@ func (s InfoServer) Info(_ context.Context, _ *hooksInfo.InfoParams) (*hooksInfo
 }
 
 type V1alpha3Server struct {
-	Done chan struct{}
+	Done              chan struct{}
+	BindingPluginName string
 }
 
 func (s V1alpha3Server) OnDefineDomain(
@@ -95,6 +96,7 @@ func (s V1alpha3Server) OnDefineDomain(
 		vmi.Spec.Domain.Devices.Interfaces,
 		vmi.Spec.Networks,
 		vmi.Status.Interfaces,
+		s.BindingPluginName,
 		opts,
 	)
 	if err != nil {

--- a/cmd/sidecars/network-slirp-binding/domain/domain.go
+++ b/cmd/sidecars/network-slirp-binding/domain/domain.go
@@ -33,16 +33,13 @@ import (
 	"kubevirt.io/kubevirt/pkg/network/vmispec"
 )
 
-// SlirpPluginName slirp binding plugin name should be registered to Kubevirt through Kubevirt CR
-const SlirpPluginName = "slirp"
-
 type SlirpNetworkConfigurator struct {
 	vmiSpecIface   *vmschema.Interface
 	vmiSpecNetwork *vmschema.Network
 	searchDomains  []string
 }
 
-func NewSlirpNetworkConfigurator(ifaces []vmschema.Interface, networks []vmschema.Network, searchDomains []string) (*SlirpNetworkConfigurator, error) {
+func NewSlirpNetworkConfigurator(ifaces []vmschema.Interface, networks []vmschema.Network, searchDomains []string, bindingPluginName string) (*SlirpNetworkConfigurator, error) {
 	network := vmispec.LookupPodNetwork(networks)
 	if network == nil {
 		return nil, fmt.Errorf("pod network not found")
@@ -55,7 +52,7 @@ func NewSlirpNetworkConfigurator(ifaces []vmschema.Interface, networks []vmschem
 	if iface.Binding == nil && iface.DeprecatedSlirp == nil {
 		return nil, fmt.Errorf("iface %q is not set with slirp network binding plugin or slirp binding method", network.Name)
 	}
-	if iface.Binding != nil && iface.Binding.Name != SlirpPluginName {
+	if iface.Binding != nil && iface.Binding.Name != bindingPluginName {
 		return nil, fmt.Errorf("iface %q is not set with slirp network binding plugin", network.Name)
 	}
 

--- a/cmd/sidecars/network-slirp-binding/domain/domain_test.go
+++ b/cmd/sidecars/network-slirp-binding/domain/domain_test.go
@@ -36,7 +36,7 @@ var _ = Describe("QEMU slirp networking", func() {
 
 		DescribeTable("should fail, given",
 			func(iface vmschema.Interface, network vmschema.Network) {
-				_, err := domain.NewSlirpNetworkConfigurator(nil, []vmschema.Network{network}, nil)
+				_, err := domain.NewSlirpNetworkConfigurator(nil, []vmschema.Network{network}, nil, "slirp-plugin")
 				Expect(err).To(HaveOccurred())
 			},
 			Entry("no pod network",
@@ -72,12 +72,12 @@ var _ = Describe("QEMU slirp networking", func() {
 				expectedDomainSpec := &domainschema.NewMinimalDomain("test").Spec
 				expectedDomainSpec.QEMUCmd = &domainschema.Commandline{QEMUArg: expectedQEMUCmdArgs}
 
-				testMutator, err := domain.NewSlirpNetworkConfigurator([]vmschema.Interface{iface}, []vmschema.Network{network}, testSearchDomain)
+				testMutator, err := domain.NewSlirpNetworkConfigurator([]vmschema.Interface{iface}, []vmschema.Network{network}, testSearchDomain, "slirp-plugin")
 				Expect(err).ToNot(HaveOccurred())
 				Expect(testMutator.Mutate(testDomainSpec)).To(Equal(expectedDomainSpec))
 			},
 			Entry("custom CIDR",
-				vmschema.Interface{Name: "slirpTest", Binding: &vmschema.PluginBinding{Name: domain.SlirpPluginName}},
+				vmschema.Interface{Name: "slirpTest", Binding: &vmschema.PluginBinding{Name: "slirp-plugin"}},
 				vmschema.Network{Name: "slirpTest", NetworkSource: vmschema.NetworkSource{Pod: &vmschema.PodNetwork{
 					VMNetworkCIDR: "192.168.100.0/24",
 				}}},
@@ -87,7 +87,7 @@ var _ = Describe("QEMU slirp networking", func() {
 				},
 			),
 			Entry("ports",
-				vmschema.Interface{Name: "slirpTest", Binding: &vmschema.PluginBinding{Name: domain.SlirpPluginName},
+				vmschema.Interface{Name: "slirpTest", Binding: &vmschema.PluginBinding{Name: "slirp-plugin"},
 					Ports: []vmschema.Port{
 						{Name: "http", Protocol: "TCP", Port: 80},
 						{Port: 8080},
@@ -100,7 +100,7 @@ var _ = Describe("QEMU slirp networking", func() {
 				},
 			),
 			Entry("slirp interface with virtio model type - should be changed to e1000",
-				vmschema.Interface{Name: "slirpTest", Binding: &vmschema.PluginBinding{Name: domain.SlirpPluginName},
+				vmschema.Interface{Name: "slirpTest", Binding: &vmschema.PluginBinding{Name: "slirp-plugin"},
 					Model: "virtio",
 				},
 				vmschema.Network{Name: "slirpTest", NetworkSource: vmschema.NetworkSource{Pod: &vmschema.PodNetwork{}}},
@@ -110,7 +110,7 @@ var _ = Describe("QEMU slirp networking", func() {
 				},
 			),
 			Entry("custom MAC address",
-				vmschema.Interface{Name: "slirpTest", Binding: &vmschema.PluginBinding{Name: domain.SlirpPluginName},
+				vmschema.Interface{Name: "slirpTest", Binding: &vmschema.PluginBinding{Name: "slirp-plugin"},
 					MacAddress: "02:02:02:02:02:02",
 				},
 				vmschema.Network{Name: "slirpTest", NetworkSource: vmschema.NetworkSource{Pod: &vmschema.PodNetwork{}}},
@@ -120,7 +120,7 @@ var _ = Describe("QEMU slirp networking", func() {
 				},
 			),
 			Entry("iface model 'rtl8139'",
-				vmschema.Interface{Name: "slirpTest", Binding: &vmschema.PluginBinding{Name: domain.SlirpPluginName},
+				vmschema.Interface{Name: "slirpTest", Binding: &vmschema.PluginBinding{Name: "slirp-plugin"},
 					Model: "rtl8139",
 				},
 				vmschema.Network{Name: "slirpTest", NetworkSource: vmschema.NetworkSource{Pod: &vmschema.PodNetwork{}}},
@@ -133,7 +133,7 @@ var _ = Describe("QEMU slirp networking", func() {
 
 		DescribeTable("should not override existing QEMU cmd args, given",
 			func(iface vmschema.Interface, network vmschema.Network, existingArgs, expectedArgs []domainschema.Arg) {
-				testMutator, err := domain.NewSlirpNetworkConfigurator([]vmschema.Interface{iface}, []vmschema.Network{network}, testSearchDomain)
+				testMutator, err := domain.NewSlirpNetworkConfigurator([]vmschema.Interface{iface}, []vmschema.Network{network}, testSearchDomain, "slirp-plugin")
 				Expect(err).ToNot(HaveOccurred())
 
 				domSpec := &domainschema.DomainSpec{
@@ -181,7 +181,7 @@ var _ = Describe("QEMU slirp networking", func() {
 				{Value: "-M"},
 			}
 
-			testMutator, err := domain.NewSlirpNetworkConfigurator([]vmschema.Interface{iface}, []vmschema.Network{network}, testSearchDomain)
+			testMutator, err := domain.NewSlirpNetworkConfigurator([]vmschema.Interface{iface}, []vmschema.Network{network}, testSearchDomain, "slirp-plugin")
 			Expect(err).ToNot(HaveOccurred())
 
 			domSpec := &domainschema.DomainSpec{
@@ -207,9 +207,9 @@ var _ = Describe("QEMU slirp networking", func() {
 			network := vmschema.Network{Name: "slirpTest", NetworkSource: vmschema.NetworkSource{Pod: &vmschema.PodNetwork{
 				VMNetworkCIDR: "592.468.300.0/24",
 			}}}
-			iface := vmschema.Interface{Name: "slirpTest", Binding: &vmschema.PluginBinding{Name: domain.SlirpPluginName}}
+			iface := vmschema.Interface{Name: "slirpTest", Binding: &vmschema.PluginBinding{Name: "slirp-plugin"}}
 
-			testMutator, err := domain.NewSlirpNetworkConfigurator([]vmschema.Interface{iface}, []vmschema.Network{network}, testSearchDomain)
+			testMutator, err := domain.NewSlirpNetworkConfigurator([]vmschema.Interface{iface}, []vmschema.Network{network}, testSearchDomain, "slirp-plugin")
 			Expect(err).ToNot(HaveOccurred())
 			_, err = testMutator.Mutate(&domainschema.DomainSpec{})
 			Expect(err).To(HaveOccurred())
@@ -217,12 +217,12 @@ var _ = Describe("QEMU slirp networking", func() {
 
 		DescribeTable("should fail given invalid port",
 			func(port int32) {
-				iface := vmschema.Interface{Name: "slirpTest", Binding: &vmschema.PluginBinding{Name: domain.SlirpPluginName},
+				iface := vmschema.Interface{Name: "slirpTest", Binding: &vmschema.PluginBinding{Name: "slirp-plugin"},
 					Ports: []vmschema.Port{{Port: port}},
 				}
 				network := vmschema.Network{Name: "slirpTest", NetworkSource: vmschema.NetworkSource{Pod: &vmschema.PodNetwork{}}}
 
-				testMutator, err := domain.NewSlirpNetworkConfigurator([]vmschema.Interface{iface}, []vmschema.Network{network}, testSearchDomain)
+				testMutator, err := domain.NewSlirpNetworkConfigurator([]vmschema.Interface{iface}, []vmschema.Network{network}, testSearchDomain, "slirp-plugin")
 				Expect(err).ToNot(HaveOccurred())
 				_, err = testMutator.Mutate(&domainschema.DomainSpec{})
 				Expect(err).To(HaveOccurred())

--- a/cmd/sidecars/network-slirp-binding/main.go
+++ b/cmd/sidecars/network-slirp-binding/main.go
@@ -36,6 +36,8 @@ import (
 	srv "kubevirt.io/kubevirt/cmd/sidecars/network-slirp-binding/server"
 )
 
+const defaultBindingPluginName = "slirp"
+
 func main() {
 	searchDomains, err := dns.ReadResolvConfSearchDomains()
 	if err != nil {
@@ -54,7 +56,11 @@ func main() {
 
 	server := grpc.NewServer([]grpc.ServerOption{}...)
 	hooksInfo.RegisterInfoServer(server, srv.InfoServer{Version: "v1alpha2"})
-	hooksV1alpha2.RegisterCallbacksServer(server, srv.V1alpha2Server{SearchDomains: searchDomains})
+	bindingPluginName := os.Getenv(hooks.NetworkBindingPluginNameEnvVar)
+	if bindingPluginName == "" {
+		bindingPluginName = defaultBindingPluginName
+	}
+	hooksV1alpha2.RegisterCallbacksServer(server, srv.V1alpha2Server{SearchDomains: searchDomains, BindingPluginName: bindingPluginName})
 
 	log.Log.Infof("Starting hook server exposing 'info' and '%s' services on socket %q", socketPath, "v1alpha2")
 	server.Serve(socket)

--- a/cmd/sidecars/network-slirp-binding/server/server.go
+++ b/cmd/sidecars/network-slirp-binding/server/server.go
@@ -57,7 +57,8 @@ func (s InfoServer) Info(_ context.Context, _ *hooksInfo.InfoParams) (*hooksInfo
 }
 
 type V1alpha2Server struct {
-	SearchDomains []string
+	SearchDomains     []string
+	BindingPluginName string
 }
 
 func (s V1alpha2Server) OnDefineDomain(_ context.Context, params *hooksV1alpha2.OnDefineDomainParams) (*hooksV1alpha2.OnDefineDomainResult, error) {
@@ -68,7 +69,7 @@ func (s V1alpha2Server) OnDefineDomain(_ context.Context, params *hooksV1alpha2.
 		return nil, fmt.Errorf("failed to unmarshal VMI: %v", err)
 	}
 
-	slirpConfigurator, err := domain.NewSlirpNetworkConfigurator(vmi.Spec.Domain.Devices.Interfaces, vmi.Spec.Networks, s.SearchDomains)
+	slirpConfigurator, err := domain.NewSlirpNetworkConfigurator(vmi.Spec.Domain.Devices.Interfaces, vmi.Spec.Networks, s.SearchDomains, s.BindingPluginName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create slirp configurator: %v", err)
 	}

--- a/docs/network/network-binding-plugin.md
+++ b/docs/network/network-binding-plugin.md
@@ -519,3 +519,12 @@ To avoid conflicts, place additional sockets in a subdirectory under `/var/run/k
 
 Note: Some plugins may need to know the path accessible from the compute container for a specific sidecar.
 In such case, use `/var/run/kubevirt-hooks/<sidecar container name>`. The sidecar's container name can be obtained from the `CONTAINER_NAME` environment variable.
+
+## Network Binding Plugin Name
+
+KubeVirt sets the `NETWORK_BINDING_PLUGIN_NAME` environment variable on sidecar containers.
+Its value is the name under which the binding plugin was registered in the KubeVirt CR.
+
+The sidecar can use this value to identify the VMI interface it should configure, by matching it against `iface.Binding.Name` in the VMI spec.
+
+This allows a single sidecar image to serve multiple binding plugin registrations that use different names.

--- a/pkg/hooks/hooks.go
+++ b/pkg/hooks/hooks.go
@@ -31,6 +31,7 @@ const HookSidecarListAnnotationName = "hooks.kubevirt.io/hookSidecars"
 const HookSocketsSharedDirectory = "/var/run/kubevirt-hooks"
 
 const ContainerNameEnvVar = "CONTAINER_NAME"
+const NetworkBindingPluginNameEnvVar = "NETWORK_BINDING_PLUGIN_NAME"
 
 type HookSidecarList []HookSidecar
 
@@ -47,13 +48,14 @@ type PVC struct {
 }
 
 type HookSidecar struct {
-	Image           string                           `json:"image,omitempty"`
-	ImagePullPolicy k8sv1.PullPolicy                 `json:"imagePullPolicy"`
-	Command         []string                         `json:"command,omitempty"`
-	Args            []string                         `json:"args,omitempty"`
-	ConfigMap       *ConfigMap                       `json:"configMap,omitempty"`
-	PVC             *PVC                             `json:"pvc,omitempty"`
-	DownwardAPI     v1.NetworkBindingDownwardAPIType `json:"-"`
+	Image                    string                           `json:"image,omitempty"`
+	ImagePullPolicy          k8sv1.PullPolicy                 `json:"imagePullPolicy"`
+	Command                  []string                         `json:"command,omitempty"`
+	Args                     []string                         `json:"args,omitempty"`
+	ConfigMap                *ConfigMap                       `json:"configMap,omitempty"`
+	PVC                      *PVC                             `json:"pvc,omitempty"`
+	DownwardAPI              v1.NetworkBindingDownwardAPIType `json:"-"`
+	NetworkBindingPluginName string                           `json:"-"`
 }
 
 func UnmarshalHookSidecarList(vmiObject *v1.VirtualMachineInstance) (HookSidecarList, error) {

--- a/pkg/network/netbinding/netbinding.go
+++ b/pkg/network/netbinding/netbinding.go
@@ -57,12 +57,13 @@ func netBindingPluginSidecar(vmi *v1.VirtualMachineInstance, config *v1.KubeVirt
 		}
 	}
 
-	for _, pluginInfo := range bindingByName {
+	for bindingName, pluginInfo := range bindingByName {
 		if pluginInfo.SidecarImage != "" {
 			pluginSidecars = append(pluginSidecars, hooks.HookSidecar{
-				Image:           pluginInfo.SidecarImage,
-				ImagePullPolicy: config.ImagePullPolicy,
-				DownwardAPI:     pluginInfo.DownwardAPI,
+				Image:                    pluginInfo.SidecarImage,
+				ImagePullPolicy:          config.ImagePullPolicy,
+				DownwardAPI:              pluginInfo.DownwardAPI,
+				NetworkBindingPluginName: bindingName,
 			})
 		}
 	}

--- a/pkg/network/netbinding/netbinding_test.go
+++ b/pkg/network/netbinding/netbinding_test.go
@@ -64,7 +64,7 @@ var _ = Describe("Network Binding", func() {
 					libvmi.WithNetwork(&v1.Network{Name: testNetworkName1}),
 				),
 				map[string]v1.InterfaceBindingPlugin{testBindingName1: {SidecarImage: testSidecarImage1}},
-				hooks.HookSidecarList{{Image: testSidecarImage1}}),
+				hooks.HookSidecarList{{Image: testSidecarImage1, NetworkBindingPluginName: testBindingName1}}),
 			Entry("VMI has multiple plugin bindings",
 				libvmi.New(libvmi.WithInterface(v1.Interface{Name: testNetworkName1, Binding: &v1.PluginBinding{Name: testBindingName1}}),
 					libvmi.WithNetwork(&v1.Network{Name: testNetworkName1}),
@@ -80,7 +80,10 @@ var _ = Describe("Network Binding", func() {
 					testBindingName1: {SidecarImage: testSidecarImage1, DownwardAPI: v1.DeviceInfo},
 					testBindingName2: {SidecarImage: testSidecarImage2},
 				},
-				hooks.HookSidecarList{{Image: testSidecarImage1, DownwardAPI: v1.DeviceInfo}, {Image: testSidecarImage2}}),
+				hooks.HookSidecarList{
+					{Image: testSidecarImage1, DownwardAPI: v1.DeviceInfo, NetworkBindingPluginName: testBindingName1},
+					{Image: testSidecarImage2, NetworkBindingPluginName: testBindingName2},
+				}),
 			Entry("VMI has no plugin bindings",
 				libvmi.New(libvmi.WithInterface(v1.Interface{
 					Name:                   testNetworkName1,
@@ -97,7 +100,7 @@ var _ = Describe("Network Binding", func() {
 					libvmi.WithNetwork(&v1.Network{Name: testNetworkName2}),
 				),
 				map[string]v1.InterfaceBindingPlugin{testBindingName1: {SidecarImage: testSidecarImage1}},
-				hooks.HookSidecarList{{Image: testSidecarImage1}}),
+				hooks.HookSidecarList{{Image: testSidecarImage1, NetworkBindingPluginName: testBindingName1}}),
 		)
 
 		It("should retrun an error when VMI has binding plugin but config doesn't exist", func() {

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -875,14 +875,23 @@ func initContainerVolumeMount() k8sv1.VolumeMount {
 }
 
 func newSidecarContainerRenderer(sidecarName string, vmiSpec *v1.VirtualMachineInstance, resources k8sv1.ResourceRequirements, requestedHookSidecar hooks.HookSidecar, userId int64) *ContainerSpecRenderer {
+	envVars := []k8sv1.EnvVar{
+		{
+			Name:  hooks.ContainerNameEnvVar,
+			Value: sidecarName,
+		},
+	}
+	if requestedHookSidecar.NetworkBindingPluginName != "" {
+		envVars = append(envVars, k8sv1.EnvVar{
+			Name:  hooks.NetworkBindingPluginNameEnvVar,
+			Value: requestedHookSidecar.NetworkBindingPluginName,
+		})
+	}
+
 	sidecarOpts := []Option{
 		WithResourceRequirements(resources),
 		WithArgs(requestedHookSidecar.Args),
-		WithExtraEnvVars([]k8sv1.EnvVar{
-			k8sv1.EnvVar{
-				Name:  hooks.ContainerNameEnvVar,
-				Value: sidecarName,
-			}}),
+		WithExtraEnvVars(envVars),
 	}
 
 	var mounts []k8sv1.VolumeMount


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Network binding plugin sidecars (passt, slirp) hardcode their expected registration name when filtering interfaces, so the plugin must be registered under that exact name in the KubeVirt CR. This PR plumbs the actual registration name from the KubeVirt configuration to each sidecar via the `NETWORK_BINDING_PLUGIN_NAME` environment variable, so users can register a plugin under any name. When the environment variable is not set, sidecars fall back to their hardcoded default for backward compatibility with older virt-controller versions.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->
  - Fixes #18419

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Network binding plugin sidecars can now infer their registration name using the `NETWORK_BINDING_PLUGIN_NAME` environment variable.
```

