### PR TITLE
tests: add Conformance to PVC expansion test

### DIFF
--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -122,7 +122,7 @@ var _ = Describe(SIG("DataVolume Integration", func() {
 	}
 
 	Context("[storage-req]PVC expansion", decorators.StorageReq, decorators.RequiresVolumeExpansion, func() {
-		DescribeTable("PVC expansion is detected by VM and can be fully used", func(volumeMode k8sv1.PersistentVolumeMode) {
+		DescribeTable("PVC expansion is detected by VM and can be fully used", decorators.StorageCritical, func(volumeMode k8sv1.PersistentVolumeMode) {
 			var sc string
 			exists := false
 			if volumeMode == k8sv1.PersistentVolumeBlock {

--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -122,7 +122,7 @@ var _ = Describe(SIG("DataVolume Integration", func() {
 	}
 
 	Context("[storage-req]PVC expansion", decorators.StorageReq, decorators.RequiresVolumeExpansion, func() {
-		DescribeTable("PVC expansion is detected by VM and can be fully used", func(volumeMode k8sv1.PersistentVolumeMode) {
+		DescribeTable("PVC expansion is detected by VM and can be fully used", decorators.Conformance, func(volumeMode k8sv1.PersistentVolumeMode) {
 			var sc string
 			exists := false
 			if volumeMode == k8sv1.PersistentVolumeBlock {


### PR DESCRIPTION
## Summary

Add `decorators.Conformance` to the "PVC expansion is detected by VM and can be fully used" `DescribeTable` so both entries (Block PVC and Filesystem PVC) are included in the storage self-certification suite.

## Why Conformance

Online volume expansion is a GA feature and a core storage capability that cloud providers depend on when running OpenShift Virtualization, The test verifies that a VM detects an online PVC resize and that the expanded space is fully usable — covering a rea= workflow (expand a VM disk while it's running, confirm the guest OS sees the new size), marking it `Conformance` ensures it is gated in the storage self-certification suite alongside other GA storage tests.

## Changes

- `tests/storage/datavolume.go`: Add `decorators.Conformance` to the PVC expansion `DescribeTable`

## Test plan

- [x] Verified the test runs standalone with `--ginkgo.focus="PVC expansion is detected by VM"`
- [x] Confirmed both Block and Filesystem entries inherit the `Conformance` label
- [x] Ran as self-validation T1 storage test on GCP (Hyperdisk Balanced) — Filesystem passed
- [x] Ran as self-validation T1 storage test on PSI (Ceph RBD) — passed

```release-note
Add Conformance decorator to PVC expansion test for storage
self-certification coverage.
```