### PR TITLE
virtwrap, storage, cbt: set cluster size during qcow2 overlay creation

### DIFF
--- a/pkg/virt-launcher/virtwrap/storage/cbt.go
+++ b/pkg/virt-launcher/virtwrap/storage/cbt.go
@@ -42,6 +42,10 @@ import (
 	convertertypes "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter/types"
 )
 
+const (
+	overlayClusterSize = 1 << 18 // 256KiB
+)
+
 func DiskHasDataStore(disk *api.Disk) bool {
 	return disk != nil && disk.Source.DataStore != nil
 }
@@ -147,7 +151,7 @@ func runOverlayQMPSession(ctx context.Context, stdin io.WriteCloser, stdout io.R
 	overlaySize int64, overlayPath string) (string, error) {
 
 	qmpCapabilities := `{"execute": "qmp_capabilities"}`
-	blockdevCreate := fmt.Sprintf(`{"execute": "blockdev-create", "arguments": {"job-id": "create", "options": {"driver": "qcow2", "file": "file", "data-file": "data-file", "data-file-raw": true, "size": %d}}}`, overlaySize)
+	blockdevCreate := fmt.Sprintf(`{"execute": "blockdev-create", "arguments": {"job-id": "create", "options": {"driver": "qcow2", "file": "file", "data-file": "data-file", "data-file-raw": true, "size": %d, "cluster-size": %d}}}`, overlaySize, overlayClusterSize)
 	queryJobs := `{"execute": "query-jobs"}`
 	jobDismiss := `{"execute": "job-dismiss", "arguments": {"id": "create"}}`
 	quit := `{"execute": "quit"}`

--- a/pkg/virt-launcher/virtwrap/storage/cbt_test.go
+++ b/pkg/virt-launcher/virtwrap/storage/cbt_test.go
@@ -402,6 +402,19 @@ var _ = Describe("Changed Block Tracking", func() {
 			Expect(stdinBuf.String()).To(ContainSubstring(fmt.Sprintf(`"size": %d`, testSize)))
 		})
 
+		It("should set cluster size of 256KiB for overlays", func() {
+			qmpOutput := `{"event": "JOB_STATUS_CHANGE", "data": {"status": "concluded", "id": "create"}}`
+			stdout := strings.NewReader(qmpOutput)
+
+			var stdinBuf writeCloserBuffer
+			ctx := context.Background()
+			const testSize int64 = 107374182400
+
+			_, err := runOverlayQMPSession(ctx, &stdinBuf, stdout, testSize, overlayPath)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(stdinBuf.String()).To(ContainSubstring(fmt.Sprintf(`"cluster-size": %d`, 1<<18)))
+		})
+
 		It("should not panic on multiple concluded events", func() {
 			qmpOutput := strings.Join([]string{
 				`{"return": {}}`,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:

Cluster size wasn't being set for the creation of a CBT qcow2 overlay.

#### After this PR:

Cluster size is set to 256KiB instead of the default 64KiB for a CBT qcow2 overlay.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/25

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

We currently create a qcow2 overlay per disk to store persistent dirty bitmaps. The overlay uses `data-file-raw` which tells QEMU that the external data file is a standalone raw image. This forces `PREALLOC_MODE_METADATA` which means that all L1/L2 tables are fully preallocated creation to maintain a 1:1 mapping between QCOW2 cluster offsets and raw data file offsets. The overlay stores only metadata and bitmaps, so its on-disk size is pure overhead. We currently create these overlays without specifying a cluster size, so QEMU uses the default of 64KiB. 

The choice of cluster size is governed by two opposing forces... On one hand, metadata wants large clusters: with 64KiB clusters, the L2 table overhead from preallocation grows linearly with disk size, for example, a 1 TiB disk produces ~128MiB of metadata overhead at 64KiB clusters. Doubling the cluster size halves the L2 overhead. On the other hand, bitmap storage wants small clusters: each persistent dirty bitmap's data and table are stored in cluster-aligned chunks, costing at least 2 full clusters per bitmap even when the raw bitmap data (`ceil(disk_size / granularity / 8), granularity = 64KiB`) is only kilobytes. At 2 MiB clusters, each bitmap wastes 4MiB from rounding; at 256KiB, only 512KiB.

256KiB was found to be optimal for most usecases (virtual disk size of ~20GiB - ~120GiB).

That's enough context. The following heatmap shows which cluster size yields the smallest total overlay for every combination of disk size and bitmap count. Each color represents the "winner", i.e., the cluster size that minimizes the total overhead at that point:
<img width="1400" height="900" alt="image" src="https://github.com/user-attachments/assets/8c168a06-a59c-41fb-8512-dc6503c6db89" />

Notice how at 256KiB, we reach a relative sweet spot since it dominates across ~20GiB - ~120GiB usecases (which are often the case for VM disks).

Alternatives include:
- 64 KiB (current default) - means that L2 metadata grows at `disk_size / 8192` bytes, which for larger disks (> ~50GiB) would consume the most amount of storage.
- 512 KiB - reduces the L2 metadata 8x vs 64KiB but each bitmap still wastes 1MiB from rounding. At small disk sizes (~10GiB), the fixed overhead from metadata structures plus bitmap waste puts it above 256KiB for most common usecases.
- 1 MiB - each bitmap wastes 2MiB from rounding, with 5 bitmaps the bitmap floor alone becomes ~12MiB and the overlay is larger than 64KiB for any disk under ~200GiB.
- 2 MiB - following the trend of the previous 2, only wins above ~1TiB.

Another graph which shows the actual overlay size with these options can be examined: 

<img width="1400" height="800" alt="image" src="https://github.com/user-attachments/assets/fa188e9a-c329-43b8-b830-033c181f1b34" />


<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

