### PR TITLE
Remove HCO-specific references from KubeVirt codebase

### DIFF
--- a/pkg/virt-operator/kubevirt_test.go
+++ b/pkg/virt-operator/kubevirt_test.go
@@ -1992,7 +1992,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			kvTestData.shouldExpectInstallStrategyDeletion()
 			kvTestData.controller.Execute()
 			kv = kvTestData.getLatestKubeVirt(kv)
-			shouldExpectHCOConditions(kv, k8sv1.ConditionTrue, k8sv1.ConditionFalse, k8sv1.ConditionFalse)
+			shouldExpectStatusConditions(kv, k8sv1.ConditionTrue, k8sv1.ConditionFalse, k8sv1.ConditionFalse)
 		})
 
 		It("delete temporary validation webhook once virt-api is deployed", func() {
@@ -2217,7 +2217,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			// be called once isReady() returns true (virt-template pods are still starting).
 			Expect(kv.Status.ObservedDeploymentID).To(Equal(initialObservedID))
 			// isUpdating() stayed true throughout, so Available remains True.
-			shouldExpectHCOConditions(kv, k8sv1.ConditionTrue, k8sv1.ConditionTrue, k8sv1.ConditionTrue)
+			shouldExpectStatusConditions(kv, k8sv1.ConditionTrue, k8sv1.ConditionTrue, k8sv1.ConditionTrue)
 
 			// Second cycle: mark all pods ready (including virt-template) and verify
 			// that ObservedDeploymentID is now advanced to the new config's ID.
@@ -2756,7 +2756,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			Expect(kv.Status.Phase).To(Equal(v1.KubeVirtPhaseDeploying))
 			Expect(kv.Status.Conditions).To(HaveLen(3))
 			Expect(kv.ObjectMeta.Finalizers).To(HaveLen(1))
-			shouldExpectHCOConditions(kv, k8sv1.ConditionFalse, k8sv1.ConditionTrue, k8sv1.ConditionFalse)
+			shouldExpectStatusConditions(kv, k8sv1.ConditionFalse, k8sv1.ConditionTrue, k8sv1.ConditionFalse)
 
 			// 7 in total are yet missing at this point
 			// because waiting on controller, controller's PDB and virt-handler daemonset until API server deploys successfully
@@ -2874,7 +2874,7 @@ var _ = Describe("KubeVirt Operator", func() {
 
 			kv = kvTestData.getLatestKubeVirt(kv)
 			// conditions should reflect an ongoing update
-			shouldExpectHCOConditions(kv, k8sv1.ConditionTrue, k8sv1.ConditionTrue, k8sv1.ConditionTrue)
+			shouldExpectStatusConditions(kv, k8sv1.ConditionTrue, k8sv1.ConditionTrue, k8sv1.ConditionTrue)
 
 			// on rollback or create, api server must be online first before controllers and daemonset.
 			// On rollback this prevents someone from posting invalid specs to
@@ -2945,7 +2945,7 @@ var _ = Describe("KubeVirt Operator", func() {
 
 			kv = kvTestData.getLatestKubeVirt(kv)
 			// conditions should reflect an ongoing update
-			shouldExpectHCOConditions(kv, k8sv1.ConditionTrue, k8sv1.ConditionTrue, k8sv1.ConditionTrue)
+			shouldExpectStatusConditions(kv, k8sv1.ConditionTrue, k8sv1.ConditionTrue, k8sv1.ConditionTrue)
 
 			Expect(kvTestData.totalUpdates).To(Equal(updateCount))
 
@@ -3021,7 +3021,7 @@ var _ = Describe("KubeVirt Operator", func() {
 
 			kv = kvTestData.getLatestKubeVirt(kv)
 			// conditions should reflect an ongoing update
-			shouldExpectHCOConditions(kv, k8sv1.ConditionTrue, k8sv1.ConditionTrue, k8sv1.ConditionTrue)
+			shouldExpectStatusConditions(kv, k8sv1.ConditionTrue, k8sv1.ConditionTrue, k8sv1.ConditionTrue)
 
 			Expect(kvTestData.totalUpdates).To(Equal(updateCount))
 
@@ -3542,7 +3542,7 @@ var _ = Describe("KubeVirt Operator", func() {
 
 			kv = kvTestData.getLatestKubeVirt(kv)
 			// conditions should reflect a successful update
-			shouldExpectHCOConditions(kv, k8sv1.ConditionTrue, k8sv1.ConditionFalse, k8sv1.ConditionFalse)
+			shouldExpectStatusConditions(kv, k8sv1.ConditionTrue, k8sv1.ConditionFalse, k8sv1.ConditionFalse)
 
 			// -1 for virt-handler which is already updated
 			Expect(kvTestData.totalPatches).To(Equal(patchCount - 1))
@@ -3613,7 +3613,7 @@ var _ = Describe("KubeVirt Operator", func() {
 
 			kv = kvTestData.getLatestKubeVirt(kv)
 			// conditions should reflect a successful update
-			shouldExpectHCOConditions(kv, k8sv1.ConditionTrue, k8sv1.ConditionFalse, k8sv1.ConditionFalse)
+			shouldExpectStatusConditions(kv, k8sv1.ConditionTrue, k8sv1.ConditionFalse, k8sv1.ConditionFalse)
 
 			o, exists, err := kvTestData.controller.stores.DeploymentCache.GetByKey(fmt.Sprintf("%s/%s", NAMESPACE, "virt-exportproxy"))
 			Expect(err).ToNot(HaveOccurred())
@@ -3737,7 +3737,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			kv = kvTestData.getLatestKubeVirt(kv)
 			Expect(kv.Status.Phase).To(Equal(v1.KubeVirtPhaseDeleted))
 			Expect(kv.Status.Conditions).To(HaveLen(3))
-			shouldExpectHCOConditions(kv, k8sv1.ConditionFalse, k8sv1.ConditionFalse, k8sv1.ConditionTrue)
+			shouldExpectStatusConditions(kv, k8sv1.ConditionFalse, k8sv1.ConditionFalse, k8sv1.ConditionTrue)
 		})
 
 		It("should remove poddisruptionbudgets on deletion", func() {
@@ -3841,7 +3841,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			expectedUncreatedResources := 5 + virtTemplateResourceCount
 
 			// KV should be progressing, resources have been added, but they are not all ready yet
-			shouldExpectHCOConditions(kvTestData.getLatestKubeVirt(kv), k8sv1.ConditionFalse, k8sv1.ConditionTrue, k8sv1.ConditionFalse)
+			shouldExpectStatusConditions(kvTestData.getLatestKubeVirt(kv), k8sv1.ConditionFalse, k8sv1.ConditionTrue, k8sv1.ConditionFalse)
 			Expect(kvTestData.totalAdds).To(Equal(resourceCount - expectedUncreatedResources + expectedTemporaryResources + externalCAConfigMapCount))
 			Expect(virtTemplateResourcesFound()).To(BeFalse())
 		},
@@ -3931,7 +3931,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			kvTestData.controller.Execute()
 
 			// KV should be available, resources have been deleted and all others are already ready
-			shouldExpectHCOConditions(kvTestData.getLatestKubeVirt(newKv), k8sv1.ConditionTrue, k8sv1.ConditionFalse, k8sv1.ConditionFalse)
+			shouldExpectStatusConditions(kvTestData.getLatestKubeVirt(newKv), k8sv1.ConditionTrue, k8sv1.ConditionFalse, k8sv1.ConditionFalse)
 			Expect(kvTestData.totalDeletions).To(Equal(virtTemplateResourceCount))
 			Expect(virtTemplateResourcesFound()).To(BeFalse())
 		})
@@ -3992,7 +3992,7 @@ var _ = Describe("KubeVirt Operator", func() {
 			kvTestData.controller.Execute()
 
 			// KV should be progressing, resources have been added, but they are not all ready yet
-			shouldExpectHCOConditions(kvTestData.getLatestKubeVirt(newKv), k8sv1.ConditionFalse, k8sv1.ConditionTrue, k8sv1.ConditionFalse)
+			shouldExpectStatusConditions(kvTestData.getLatestKubeVirt(newKv), k8sv1.ConditionFalse, k8sv1.ConditionTrue, k8sv1.ConditionFalse)
 			Expect(kvTestData.totalAdds).To(Equal(virtTemplateResourceCount + externalCAConfigMapCount))
 		})
 	})
@@ -4270,7 +4270,7 @@ func injectMetadata(objectMeta *metav1.ObjectMeta, config *util.KubeVirtDeployme
 	}
 }
 
-func shouldExpectHCOConditions(kv *v1.KubeVirt, available k8sv1.ConditionStatus, progressing k8sv1.ConditionStatus, degraded k8sv1.ConditionStatus) {
+func shouldExpectStatusConditions(kv *v1.KubeVirt, available k8sv1.ConditionStatus, progressing k8sv1.ConditionStatus, degraded k8sv1.ConditionStatus) {
 	getType := func(c v1.KubeVirtCondition) v1.KubeVirtConditionType { return c.Type }
 	getStatus := func(c v1.KubeVirtCondition) k8sv1.ConditionStatus { return c.Status }
 	Expect(kv.Status.Conditions).To(ContainElement(

--- a/pkg/virt-operator/util/client.go
+++ b/pkg/virt-operator/util/client.go
@@ -87,7 +87,7 @@ func UpdateConditionsAvailable(kv *virtv1.KubeVirt) {
 
 func UpdateConditionsFailedExists(kv *virtv1.KubeVirt) {
 	updateCondition(kv, virtv1.KubeVirtConditionSynchronized, k8sv1.ConditionFalse, ConditionReasonDeploymentFailedExisting, "There is an active KubeVirt deployment")
-	// don' t set any other conditions here, so HCO just ignores this KubeVirt CR
+	// don't set any other conditions here, so the managing operator just ignores this KubeVirt CR
 }
 
 func UpdateConditionsFailedError(kv *virtv1.KubeVirt, err error) {

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -2738,7 +2738,6 @@ const (
 	// Whether all resources were created and up-to-date
 	KubeVirtConditionCreated KubeVirtConditionType = "Created"
 
-	// Conditions for HCO, see https://github.com/kubevirt/hyperconverged-cluster-operator/blob/master/docs/conditions.md
 	// Whether KubeVirt is functional and available in the cluster.
 	KubeVirtConditionAvailable KubeVirtConditionType = "Available"
 	// Whether the operator is actively making changes to KubeVirt


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
KubeVirt is agnostic to which uber operator manages it.
The Available/Progressing/Degraded conditions are standard
Kubernetes operator conditions, not HCO-specific.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

