### PR TITLE
VEP 190: Guard plugin ValidatingAdmissionPolicies behind Plugins feature gate

### DIFF
--- a/pkg/virt-operator/kubevirt_test.go
+++ b/pkg/virt-operator/kubevirt_test.go
@@ -92,8 +92,8 @@ const (
 	NAMESPACE = "kubevirt-test"
 
 	// +1 for ContainerPathVolumes webhook (always enabled in tests)
-	resourceCount = 104 + virtTemplateResourceCount
-	patchCount    = 72 + virtTemplatePatchCount
+	resourceCount = 96 + virtTemplateResourceCount
+	patchCount    = 64 + virtTemplatePatchCount
 	updateCount   = 33 + virtTemplateUpdateCount
 
 	// 1 because a temporary validation webhook is created to block new CRDs until api server is deployed
@@ -1400,10 +1400,12 @@ func (k *KubeVirtTestData) addAllWithExclusionMap(config *util.KubeVirtDeploymen
 
 	userName := fmt.Sprintf("system:serviceaccount:%s:%s", config.GetNamespace(), components.HandlerServiceAccountName)
 	all = append(all, vap.NewHandlerV1ValidatingAdmissionPolicy(userName), vap.NewHandlerV1ValidatingAdmissionPolicyBinding())
-	all = append(all, vap.NewPluginValidatingAdmissionPolicy(), vap.NewPluginValidatingAdmissionPolicyBinding())
-	all = append(all, vap.NewPluginWarningAdmissionPolicy(), vap.NewPluginWarningAdmissionPolicyBinding())
-	all = append(all, vap.NewSidecarSubPathValidatingAdmissionPolicy(), vap.NewSidecarSubPathValidatingAdmissionPolicyBinding())
-	all = append(all, vap.NewPluginSocketPathValidatingAdmissionPolicy(), vap.NewPluginSocketPathValidatingAdmissionPolicyBinding())
+	if config.PluginsEnabled() {
+		all = append(all, vap.NewPluginValidatingAdmissionPolicy(), vap.NewPluginValidatingAdmissionPolicyBinding())
+		all = append(all, vap.NewPluginWarningAdmissionPolicy(), vap.NewPluginWarningAdmissionPolicyBinding())
+		all = append(all, vap.NewSidecarSubPathValidatingAdmissionPolicy(), vap.NewSidecarSubPathValidatingAdmissionPolicyBinding())
+		all = append(all, vap.NewPluginSocketPathValidatingAdmissionPolicy(), vap.NewPluginSocketPathValidatingAdmissionPolicyBinding())
+	}
 
 	if config.VirtTemplateDeploymentEnabled() {
 		resources, err := components.NewVirtTemplateResources(config)

--- a/pkg/virt-operator/resource/generate/install/strategy.go
+++ b/pkg/virt-operator/resource/generate/install/strategy.go
@@ -633,16 +633,18 @@ func GenerateCurrentInstallStrategy(config *operatorutil.KubeVirtDeploymentConfi
 	virtHandlerServiceAccount := getVirtHandlerServiceAccount(config.GetNamespace())
 	strategy.validatingAdmissionPolicies = append(strategy.validatingAdmissionPolicies, vap.NewHandlerV1ValidatingAdmissionPolicy(virtHandlerServiceAccount))
 
-	strategy.validatingAdmissionPolicyBindings = append(strategy.validatingAdmissionPolicyBindings, vap.NewPluginValidatingAdmissionPolicyBinding())
-	strategy.validatingAdmissionPolicies = append(strategy.validatingAdmissionPolicies, vap.NewPluginValidatingAdmissionPolicy())
-	strategy.validatingAdmissionPolicyBindings = append(strategy.validatingAdmissionPolicyBindings, vap.NewPluginWarningAdmissionPolicyBinding())
-	strategy.validatingAdmissionPolicies = append(strategy.validatingAdmissionPolicies, vap.NewPluginWarningAdmissionPolicy())
+	if config.PluginsEnabled() {
+		strategy.validatingAdmissionPolicyBindings = append(strategy.validatingAdmissionPolicyBindings, vap.NewPluginValidatingAdmissionPolicyBinding())
+		strategy.validatingAdmissionPolicies = append(strategy.validatingAdmissionPolicies, vap.NewPluginValidatingAdmissionPolicy())
+		strategy.validatingAdmissionPolicyBindings = append(strategy.validatingAdmissionPolicyBindings, vap.NewPluginWarningAdmissionPolicyBinding())
+		strategy.validatingAdmissionPolicies = append(strategy.validatingAdmissionPolicies, vap.NewPluginWarningAdmissionPolicy())
 
-	strategy.validatingAdmissionPolicyBindings = append(strategy.validatingAdmissionPolicyBindings, vap.NewSidecarSubPathValidatingAdmissionPolicyBinding())
-	strategy.validatingAdmissionPolicies = append(strategy.validatingAdmissionPolicies, vap.NewSidecarSubPathValidatingAdmissionPolicy())
+		strategy.validatingAdmissionPolicyBindings = append(strategy.validatingAdmissionPolicyBindings, vap.NewSidecarSubPathValidatingAdmissionPolicyBinding())
+		strategy.validatingAdmissionPolicies = append(strategy.validatingAdmissionPolicies, vap.NewSidecarSubPathValidatingAdmissionPolicy())
 
-	strategy.validatingAdmissionPolicyBindings = append(strategy.validatingAdmissionPolicyBindings, vap.NewPluginSocketPathValidatingAdmissionPolicyBinding())
-	strategy.validatingAdmissionPolicies = append(strategy.validatingAdmissionPolicies, vap.NewPluginSocketPathValidatingAdmissionPolicy())
+		strategy.validatingAdmissionPolicyBindings = append(strategy.validatingAdmissionPolicyBindings, vap.NewPluginSocketPathValidatingAdmissionPolicyBinding())
+		strategy.validatingAdmissionPolicies = append(strategy.validatingAdmissionPolicies, vap.NewPluginSocketPathValidatingAdmissionPolicy())
+	}
 
 	instancetypes, err := components.NewClusterInstancetypes()
 	if err != nil {

--- a/pkg/virt-operator/util/config.go
+++ b/pkg/virt-operator/util/config.go
@@ -104,6 +104,9 @@ const (
 	AdditionalPropertiesVMStatsCollectorEnabled = "VMStatsCollectorEnabled"
 
 	// lookup key in AdditionalProperties
+	AdditionalPropertiesPluginsEnabled = "PluginsEnabled"
+
+	// lookup key in AdditionalProperties
 	AdditionalPropertiesSynchronizationPort       = "SynchronizationPort"
 	DefaultSynchronizationPort              int32 = 9185
 
@@ -208,6 +211,10 @@ func GetTargetConfigFromKVWithEnvVarManager(kv *v1.KubeVirt, envVarManager EnvVa
 
 	if isFeatureGateEnabledInKvConfig(&kv.Spec.Configuration, featuregate.VMStatsCollector) {
 		additionalProperties[AdditionalPropertiesVMStatsCollectorEnabled] = ""
+	}
+
+	if isFeatureGateEnabledInKvConfig(&kv.Spec.Configuration, featuregate.PluginsGate) {
+		additionalProperties[AdditionalPropertiesPluginsEnabled] = ""
 	}
 
 	if isFeatureGateEnabledInKvConfig(&kv.Spec.Configuration, featuregate.OptOutRoleAggregation) {
@@ -581,6 +588,11 @@ func (c *KubeVirtDeploymentConfig) VMStatsCollectorEnabled() bool {
 
 func (c *KubeVirtDeploymentConfig) OptOutRoleAggregationEnabled() bool {
 	_, enabled := c.AdditionalProperties[AdditionalPropertiesOptOutRoleAggregation]
+	return enabled
+}
+
+func (c *KubeVirtDeploymentConfig) PluginsEnabled() bool {
+	_, enabled := c.AdditionalProperties[AdditionalPropertiesPluginsEnabled]
 	return enabled
 }
 


### PR DESCRIPTION
### What this PR does
#### Before this PR:
Plugin-related ValidatingAdmissionPolicies (Plugin CRD validation, sidecar subPath enforcement, plugin socket path validation) were deployed unconditionally, even when the Plugins feature gate was disabled.

#### After this PR:
These VAPs are only deployed when `config.PluginsEnabled()` returns true. A new `AdditionalPropertiesPluginsEnabled` constant, config builder entry, and `PluginsEnabled()` method gate the deployment. The test helper mirrors the same guard.

### References
- VEP: https://github.com/kubevirt/enhancements/issues/190

### Checklist

- [x] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- ~~- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required~~
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- ~~- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.~~
- ~~- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered~~
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
NONE
```
