### PR TITLE
expansion tests: exercise in CI/use CSI storage class

### DIFF
--- a/automation/repeated_test.sh
+++ b/automation/repeated_test.sh
@@ -253,11 +253,6 @@ add_to_label_filter '(!requires-arm64)' '&&'
 add_to_label_filter '(!requires-s390x)' '&&'
 add_to_label_filter '(!requires-cross-arch-emulation)' '&&'
 add_to_label_filter '(!RequiresPersistentReservation)' '&&'
-rwofs_sc=$(jq -er .storageRWOFileSystem "${kubevirt_test_config}")
-if [[ "${rwofs_sc}" == "local" ]]; then
-    # local is a primitive non CSI storage class that doesn't support expansion
-    add_to_label_filter "(!RequiresVolumeExpansion)" "&&"
-fi
 
 if ! kubectl get clusterversion version &>/dev/null; then
   add_to_label_filter '(!OpenShift)' '&&'

--- a/automation/test.sh
+++ b/automation/test.sh
@@ -620,12 +620,6 @@ if [[ -z ${KUBEVIRT_E2E_FOCUS} && -z ${KUBEVIRT_E2E_SKIP} && -z ${label_filter} 
     add_to_label_filter "(!ImageVolume)" "&&"
   fi
 
-  rwofs_sc=$(jq -er .storageRWOFileSystem "${kubevirt_test_config}")
-  if [[ "${rwofs_sc}" == "local" ]]; then
-    # local is a primitive non CSI storage class that doesn't support expansion
-    add_to_label_filter "(!RequiresVolumeExpansion)" "&&"
-  fi
-
   vmstate_sc=$(jq -r .storageVMState "${kubevirt_test_config}")
   if [[ "${vmstate_sc}" == "rook-ceph-block" ]]; then
     # ceph block doesn't do RWX FS

--- a/tests/libstorage/datavolume.go
+++ b/tests/libstorage/datavolume.go
@@ -71,7 +71,7 @@ func AddDataVolume(vm *v1.VirtualMachine, diskName string, dataVolume *v1beta1.D
 }
 
 func CreateBlankFSDataVolume(name, namespace, size string, labels map[string]string) *v1beta1.DataVolume {
-	sc, _ := GetRWOFileSystemStorageClass()
+	sc, _ := GetCSIStorageClass()
 	dv := libdv.NewDataVolume(
 		libdv.WithNamespace(namespace),
 		libdv.WithName(name),

--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -241,6 +241,8 @@ var _ = Describe(SIG("DataVolume Integration", func() {
 			_, err = fmt.Sscanf(fstatOutput, "%d %d", &freeBlocks, &ioBlockSize)
 			Expect(err).ToNot(HaveOccurred())
 			freeSize := freeBlocks * ioBlockSize
+			err = virtClient.CoreV1().Pods(executorPod.Namespace).Delete(context.Background(), executorPod.Name, metav1.DeleteOptions{})
+			Expect(err).ToNot(HaveOccurred())
 
 			vmi := libstorage.RenderVMIWithDataVolume(dataVolume.Name, dataVolume.Namespace)
 			vmi = libvmops.RunVMIAndExpectLaunch(vmi, 500)

--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -131,7 +131,7 @@ var _ = Describe(SIG("DataVolume Integration", func() {
 					Fail("Fail test when Block storage is not present")
 				}
 			} else {
-				sc, exists = libstorage.GetRWOFileSystemStorageClass()
+				sc, exists = libstorage.GetCSIStorageClass()
 				if !exists {
 					Fail("Fail test when Filesystem storage is not present")
 				}
@@ -206,8 +206,7 @@ var _ = Describe(SIG("DataVolume Integration", func() {
 		)
 
 		It("Check disk expansion accounts for actual usable size", func() {
-
-			sc, exists := libstorage.GetRWOFileSystemStorageClass()
+			sc, exists := libstorage.GetCSIStorageClass()
 			if !exists {
 				Fail("Fail test when Filesystem storage is not present")
 			}

--- a/tests/storage/migration.go
+++ b/tests/storage/migration.go
@@ -157,7 +157,7 @@ var _ = Describe(SIG("Volumes update with migration", decorators.RequiresTwoSche
 			sc, exist := libstorage.GetRWOFileSystemStorageClass()
 			Expect(exist).To(BeTrue())
 			dv := libdv.NewDataVolume(
-				libdv.WithRegistryURLSource(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine)),
+				libdv.WithRegistryURLSource(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpineTestTooling)),
 				libdv.WithStorage(libdv.StorageWithStorageClass(sc),
 					libdv.StorageWithVolumeSize(size),
 					libdv.StorageWithFilesystemVolumeMode(),
@@ -337,11 +337,13 @@ var _ = Describe(SIG("Volumes update with migration", decorators.RequiresTwoSche
 				Expect(console.LoginToAlpine(vmi)).To(Succeed())
 
 				By("Waiting for notification about size change")
+				// fs overhead could get in the way, assert that the size is greater than 3Gi
+				sizeThreshold := resource.MustParse("3Gi")
 				Eventually(func() error {
 					err := console.SafeExpectBatch(vmi, []expect.Batcher{
 						&expect.BSnd{S: "\n"},
 						&expect.BExp{R: ""},
-						&expect.BSnd{S: "[ $(lsblk /dev/vda -o SIZE -n |sed -e \"s/ //g\") == \"4G\" ] && true\n"},
+						&expect.BSnd{S: fmt.Sprintf("[ $(lsblk /dev/vda -b -d -n -o SIZE) -gt %d ]; echo $?\n", sizeThreshold.Value())},
 						&expect.BExp{R: "0"},
 					}, 10)
 					return err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
We've been opting out of them in CI for a while but really there's no reason to.
Addressed a couple of bugs in separate commits.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

