### PR TITLE
storage/admitters: decouple VMExport admitter from virt-config

### DIFF
--- a/pkg/storage/admitters/vmexport.go
+++ b/pkg/storage/admitters/vmexport.go
@@ -36,7 +36,6 @@ import (
 	templateapi "kubevirt.io/virt-template-api/core"
 
 	webhookutils "kubevirt.io/kubevirt/pkg/util/webhooks"
-	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 )
 
 const (
@@ -47,13 +46,18 @@ const (
 	vmTemplateKind = "VirtualMachineTemplate"
 )
 
+type vmExportConfigChecker interface {
+	OCIExportEnabled() bool
+	VirtTemplateDeploymentEnabled() bool
+}
+
 // VMExportAdmitter validates VirtualMachineExports
 type VMExportAdmitter struct {
-	Config *virtconfig.ClusterConfig
+	Config vmExportConfigChecker
 }
 
 // NewVMExportAdmitter creates a VMExportAdmitter
-func NewVMExportAdmitter(config *virtconfig.ClusterConfig) *VMExportAdmitter {
+func NewVMExportAdmitter(config vmExportConfigChecker) *VMExportAdmitter {
 	return &VMExportAdmitter{
 		Config: config,
 	}

--- a/pkg/storage/admitters/vmexport.go
+++ b/pkg/storage/admitters/vmexport.go
@@ -53,13 +53,13 @@ type vmExportConfigChecker interface {
 
 // VMExportAdmitter validates VirtualMachineExports
 type VMExportAdmitter struct {
-	Config vmExportConfigChecker
+	config vmExportConfigChecker
 }
 
 // NewVMExportAdmitter creates a VMExportAdmitter
 func NewVMExportAdmitter(config vmExportConfigChecker) *VMExportAdmitter {
 	return &VMExportAdmitter{
-		Config: config,
+		config: config,
 	}
 }
 
@@ -97,7 +97,7 @@ func (admitter *VMExportAdmitter) Admit(_ context.Context, ar *admissionv1.Admis
 			causes = append(causes, admitter.validateVMBackupName(sourceField.Child("name"), vmExport.Spec.Source.Name)...)
 			causes = append(causes, admitter.validateVMBackupApiGroup(sourceField.Child("APIGroup"), vmExport.Spec.Source.APIGroup)...)
 		case vmTemplateKind:
-			if !admitter.Config.OCIExportEnabled() || !admitter.Config.VirtTemplateDeploymentEnabled() {
+			if !admitter.config.OCIExportEnabled() || !admitter.config.VirtTemplateDeploymentEnabled() {
 				causes = append(causes, metav1.StatusCause{
 					Type:    metav1.CauseTypeFieldValueInvalid,
 					Message: "VirtualMachineTemplate source requires the OCIExport feature gate and virt-template deployment to be enabled",

--- a/pkg/storage/admitters/vmexport_test.go
+++ b/pkg/storage/admitters/vmexport_test.go
@@ -348,7 +348,7 @@ func createExportUpdateAdmissionReview(old, current *exportv1.VirtualMachineExpo
 }
 
 func createTestVMExportAdmitter(config vmExportConfigChecker) *VMExportAdmitter {
-	return &VMExportAdmitter{Config: config}
+	return &VMExportAdmitter{config: config}
 }
 
 type stubVMExportConfigChecker struct {

--- a/pkg/storage/admitters/vmexport_test.go
+++ b/pkg/storage/admitters/vmexport_test.go
@@ -31,14 +31,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	v1 "kubevirt.io/api/core/v1"
 	exportv1 "kubevirt.io/api/export/v1"
 	templateapi "kubevirt.io/virt-template-api/core"
 
-	"kubevirt.io/kubevirt/pkg/testutils"
 	"kubevirt.io/kubevirt/pkg/virt-api/webhooks"
-	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
-	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 )
 
 var _ = Describe("Validating VirtualMachineExport Admitter", func() {
@@ -48,24 +44,6 @@ var _ = Describe("Validating VirtualMachineExport Admitter", func() {
 	backupApiGroup := "backup.kubevirt.io"
 	templateApiGroup := templateapi.GroupName
 
-	config, _, _ := testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{})
-	ociOnlyConfig, _, _ := testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{
-		DeveloperConfiguration: &v1.DeveloperConfiguration{
-			FeatureGates:         []string{featuregate.OCIExport},
-			DisabledFeatureGates: []string{featuregate.Template},
-		},
-	})
-	templateOnlyConfig, _, _ := testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{
-		DeveloperConfiguration: &v1.DeveloperConfiguration{
-			FeatureGates: []string{featuregate.Template},
-		},
-	})
-	vmTemplateExportConfig, _, _ := testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{
-		DeveloperConfiguration: &v1.DeveloperConfiguration{
-			FeatureGates: []string{featuregate.Template, featuregate.OCIExport},
-		},
-	})
-
 	Context("VMExport", func() {
 		It("should reject invalid request resource", func() {
 			ar := &admissionv1.AdmissionReview{
@@ -74,7 +52,7 @@ var _ = Describe("Validating VirtualMachineExport Admitter", func() {
 				},
 			}
 
-			resp := createTestVMExportAdmitter(config).Admit(context.Background(), ar)
+			resp := createTestVMExportAdmitter(stubVMExportConfigChecker{}).Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeFalse())
 			Expect(resp.Result.Message).Should(ContainSubstring("unexpected resource"))
 		})
@@ -126,7 +104,7 @@ var _ = Describe("Validating VirtualMachineExport Admitter", func() {
 				},
 			}
 			ar := createExportAdmissionReview(export)
-			resp := createTestVMExportAdmitter(config).Admit(context.Background(), ar)
+			resp := createTestVMExportAdmitter(stubVMExportConfigChecker{}).Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeFalse())
 			Expect(resp.Result.Message).Should(ContainSubstring(errorString))
 		},
@@ -137,34 +115,42 @@ var _ = Describe("Validating VirtualMachineExport Admitter", func() {
 		)
 
 		It("should reject blank VMTemplate name when Template gate enabled", func() {
+			clusterConfig := stubVMExportConfigChecker{
+				ociExportEnabled:              true,
+				virtTemplateDeploymentEnabled: true,
+			}
 			export := &exportv1.VirtualMachineExport{
 				Spec: exportv1.VirtualMachineExportSpec{
 					Source: createBlankVMTemplateObjectRef(),
 				},
 			}
 			ar := createExportAdmissionReview(export)
-			resp := createTestVMExportAdmitter(vmTemplateExportConfig).Admit(context.Background(), ar)
+			resp := createTestVMExportAdmitter(clusterConfig).Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeFalse())
 			Expect(resp.Result.Message).Should(ContainSubstring("VirtualMachineTemplate name must not be empty"))
 		})
 
-		DescribeTable("should reject VMTemplate source when required feature gates are missing", func(cfg *virtconfig.ClusterConfig) {
+		DescribeTable("should reject VMTemplate source when required feature gates are missing", func(clusterConfig stubVMExportConfigChecker) {
 			export := &exportv1.VirtualMachineExport{
 				Spec: exportv1.VirtualMachineExportSpec{
 					Source: createBlankVMTemplateObjectRef(),
 				},
 			}
 			ar := createExportAdmissionReview(export)
-			resp := createTestVMExportAdmitter(cfg).Admit(context.Background(), ar)
+			resp := createTestVMExportAdmitter(clusterConfig).Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeFalse())
 			Expect(resp.Result.Message).Should(ContainSubstring("OCIExport feature gate and virt-template deployment"))
 		},
-			Entry("no feature gates", config),
-			Entry("only OCIExport", ociOnlyConfig),
-			Entry("only Template", templateOnlyConfig),
+			Entry("no feature gates", stubVMExportConfigChecker{}),
+			Entry("only OCIExport", stubVMExportConfigChecker{ociExportEnabled: true}),
+			Entry("only Template", stubVMExportConfigChecker{virtTemplateDeploymentEnabled: true}),
 		)
 
 		It("should accept valid VMTemplate source when both gates enabled", func() {
+			clusterConfig := stubVMExportConfigChecker{
+				ociExportEnabled:              true,
+				virtTemplateDeploymentEnabled: true,
+			}
 			export := &exportv1.VirtualMachineExport{
 				Spec: exportv1.VirtualMachineExportSpec{
 					Source: corev1.TypedLocalObjectReference{
@@ -175,7 +161,7 @@ var _ = Describe("Validating VirtualMachineExport Admitter", func() {
 				},
 			}
 			ar := createExportAdmissionReview(export)
-			resp := createTestVMExportAdmitter(vmTemplateExportConfig).Admit(context.Background(), ar)
+			resp := createTestVMExportAdmitter(clusterConfig).Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeTrue())
 		})
 
@@ -191,7 +177,7 @@ var _ = Describe("Validating VirtualMachineExport Admitter", func() {
 			}
 
 			ar := createExportAdmissionReview(export)
-			resp := createTestVMExportAdmitter(config).Admit(context.Background(), ar)
+			resp := createTestVMExportAdmitter(stubVMExportConfigChecker{}).Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeFalse())
 			Expect(resp.Result.Details.Causes).To(HaveLen(1))
 			Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.source.kind"))
@@ -219,7 +205,7 @@ var _ = Describe("Validating VirtualMachineExport Admitter", func() {
 			}
 
 			ar := createExportUpdateAdmissionReview(oldExport, export)
-			resp := createTestVMExportAdmitter(config).Admit(context.Background(), ar)
+			resp := createTestVMExportAdmitter(stubVMExportConfigChecker{}).Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeFalse())
 			Expect(resp.Result.Details.Causes).To(HaveLen(1))
 			Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec"))
@@ -250,7 +236,7 @@ var _ = Describe("Validating VirtualMachineExport Admitter", func() {
 			}
 
 			ar := createExportUpdateAdmissionReview(oldExport, export)
-			resp := createTestVMExportAdmitter(config).Admit(context.Background(), ar)
+			resp := createTestVMExportAdmitter(stubVMExportConfigChecker{}).Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeTrue())
 		})
 
@@ -266,7 +252,7 @@ var _ = Describe("Validating VirtualMachineExport Admitter", func() {
 			}
 
 			ar := createExportAdmissionReview(export)
-			resp := createTestVMExportAdmitter(config).Admit(context.Background(), ar)
+			resp := createTestVMExportAdmitter(stubVMExportConfigChecker{}).Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeTrue(), "should allow APIGroup: %s, Kind: %s", apiGroup, kind)
 		},
 			Entry("persistent volume claim blank", "", pvc),
@@ -286,7 +272,7 @@ var _ = Describe("Validating VirtualMachineExport Admitter", func() {
 			}
 
 			ar := createExportAdmissionReview(export)
-			resp := createTestVMExportAdmitter(config).Admit(context.Background(), ar)
+			resp := createTestVMExportAdmitter(stubVMExportConfigChecker{}).Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeFalse(), "should reject APIGroup: %s, Kind: %s", apiGroup, kind)
 		},
 			Entry("persistent volume claim", "invalid", pvc),
@@ -296,6 +282,10 @@ var _ = Describe("Validating VirtualMachineExport Admitter", func() {
 		)
 
 		It("should reject invalid VMTemplate apigroup", func() {
+			clusterConfig := stubVMExportConfigChecker{
+				ociExportEnabled:              true,
+				virtTemplateDeploymentEnabled: true,
+			}
 			invalidGroup := "invalid"
 			export := &exportv1.VirtualMachineExport{
 				Spec: exportv1.VirtualMachineExportSpec{
@@ -307,7 +297,7 @@ var _ = Describe("Validating VirtualMachineExport Admitter", func() {
 				},
 			}
 			ar := createExportAdmissionReview(export)
-			resp := createTestVMExportAdmitter(vmTemplateExportConfig).Admit(context.Background(), ar)
+			resp := createTestVMExportAdmitter(clusterConfig).Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeFalse())
 		})
 	})
@@ -357,6 +347,16 @@ func createExportUpdateAdmissionReview(old, current *exportv1.VirtualMachineExpo
 	return ar
 }
 
-func createTestVMExportAdmitter(config *virtconfig.ClusterConfig) *VMExportAdmitter {
+func createTestVMExportAdmitter(config vmExportConfigChecker) *VMExportAdmitter {
 	return &VMExportAdmitter{Config: config}
+}
+
+type stubVMExportConfigChecker struct {
+	ociExportEnabled              bool
+	virtTemplateDeploymentEnabled bool
+}
+
+func (s stubVMExportConfigChecker) OCIExportEnabled() bool { return s.ociExportEnabled }
+func (s stubVMExportConfigChecker) VirtTemplateDeploymentEnabled() bool {
+	return s.virtTemplateDeploymentEnabled
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
The VMExport admitter only needs two config methods: `OCIExportEnabled` and `VirtTemplateDeploymentEnabled`. Introduce a `vmExportConfigChecker` interface so the admitter no longer depends on the concrete `ClusterConfig` type. The production caller continues to pass `*virtconfig.ClusterConfig` which satisfies the interface.

In tests, replace the heavyweight `NewFakeClusterConfigUsingKVConfig` setup with a simple stub that directly controls the two booleans.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

