### PR TITLE
pkg/network: refactor to NewInterface builder pattern

### DIFF
--- a/pkg/network/controllers/vm_test.go
+++ b/pkg/network/controllers/vm_test.go
@@ -69,25 +69,25 @@ var _ = Describe("VM Network Controller", func() {
 		Entry(
 			"the VM & VMI have identical interfaces",
 			libvmi.NewVirtualMachine(libvmi.New(
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetName1)),
+				libvmi.WithInterface(libvmi.NewInterface(defaultNetName, libvmi.WithMasqueradeBinding())),
+				libvmi.WithInterface(libvmi.NewInterface(secondaryNetName1, libvmi.WithBridgeBinding())),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 				libvmi.WithNetwork(libvmi.MultusNetwork(secondaryNetName1, nadName)),
 			)),
 			libvmi.New(
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetName1)),
+				libvmi.WithInterface(libvmi.NewInterface(defaultNetName, libvmi.WithMasqueradeBinding())),
+				libvmi.WithInterface(libvmi.NewInterface(secondaryNetName1, libvmi.WithBridgeBinding())),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 				libvmi.WithNetwork(libvmi.MultusNetwork(secondaryNetName1, nadName)),
 			),
 		),
 		Entry("there is an interface status that does not match a spec interface",
 			libvmi.NewVirtualMachine(libvmi.New(
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+				libvmi.WithInterface(libvmi.NewInterface(defaultNetName, libvmi.WithMasqueradeBinding())),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 			)),
 			libvmi.New(
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+				libvmi.WithInterface(libvmi.NewInterface(defaultNetName, libvmi.WithMasqueradeBinding())),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 				libvmistatus.WithStatus(libvmistatus.New(
 					libvmistatus.WithInterfaceStatus(v1.VirtualMachineInstanceNetworkInterface{Name: "DEFAULT"}),
@@ -110,12 +110,12 @@ var _ = Describe("VM Network Controller", func() {
 			})
 
 		vmi := libvmi.New(
-			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+			libvmi.WithInterface(libvmi.NewInterface(defaultNetName, libvmi.WithMasqueradeBinding())),
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
 		)
 		vm := libvmi.NewVirtualMachine(vmi.DeepCopy())
 
-		vm = plugNetworkInterface(vm, libvmi.InterfaceDeviceWithBridgeBinding("foonet"))
+		vm = plugNetworkInterface(vm, libvmi.NewInterface("foonet", libvmi.WithBridgeBinding()))
 
 		// Simulate the existence of the VMI on the server (to allow the Sync to patch it).
 		_, err := clientset.KubevirtV1().VirtualMachineInstances(vmi.Namespace).Create(context.Background(), vmi, k8smetav1.CreateOptions{})
@@ -132,7 +132,7 @@ var _ = Describe("VM Network Controller", func() {
 		clientset := fake.NewSimpleClientset()
 		c := controllers.NewVMController(clientset)
 		vmi := libvmi.New(
-			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+			libvmi.WithInterface(libvmi.NewInterface(defaultNetName, libvmi.WithMasqueradeBinding())),
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
 		)
 		vm := libvmi.NewVirtualMachine(vmi.DeepCopy())
@@ -158,8 +158,8 @@ var _ = Describe("VM Network Controller", func() {
 		Expect(updatedVMI.Spec.Networks).To(Equal(updatedVM.Spec.Template.Spec.Networks))
 		Expect(updatedVMI.Spec.Domain.Devices.Interfaces).To(Equal(updatedVM.Spec.Template.Spec.Domain.Devices.Interfaces))
 	},
-		Entry("when the plugged interface uses bridge binding", libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetName1)),
-		Entry("when the plugged interface uses SR-IOV binding", libvmi.InterfaceDeviceWithSRIOVBinding(secondaryNetName1)),
+		Entry("when the plugged interface uses bridge binding", libvmi.NewInterface(secondaryNetName1, libvmi.WithBridgeBinding())),
+		Entry("when the plugged interface uses SR-IOV binding", libvmi.NewInterface(secondaryNetName1, libvmi.WithSRIOVBinding())),
 		Entry("when the plugged interface has link state down", v1.Interface{
 			Name: secondaryNetName1,
 			InterfaceBindingMethod: v1.InterfaceBindingMethod{
@@ -180,7 +180,7 @@ var _ = Describe("VM Network Controller", func() {
 		clientset := fake.NewSimpleClientset()
 		c := controllers.NewVMController(clientset)
 		vmi := libvmi.New(
-			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+			libvmi.WithInterface(libvmi.NewInterface(defaultNetName, libvmi.WithMasqueradeBinding())),
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
 		)
 
@@ -222,11 +222,11 @@ var _ = Describe("VM Network Controller", func() {
 
 		multusAndDomainInfoSource := vmispec.NewInfoSource(vmispec.InfoSourceMultusStatus, vmispec.InfoSourceDomain)
 
-		secondaryIface := libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetName1)
+		secondaryIface := libvmi.NewInterface(secondaryNetName1, libvmi.WithBridgeBinding())
 		secondaryIface.State = currentIfaceState
 
 		vmi := libvmi.New(
-			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+			libvmi.WithInterface(libvmi.NewInterface(defaultNetName, libvmi.WithMasqueradeBinding())),
 			libvmi.WithInterface(secondaryIface),
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
 			libvmi.WithNetwork(libvmi.MultusNetwork(secondaryNetName1, nadName)),
@@ -280,7 +280,7 @@ var _ = Describe("VM Network Controller", func() {
 		vmi := libvmi.New()
 		vm := libvmi.NewVirtualMachine(vmi.DeepCopy())
 
-		plugNetworkInterface(vm, libvmi.InterfaceWithBindingPlugin(secondaryNetName1, v1.PluginBinding{Name: "someplugin"}))
+		plugNetworkInterface(vm, libvmi.NewInterface(secondaryNetName1, libvmi.WithBindingPlugin(v1.PluginBinding{Name: "someplugin"})))
 
 		// Simulate the existence of the VMI on the server (to allow the Sync to patch it).
 		_, err := clientset.KubevirtV1().VirtualMachineInstances(vmi.Namespace).Create(context.Background(), vmi, k8smetav1.CreateOptions{})
@@ -305,10 +305,10 @@ var _ = Describe("VM Network Controller", func() {
 	It("sync succeeds to clear hotunplug interfaces from running VM", func() {
 		clientset := fake.NewSimpleClientset()
 		c := controllers.NewVMController(clientset)
-		unpluggedIface := libvmi.InterfaceDeviceWithBridgeBinding("foonet")
+		unpluggedIface := libvmi.NewInterface("foonet", libvmi.WithBridgeBinding())
 		unpluggedIface.State = v1.InterfaceStateAbsent
 		vmi := libvmi.New(
-			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+			libvmi.WithInterface(libvmi.NewInterface(defaultNetName, libvmi.WithMasqueradeBinding())),
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
 			libvmi.WithInterface(unpluggedIface),
 			libvmi.WithNetwork(libvmi.MultusNetwork("foonet", "foonet-nad")),
@@ -341,10 +341,10 @@ var _ = Describe("VM Network Controller", func() {
 	It("sync succeeds to clear hotunplug interfaces from stopped VM", func() {
 		clientset := fake.NewSimpleClientset()
 		c := controllers.NewVMController(clientset)
-		unpluggedIface := libvmi.InterfaceDeviceWithBridgeBinding("foonet")
+		unpluggedIface := libvmi.NewInterface("foonet", libvmi.WithBridgeBinding())
 		unpluggedIface.State = v1.InterfaceStateAbsent
 		vmi := libvmi.New(
-			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+			libvmi.WithInterface(libvmi.NewInterface(defaultNetName, libvmi.WithMasqueradeBinding())),
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
 			libvmi.WithInterface(unpluggedIface),
 			libvmi.WithNetwork(libvmi.MultusNetwork("foonet", "foonet-nad")),
@@ -364,9 +364,9 @@ var _ = Describe("VM Network Controller", func() {
 		clientset := fake.NewSimpleClientset()
 		c := controllers.NewVMController(clientset)
 		vmi := libvmi.New(
-			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+			libvmi.WithInterface(libvmi.NewInterface(defaultNetName, libvmi.WithMasqueradeBinding())),
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
-			libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding("foonet")),
+			libvmi.WithInterface(libvmi.NewInterface("foonet", libvmi.WithBridgeBinding())),
 			libvmi.WithNetwork(libvmi.MultusNetwork("foonet", "foonet-nad")),
 		)
 		// Make sure the interfaces are visible on the status as well (otherwise hotunplug is not triggered)
@@ -508,9 +508,9 @@ var _ = Describe("VM Network Controller", func() {
 		clientset := fake.NewSimpleClientset()
 		c := controllers.NewVMController(clientset)
 		vmi := libvmi.New(
-			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+			libvmi.WithInterface(libvmi.NewInterface(defaultNetName, libvmi.WithMasqueradeBinding())),
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
-			libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding("foonet")),
+			libvmi.WithInterface(libvmi.NewInterface("foonet", libvmi.WithBridgeBinding())),
 			libvmi.WithNetwork(libvmi.MultusNetwork("foonet", "foonet-nad")),
 			libvmistatus.WithStatus(
 				libvmistatus.New(
@@ -565,11 +565,11 @@ var _ = Describe("VM Network Controller", func() {
 
 		multusAndDomainInfoSource := vmispec.NewInfoSource(vmispec.InfoSourceMultusStatus, vmispec.InfoSourceDomain)
 
-		ifaceToDetach := libvmi.InterfaceDeviceWithBridgeBinding(netToDetachName)
+		ifaceToDetach := libvmi.NewInterface(netToDetachName, libvmi.WithBridgeBinding())
 		netToDetach := libvmi.MultusNetwork(netToDetachName, netToDetachNADName)
 
 		vmi := libvmi.New(
-			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+			libvmi.WithInterface(libvmi.NewInterface(defaultNetName, libvmi.WithMasqueradeBinding())),
 			libvmi.WithInterface(ifaceToDetach),
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
 			libvmi.WithNetwork(netToDetach),
@@ -594,7 +594,7 @@ var _ = Describe("VM Network Controller", func() {
 		// Mark the secondary interface for hotunplug
 		vm.Spec.Template.Spec.Domain.Devices.Interfaces[1].State = v1.InterfaceStateAbsent
 
-		vm = plugNetworkInterface(vm, libvmi.InterfaceDeviceWithBridgeBinding(netToAttachName))
+		vm = plugNetworkInterface(vm, libvmi.NewInterface(netToAttachName, libvmi.WithBridgeBinding()))
 
 		// Simulate the existence of the VMI on the server (to allow the Sync to patch it).
 		_, err := clientset.KubevirtV1().VirtualMachineInstances(vmi.Namespace).Create(context.Background(), vmi, k8smetav1.CreateOptions{})
@@ -625,8 +625,8 @@ var _ = Describe("VM Network Controller", func() {
 		c := controllers.NewVMController(clientset)
 
 		vmi := libvmi.New(
-			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
-			libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(netToDetachName)),
+			libvmi.WithInterface(libvmi.NewInterface(defaultNetName, libvmi.WithMasqueradeBinding())),
+			libvmi.WithInterface(libvmi.NewInterface(netToDetachName, libvmi.WithBridgeBinding())),
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
 			libvmi.WithNetwork(libvmi.MultusNetwork(netToDetachName, netToDetachNADName)),
 			libvmistatus.WithStatus(
@@ -671,8 +671,8 @@ var _ = Describe("VM Network Controller", func() {
 		c := controllers.NewVMController(clientset)
 
 		vmi := libvmi.New(
-			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
-			libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetName1)),
+			libvmi.WithInterface(libvmi.NewInterface(defaultNetName, libvmi.WithMasqueradeBinding())),
+			libvmi.WithInterface(libvmi.NewInterface(secondaryNetName1, libvmi.WithBridgeBinding())),
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
 			libvmi.WithNetwork(libvmi.MultusNetwork(secondaryNetName1, nadName)),
 			libvmistatus.WithStatus(
@@ -713,10 +713,10 @@ var _ = Describe("VM Network Controller", func() {
 
 		By("Creating a new VM)")
 		vmi := libvmi.New(
-			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
-			libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetName1)),
-			libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetName2)),
-			libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetName3)),
+			libvmi.WithInterface(libvmi.NewInterface(defaultNetName, libvmi.WithMasqueradeBinding())),
+			libvmi.WithInterface(libvmi.NewInterface(secondaryNetName1, libvmi.WithBridgeBinding())),
+			libvmi.WithInterface(libvmi.NewInterface(secondaryNetName2, libvmi.WithBridgeBinding())),
+			libvmi.WithInterface(libvmi.NewInterface(secondaryNetName3, libvmi.WithBridgeBinding())),
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
 			libvmi.WithNetwork(libvmi.MultusNetwork(secondaryNetName1, nadName)),
 			libvmi.WithNetwork(libvmi.MultusNetwork(secondaryNetName2, nadName2)),
@@ -744,10 +744,10 @@ var _ = Describe("VM Network Controller", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		expectedIfaces := []v1.Interface{
-			libvmi.InterfaceDeviceWithMasqueradeBinding(),
-			libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetName1),
-			libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetName2),
-			libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetName3),
+			libvmi.NewInterface(defaultNetName, libvmi.WithMasqueradeBinding()),
+			libvmi.NewInterface(secondaryNetName1, libvmi.WithBridgeBinding()),
+			libvmi.NewInterface(secondaryNetName2, libvmi.WithBridgeBinding()),
+			libvmi.NewInterface(secondaryNetName3, libvmi.WithBridgeBinding()),
 		}
 		expectedNets := []v1.Network{
 			*v1.DefaultPodNetwork(),
@@ -771,7 +771,7 @@ var _ = Describe("VM Network Controller", func() {
 		clientset := fake.NewSimpleClientset()
 		c := controllers.NewVMController(clientset)
 
-		expectedIfaces := []v1.Interface{libvmi.InterfaceDeviceWithMasqueradeBinding()}
+		expectedIfaces := []v1.Interface{libvmi.NewInterface(defaultNetName, libvmi.WithMasqueradeBinding())}
 		expectedNets := []v1.Network{*v1.DefaultPodNetwork()}
 
 		vmi := libvmi.New(

--- a/pkg/network/controllers/vmi_test.go
+++ b/pkg/network/controllers/vmi_test.go
@@ -179,7 +179,7 @@ var _ = Describe("Status Update", func() {
 		func(podAnnotations map[string]string) {
 			vmi := libvmi.New(
 				libvmi.WithNamespace(testNamespace),
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(alternativeNetworkName)),
+				libvmi.WithInterface(libvmi.NewInterface(alternativeNetworkName, libvmi.WithBridgeBinding())),
 				libvmi.WithNetwork(&v1.Network{
 					Name: alternativeNetworkName,
 					NetworkSource: v1.NetworkSource{
@@ -223,7 +223,7 @@ var _ = Describe("Status Update", func() {
 
 		vmi := libvmi.New(
 			libvmi.WithNamespace(testNamespace),
-			libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(alternativeNetworkName)),
+			libvmi.WithInterface(libvmi.NewInterface(alternativeNetworkName, libvmi.WithBridgeBinding())),
 			libvmi.WithNetwork(&v1.Network{
 				Name: alternativeNetworkName,
 				NetworkSource: v1.NetworkSource{
@@ -266,7 +266,7 @@ var _ = Describe("Status Update", func() {
 	It("Shouldn't generate interface status for secondary interface (not matched on status) when Multus network status is absent", func() {
 		vmi := libvmi.New(
 			libvmi.WithNamespace(testNamespace),
-			libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetworkName)),
+			libvmi.WithInterface(libvmi.NewInterface(secondaryNetworkName, libvmi.WithBridgeBinding())),
 			libvmi.WithNetwork(libvmi.MultusNetwork(secondaryNetworkName, secondaryNetworkAttachmentDefinitionName)),
 		)
 
@@ -281,7 +281,7 @@ var _ = Describe("Status Update", func() {
 		func(podAnnotations map[string]string, expectedInterfaces []v1.VirtualMachineInstanceNetworkInterface) {
 			vmi := libvmi.New(
 				libvmi.WithNamespace(testNamespace),
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetworkName)),
+				libvmi.WithInterface(libvmi.NewInterface(secondaryNetworkName, libvmi.WithBridgeBinding())),
 				libvmi.WithNetwork(libvmi.MultusNetwork(secondaryNetworkName, secondaryNetworkAttachmentDefinitionName)),
 			)
 
@@ -314,7 +314,7 @@ var _ = Describe("Status Update", func() {
 			vmi := libvmi.New(
 				libvmi.WithNamespace(testNamespace),
 				libvmi.WithInterface(*v1.DefaultBridgeNetworkInterface()),
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetworkName)),
+				libvmi.WithInterface(libvmi.NewInterface(secondaryNetworkName, libvmi.WithBridgeBinding())),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 				libvmi.WithNetwork(libvmi.MultusNetwork(secondaryNetworkName, secondaryNetworkAttachmentDefinitionName)),
 			)
@@ -352,7 +352,7 @@ var _ = Describe("Status Update", func() {
 		vmi := libvmi.New(
 			libvmi.WithNamespace(testNamespace),
 			libvmi.WithInterface(*v1.DefaultBridgeNetworkInterface()),
-			libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetworkName)),
+			libvmi.WithInterface(libvmi.NewInterface(secondaryNetworkName, libvmi.WithBridgeBinding())),
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
 			libvmi.WithNetwork(libvmi.MultusNetwork(secondaryNetworkName, secondaryNetworkAttachmentDefinitionName)),
 			libvmistatus.WithStatus(libvmistatus.New(WithInterfacesStatus(existingInterfacesStatus))),
@@ -379,7 +379,7 @@ var _ = Describe("Status Update", func() {
 
 		vmi := libvmi.New(
 			libvmi.WithNamespace(testNamespace),
-			libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetworkName)),
+			libvmi.WithInterface(libvmi.NewInterface(secondaryNetworkName, libvmi.WithBridgeBinding())),
 			libvmi.WithNetwork(libvmi.MultusNetwork(secondaryNetworkName, secondaryNetworkAttachmentDefinitionName)),
 			libvmistatus.WithStatus(libvmistatus.New(WithInterfacesStatus(existingInterfacesStatus))),
 		)
@@ -405,7 +405,7 @@ var _ = Describe("Status Update", func() {
 
 		vmi := libvmi.New(
 			libvmi.WithNamespace(testNamespace),
-			libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetworkName)),
+			libvmi.WithInterface(libvmi.NewInterface(secondaryNetworkName, libvmi.WithBridgeBinding())),
 			libvmi.WithNetwork(libvmi.MultusNetwork(secondaryNetworkName, secondaryNetworkAttachmentDefinitionName)),
 			libvmistatus.WithStatus(libvmistatus.New(WithInterfacesStatus(existingInterfacesStatus))),
 		)
@@ -430,7 +430,7 @@ var _ = Describe("Status Update", func() {
 
 		vmi := libvmi.New(
 			libvmi.WithNamespace(testNamespace),
-			libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetworkName)),
+			libvmi.WithInterface(libvmi.NewInterface(secondaryNetworkName, libvmi.WithBridgeBinding())),
 			libvmi.WithNetwork(libvmi.MultusNetwork(secondaryNetworkName, secondaryNetworkAttachmentDefinitionName)),
 			libvmistatus.WithStatus(libvmistatus.New(WithInterfacesStatus(existingInterfacesStatus))),
 		)
@@ -455,7 +455,7 @@ var _ = Describe("Status Update", func() {
 
 		vmi := libvmi.New(
 			libvmi.WithNamespace(testNamespace),
-			libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetworkName)),
+			libvmi.WithInterface(libvmi.NewInterface(secondaryNetworkName, libvmi.WithBridgeBinding())),
 			libvmi.WithNetwork(libvmi.MultusNetwork(secondaryNetworkName, secondaryNetworkAttachmentDefinitionName)),
 			libvmistatus.WithStatus(libvmistatus.New(WithInterfacesStatus(existingInterfacesStatus))),
 		)
@@ -482,7 +482,7 @@ var _ = Describe("Status Update", func() {
 
 		vmi := libvmi.New(
 			libvmi.WithNamespace(testNamespace),
-			libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetworkName)),
+			libvmi.WithInterface(libvmi.NewInterface(secondaryNetworkName, libvmi.WithBridgeBinding())),
 			libvmi.WithNetwork(libvmi.MultusNetwork(secondaryNetworkName, secondaryNetworkAttachmentDefinitionName)),
 			libvmistatus.WithStatus(libvmistatus.New(WithInterfacesStatus(existingInterfacesStatus))),
 		)
@@ -518,8 +518,8 @@ var _ = Describe("Status Update", func() {
 		vmi := libvmi.New(
 			libvmi.WithNamespace(testNamespace),
 			libvmi.WithInterface(*v1.DefaultBridgeNetworkInterface()),
-			libvmi.WithInterface(libvmi.InterfaceDeviceWithSRIOVBinding(redIfaceName)),
-			libvmi.WithInterface(libvmi.InterfaceDeviceWithSRIOVBinding(blueIfaceName)),
+			libvmi.WithInterface(libvmi.NewInterface(redIfaceName, libvmi.WithSRIOVBinding())),
+			libvmi.WithInterface(libvmi.NewInterface(blueIfaceName, libvmi.WithSRIOVBinding())),
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
 			libvmi.WithNetwork(libvmi.DRANetwork(redIfaceName, draClaimName, redRequest)),
 			libvmi.WithNetwork(libvmi.DRANetwork(blueIfaceName, draClaimName, blueRequest)),

--- a/pkg/network/migration/evaluator_test.go
+++ b/pkg/network/migration/evaluator_test.go
@@ -55,7 +55,7 @@ var _ = Describe("Evaluator", func() {
 		Entry("when status equals to spec",
 			libvmi.New(
 				libvmi.WithInterface(*v1.DefaultBridgeNetworkInterface()),
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetworkName)),
+				libvmi.WithInterface(libvmi.NewInterface(secondaryNetworkName, libvmi.WithBridgeBinding())),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 				libvmi.WithNetwork(libvmi.MultusNetwork(secondaryNetworkName, nadName)),
 				libvmistatus.WithStatus(
@@ -107,7 +107,7 @@ var _ = Describe("Evaluator", func() {
 		Entry("when a secondary iface using bridge binding is hotplugged",
 			libvmi.New(
 				libvmi.WithInterface(*v1.DefaultBridgeNetworkInterface()),
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetworkName)),
+				libvmi.WithInterface(libvmi.NewInterface(secondaryNetworkName, libvmi.WithBridgeBinding())),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 				libvmi.WithNetwork(libvmi.MultusNetwork(secondaryNetworkName, nadName)),
 				libvmistatus.WithStatus(
@@ -151,7 +151,7 @@ var _ = Describe("Evaluator", func() {
 	It("Should require an immediate migration when a secondary iface using SR-IOV binding is hotplugged", func() {
 		vmi := libvmi.New(
 			libvmi.WithInterface(*v1.DefaultBridgeNetworkInterface()),
-			libvmi.WithInterface(libvmi.InterfaceDeviceWithSRIOVBinding(secondaryNetworkName)),
+			libvmi.WithInterface(libvmi.NewInterface(secondaryNetworkName, libvmi.WithSRIOVBinding())),
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
 			libvmi.WithNetwork(libvmi.MultusNetwork(secondaryNetworkName, nadName)),
 			libvmistatus.WithStatus(
@@ -174,7 +174,7 @@ var _ = Describe("Evaluator", func() {
 		DescribeTable("When migration is pending", func(stubNow time.Time, expectedResult k8scorev1.ConditionStatus) {
 			vmi := libvmi.New(
 				libvmi.WithInterface(*v1.DefaultBridgeNetworkInterface()),
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetworkName)),
+				libvmi.WithInterface(libvmi.NewInterface(secondaryNetworkName, libvmi.WithBridgeBinding())),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 				libvmi.WithNetwork(libvmi.MultusNetwork(secondaryNetworkName, nadName)),
 				libvmistatus.WithStatus(
@@ -234,7 +234,7 @@ var _ = Describe("Evaluator", func() {
 			Entry("no migration when NAD name in spec matches that in pod annotation",
 				libvmi.New(
 					libvmi.WithNamespace(testNamespace),
-					libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetworkName1)),
+					libvmi.WithInterface(libvmi.NewInterface(secondaryNetworkName1, libvmi.WithBridgeBinding())),
 					libvmi.WithNetwork(libvmi.MultusNetwork(secondaryNetworkName1, nadName1)),
 					libvmistatus.WithStatus(libvmistatus.New(
 						libvmistatus.WithInterfaceStatus(v1.VirtualMachineInstanceNetworkInterface{
@@ -253,7 +253,7 @@ var _ = Describe("Evaluator", func() {
 			Entry("immediate migration when NAD name in spec differs from that in pod annotation",
 				libvmi.New(
 					libvmi.WithNamespace(testNamespace),
-					libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetworkName1)),
+					libvmi.WithInterface(libvmi.NewInterface(secondaryNetworkName1, libvmi.WithBridgeBinding())),
 					libvmi.WithNetwork(libvmi.MultusNetwork(secondaryNetworkName1, nadName2)),
 					libvmistatus.WithStatus(libvmistatus.New(
 						libvmistatus.WithInterfaceStatus(v1.VirtualMachineInstanceNetworkInterface{
@@ -273,8 +273,8 @@ var _ = Describe("Evaluator", func() {
 				"immediate migration when a VM has NADs in different namespaces and one is out of sync",
 				libvmi.New(
 					libvmi.WithNamespace(testNamespace),
-					libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetworkName1)),
-					libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetworkName2)),
+					libvmi.WithInterface(libvmi.NewInterface(secondaryNetworkName1, libvmi.WithBridgeBinding())),
+					libvmi.WithInterface(libvmi.NewInterface(secondaryNetworkName2, libvmi.WithBridgeBinding())),
 					libvmi.WithNetwork(libvmi.MultusNetwork(secondaryNetworkName1, testNamespace+"/"+nadName2)),
 					libvmi.WithNetwork(libvmi.MultusNetwork(secondaryNetworkName2, otherNamespace+"/"+nadName2)),
 					libvmistatus.WithStatus(libvmistatus.New(

--- a/pkg/network/passt/repair_test.go
+++ b/pkg/network/passt/repair_test.go
@@ -39,7 +39,7 @@ var _ = Describe("Passt Repair Handler", func() {
 		var vmi *v1.VirtualMachineInstance
 		BeforeEach(func() {
 			vmi = libvmi.New(
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding("default")),
+				libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithBridgeBinding())),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 			)
 		})
@@ -80,15 +80,15 @@ var _ = Describe("Passt Repair Handler", func() {
 	},
 		Entry("When an iface is connected to pod network using passt binding",
 			libvmi.New(
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithPasstBinding("default")),
+				libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithPasstBinding())),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 			),
 		),
 		Entry("When an iface is connected to Multus default network using passt binding",
 			libvmi.New(
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithPasstBinding("default")),
+				libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithPasstBinding())),
 				libvmi.WithNetwork(&v1.Network{
-					Name: "default",
+					Name: v1.DefaultPodNetwork().Name,
 					NetworkSource: v1.NetworkSource{
 						Multus: &v1.MultusNetwork{
 							NetworkName: "alternative",
@@ -117,15 +117,15 @@ var _ = Describe("Passt Repair Handler", func() {
 	},
 		Entry("When an iface is connected to pod network using passt binding",
 			libvmi.New(
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithPasstBinding("default")),
+				libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithPasstBinding())),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 			),
 		),
 		Entry("When an iface is connected to Multus default network using passt binding",
 			libvmi.New(
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithPasstBinding("default")),
+				libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithPasstBinding())),
 				libvmi.WithNetwork(&v1.Network{
-					Name: "default",
+					Name: v1.DefaultPodNetwork().Name,
 					NetworkSource: v1.NetworkSource{
 						Multus: &v1.MultusNetwork{
 							NetworkName: "alternative",
@@ -138,7 +138,7 @@ var _ = Describe("Passt Repair Handler", func() {
 	)
 
 	vmi := libvmi.New(
-		libvmi.WithInterface(libvmi.InterfaceDeviceWithPasstBinding("default")),
+		libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithPasstBinding())),
 		libvmi.WithNetwork(v1.DefaultPodNetwork()),
 	)
 
@@ -185,7 +185,7 @@ var _ = Describe("Passt Repair Handler", func() {
 
 	It("Should not run HandleMigrationSource because it is already running", func() {
 		vmi := libvmi.New(
-			libvmi.WithInterface(libvmi.InterfaceDeviceWithPasstBinding("default")),
+			libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithPasstBinding())),
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
 		)
 
@@ -214,7 +214,7 @@ var _ = Describe("Passt Repair Handler", func() {
 		}
 
 		vmi := libvmi.New(
-			libvmi.WithInterface(libvmi.InterfaceDeviceWithPasstBinding("default")),
+			libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithPasstBinding())),
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
 		)
 

--- a/pkg/network/pod/annotations/generator_test.go
+++ b/pkg/network/pod/annotations/generator_test.go
@@ -47,9 +47,8 @@ var _ = Describe("Annotations Generator", func() {
 
 	Context("Multus", func() {
 		const (
-			defaultNetworkName = "default"
-			network1Name       = "test1"
-			network2Name       = "other-test1"
+			network1Name = "test1"
+			network2Name = "other-test1"
 
 			defaultNetworkAttachmentDefinitionName = "default"
 			networkAttachmentDefinitionName1       = "test1"
@@ -59,10 +58,10 @@ var _ = Describe("Annotations Generator", func() {
 		It("should generate the Multus networks annotation", func() {
 			vmi := libvmi.New(
 				libvmi.WithNamespace(testNamespace),
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(defaultNetworkName)),
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(network1Name)),
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(network2Name)),
-				libvmi.WithNetwork(libvmi.MultusNetwork(defaultNetworkName, defaultNetworkAttachmentDefinitionName)),
+				libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithBridgeBinding())),
+				libvmi.WithInterface(libvmi.NewInterface(network1Name, libvmi.WithBridgeBinding())),
+				libvmi.WithInterface(libvmi.NewInterface(network2Name, libvmi.WithBridgeBinding())),
+				libvmi.WithNetwork(libvmi.MultusNetwork(v1.DefaultPodNetwork().Name, defaultNetworkAttachmentDefinitionName)),
 				libvmi.WithNetwork(libvmi.MultusNetwork(network1Name, networkAttachmentDefinitionName1)),
 				libvmi.WithNetwork(libvmi.MultusNetwork(network2Name, networkAttachmentDefinitionName2)),
 			)
@@ -83,9 +82,9 @@ var _ = Describe("Annotations Generator", func() {
 		It("should generate the Multus networks and Multus default network annotations", func() {
 			vmi := libvmi.New(
 				libvmi.WithNamespace(testNamespace),
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(defaultNetworkName)),
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(network1Name)),
-				libvmi.WithNetwork(newMultusDefaultPodNetwork(defaultNetworkName, defaultNetworkAttachmentDefinitionName)),
+				libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithBridgeBinding())),
+				libvmi.WithInterface(libvmi.NewInterface(network1Name, libvmi.WithBridgeBinding())),
+				libvmi.WithNetwork(newMultusDefaultPodNetwork(v1.DefaultPodNetwork().Name, defaultNetworkAttachmentDefinitionName)),
 				libvmi.WithNetwork(libvmi.MultusNetwork(network1Name, networkAttachmentDefinitionName1)),
 			)
 
@@ -102,13 +101,13 @@ var _ = Describe("Annotations Generator", func() {
 		It("should generate the Multus networks annotation when an interface has a custom MAC address", func() {
 			const customMACAddress = "de:ad:00:00:be:af"
 
-			sriovNIC := libvmi.InterfaceDeviceWithSRIOVBinding(network1Name)
-
 			vmi := libvmi.New(
 				libvmi.WithNamespace(testNamespace),
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(defaultNetworkName)),
-				libvmi.WithInterface(libvmi.InterfaceWithMac(sriovNIC, customMACAddress)),
-				libvmi.WithNetwork(libvmi.MultusNetwork(defaultNetworkName, defaultNetworkAttachmentDefinitionName)),
+				libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithBridgeBinding())),
+				libvmi.WithInterface(libvmi.NewInterface(
+					network1Name, libvmi.WithSRIOVBinding(), libvmi.WithMac(customMACAddress),
+				)),
+				libvmi.WithNetwork(libvmi.MultusNetwork(v1.DefaultPodNetwork().Name, defaultNetworkAttachmentDefinitionName)),
 				libvmi.WithNetwork(libvmi.MultusNetwork(network1Name, networkAttachmentDefinitionName1)),
 			)
 
@@ -179,8 +178,8 @@ var _ = Describe("Annotations Generator", func() {
 			vmi = libvmi.New(
 				libvmi.WithNamespace(testNamespace),
 				libvmi.WithInterface(*v1.DefaultBridgeNetworkInterface()),
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(networkName1)),
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(networkName2)),
+				libvmi.WithInterface(libvmi.NewInterface(networkName1, libvmi.WithBridgeBinding())),
+				libvmi.WithInterface(libvmi.NewInterface(networkName2, libvmi.WithBridgeBinding())),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 				libvmi.WithNetwork(libvmi.MultusNetwork(networkName1, networkAttachmentDefinitionName1)),
 				libvmi.WithNetwork(libvmi.MultusNetwork(networkName2, networkAttachmentDefinitionName2)),
@@ -313,7 +312,7 @@ var _ = Describe("Annotations Generator", func() {
 		It("Should not generate the network info annotation when there are no networks with binding plugin / SR-IOV", func() {
 			vmi := libvmi.New(
 				libvmi.WithNamespace(testNamespace),
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(networkName1)),
+				libvmi.WithInterface(libvmi.NewInterface(networkName1, libvmi.WithBridgeBinding())),
 				libvmi.WithNetwork(libvmi.MultusNetwork(networkName1, networkAttachmentDefinitionName1)),
 			)
 
@@ -328,7 +327,9 @@ var _ = Describe("Annotations Generator", func() {
 		It("Should not generate the network info annotation when there are networks with binding plugin but none with device-info", func() {
 			vmi := libvmi.New(
 				libvmi.WithNamespace(testNamespace),
-				libvmi.WithInterface(libvmi.InterfaceWithBindingPlugin(networkName1, v1.PluginBinding{Name: nonDeviceInfoPlugin})),
+				libvmi.WithInterface(libvmi.NewInterface(
+					networkName1, libvmi.WithBindingPlugin(v1.PluginBinding{Name: nonDeviceInfoPlugin}),
+				)),
 				libvmi.WithNetwork(libvmi.MultusNetwork(networkName1, networkAttachmentDefinitionName1)),
 			)
 
@@ -343,7 +344,9 @@ var _ = Describe("Annotations Generator", func() {
 		It("Should generate the network info annotation when there is one binding plugin with device info", func() {
 			vmi := libvmi.New(
 				libvmi.WithNamespace(testNamespace),
-				libvmi.WithInterface(libvmi.InterfaceWithBindingPlugin(networkName2, v1.PluginBinding{Name: deviceInfoPlugin})),
+				libvmi.WithInterface(libvmi.NewInterface(
+					networkName2, libvmi.WithBindingPlugin(v1.PluginBinding{Name: deviceInfoPlugin}),
+				)),
 				libvmi.WithNetwork(libvmi.MultusNetwork(networkName2, networkAttachmentDefinitionName2)),
 			)
 
@@ -366,7 +369,9 @@ var _ = Describe("Annotations Generator", func() {
 		It("Should add mac address, if available, to the network info annotation when there is one binding plugin with device info", func() {
 			vmi := libvmi.New(
 				libvmi.WithNamespace(testNamespace),
-				libvmi.WithInterface(libvmi.InterfaceWithBindingPlugin(networkName5, v1.PluginBinding{Name: deviceInfoPlugin})),
+				libvmi.WithInterface(libvmi.NewInterface(
+					networkName5, libvmi.WithBindingPlugin(v1.PluginBinding{Name: deviceInfoPlugin}),
+				)),
 				libvmi.WithNetwork(libvmi.MultusNetwork(networkName5, networkAttachmentDefinitionName5)),
 			)
 
@@ -391,7 +396,7 @@ var _ = Describe("Annotations Generator", func() {
 		It("Should generate the network info annotation when there is an SR-IOV interface", func() {
 			vmi := libvmi.New(
 				libvmi.WithNamespace(testNamespace),
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithSRIOVBinding(networkName3)),
+				libvmi.WithInterface(libvmi.NewInterface(networkName3, libvmi.WithSRIOVBinding())),
 				libvmi.WithNetwork(libvmi.MultusNetwork(networkName3, networkAttachmentDefinitionName3)),
 			)
 
@@ -414,10 +419,14 @@ var _ = Describe("Annotations Generator", func() {
 		It("Should generate the network info annotation when there is SR-IOV interface and binding plugin interface with device-info", func() {
 			vmi := libvmi.New(
 				libvmi.WithNamespace(testNamespace),
-				libvmi.WithInterface(libvmi.InterfaceWithBindingPlugin(networkName2, v1.PluginBinding{Name: deviceInfoPlugin})),
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithSRIOVBinding(networkName3)),
-				libvmi.WithInterface(libvmi.InterfaceWithBindingPlugin(networkName1, v1.PluginBinding{Name: nonDeviceInfoPlugin})),
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(networkName4)),
+				libvmi.WithInterface(libvmi.NewInterface(
+					networkName2, libvmi.WithBindingPlugin(v1.PluginBinding{Name: deviceInfoPlugin}),
+				)),
+				libvmi.WithInterface(libvmi.NewInterface(networkName3, libvmi.WithSRIOVBinding())),
+				libvmi.WithInterface(libvmi.NewInterface(
+					networkName1, libvmi.WithBindingPlugin(v1.PluginBinding{Name: nonDeviceInfoPlugin}),
+				)),
+				libvmi.WithInterface(libvmi.NewInterface(networkName4, libvmi.WithBridgeBinding())),
 				libvmi.WithNetwork(libvmi.MultusNetwork(networkName2, networkAttachmentDefinitionName2)),
 				libvmi.WithNetwork(libvmi.MultusNetwork(networkName3, networkAttachmentDefinitionName3)),
 				libvmi.WithNetwork(libvmi.MultusNetwork(networkName1, networkAttachmentDefinitionName1)),
@@ -552,7 +561,7 @@ var _ = Describe("Annotations Generator", func() {
 				vmi := libvmi.New(
 					libvmi.WithNamespace(testNamespace),
 					libvmi.WithInterface(*v1.DefaultBridgeNetworkInterface()),
-					libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(network1Name)),
+					libvmi.WithInterface(libvmi.NewInterface(network1Name, libvmi.WithBridgeBinding())),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					libvmi.WithNetwork(libvmi.MultusNetwork(network1Name, networkAttachmentDefinitionName1)),
 				)
@@ -581,7 +590,7 @@ var _ = Describe("Annotations Generator", func() {
 			vmi := libvmi.New(
 				libvmi.WithNamespace(testNamespace),
 				libvmi.WithInterface(*v1.DefaultBridgeNetworkInterface()),
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(network1Name)),
+				libvmi.WithInterface(libvmi.NewInterface(network1Name, libvmi.WithBridgeBinding())),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 				libvmi.WithNetwork(libvmi.MultusNetwork(network1Name, networkAttachmentDefinitionName1)),
 				libvmistatus.WithStatus(
@@ -610,7 +619,7 @@ var _ = Describe("Annotations Generator", func() {
 				vmi := libvmi.New(
 					libvmi.WithNamespace(testNamespace),
 					libvmi.WithInterface(*v1.DefaultBridgeNetworkInterface()),
-					libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(network1Name)),
+					libvmi.WithInterface(libvmi.NewInterface(network1Name, libvmi.WithBridgeBinding())),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					libvmi.WithNetwork(libvmi.MultusNetwork(network1Name, networkAttachmentDefinitionName1)),
 				)
@@ -630,8 +639,8 @@ var _ = Describe("Annotations Generator", func() {
 				vmi := libvmi.New(
 					libvmi.WithNamespace(testNamespace),
 					libvmi.WithInterface(*v1.DefaultBridgeNetworkInterface()),
-					libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(network1Name)),
-					libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(network2Name)),
+					libvmi.WithInterface(libvmi.NewInterface(network1Name, libvmi.WithBridgeBinding())),
+					libvmi.WithInterface(libvmi.NewInterface(network2Name, libvmi.WithBridgeBinding())),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					libvmi.WithNetwork(libvmi.MultusNetwork(network1Name, networkAttachmentDefinitionName1)),
 					libvmi.WithNetwork(libvmi.MultusNetwork(network2Name, networkAttachmentDefinitionName2)),
@@ -656,8 +665,8 @@ var _ = Describe("Annotations Generator", func() {
 			vmi := libvmi.New(
 				libvmi.WithNamespace(testNamespace),
 				libvmi.WithInterface(*v1.DefaultBridgeNetworkInterface()),
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(network1Name)),
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(network2Name)),
+				libvmi.WithInterface(libvmi.NewInterface(network1Name, libvmi.WithBridgeBinding())),
+				libvmi.WithInterface(libvmi.NewInterface(network2Name, libvmi.WithBridgeBinding())),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 				libvmi.WithNetwork(libvmi.MultusNetwork(network1Name, networkAttachmentDefinitionName1)),
 				libvmi.WithNetwork(libvmi.MultusNetwork(network2Name, networkAttachmentDefinitionName2)),
@@ -677,7 +686,7 @@ var _ = Describe("Annotations Generator", func() {
 			vmi := libvmi.New(
 				libvmi.WithNamespace(testNamespace),
 				libvmi.WithInterface(*v1.DefaultBridgeNetworkInterface()),
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithSRIOVBinding(network1Name)),
+				libvmi.WithInterface(libvmi.NewInterface(network1Name, libvmi.WithSRIOVBinding())),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 				libvmi.WithNetwork(libvmi.MultusNetwork(network1Name, networkAttachmentDefinitionName1)),
 				libvmistatus.WithStatus(libvmistatus.New(
@@ -696,13 +705,13 @@ var _ = Describe("Annotations Generator", func() {
 		})
 
 		It("Should generate network attachment annotation when a secondary interface is hot unplugged", func() {
-			ifaceWithStateAbsent := libvmi.InterfaceDeviceWithBridgeBinding(network1Name)
+			ifaceWithStateAbsent := libvmi.NewInterface(network1Name, libvmi.WithBridgeBinding())
 			ifaceWithStateAbsent.State = v1.InterfaceStateAbsent
 			vmi := libvmi.New(
 				libvmi.WithNamespace(testNamespace),
 				libvmi.WithInterface(*v1.DefaultBridgeNetworkInterface()),
 				libvmi.WithInterface(ifaceWithStateAbsent),
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(network2Name)),
+				libvmi.WithInterface(libvmi.NewInterface(network2Name, libvmi.WithBridgeBinding())),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 				libvmi.WithNetwork(libvmi.MultusNetwork(network1Name, networkAttachmentDefinitionName1)),
 				libvmi.WithNetwork(libvmi.MultusNetwork(network2Name, networkAttachmentDefinitionName2)),
@@ -734,7 +743,7 @@ var _ = Describe("Annotations Generator", func() {
 		})
 
 		It("Should remove the Multus network attachment annotation when the last secondary interface is hot unplugged", func() {
-			ifaceWithStateAbsent := libvmi.InterfaceDeviceWithBridgeBinding(network1Name)
+			ifaceWithStateAbsent := libvmi.NewInterface(network1Name, libvmi.WithBridgeBinding())
 			ifaceWithStateAbsent.State = v1.InterfaceStateAbsent
 			vmi := libvmi.New(
 				libvmi.WithNamespace(testNamespace),

--- a/pkg/network/resources/memory_test.go
+++ b/pkg/network/resources/memory_test.go
@@ -201,7 +201,7 @@ var _ = Describe("Network Binding plugin compute resource overhead", func() {
 		),
 		Entry("when vmi has passt binding",
 			libvmi.New(
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithPasstBinding("")),
+				libvmi.WithInterface(libvmi.NewInterface("", libvmi.WithPasstBinding())),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 			),
 			map[string]v1.InterfaceBindingPlugin{},
@@ -209,7 +209,7 @@ var _ = Describe("Network Binding plugin compute resource overhead", func() {
 		),
 		Entry("when vmi has passt binding and a binding plugin",
 			libvmi.New(
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithPasstBinding("")),
+				libvmi.WithInterface(libvmi.NewInterface("", libvmi.WithPasstBinding())),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 				libvmi.WithInterface(v1.Interface{Name: iface1name, Binding: &v1.PluginBinding{Name: plugin1name}}),
 				libvmi.WithNetwork(&v1.Network{Name: iface1name}),

--- a/pkg/network/setup/filters_test.go
+++ b/pkg/network/setup/filters_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Network setup filters", func() {
 	Context("FilterNetsForVMStartup", func() {
 		It("Should return a list non-absent networks", func() {
 			const absentNetName = "absent-net"
-			absentIface := libvmi.InterfaceDeviceWithBridgeBinding(absentNetName)
+			absentIface := libvmi.NewInterface(absentNetName, libvmi.WithBridgeBinding())
 			absentIface.State = v1.InterfaceStateAbsent
 
 			vmi := libvmi.New(
@@ -68,7 +68,7 @@ var _ = Describe("Network setup filters", func() {
 		It("Should return an empty list when interface status is not reported", func() {
 			vmi := libvmi.New(
 				libvmi.WithInterface(*v1.DefaultBridgeNetworkInterface()),
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(net1Name)),
+				libvmi.WithInterface(libvmi.NewInterface(net1Name, libvmi.WithBridgeBinding())),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 				libvmi.WithNetwork(libvmi.MultusNetwork(net1Name, nad1Name)),
 			)
@@ -79,8 +79,8 @@ var _ = Describe("Network setup filters", func() {
 		It("Should return an empty list when there are no networks to hot plug/unplug", func() {
 			vmi := libvmi.New(
 				libvmi.WithInterface(*v1.DefaultBridgeNetworkInterface()),
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(net1Name)),
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(net2Name)),
+				libvmi.WithInterface(libvmi.NewInterface(net1Name, libvmi.WithBridgeBinding())),
+				libvmi.WithInterface(libvmi.NewInterface(net2Name, libvmi.WithBridgeBinding())),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 				libvmi.WithNetwork(libvmi.MultusNetwork(net1Name, nad1Name)),
 				libvmi.WithNetwork(libvmi.MultusNetwork(net2Name, nad2Name)),
@@ -109,8 +109,8 @@ var _ = Describe("Network setup filters", func() {
 			multusAndDomainInfoSource := vmispec.NewInfoSource(vmispec.InfoSourceMultusStatus, vmispec.InfoSourceDomain)
 			vmi := libvmi.New(
 				libvmi.WithInterface(*v1.DefaultBridgeNetworkInterface()),
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(net1Name)),
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(net2Name)),
+				libvmi.WithInterface(libvmi.NewInterface(net1Name, libvmi.WithBridgeBinding())),
+				libvmi.WithInterface(libvmi.NewInterface(net2Name, libvmi.WithBridgeBinding())),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 				libvmi.WithNetwork(libvmi.MultusNetwork(net1Name, nad1Name)),
 				libvmi.WithNetwork(libvmi.MultusNetwork(net2Name, nad2Name)),
@@ -136,10 +136,10 @@ var _ = Describe("Network setup filters", func() {
 		})
 
 		It("Should return a network to hotunplug when its interface is marked as absent and not in the domain", func() {
-			absentIface1 := libvmi.InterfaceDeviceWithBridgeBinding(net1Name)
+			absentIface1 := libvmi.NewInterface(net1Name, libvmi.WithBridgeBinding())
 			absentIface1.State = v1.InterfaceStateAbsent
 
-			absentIface2 := libvmi.InterfaceDeviceWithBridgeBinding(net2Name)
+			absentIface2 := libvmi.NewInterface(net2Name, libvmi.WithBridgeBinding())
 			absentIface2.State = v1.InterfaceStateAbsent
 
 			vmi := libvmi.New(
@@ -171,13 +171,13 @@ var _ = Describe("Network setup filters", func() {
 		})
 
 		It("Should return networks to hotplug and hotunplug", func() {
-			absentIface := libvmi.InterfaceDeviceWithBridgeBinding(net1Name)
+			absentIface := libvmi.NewInterface(net1Name, libvmi.WithBridgeBinding())
 			absentIface.State = v1.InterfaceStateAbsent
 
 			vmi := libvmi.New(
 				libvmi.WithInterface(*v1.DefaultBridgeNetworkInterface()),
 				libvmi.WithInterface(absentIface),
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(net2Name)),
+				libvmi.WithInterface(libvmi.NewInterface(net2Name, libvmi.WithBridgeBinding())),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 				libvmi.WithNetwork(libvmi.MultusNetwork(net1Name, nad1Name)),
 				libvmi.WithNetwork(libvmi.MultusNetwork(net2Name, nad2Name)),
@@ -209,7 +209,7 @@ var _ = Describe("Network setup filters", func() {
 	Context("FilterNetsForMigrationTarget", func() {
 		It("Should return a list of all networks - no matter their interface state", func() {
 			const absentNetName = "absent-net"
-			absentIface := libvmi.InterfaceDeviceWithBridgeBinding(absentNetName)
+			absentIface := libvmi.NewInterface(absentNetName, libvmi.WithBridgeBinding())
 			absentIface.State = v1.InterfaceStateAbsent
 
 			vmi := libvmi.New(

--- a/pkg/network/setup/launcher/configurator_test.go
+++ b/pkg/network/setup/launcher/configurator_test.go
@@ -52,15 +52,19 @@ var _ = Describe("SetupPodNetworkPhase2", func() {
 			Expect(domain).To(Equal(expectedDomain))
 		},
 		Entry("SR-IOV", libvmi.New(
-			libvmi.WithInterface(libvmi.InterfaceDeviceWithSRIOVBinding("sriov")),
+			libvmi.WithInterface(libvmi.NewInterface("sriov", libvmi.WithSRIOVBinding())),
 			libvmi.WithNetwork(libvmi.MultusNetwork("sriov", "sriov-nad")),
 		), domainWithSRIOVHostDevice()),
 		Entry("Passt", libvmi.New(
-			libvmi.WithInterface(libvmi.InterfaceDeviceWithPasstBinding(v1.DefaultPodNetwork().Name)),
+			libvmi.WithInterface(libvmi.NewInterface(
+				v1.DefaultPodNetwork().Name, libvmi.WithPasstBinding(),
+			)),
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
 		), domainWithPasstInterface()),
 		Entry("binding plugin without tap domain attachment", libvmi.New(
-			libvmi.WithInterface(libvmi.InterfaceWithBindingPlugin("foo", v1.PluginBinding{Name: "foo"})),
+			libvmi.WithInterface(libvmi.NewInterface(
+				"foo", libvmi.WithBindingPlugin(v1.PluginBinding{Name: "foo"}),
+			)),
 			libvmi.WithNetwork(libvmi.MultusNetwork("foo", "foo-nad")),
 		), &api.Domain{}),
 	)
@@ -83,15 +87,22 @@ var _ = Describe("SetupPodNetworkPhase2", func() {
 			Expect(domain).To(Equal(expectedDomain))
 		},
 		Entry("bridge", libvmi.New(
-			libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(v1.DefaultPodNetwork().Name)),
+			libvmi.WithInterface(libvmi.NewInterface(
+				v1.DefaultPodNetwork().Name, libvmi.WithBridgeBinding(),
+			)),
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
 		), stubDHCPFactory(&stubDHCPConfigurator{})),
 		Entry("masquerade", libvmi.New(
-			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+			libvmi.WithInterface(libvmi.NewInterface(
+				v1.DefaultPodNetwork().Name, libvmi.WithMasqueradeBinding(),
+			)),
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
 		), stubDHCPFactory(&stubDHCPConfigurator{})),
 		Entry("macvtap", libvmi.New(
-			libvmi.WithInterface(libvmi.InterfaceWithMacvtapBindingPlugin(v1.DefaultPodNetwork().Name)),
+			libvmi.WithInterface(libvmi.NewInterface(
+				v1.DefaultPodNetwork().Name,
+				libvmi.WithBindingPlugin(v1.PluginBinding{Name: "macvtap"}),
+			)),
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
 		), nil),
 	)
@@ -111,11 +122,15 @@ var _ = Describe("SetupPodNetworkPhase2", func() {
 			}).To(Panic())
 		},
 		Entry("bridge", libvmi.New(
-			libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(v1.DefaultPodNetwork().Name)),
+			libvmi.WithInterface(libvmi.NewInterface(
+				v1.DefaultPodNetwork().Name, libvmi.WithBridgeBinding(),
+			)),
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
 		)),
 		Entry("masquerade", libvmi.New(
-			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+			libvmi.WithInterface(libvmi.NewInterface(
+				v1.DefaultPodNetwork().Name, libvmi.WithMasqueradeBinding(),
+			)),
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
 		)),
 	)

--- a/pkg/network/vmispec/interface_test.go
+++ b/pkg/network/vmispec/interface_test.go
@@ -106,7 +106,7 @@ var _ = Describe("VMI network spec", func() {
 			),
 			Entry("when the VMI uses passtBinding to connect to the pod network",
 				libvmi.New(
-					libvmi.WithInterface(libvmi.InterfaceDeviceWithPasstBinding(podNet0)),
+					libvmi.WithInterface(libvmi.NewInterface(podNet0, libvmi.WithPasstBinding())),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 				),
 			),
@@ -143,7 +143,7 @@ var _ = Describe("VMI network spec", func() {
 	Context("binding plugin network with device info", func() {
 		It("returns false given non binding-plugin interface", func() {
 			Expect(netvmispec.HasBindingPluginDeviceInfo(
-				libvmi.InterfaceDeviceWithBridgeBinding("net1"),
+				libvmi.NewInterface("net1", libvmi.WithBridgeBinding()),
 				bindingPlugins,
 			)).To(BeFalse())
 		})

--- a/pkg/network/vmliveupdate/restart_test.go
+++ b/pkg/network/vmliveupdate/restart_test.go
@@ -50,8 +50,8 @@ var _ = Describe("IsRestartRequired", func() {
 			libvmi.New(libvmi.WithAutoAttachPodInterface(false))),
 		Entry("With interfaces and networks",
 			libvmi.New(
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetName1)),
+				libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithMasqueradeBinding())),
+				libvmi.WithInterface(libvmi.NewInterface(secondaryNetName1, libvmi.WithBridgeBinding())),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 				libvmi.WithNetwork(libvmi.MultusNetwork(secondaryNetName1, secondaryNADName1)),
 			),
@@ -60,14 +60,14 @@ var _ = Describe("IsRestartRequired", func() {
 
 	It("should not require restart when networks are added", func() {
 		vmi := libvmi.New(
-			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+			libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithMasqueradeBinding())),
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
 		)
 		vm := libvmi.NewVirtualMachine(vmi).DeepCopy()
 
 		vm.Spec.Template.Spec.Domain.Devices.Interfaces = append(
 			vm.Spec.Template.Spec.Domain.Devices.Interfaces,
-			libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetName1),
+			libvmi.NewInterface(secondaryNetName1, libvmi.WithBridgeBinding()),
 		)
 
 		vm.Spec.Template.Spec.Networks = append(
@@ -78,7 +78,7 @@ var _ = Describe("IsRestartRequired", func() {
 	})
 
 	DescribeTable("should not require restart when interface state changes", func(current, desired v1.InterfaceState) {
-		iface := libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetName1)
+		iface := libvmi.NewInterface(secondaryNetName1, libvmi.WithBridgeBinding())
 		iface.State = current
 
 		vmi := libvmi.New(
@@ -107,15 +107,15 @@ var _ = Describe("IsRestartRequired", func() {
 
 	It("should not require restart when secondary NICs are hotplugged", func() {
 		vmi := libvmi.New(
-			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+			libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithMasqueradeBinding())),
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
 		)
 
 		vm := libvmi.NewVirtualMachine(vmi).DeepCopy()
 
 		ifacesToHotplug := []v1.Interface{
-			libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetName1),
-			libvmi.InterfaceDeviceWithSRIOVBinding(secondaryNetName2),
+			libvmi.NewInterface(secondaryNetName1, libvmi.WithBridgeBinding()),
+			libvmi.NewInterface(secondaryNetName2, libvmi.WithSRIOVBinding()),
 		}
 
 		netsToHotplug := []v1.Network{
@@ -135,9 +135,9 @@ var _ = Describe("IsRestartRequired", func() {
 
 	It("should not require restart when interfaces or networks order is changed", func() {
 		vmi := libvmi.New(
-			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
-			libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetName1)),
-			libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetName2)),
+			libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithMasqueradeBinding())),
+			libvmi.WithInterface(libvmi.NewInterface(secondaryNetName1, libvmi.WithBridgeBinding())),
+			libvmi.WithInterface(libvmi.NewInterface(secondaryNetName2, libvmi.WithBridgeBinding())),
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
 			libvmi.WithNetwork(libvmi.MultusNetwork(secondaryNetName1, secondaryNADName1)),
 			libvmi.WithNetwork(libvmi.MultusNetwork(secondaryNetName2, secondaryNADName2)),
@@ -152,7 +152,7 @@ var _ = Describe("IsRestartRequired", func() {
 	})
 
 	It("should require restart when interface binding changes", func() {
-		iface := libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetName1)
+		iface := libvmi.NewInterface(secondaryNetName1, libvmi.WithBridgeBinding())
 
 		vmi := libvmi.New(
 			libvmi.WithInterface(iface),
@@ -160,7 +160,7 @@ var _ = Describe("IsRestartRequired", func() {
 		)
 
 		vm := libvmi.NewVirtualMachine(vmi).DeepCopy()
-		vm.Spec.Template.Spec.Domain.Devices.Interfaces[0] = libvmi.InterfaceDeviceWithMasqueradeBinding()
+		vm.Spec.Template.Spec.Domain.Devices.Interfaces[0] = libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithMasqueradeBinding())
 
 		Expect(vmliveupdate.IsRestartRequired(vm, vmi)).To(BeTrue())
 	})
@@ -170,7 +170,7 @@ var _ = Describe("IsRestartRequired", func() {
 		desired v1.Network,
 	) {
 		vmi := libvmi.New(
-			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+			libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithMasqueradeBinding())),
 			libvmi.WithNetwork(&current),
 		)
 
@@ -188,7 +188,7 @@ var _ = Describe("IsRestartRequired", func() {
 	DescribeTable("should set restart requirement for NAD name changes based on migratability",
 		func(conditions []v1.VirtualMachineInstanceCondition, expectedRestart bool) {
 			vmi := libvmi.New(
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetName1)),
+				libvmi.WithInterface(libvmi.NewInterface(secondaryNetName1, libvmi.WithBridgeBinding())),
 				libvmi.WithNetwork(libvmi.MultusNetwork(secondaryNetName1, secondaryNADName1)),
 			)
 			vmi.Status.Conditions = conditions
@@ -209,8 +209,8 @@ var _ = Describe("IsRestartRequired", func() {
 
 	It("Should require restart when interfaces and networks are removed", func() {
 		vmi := libvmi.New(
-			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
-			libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetName1)),
+			libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithMasqueradeBinding())),
+			libvmi.WithInterface(libvmi.NewInterface(secondaryNetName1, libvmi.WithBridgeBinding())),
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
 			libvmi.WithNetwork(libvmi.MultusNetwork(secondaryNetName1, secondaryNADName1)),
 		)
@@ -227,7 +227,7 @@ var _ = Describe("IsRestartRequired", func() {
 
 		vm := libvmi.NewVirtualMachine(
 			libvmi.New(
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+				libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithMasqueradeBinding())),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 			),
 		)


### PR DESCRIPTION
### What this PR does
#### Before this PR:
Test files in `pkg/network/` use legacy interface builders (`InterfaceDeviceWith*`, `InterfaceWith*`) to construct interfaces.

#### After this PR:
All 10 test files in `pkg/network/` (138 call sites) use `NewInterface` with option functions (`WithMasqueradeBinding`, `WithBridgeBinding`, `WithMac`, etc.) introduced in #18263.

Also replaces `v1.DefaultPodNetwork().Name` with local constants for readability.

### References

- Introduced the builder pattern: #18263
- First migration PR (`tests/network/`): #18391

### Why we need it and why it was done in this way

Migrating callers to the new builder pattern is a prerequisite for eventually deprecating the legacy functions. Splitting by directory keeps PRs reviewable and reduces merge conflict risk.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

/kind cleanup

```release-note
NONE
```