### PR TITLE
VEP 183: Defer SR-IOV from network DRA beta scope

### DIFF
--- a/pkg/network/admitter/dra.go
+++ b/pkg/network/admitter/dra.go
@@ -142,12 +142,12 @@ func validateDRAClaimAndRequestNames(field *k8sfield.Path, idx int, claimName, r
 
 func validateDRANetworkInterfaceBinding(field *k8sfield.Path, interfaces []v1.Interface, networkName string) []metav1.StatusCause {
 	iface := vmispec.LookupInterfaceByName(interfaces, networkName)
-	if iface == nil || iface.SRIOV != nil || iface.Binding != nil {
+	if iface == nil || iface.Binding != nil {
 		return nil
 	}
 	return []metav1.StatusCause{{
 		Type:    metav1.CauseTypeFieldValueInvalid,
-		Message: fmt.Sprintf("DRA network %q requires an SR-IOV or binding plugin interface", networkName),
+		Message: fmt.Sprintf("DRA network %q requires a binding plugin interface", networkName),
 		Field:   field.Child("domain", "devices", "interfaces").String(),
 	}}
 }

--- a/pkg/network/admitter/dra_test.go
+++ b/pkg/network/admitter/dra_test.go
@@ -82,16 +82,12 @@ var _ = Describe("Validate network DRA", func() {
 		spec := newDRASpec()
 		spec.Domain.Devices.Interfaces = []v1.Interface{
 			{
-				Name: "dra-net-1",
-				InterfaceBindingMethod: v1.InterfaceBindingMethod{
-					SRIOV: &v1.InterfaceSRIOV{},
-				},
+				Name:    "dra-net-1",
+				Binding: &v1.PluginBinding{Name: "netbinding"},
 			},
 			{
-				Name: "dra-net-2",
-				InterfaceBindingMethod: v1.InterfaceBindingMethod{
-					SRIOV: &v1.InterfaceSRIOV{},
-				},
+				Name:    "dra-net-2",
+				Binding: &v1.PluginBinding{Name: "netbinding"},
 			},
 		}
 		spec.Networks = []v1.Network{
@@ -125,16 +121,12 @@ var _ = Describe("Validate network DRA", func() {
 		spec := newDRASpec()
 		spec.Domain.Devices.Interfaces = []v1.Interface{
 			{
-				Name: "multus-net",
-				InterfaceBindingMethod: v1.InterfaceBindingMethod{
-					SRIOV: &v1.InterfaceSRIOV{},
-				},
+				Name:    "multus-net",
+				Binding: &v1.PluginBinding{Name: "netbinding"},
 			},
 			{
-				Name: "dra-net",
-				InterfaceBindingMethod: v1.InterfaceBindingMethod{
-					SRIOV: &v1.InterfaceSRIOV{},
-				},
+				Name:    "dra-net",
+				Binding: &v1.PluginBinding{Name: "netbinding"},
 			},
 		}
 		spec.Networks = []v1.Network{
@@ -151,16 +143,20 @@ var _ = Describe("Validate network DRA", func() {
 		Expect(causes[0].Field).To(Equal("fake.networks"))
 	})
 
-	It("should reject DRA network with non-SRIOV interface binding", func() {
-		spec := newDRASpec()
-		spec.Domain.Devices.Interfaces[0] = *v1.DefaultBridgeNetworkInterface()
-		spec.Domain.Devices.Interfaces[0].Name = "dra-net"
-		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{networkDRAEnabled: true})
-		causes := validator.Validate()
-		Expect(causes).To(HaveLen(1))
-		Expect(causes[0].Message).To(Equal(`DRA network "dra-net" requires an SR-IOV or binding plugin interface`))
-		Expect(causes[0].Field).To(Equal("fake.domain.devices.interfaces"))
-	})
+	DescribeTable("should reject DRA network with core interface binding",
+		func(iface v1.Interface) {
+			spec := newDRASpec()
+			iface.Name = "dra-net"
+			spec.Domain.Devices.Interfaces = []v1.Interface{iface}
+			validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{networkDRAEnabled: true})
+			causes := validator.Validate()
+			Expect(causes).To(ContainElement(HaveField("Message", `DRA network "dra-net" requires a binding plugin interface`)))
+		},
+		Entry("bridge", v1.Interface{InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}}),
+		Entry("masquerade", v1.Interface{InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}}}),
+		Entry("SR-IOV", v1.Interface{InterfaceBindingMethod: v1.InterfaceBindingMethod{SRIOV: &v1.InterfaceSRIOV{}}}),
+		Entry("passtBinding", v1.Interface{InterfaceBindingMethod: v1.InterfaceBindingMethod{PasstBinding: &v1.InterfacePasstBinding{}}}),
+	)
 
 	It("should accept DRA network with plugin interface binding", func() {
 		spec := newDRASpec()
@@ -205,10 +201,8 @@ func newDRASpec() *v1.VirtualMachineInstanceSpec {
 			Devices: v1.Devices{
 				Interfaces: []v1.Interface{
 					{
-						Name: "dra-net",
-						InterfaceBindingMethod: v1.InterfaceBindingMethod{
-							SRIOV: &v1.InterfaceSRIOV{},
-						},
+						Name:    "dra-net",
+						Binding: &v1.PluginBinding{Name: "netbinding"},
 					},
 				},
 			},

--- a/pkg/network/admitter/netsource_test.go
+++ b/pkg/network/admitter/netsource_test.go
@@ -87,15 +87,15 @@ var _ = Describe("Validate network source", func() {
 	})
 
 	It("should accept resourceClaim network type", func() {
-		const draSRIOVNetName = "sriov-dra"
+		const draNetName = "dra-net"
 		spec := &v1.VirtualMachineInstanceSpec{}
 		spec.Domain.Devices.Interfaces = []v1.Interface{
-			{Name: draSRIOVNetName, InterfaceBindingMethod: v1.InterfaceBindingMethod{SRIOV: &v1.InterfaceSRIOV{}}},
+			{Name: draNetName, Binding: &v1.PluginBinding{Name: "netbinding"}},
 		}
 		spec.ResourceClaims = []v1.VirtualMachineInstanceResourceClaim{{Name: "claim1", ResourceClaimName: ptr.To("claim1")}}
 		spec.Networks = []v1.Network{
 			{
-				Name: draSRIOVNetName,
+				Name: draNetName,
 				NetworkSource: v1.NetworkSource{
 					ResourceClaim: &v1.ClaimRequest{
 						ClaimName:   "claim1",
@@ -113,7 +113,7 @@ var _ = Describe("Validate network source", func() {
 		func(networkSource v1.NetworkSource) {
 			spec := &v1.VirtualMachineInstanceSpec{}
 			spec.Domain.Devices.Interfaces = []v1.Interface{
-				{Name: "default", InterfaceBindingMethod: v1.InterfaceBindingMethod{SRIOV: &v1.InterfaceSRIOV{}}},
+				{Name: "default", Binding: &v1.PluginBinding{Name: "netbinding"}},
 			}
 			spec.ResourceClaims = []v1.VirtualMachineInstanceResourceClaim{{Name: "claim1", ResourceClaimName: ptr.To("claim1")}}
 			spec.Networks = []v1.Network{

--- a/pkg/network/controllers/vmi_test.go
+++ b/pkg/network/controllers/vmi_test.go
@@ -502,11 +502,11 @@ var _ = Describe("Status Update", func() {
 
 	It("Should keep existing DRA interface statuses when Multus network-status is missing", func() {
 		const (
-			draClaimName  = "sriov"
+			draClaimName  = "dra-claim"
 			redIfaceName  = "red"
-			redRequest    = "vf1"
+			redRequest    = "req1"
 			blueIfaceName = "blue"
-			blueRequest   = "vf2"
+			blueRequest   = "req2"
 		)
 
 		existingInterfacesStatus := []v1.VirtualMachineInstanceNetworkInterface{
@@ -518,8 +518,8 @@ var _ = Describe("Status Update", func() {
 		vmi := libvmi.New(
 			libvmi.WithNamespace(testNamespace),
 			libvmi.WithInterface(*v1.DefaultBridgeNetworkInterface()),
-			libvmi.WithInterface(libvmi.NewInterface(redIfaceName, libvmi.WithSRIOVBinding())),
-			libvmi.WithInterface(libvmi.NewInterface(blueIfaceName, libvmi.WithSRIOVBinding())),
+			libvmi.WithInterface(libvmi.NewInterface(redIfaceName, libvmi.WithBindingPlugin(v1.PluginBinding{Name: "netbinding"}))),
+			libvmi.WithInterface(libvmi.NewInterface(blueIfaceName, libvmi.WithBindingPlugin(v1.PluginBinding{Name: "netbinding"}))),
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
 			libvmi.WithNetwork(libvmi.DRANetwork(redIfaceName, draClaimName, redRequest)),
 			libvmi.WithNetwork(libvmi.DRANetwork(blueIfaceName, draClaimName, blueRequest)),

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -1351,7 +1351,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 			vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{
-				{Name: "dra-net", InterfaceBindingMethod: v1.InterfaceBindingMethod{SRIOV: &v1.InterfaceSRIOV{}}},
+				{Name: "dra-net", Binding: &v1.PluginBinding{Name: "netbinding"}},
 			}
 			vmi.Spec.Domain.Devices.GPUs = []v1.GPU{
 				{
@@ -1387,7 +1387,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 			vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{
-				{Name: "dra-net", InterfaceBindingMethod: v1.InterfaceBindingMethod{SRIOV: &v1.InterfaceSRIOV{}}},
+				{Name: "dra-net", Binding: &v1.PluginBinding{Name: "netbinding"}},
 			}
 			vmi.Spec.Domain.Devices.HostDevices = []v1.HostDevice{
 				{

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -1399,7 +1399,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 			vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{
-				{Name: "dra-net", InterfaceBindingMethod: v1.InterfaceBindingMethod{SRIOV: &v1.InterfaceSRIOV{}}},
+				{Name: "dra-net", Binding: &v1.PluginBinding{Name: "netbinding"}},
 			}
 			vmi.Spec.Domain.Devices.GPUs = []v1.GPU{
 				{
@@ -1435,7 +1435,7 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 				},
 			}
 			vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{
-				{Name: "dra-net", InterfaceBindingMethod: v1.InterfaceBindingMethod{SRIOV: &v1.InterfaceSRIOV{}}},
+				{Name: "dra-net", Binding: &v1.PluginBinding{Name: "netbinding"}},
 			}
 			vmi.Spec.Domain.Devices.HostDevices = []v1.HostDevice{
 				{

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -6514,10 +6514,8 @@ func newVMIWithDRANetwork(name string) *v1.VirtualMachineInstance {
 	vmi := api.NewMinimalVMI(name)
 	vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{
 		{
-			Name: "dra-net",
-			InterfaceBindingMethod: v1.InterfaceBindingMethod{
-				SRIOV: &v1.InterfaceSRIOV{},
-			},
+			Name:    "dra-net",
+			Binding: &v1.PluginBinding{Name: "netbinding"},
 		},
 	}
 	vmi.Spec.Networks = []v1.Network{

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/sriov/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/sriov/BUILD.bazel
@@ -10,7 +10,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/apimachinery/wait:go_default_library",
-        "//pkg/dra:go_default_library",
         "//pkg/network/deviceinfo:go_default_library",
         "//pkg/network/downwardapi:go_default_library",
         "//pkg/network/vmispec:go_default_library",
@@ -32,7 +31,6 @@ go_test(
     race = "on",
     deps = [
         ":go_default_library",
-        "//pkg/dra/metadata:go_default_library",
         "//pkg/network/deviceinfo:go_default_library",
         "//pkg/network/vmispec:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
@@ -42,9 +40,6 @@ go_test(
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
-        "//vendor/k8s.io/api/resource/v1:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
-        "//vendor/k8s.io/utils/ptr:go_default_library",
         "//vendor/libvirt.org/go/libvirt:go_default_library",
     ],
 )

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/sriov/hostdev.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/sriov/hostdev.go
@@ -32,7 +32,6 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 
 	virtwait "kubevirt.io/kubevirt/pkg/apimachinery/wait"
-	drautil "kubevirt.io/kubevirt/pkg/dra"
 	"kubevirt.io/kubevirt/pkg/network/deviceinfo"
 	"kubevirt.io/kubevirt/pkg/network/downwardapi"
 	"kubevirt.io/kubevirt/pkg/network/vmispec"
@@ -139,80 +138,6 @@ func newDecorateHook(iface v1.Interface) func(hostDevice *api.HostDevice) error 
 		}
 		return nil
 	}
-}
-
-// CreateDRAHostDevices creates SR-IOV host devices for networks that use DRA.
-// PCI addresses are resolved from pod-local DRA metadata files.
-func CreateDRAHostDevices(vmi *v1.VirtualMachineInstance, metadataBasePath string) ([]api.HostDevice, error) {
-	sriovInterfaces := vmispec.FilterSRIOVInterfaces(vmi.Spec.Domain.Devices.Interfaces)
-	if len(sriovInterfaces) == 0 {
-		return []api.HostDevice{}, nil
-	}
-
-	networksByName := vmispec.IndexNetworkSpecByName(vmi.Spec.Networks)
-
-	// filter to only DRA-backed SR-IOV interfaces
-	var sriovDRAInterfaces []v1.Interface
-	for _, iface := range sriovInterfaces {
-		if net, exists := networksByName[iface.Name]; exists && vmispec.IsDRANetwork(net) {
-			sriovDRAInterfaces = append(sriovDRAInterfaces, iface)
-		}
-	}
-
-	if len(sriovDRAInterfaces) == 0 {
-		return []api.HostDevice{}, nil
-	}
-
-	var hostDevices []api.HostDevice
-	for _, iface := range sriovDRAInterfaces {
-		network := networksByName[iface.Name]
-		claimName := network.NetworkSource.ResourceClaim.ClaimName
-		requestName := network.NetworkSource.ResourceClaim.RequestName
-
-		pciAddress, err := drautil.GetPCIAddressForClaim(
-			metadataBasePath,
-			vmi.Spec.ResourceClaims,
-			claimName,
-			requestName,
-		)
-		if err != nil {
-			return nil, fmt.Errorf(
-				"failed to resolve PCI address for SR-IOV DRA interface %s (claim %s request %s): %w",
-				iface.Name,
-				claimName,
-				requestName,
-				err,
-			)
-		}
-
-		hostAddr, err := device.NewPciAddressField(pciAddress)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create PCI address for SR-IOV DRA interface %s: %v", iface.Name, err)
-		}
-
-		hostDevice := api.HostDevice{
-			Alias:   api.NewUserDefinedAlias(deviceinfo.SRIOVAliasPrefix + iface.Name),
-			Source:  api.HostDeviceSource{Address: hostAddr},
-			Type:    api.HostDevicePCI,
-			Managed: "no",
-		}
-
-		if iface.PciAddress != "" {
-			addr, err := device.NewPciAddressField(iface.PciAddress)
-			if err != nil {
-				return nil, fmt.Errorf("failed to interpret the guest PCI address for interface %s: %v", iface.Name, err)
-			}
-			hostDevice.Address = addr
-		}
-
-		if iface.BootOrder != nil {
-			hostDevice.BootOrder = &api.BootOrder{Order: *iface.BootOrder}
-		}
-
-		hostDevices = append(hostDevices, hostDevice)
-	}
-
-	return hostDevices, nil
 }
 
 func SafelyDetachHostDevices(domainSpec *api.DomainSpec, eventDetach hostdevice.EventRegistrar, dom hostdevice.DeviceDetacher, timeout time.Duration) error {

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/sriov/hostdev_test.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/sriov/hostdev_test.go
@@ -20,17 +20,9 @@
 package sriov_test
 
 import (
-	"encoding/json"
 	"fmt"
-	"os"
-	"path/filepath"
 	"time"
 
-	resourcev1 "k8s.io/api/resource/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
-
-	"kubevirt.io/kubevirt/pkg/dra/metadata"
 	"kubevirt.io/kubevirt/pkg/network/vmispec"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/device"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/device/hostdevice"
@@ -50,9 +42,6 @@ import (
 const (
 	netname1 = "net1"
 	netname2 = "net2"
-
-	sriovDRADriverName       = "sriovnetwork.k8snetworkplumbingwg.io"
-	sriovDRAMetadataFileName = sriovDRADriverName + "-metadata.json"
 )
 
 var _ = Describe("SRIOV HostDevice", func() {
@@ -332,143 +321,6 @@ var _ = Describe("SRIOV HostDevice", func() {
 		)
 	})
 
-	Context("DRA SR-IOV creation", func() {
-		It("uses metadata file path for direct ResourceClaim", func() {
-			tempDir := GinkgoT().TempDir()
-
-			vmi := newDRAVMI("claim-ref", "vf")
-			vmi.Spec.ResourceClaims = []v1.VirtualMachineInstanceResourceClaim{{
-				Name:              "claim-ref",
-				ResourceClaimName: ptr.To("manual-vf-claim"),
-			}}
-			Expect(writeMetadataFile(tempDir, "resourceclaims", "manual-vf-claim", "vf", "0000:65:0a.3")).To(Succeed())
-
-			devices, err := sriov.CreateDRAHostDevices(vmi, tempDir)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(devices).To(HaveLen(1))
-
-			expectedHostAddr, err := device.NewPciAddressField("0000:65:0a.3")
-			Expect(err).ToNot(HaveOccurred())
-			expectedGuestAddr, err := device.NewPciAddressField("0000:20:00.0")
-			Expect(err).ToNot(HaveOccurred())
-			expectedHostDevice := api.HostDevice{
-				Alias:   newSRIOVAlias(netname1),
-				Source:  api.HostDeviceSource{Address: expectedHostAddr},
-				Type:    api.HostDevicePCI,
-				Managed: "no",
-				Address: expectedGuestAddr,
-			}
-			Expect(devices).To(Equal([]api.HostDevice{expectedHostDevice}))
-		})
-
-		It("uses metadata file path for ResourceClaimTemplate-backed pod claim", func() {
-			tempDir := GinkgoT().TempDir()
-
-			vmi := newDRAVMI("generated-claim-ref", "vf")
-			vmi.Spec.ResourceClaims = []v1.VirtualMachineInstanceResourceClaim{{
-				Name: "generated-claim-ref",
-			}}
-			Expect(writeMetadataFile(tempDir, "resourceclaimtemplates", "generated-claim-ref", "vf", "0000:65:0a.4")).To(Succeed())
-
-			devices, err := sriov.CreateDRAHostDevices(vmi, tempDir)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(devices).To(HaveLen(1))
-
-			expectedHostAddr, err := device.NewPciAddressField("0000:65:0a.4")
-			Expect(err).ToNot(HaveOccurred())
-			Expect(devices[0].Source.Address).To(Equal(expectedHostAddr))
-		})
-
-		It("propagates boot order from DRA SR-IOV interface", func() {
-			tempDir := GinkgoT().TempDir()
-
-			vmi := newDRAVMI("claim-ref", "vf")
-			vmi.Spec.ResourceClaims = []v1.VirtualMachineInstanceResourceClaim{{
-				Name:              "claim-ref",
-				ResourceClaimName: ptr.To("manual-vf-claim"),
-			}}
-			bootOrder := uint(1)
-			vmi.Spec.Domain.Devices.Interfaces[0].BootOrder = &bootOrder
-			Expect(writeMetadataFile(tempDir, "resourceclaims", "manual-vf-claim", "vf", "0000:65:0a.5")).To(Succeed())
-
-			devices, err := sriov.CreateDRAHostDevices(vmi, tempDir)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(devices).To(HaveLen(1))
-			Expect(devices[0].BootOrder).To(Equal(&api.BootOrder{Order: bootOrder}))
-		})
-
-		It("does not set guest PCI address when DRA SR-IOV interface has no guest PCI address", func() {
-			tempDir := GinkgoT().TempDir()
-
-			vmi := newDRAVMI("claim-ref", "vf")
-			vmi.Spec.Domain.Devices.Interfaces[0].PciAddress = ""
-			vmi.Spec.ResourceClaims = []v1.VirtualMachineInstanceResourceClaim{{
-				Name:              "claim-ref",
-				ResourceClaimName: ptr.To("manual-vf-claim"),
-			}}
-			Expect(writeMetadataFile(tempDir, "resourceclaims", "manual-vf-claim", "vf", "0000:65:0a.6")).To(Succeed())
-
-			devices, err := sriov.CreateDRAHostDevices(vmi, tempDir)
-			Expect(err).ToNot(HaveOccurred())
-			Expect(devices).To(HaveLen(1))
-			Expect(devices[0].Address).To(BeNil())
-		})
-
-		It("fails when DRA SR-IOV interface has malformed guest PCI address", func() {
-			tempDir := GinkgoT().TempDir()
-
-			vmi := newDRAVMI("claim-ref", "vf")
-			vmi.Spec.Domain.Devices.Interfaces[0].PciAddress = "not-a-pci-address"
-			vmi.Spec.ResourceClaims = []v1.VirtualMachineInstanceResourceClaim{{
-				Name:              "claim-ref",
-				ResourceClaimName: ptr.To("manual-vf-claim"),
-			}}
-			Expect(writeMetadataFile(tempDir, "resourceclaims", "manual-vf-claim", "vf", "0000:65:0a.7")).To(Succeed())
-
-			_, err := sriov.CreateDRAHostDevices(vmi, tempDir)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("failed to interpret the guest PCI address for interface net1"))
-		})
-
-		It("fails when metadata file is missing for direct ResourceClaim", func() {
-			tempDir := GinkgoT().TempDir()
-
-			vmi := newDRAVMI("claim-ref", "vf")
-			vmi.Spec.ResourceClaims = []v1.VirtualMachineInstanceResourceClaim{{
-				Name:              "claim-ref",
-				ResourceClaimName: ptr.To("manual-vf-claim"),
-			}}
-
-			_, err := sriov.CreateDRAHostDevices(vmi, tempDir)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("failed to resolve PCI address for SR-IOV DRA interface net1"))
-		})
-
-		It("fails when metadata has invalid host pciBusID", func() {
-			tempDir := GinkgoT().TempDir()
-
-			vmi := newDRAVMI("claim-ref", "vf")
-			vmi.Spec.ResourceClaims = []v1.VirtualMachineInstanceResourceClaim{{
-				Name:              "claim-ref",
-				ResourceClaimName: ptr.To("manual-vf-claim"),
-			}}
-			Expect(writeMetadataFile(tempDir, "resourceclaims", "manual-vf-claim", "vf", "not-a-pci-address")).To(Succeed())
-
-			_, err := sriov.CreateDRAHostDevices(vmi, tempDir)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("failed to create PCI address for SR-IOV DRA interface net1"))
-		})
-
-		It("returns no host devices when there are no SR-IOV DRA interfaces", func() {
-			vmi := newDRAVMI("claim-ref", "vf")
-			vmi.Spec.Domain.Devices.Interfaces[0].SRIOV = nil
-
-			devices, err := sriov.CreateDRAHostDevices(vmi, GinkgoT().TempDir())
-			Expect(err).ToNot(HaveOccurred())
-			Expect(devices).To(BeEmpty())
-		})
-	})
-
 	Context("safe detachment", func() {
 		hostDevice := api.HostDevice{Alias: api.NewUserDefinedAlias(netsriov.SRIOVAliasPrefix + "net1")}
 
@@ -565,66 +417,6 @@ func newSRIOVInterfaceWithBootOrder(name string, bootOrder uint) v1.Interface {
 	iface.BootOrder = &bootOrder
 
 	return iface
-}
-
-func newDRAVMI(claimRefName, requestName string) *v1.VirtualMachineInstance {
-	iface := newSRIOVInterface(netname1)
-	iface.PciAddress = "0000:20:00.0"
-
-	return &v1.VirtualMachineInstance{
-		Spec: v1.VirtualMachineInstanceSpec{
-			Domain: v1.DomainSpec{
-				Devices: v1.Devices{
-					Interfaces: []v1.Interface{iface},
-				},
-			},
-			Networks: []v1.Network{{
-				Name: netname1,
-				NetworkSource: v1.NetworkSource{
-					ResourceClaim: &v1.ClaimRequest{
-						ClaimName:   claimRefName,
-						RequestName: requestName,
-					},
-				},
-			}},
-		},
-	}
-}
-
-func writeRawMetadataFile(basePath, claimSubdir, claimName, requestName, metadataJSON string) error {
-	dir := filepath.Join(basePath, claimSubdir, claimName, requestName)
-	if err := os.MkdirAll(dir, 0755); err != nil {
-		return err
-	}
-	return os.WriteFile(filepath.Join(dir, sriovDRAMetadataFileName), []byte(metadataJSON), 0644)
-}
-
-func writeMetadataFile(basePath, claimSubdir, claimName, requestName, pciAddress string) error {
-	md := metadata.DeviceMetadata{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: metadata.APIVersionV1Alpha1,
-			Kind:       "DeviceMetadata",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: claimName,
-		},
-		Requests: []metadata.DeviceMetadataRequest{{
-			Name: requestName,
-			Devices: []metadata.Device{{
-				Driver: sriovDRADriverName,
-				Pool:   "pool0",
-				Name:   "dev0",
-				Attributes: map[resourcev1.QualifiedName]resourcev1.DeviceAttribute{
-					metadata.PCIBusIDAttribute: {StringValue: ptr.To(pciAddress)},
-				},
-			}},
-		}},
-	}
-	data, err := json.Marshal(md)
-	if err != nil {
-		return err
-	}
-	return writeRawMetadataFile(basePath, claimSubdir, claimName, requestName, string(data))
 }
 
 type stubPCIAddressPool struct {

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -1300,14 +1300,6 @@ func (l *LibvirtDomainManager) generateConverterContext(vmi *v1.VirtualMachineIn
 			return nil, err
 		}
 
-		sriovDRADevices, err := sriov.CreateDRAHostDevices(vmi, drautil.DefaultMetadataBasePath)
-		if err != nil {
-			return nil, err
-		}
-		// The two builders partition SR-IOV interfaces by source: Multus-backed vs DRA-backed.
-		// They are mutually exclusive, so appending cannot introduce duplicates.
-		sriovDevices = append(sriovDevices, sriovDRADevices...)
-
 		c.HotplugVolumes = hotplugVolumes
 		c.SRIOVDevices = sriovDevices
 

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -1356,14 +1356,6 @@ func (l *LibvirtDomainManager) generateConverterContext(vmi *v1.VirtualMachineIn
 			return nil, err
 		}
 
-		sriovDRADevices, err := sriov.CreateDRAHostDevices(vmi, drautil.DefaultMetadataBasePath)
-		if err != nil {
-			return nil, err
-		}
-		// The two builders partition SR-IOV interfaces by source: Multus-backed vs DRA-backed.
-		// They are mutually exclusive, so appending cannot introduce duplicates.
-		sriovDevices = append(sriovDevices, sriovDRADevices...)
-
 		c.HotplugVolumes = hotplugVolumes
 		c.SRIOVDevices = sriovDevices
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
SR-IOV is being deferred from the network DRA beta scope due to competing industry approaches for integrating SR-IOV with DRA (bypass Multus vs. keep Multus with DRA driver).
  
It is no longer possible to use SR-IOV binding with DRA networks - the network admitter rejects them and only allows interfaces using binding plugins.
The virt-launcher logic that resolved PCI addresses from DRA device metadata for SR-IOV passthrough is removed.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process 
-->

- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/183

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
~~This PR is a draft until kubevirt/enhancements#332 is merged.~~
<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
SR-IOV interfaces are no longer supported with DRA networks.
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * DRA network interfaces now require a binding plugin and no longer accept SR-IOV, bridge, masquerade, or passt interfaces.
  * Updated validation messaging to clarify the binding plugin requirement.
  * Removed legacy DRA-backed SR-IOV device handling, ensuring SR-IOV devices use the standard device configuration path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->