### PR TITLE
converter, compute: Cover with linter

### DIFF
--- a/hack/linter/lint-paths.txt
+++ b/hack/linter/lint-paths.txt
@@ -66,6 +66,7 @@ pkg/virt-launcher/metadata
 pkg/virt-launcher/premigration-hook-server/network
 pkg/virt-launcher/virtwrap/access-credentials
 pkg/virt-launcher/virtwrap/agent-poller
+pkg/virt-launcher/virtwrap/converter/compute
 pkg/virt-launcher/virtwrap/converter/metadata
 pkg/virt-launcher/virtwrap/converter/network
 pkg/virt-launcher/virtwrap/converter/storage

--- a/pkg/virt-launcher/virtwrap/converter/compute/clock.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/clock.go
@@ -34,7 +34,7 @@ func (c ClockDomainConfigurator) Configure(vmi *v1.VirtualMachineInstance, domai
 	if vmi.Spec.Domain.Clock != nil {
 		clock := vmi.Spec.Domain.Clock
 		newClock := &api.Clock{}
-		convert_v1_Clock_To_api_Clock(clock, newClock)
+		convertClockToAPIClock(clock, newClock)
 		domain.Spec.Clock = newClock
 	}
 
@@ -52,7 +52,7 @@ func (c ClockDomainConfigurator) Configure(vmi *v1.VirtualMachineInstance, domai
 	return nil
 }
 
-func convert_v1_Clock_To_api_Clock(source *v1.Clock, clock *api.Clock) {
+func convertClockToAPIClock(source *v1.Clock, clock *api.Clock) {
 	if source.UTC != nil {
 		clock.Offset = "utc"
 		if source.UTC.OffsetSeconds != nil {

--- a/pkg/virt-launcher/virtwrap/converter/compute/clock.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/clock.go
@@ -102,7 +102,7 @@ func boolToYesNo(value *bool, defaultYes bool) string {
 	return boolToString(value, defaultYes, "yes", "no")
 }
 
-func boolToString(value *bool, defaultPositive bool, positive string, negative string) string {
+func boolToString(value *bool, defaultPositive bool, positive, negative string) string {
 	toString := func(value bool) string {
 		if value {
 			return positive

--- a/pkg/virt-launcher/virtwrap/converter/compute/console_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/console_test.go
@@ -33,7 +33,6 @@ import (
 )
 
 var _ = Describe("Console Domain Configurator", func() {
-
 	const uid = "test-uid"
 	serialPort := uint(0)
 	socketPath := fmt.Sprintf("%s/%s/virt-serial%d", util.VirtPrivateDir, uid, serialPort)

--- a/pkg/virt-launcher/virtwrap/converter/compute/controllers.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/controllers.go
@@ -77,7 +77,10 @@ func (c ControllersDomainConfigurator) Configure(vmi *v1.VirtualMachineInstance,
 	}
 
 	if requiresVirtioSerialController(vmi) {
-		domain.Spec.Devices.Controllers = append(domain.Spec.Devices.Controllers, newVirtioSerialController(c.virtioSerialModel, controllerDriver))
+		domain.Spec.Devices.Controllers = append(
+			domain.Spec.Devices.Controllers,
+			newVirtioSerialController(c.virtioSerialModel, controllerDriver),
+		)
 	}
 
 	return nil
@@ -213,7 +216,11 @@ func shouldConfigSCSIThread(vmi *v1.VirtualMachineInstance) bool {
 	})
 }
 
-func assignSCSIControllerIOThread(vmi *v1.VirtualMachineInstance, autoThreads uint, scsiControllerDriver *api.ControllerDriver) *api.ControllerDriver {
+func assignSCSIControllerIOThread(
+	vmi *v1.VirtualMachineInstance,
+	autoThreads uint,
+	scsiControllerDriver *api.ControllerDriver,
+) *api.ControllerDriver {
 	if autoThreads == 0 || !shouldConfigSCSIThread(vmi) {
 		return scsiControllerDriver
 	}

--- a/pkg/virt-launcher/virtwrap/converter/compute/controllers.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/controllers.go
@@ -68,7 +68,7 @@ func (c ControllersDomainConfigurator) Configure(vmi *v1.VirtualMachineInstance,
 	}
 
 	if requiresSCSIController(vmi) {
-		scsiControllerDriver := assignSCSIControllerIOThread(vmi, uint(c.autoThreads), controllerDriver.DeepCopy())
+		scsiControllerDriver := assignSCSIControllerIOThread(vmi, c.autoThreads, controllerDriver.DeepCopy())
 		domain.Spec.Devices.Controllers = append(domain.Spec.Devices.Controllers, newSCSIController(c.scsiModel, scsiControllerDriver))
 	}
 

--- a/pkg/virt-launcher/virtwrap/converter/compute/controllers_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/controllers_test.go
@@ -31,7 +31,6 @@ import (
 )
 
 var _ = Describe("Controllers Domain Configurator", func() {
-
 	const (
 		usbNeeded                   = true
 		pciHole64DisablingSupported = true

--- a/pkg/virt-launcher/virtwrap/converter/compute/controllers_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/controllers_test.go
@@ -155,7 +155,7 @@ var _ = Describe("Controllers Domain Configurator", func() {
 		Entry("when VMI has multiple SCSI disks with dedicatedIOThread, VMI has 4 shared IO threads",
 			libvmi.New(
 				libvmi.WithDisk("scsi-disk1", v1.DiskBusSCSI, libvmi.WithDedicatedIOThreads(true)),
-				libvmi.WithDisk("scsi-disk1", v1.DiskBusSCSI, libvmi.WithDedicatedIOThreads(true)),
+				libvmi.WithDisk("scsi-disk2", v1.DiskBusSCSI, libvmi.WithDedicatedIOThreads(true)),
 			),
 			!usbNeeded,
 			4,

--- a/pkg/virt-launcher/virtwrap/converter/compute/controllers_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/controllers_test.go
@@ -36,7 +36,12 @@ var _ = Describe("Controllers Domain Configurator", func() {
 		pciHole64DisablingSupported = true
 	)
 
-	DescribeTable("should configure USB and SCSI controllers", func(vmi *v1.VirtualMachineInstance, isUSBNeeded bool, autoThreads int, expectedControllers []api.Controller) {
+	DescribeTable("should configure USB and SCSI controllers", func(
+		vmi *v1.VirtualMachineInstance,
+		isUSBNeeded bool,
+		autoThreads int,
+		expectedControllers []api.Controller,
+	) {
 		var domain api.Domain
 
 		Expect(compute.NewControllersDomainConfigurator(
@@ -127,7 +132,9 @@ var _ = Describe("Controllers Domain Configurator", func() {
 			4,
 			[]api.Controller{
 				{Type: "usb", Index: "0", Model: "none"},
-				{Type: "scsi", Index: "0", Model: "test-model", Driver: &api.ControllerDriver{Queues: pointer.P[uint](1), IOThread: pointer.P[uint](2)}},
+				{Type: "scsi", Index: "0", Model: "test-model", Driver: &api.ControllerDriver{
+					Queues: pointer.P[uint](1), IOThread: pointer.P[uint](2),
+				}},
 				{Type: "virtio-serial", Index: "0", Model: "virtio-test-model"},
 			}),
 		Entry("when VMI has SCSI disk with dedicatedIOThread and Virtio disks, VMI has 2 shared IO threads, should roll over controller thread",
@@ -140,7 +147,9 @@ var _ = Describe("Controllers Domain Configurator", func() {
 			2,
 			[]api.Controller{
 				{Type: "usb", Index: "0", Model: "none"},
-				{Type: "scsi", Index: "0", Model: "test-model", Driver: &api.ControllerDriver{Queues: pointer.P[uint](1), IOThread: pointer.P[uint](1)}},
+				{Type: "scsi", Index: "0", Model: "test-model", Driver: &api.ControllerDriver{
+					Queues: pointer.P[uint](1), IOThread: pointer.P[uint](1),
+				}},
 				{Type: "virtio-serial", Index: "0", Model: "virtio-test-model"},
 			}),
 		Entry("when VMI has multiple SCSI disks with dedicatedIOThread, VMI has 4 shared IO threads",
@@ -152,7 +161,9 @@ var _ = Describe("Controllers Domain Configurator", func() {
 			4,
 			[]api.Controller{
 				{Type: "usb", Index: "0", Model: "none"},
-				{Type: "scsi", Index: "0", Model: "test-model", Driver: &api.ControllerDriver{Queues: pointer.P[uint](1), IOThread: pointer.P[uint](1)}},
+				{Type: "scsi", Index: "0", Model: "test-model", Driver: &api.ControllerDriver{
+					Queues: pointer.P[uint](1), IOThread: pointer.P[uint](1),
+				}},
 				{Type: "virtio-serial", Index: "0", Model: "virtio-test-model"},
 			}),
 		Entry("when VMI has SCSI disk with dedicatedIOThread and VMI has no IOThreads",
@@ -175,7 +186,11 @@ var _ = Describe("Controllers Domain Configurator", func() {
 			}),
 	)
 
-	DescribeTable("should configure PCI controller based on arch support and annotation", func(vmi *v1.VirtualMachineInstance, supportPCIHole64Disabling bool, expectedControllers []api.Controller) {
+	DescribeTable("should configure PCI controller based on arch support and annotation", func(
+		vmi *v1.VirtualMachineInstance,
+		supportPCIHole64Disabling bool,
+		expectedControllers []api.Controller,
+	) {
 		var domain api.Domain
 
 		configurator := compute.NewControllersDomainConfigurator(
@@ -255,8 +270,14 @@ var _ = Describe("Controllers Domain Configurator", func() {
 			0,
 			newDomainWithControllers([]api.Controller{
 				{Type: "usb", Index: "0", Model: "none"},
-				{Type: "scsi", Index: "0", Model: "test-model", Driver: &api.ControllerDriver{IOMMU: "on"}},
-				{Type: "virtio-serial", Index: "0", Model: "virtio-test-model", Driver: &api.ControllerDriver{IOMMU: "on"}},
+				{
+					Type: "scsi", Index: "0", Model: "test-model",
+					Driver: &api.ControllerDriver{IOMMU: "on"},
+				},
+				{
+					Type: "virtio-serial", Index: "0", Model: "virtio-test-model",
+					Driver: &api.ControllerDriver{IOMMU: "on"},
+				},
 			})),
 		Entry("when PV is active, SCSI and virtio-serial get IOMMU driver",
 			false, true,
@@ -264,8 +285,14 @@ var _ = Describe("Controllers Domain Configurator", func() {
 			0,
 			newDomainWithControllers([]api.Controller{
 				{Type: "usb", Index: "0", Model: "none"},
-				{Type: "scsi", Index: "0", Model: "test-model", Driver: &api.ControllerDriver{IOMMU: "on"}},
-				{Type: "virtio-serial", Index: "0", Model: "virtio-test-model", Driver: &api.ControllerDriver{IOMMU: "on"}},
+				{
+					Type: "scsi", Index: "0", Model: "test-model",
+					Driver: &api.ControllerDriver{IOMMU: "on"},
+				},
+				{
+					Type: "virtio-serial", Index: "0", Model: "virtio-test-model",
+					Driver: &api.ControllerDriver{IOMMU: "on"},
+				},
 			})),
 		Entry("when SEV is active with SCSI IOThreads, IOMMU is preserved alongside IOThread and Queues",
 			true, false,
@@ -276,12 +303,25 @@ var _ = Describe("Controllers Domain Configurator", func() {
 			4,
 			newDomainWithControllers([]api.Controller{
 				{Type: "usb", Index: "0", Model: "none"},
-				{Type: "scsi", Index: "0", Model: "test-model", Driver: &api.ControllerDriver{IOMMU: "on", Queues: pointer.P[uint](1), IOThread: pointer.P[uint](2)}},
-				{Type: "virtio-serial", Index: "0", Model: "virtio-test-model", Driver: &api.ControllerDriver{IOMMU: "on"}},
+				{
+					Type: "scsi", Index: "0", Model: "test-model",
+					Driver: &api.ControllerDriver{
+						IOMMU:    "on",
+						Queues:   pointer.P[uint](1),
+						IOThread: pointer.P[uint](2),
+					},
+				},
+				{
+					Type: "virtio-serial", Index: "0", Model: "virtio-test-model",
+					Driver: &api.ControllerDriver{IOMMU: "on"},
+				},
 			})),
 	)
 
-	DescribeTable("should configure virtio-serial controller based on serial console setting", func(vmiOpts []libvmi.Option, expectedControllers []api.Controller) {
+	DescribeTable("should configure virtio-serial controller based on serial console setting", func(
+		vmiOpts []libvmi.Option,
+		expectedControllers []api.Controller,
+	) {
 		var domain api.Domain
 
 		// withHotplugDisabled() is applied to all entries to prevent the SCSI controller

--- a/pkg/virt-launcher/virtwrap/converter/compute/cpu.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/cpu.go
@@ -61,15 +61,15 @@ func (c CPUDomainConfigurator) configureCPUTopology(vmi *v1.VirtualMachineInstan
 	cpuCount := vcpu.CalculateRequestedVCPUs(cpuTopology)
 
 	if vmiCPU := vmi.Spec.Domain.CPU; vmiCPU != nil && vmiCPU.MaxSockets != 0 && c.isHotplugSupported {
-		minEnabledCpuCount := cpuTopology.Cores * cpuTopology.Threads
-		enabledCpuCount := cpuCount
+		minEnabledCPUCount := cpuTopology.Cores * cpuTopology.Threads
+		enabledCPUCount := cpuCount
 		cpuTopology.Sockets = vmiCPU.MaxSockets
 		cpuCount = vcpu.CalculateRequestedVCPUs(cpuTopology)
 
 		VCPUs := &api.VCPUs{}
 		for id := uint32(0); id < cpuCount; id++ {
-			isEnabled := id < enabledCpuCount
-			isHotpluggable := id >= minEnabledCpuCount
+			isEnabled := id < enabledCPUCount
+			isHotpluggable := id >= minEnabledCPUCount
 			VCPUs.VCPU = append(VCPUs.VCPU, api.VCPUsVCPU{
 				ID:           id,
 				Enabled:      boolToYesNo(&isEnabled, true),

--- a/pkg/virt-launcher/virtwrap/converter/compute/cpu.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/cpu.go
@@ -157,7 +157,8 @@ func (c CPUDomainConfigurator) configureSyntheticNUMA(vmi *v1.VirtualMachineInst
 		return
 	}
 
-	memKiB := uint64(vcpu.GetVirtualMemory(vmi).Value() / int64(1024))
+	const bytesPerKiB = 1024
+	memKiB := uint64(vcpu.GetVirtualMemory(vmi).Value() / int64(bytesPerKiB)) //nolint:gosec // G115: memory is always positive
 	domain.Spec.CPU.NUMA = &api.NUMA{
 		Cells: []api.NUMACell{
 			{

--- a/pkg/virt-launcher/virtwrap/converter/compute/cpu.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/cpu.go
@@ -139,7 +139,9 @@ func (c CPUDomainConfigurator) configureCPUFeatures(vmi *v1.VirtualMachineInstan
 	*/
 
 	_, exists := existingFeatures["mpx"]
-	if c.requiresMPXCPUValidation && !exists && vmi.Spec.Domain.CPU.Model != v1.CPUModeHostModel && vmi.Spec.Domain.CPU.Model != v1.CPUModeHostPassthrough {
+	if c.requiresMPXCPUValidation && !exists &&
+		vmi.Spec.Domain.CPU.Model != v1.CPUModeHostModel &&
+		vmi.Spec.Domain.CPU.Model != v1.CPUModeHostPassthrough {
 		domain.Spec.CPU.Features = append(domain.Spec.CPU.Features, api.CPUFeature{
 			Name:   "mpx",
 			Policy: "disable",

--- a/pkg/virt-launcher/virtwrap/converter/compute/graphics_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/graphics_test.go
@@ -35,7 +35,6 @@ import (
 
 var _ = Describe("Graphics Domain Configurator", func() {
 	Context("AutoattachGraphicsDevice", func() {
-
 		DescribeTable("should not configure video and VNC when AutoattachGraphicsDevice is false", func(arch string) {
 			vmi := libvmi.New(libvmi.WithAutoattachGraphicsDevice(false))
 

--- a/pkg/virt-launcher/virtwrap/converter/compute/hypervisor_features.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/hypervisor_features.go
@@ -44,7 +44,7 @@ func (h HypervisorFeaturesDomainConfigurator) Configure(vmi *v1.VirtualMachineIn
 		return nil
 	}
 
-	convert_v1_Features_To_api_Features(vmi.Spec.Domain.Features, domain.Spec.Features, h.useLaunchSecurityTDX)
+	convertFeaturesToAPIFeatures(vmi.Spec.Domain.Features, domain.Spec.Features, h.useLaunchSecurityTDX)
 
 	if h.hasVMPort {
 		domain.Spec.Features.VMPort = &api.FeatureState{State: "off"}
@@ -53,7 +53,7 @@ func (h HypervisorFeaturesDomainConfigurator) Configure(vmi *v1.VirtualMachineIn
 	return nil
 }
 
-func convert_v1_Features_To_api_Features(source *v1.Features, features *api.Features, useLaunchSecurityTDX bool) {
+func convertFeaturesToAPIFeatures(source *v1.Features, features *api.Features, useLaunchSecurityTDX bool) {
 	if source.ACPI.Enabled == nil || *source.ACPI.Enabled {
 		features.ACPI = &api.FeatureEnabled{}
 	}
@@ -69,7 +69,7 @@ func convert_v1_Features_To_api_Features(source *v1.Features, features *api.Feat
 	}
 	if source.Hyperv != nil {
 		features.Hyperv = &api.FeatureHyperv{}
-		convert_v1_FeatureHyperv_To_api_FeatureHyperv(source.Hyperv, features.Hyperv)
+		convertFeatureHypervToAPIFeatureHyperv(source.Hyperv, features.Hyperv)
 	} else if source.HypervPassthrough != nil && *source.HypervPassthrough.Enabled {
 		features.Hyperv = &api.FeatureHyperv{
 			Mode: api.HypervModePassthrough,
@@ -95,7 +95,7 @@ func convert_v1_Features_To_api_Features(source *v1.Features, features *api.Feat
 	}
 }
 
-func convert_v1_FeatureHyperv_To_api_FeatureHyperv(source *v1.FeatureHyperv, hyperv *api.FeatureHyperv) {
+func convertFeatureHypervToAPIFeatureHyperv(source *v1.FeatureHyperv, hyperv *api.FeatureHyperv) {
 	if source.Spinlocks != nil {
 		hyperv.Spinlocks = &api.FeatureSpinlocks{
 			State:   boolToOnOff(source.Spinlocks.Enabled, true),

--- a/pkg/virt-launcher/virtwrap/converter/compute/memory.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/memory.go
@@ -26,8 +26,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter/vcpu"
 )
 
-type MemoryConfigurator struct {
-}
+type MemoryConfigurator struct{}
 
 func (r MemoryConfigurator) Configure(vmi *v1.VirtualMachineInstance, domain *api.Domain) error {
 	if vmi.Spec.Domain.Memory == nil ||

--- a/pkg/virt-launcher/virtwrap/converter/compute/memory_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/memory_test.go
@@ -74,9 +74,9 @@ var _ = Describe("Memory Domain Configurator", func() {
 	})
 
 	Context("configure multiple memory fields", func() {
-		var guestMemory resource.Quantity = resource.MustParse("32Mi")
-		var maxGuestMemory resource.Quantity = resource.MustParse("128Mi")
-		var guestMemoryOption libvmi.Option = libvmi.WithGuestMemory(guestMemory.String())
+		guestMemory := resource.MustParse("32Mi")
+		maxGuestMemory := resource.MustParse("128Mi")
+		guestMemoryOption := libvmi.WithGuestMemory(guestMemory.String())
 
 		DescribeTable("maxGuest and guest memory settings",
 			func(vmi *v1.VirtualMachineInstance, expectedGuestMemory, expectedMaxMemory *resource.Quantity) {

--- a/pkg/virt-launcher/virtwrap/converter/compute/memory_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/memory_test.go
@@ -79,7 +79,7 @@ var _ = Describe("Memory Domain Configurator", func() {
 		var guestMemoryOption libvmi.Option = libvmi.WithGuestMemory(guestMemory.String())
 
 		DescribeTable("maxGuest and guest memory settings",
-			func(vmi *v1.VirtualMachineInstance, expectedGuestMemory *resource.Quantity, expectedMaxMemory *resource.Quantity) {
+			func(vmi *v1.VirtualMachineInstance, expectedGuestMemory, expectedMaxMemory *resource.Quantity) {
 				domain := &api.Domain{}
 				configurator := compute.MemoryConfigurator{}
 				Expect(configurator.Configure(vmi, domain)).To(Succeed())

--- a/pkg/virt-launcher/virtwrap/converter/compute/memory_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/memory_test.go
@@ -106,7 +106,11 @@ var _ = Describe("Memory Domain Configurator", func() {
 			},
 			Entry("maxGuest is missing", libvmi.New(guestMemoryOption), &guestMemory, nil),
 			Entry("maxGuest equal to guest memory", libvmi.New(guestMemoryOption, libvmi.WithMaxGuest(guestMemory.String())), &guestMemory, nil),
-			Entry("maxGuest greater than guest memory", libvmi.New(guestMemoryOption, libvmi.WithMaxGuest(maxGuestMemory.String())), &guestMemory, &maxGuestMemory),
+			Entry("maxGuest greater than guest memory",
+				libvmi.New(guestMemoryOption, libvmi.WithMaxGuest(maxGuestMemory.String())),
+				&guestMemory,
+				&maxGuestMemory,
+			),
 		)
 
 		DescribeTable("guest memory and resource requests/limits settings",

--- a/pkg/virt-launcher/virtwrap/converter/compute/os.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/os.go
@@ -200,7 +200,7 @@ func configureACPI(firmware *v1.Firmware, domain *api.Domain, volumes []v1.Volum
 	}
 
 	if firmware.ACPI.SlicNameRef == "" && firmware.ACPI.MsdmNameRef == "" {
-		return fmt.Errorf("No ACPI tables were set. Expecting at least one.")
+		return fmt.Errorf("no ACPI tables were set, expecting at least one")
 	}
 
 	if domain.Spec.OS.ACPI == nil {
@@ -237,7 +237,7 @@ func createACPITable(tableType, volumeName string, volumes []v1.Volume) (*api.AC
 
 		if volume.Secret == nil {
 			// Unsupported. This should have been blocked by webhook, so warn user.
-			return nil, fmt.Errorf("Firmware's volume type is unsupported for %s", tableType)
+			return nil, fmt.Errorf("firmware's volume type is unsupported for %s", tableType)
 		}
 
 		// Return path to table's binary data
@@ -249,5 +249,5 @@ func createACPITable(tableType, volumeName string, volumes []v1.Volume) (*api.AC
 		}, nil
 	}
 
-	return nil, fmt.Errorf("Firmware's volume for %s was not found", tableType)
+	return nil, fmt.Errorf("firmware's volume for %s was not found", tableType)
 }

--- a/pkg/virt-launcher/virtwrap/converter/compute/os.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/os.go
@@ -58,7 +58,7 @@ func NewOSDomainConfigurator(isSMBiosNeeded bool, efiConfiguration *EFIConfigura
 }
 
 func (o OSDomainConfigurator) Configure(vmi *v1.VirtualMachineInstance, domain *api.Domain) error {
-	if err := o.convert_v1_Firmware_To_related_apis(vmi, domain); err != nil {
+	if err := o.convertFirmwareToRelatedAPIs(vmi, domain); err != nil {
 		return err
 	}
 
@@ -94,7 +94,7 @@ func configureBootMenu(vmi *v1.VirtualMachineInstance, domain *api.Domain) {
 	}
 }
 
-func (o OSDomainConfigurator) convert_v1_Firmware_To_related_apis(vmi *v1.VirtualMachineInstance, domain *api.Domain) error {
+func (o OSDomainConfigurator) convertFirmwareToRelatedAPIs(vmi *v1.VirtualMachineInstance, domain *api.Domain) error {
 	firmware := vmi.Spec.Domain.Firmware
 	if firmware == nil {
 		return nil

--- a/pkg/virt-launcher/virtwrap/converter/compute/os_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/os_test.go
@@ -280,14 +280,18 @@ func withStartStrategy(strategy v1.StartStrategy) libvmi.Option {
 	}
 }
 
+func ensureBootloader(vmi *v1.VirtualMachineInstance) {
+	if vmi.Spec.Domain.Firmware == nil {
+		vmi.Spec.Domain.Firmware = &v1.Firmware{}
+	}
+	if vmi.Spec.Domain.Firmware.Bootloader == nil {
+		vmi.Spec.Domain.Firmware.Bootloader = &v1.Bootloader{}
+	}
+}
+
 func withBIOSUseSerial(useSerial bool) libvmi.Option {
 	return func(vmi *v1.VirtualMachineInstance) {
-		if vmi.Spec.Domain.Firmware == nil {
-			vmi.Spec.Domain.Firmware = &v1.Firmware{}
-		}
-		if vmi.Spec.Domain.Firmware.Bootloader == nil {
-			vmi.Spec.Domain.Firmware.Bootloader = &v1.Bootloader{}
-		}
+		ensureBootloader(vmi)
 		vmi.Spec.Domain.Firmware.Bootloader.BIOS = &v1.BIOS{
 			UseSerial: pointer.P(useSerial),
 		}
@@ -307,12 +311,7 @@ func withKernelArgs(args string) libvmi.Option {
 
 func withEFIBootloader(secureBoot bool) libvmi.Option {
 	return func(vmi *v1.VirtualMachineInstance) {
-		if vmi.Spec.Domain.Firmware == nil {
-			vmi.Spec.Domain.Firmware = &v1.Firmware{}
-		}
-		if vmi.Spec.Domain.Firmware.Bootloader == nil {
-			vmi.Spec.Domain.Firmware.Bootloader = &v1.Bootloader{}
-		}
+		ensureBootloader(vmi)
 		vmi.Spec.Domain.Firmware.Bootloader.EFI = &v1.EFI{
 			SecureBoot: pointer.P(secureBoot),
 		}

--- a/pkg/virt-launcher/virtwrap/converter/compute/os_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/os_test.go
@@ -37,7 +37,6 @@ import (
 )
 
 var _ = Describe("OS Domain Configurator", func() {
-
 	const (
 		smbiosEnabled    = true
 		useSerialEnabled = true

--- a/pkg/virt-launcher/virtwrap/converter/compute/os_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/os_test.go
@@ -255,13 +255,13 @@ var _ = Describe("OS Domain Configurator", func() {
 		},
 			Entry("when ACPI volume is not found",
 				libvmi.New(withACPISlic("missing-volume")),
-				"Firmware's volume for slic was not found"),
+				"firmware's volume for slic was not found"),
 			Entry("when ACPI is set but no tables are specified",
 				libvmi.New(withEmptyACPI()),
-				"No ACPI tables were set. Expecting at least one."),
+				"no ACPI tables were set, expecting at least one"),
 			Entry("when ACPI volume is not a secret",
 				libvmi.New(withACPISlic("config-volume"), withConfigMapVolume("config-volume")),
-				"Firmware's volume type is unsupported for slic"),
+				"firmware's volume type is unsupported for slic"),
 		)
 	})
 })

--- a/pkg/virt-launcher/virtwrap/converter/compute/qemu_cmd.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/qemu_cmd.go
@@ -49,7 +49,10 @@ func (q QemuCmdDomainConfigurator) Configure(vmi *v1.VirtualMachineInstance, dom
 		initializeQEMUCmdAndQEMUArg(domain)
 		domain.Spec.QEMUCmd.QEMUArg = append(domain.Spec.QEMUCmd.QEMUArg, api.Arg{Value: "-fw_cfg"})
 		ignitionpath := fmt.Sprintf("%s/%s", ignition.GetDomainBasePath(vmi.Name, vmi.Namespace), ignition.IgnitionFile)
-		domain.Spec.QEMUCmd.QEMUArg = append(domain.Spec.QEMUCmd.QEMUArg, api.Arg{Value: fmt.Sprintf("name=opt/com.coreos/config,file=%s", ignitionpath)})
+		domain.Spec.QEMUCmd.QEMUArg = append(
+			domain.Spec.QEMUCmd.QEMUArg,
+			api.Arg{Value: fmt.Sprintf("name=opt/com.coreos/config,file=%s", ignitionpath)},
+		)
 	}
 
 	if q.verboseLogEnabled {

--- a/pkg/virt-launcher/virtwrap/converter/compute/sysinfo.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/sysinfo.go
@@ -60,7 +60,7 @@ func buildSystem(firmware *v1.Firmware, smBIOS *SMBIOS) []api.Entry {
 	if firmware != nil {
 		systemEntries = []api.Entry{{Name: "uuid", Value: string(firmware.UUID)}}
 
-		if len(firmware.Serial) > 0 {
+		if firmware.Serial != "" {
 			systemEntries = append(systemEntries, api.Entry{Name: "serial", Value: firmware.Serial})
 		}
 	}

--- a/pkg/virt-launcher/virtwrap/converter/compute/usb_redir.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/usb_redir.go
@@ -29,7 +29,7 @@ import (
 
 type UsbRedirectDeviceDomainConfigurator struct{}
 
-func (_ UsbRedirectDeviceDomainConfigurator) Configure(vmi *v1.VirtualMachineInstance, domain *api.Domain) error {
+func (UsbRedirectDeviceDomainConfigurator) Configure(vmi *v1.VirtualMachineInstance, domain *api.Domain) error {
 	clientDevices := vmi.Spec.Domain.Devices.ClientPassthrough
 
 	// Default is to have USB Redirection disabled

--- a/pkg/virt-launcher/virtwrap/converter/compute/vsock_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/vsock_test.go
@@ -117,6 +117,6 @@ var _ = Describe("VSOCK Domain Configurator", func() {
 
 func createFakeVsockModeFile(tmpDir, vsockMode string) {
 	vsockPath := filepath.Join(tmpDir, "sys", "net", "vsock")
-	Expect(os.MkdirAll(vsockPath, 0755)).To(Succeed())
-	Expect(os.WriteFile(filepath.Join(vsockPath, "ns_mode"), []byte(vsockMode+"\n"), 0600)).To(Succeed())
+	Expect(os.MkdirAll(vsockPath, 0o755)).To(Succeed())
+	Expect(os.WriteFile(filepath.Join(vsockPath, "ns_mode"), []byte(vsockMode+"\n"), 0o600)).To(Succeed())
 }

--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -3874,17 +3874,17 @@ var _ = Describe("Converter", func() {
 					VolumeSource: v1.VolumeSource{
 						ConfigMap: &v1.ConfigMapVolumeSource{},
 					},
-				}, "", nil, "Firmware's volume type is unsupported for slic"),
+				}, "", nil, "firmware's volume type is unsupported for slic"),
 			Entry("msdm with configmap", "", nil,
 				"vol-msdm", &v1.Volume{
 					Name: "vol-msdm",
 					VolumeSource: v1.VolumeSource{
 						ConfigMap: &v1.ConfigMapVolumeSource{},
 					},
-				}, "Firmware's volume type is unsupported for msdm"),
+				}, "firmware's volume type is unsupported for msdm"),
 			// without matching volume source
-			Entry("slic without volume", "vol-slic", &v1.Volume{}, "", &v1.Volume{}, "Firmware's volume for slic was not found"),
-			Entry("msdm without volume", "", &v1.Volume{}, "vol-msdm", &v1.Volume{}, "Firmware's volume for msdm was not found"),
+			Entry("slic without volume", "vol-slic", &v1.Volume{}, "", &v1.Volume{}, "firmware's volume for slic was not found"),
+			Entry("msdm without volume", "", &v1.Volume{}, "vol-msdm", &v1.Volume{}, "firmware's volume for msdm was not found"),
 			// try both togeter, correct input
 			Entry("slic and msdm with secret",
 				"vol-slic", &v1.Volume{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
The `converter/compute` package is not covered by the project's linter.
This PR fixes all lint violations and adds the package to `lint-paths.txt`:
- Run `make gofumpt` to fix formatting
- Wrap long lines to stay within the 140-character lll limit
- Rename underscore-separated functions to camelCase and fix variable casing (ST1003), drop unused receiver name (ST1006)
- Lowercase error strings (ST1005), remove unnecessary `uint()` cast, simplify var declarations (ST1023), replace `len(s) > 0` with `s != ""` (S1009)
- Fix a test bug where a "multiple SCSI disks" entry reused the same disk name
- Deduplicate bootloader nil-guard logic in OS test helpers
- Suppress gosec G115 with a nolint directive for a safe int64-to-uint64 memory conversion

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

