### PR TITLE
sidecar hooks: preserve QEMUCmd across XML round-trip

### DIFF
--- a/pkg/virt-launcher/virtwrap/converter/translate/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/converter/translate/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
+        "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/libvirt.org/go/libvirtxml:go_default_library",
     ],
 )

--- a/pkg/virt-launcher/virtwrap/converter/translate/translate.go
+++ b/pkg/virt-launcher/virtwrap/converter/translate/translate.go
@@ -22,8 +22,12 @@ package translate
 import (
 	"encoding/xml"
 	"fmt"
+	"io"
+	"strings"
 
 	libvirtxml "libvirt.org/go/libvirtxml"
+
+	"kubevirt.io/client-go/log"
 
 	api "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )
@@ -63,29 +67,106 @@ func FromLibvirtDomain(domain *libvirtxml.Domain) (*api.DomainSpec, error) {
 	if err := xml.Unmarshal([]byte(xmlStr), spec); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal XML into DomainSpec: %w", err)
 	}
-	transferQEMUCommandline(domain, spec)
+	TransferQEMUCommandline(xmlStr, spec)
 	return spec, nil
 }
 
 const qemuNamespace = "http://libvirt.org/schemas/domain/qemu/1.0"
 
-// transferQEMUCommandline copies QEMU commandline args and envs from the
-// libvirtxml Domain to the KubeVirt DomainSpec. Go's encoding/xml cannot
-// unmarshal elements with namespace-prefixed struct tags (e.g. xml:"qemu:commandline"),
-// so this transfer must be done at the struct level.
-func transferQEMUCommandline(domain *libvirtxml.Domain, spec *api.DomainSpec) {
-	if domain.QEMUCommandline == nil {
+// TransferQEMUCommandline extracts qemu:commandline args and envs from raw
+// domain XML and applies them to the KubeVirt DomainSpec. Go's encoding/xml
+// cannot unmarshal namespace-prefixed struct tags (e.g. xml:"qemu:commandline"),
+// so this function uses token-level parsing via xml.Decoder, which resolves
+// namespace URIs correctly. Only elements in the QEMU namespace are inspected;
+// the rest of the domain XML is skipped, so this works with any well-formed
+// XML regardless of schema strictness.
+func TransferQEMUCommandline(domainXML string, spec *api.DomainSpec) {
+	args, envs, hasCommandline := parseQEMUCommandline(domainXML)
+
+	if !hasCommandline {
+		log.Log.Warning("no qemu:commandline section found in domain XML")
 		return
 	}
 	spec.XmlNS = qemuNamespace
-	if len(domain.QEMUCommandline.Args) == 0 && len(domain.QEMUCommandline.Envs) == 0 {
+	if len(args) == 0 && len(envs) == 0 {
 		return
 	}
-	spec.QEMUCmd = &api.Commandline{}
-	for _, arg := range domain.QEMUCommandline.Args {
-		spec.QEMUCmd.QEMUArg = append(spec.QEMUCmd.QEMUArg, api.Arg{Value: arg.Value})
+	spec.QEMUCmd = &api.Commandline{
+		QEMUArg: args,
+		QEMUEnv: envs,
 	}
-	for _, env := range domain.QEMUCommandline.Envs {
-		spec.QEMUCmd.QEMUEnv = append(spec.QEMUCmd.QEMUEnv, api.Env{Name: env.Name, Value: env.Value})
+}
+
+func parseQEMUCommandline(domainXML string) ([]api.Arg, []api.Env, bool) {
+	decoder := xml.NewDecoder(strings.NewReader(domainXML))
+
+	var (
+		args           []api.Arg
+		envs           []api.Env
+		inCommandline  bool
+		hasCommandline bool
+	)
+
+	for {
+		token, err := decoder.Token()
+		if err != nil {
+			if err != io.EOF {
+				log.Log.Warningf("unexpected error parsing domain XML for QEMUCmd: %v", err)
+			}
+			break
+		}
+
+		switch t := token.(type) {
+		case xml.StartElement:
+			if t.Name.Space != qemuNamespace {
+				continue
+			}
+			switch t.Name.Local {
+			case "commandline":
+				inCommandline = true
+				hasCommandline = true
+			case "arg":
+				if inCommandline {
+					args = append(args, parseArgAttrs(t))
+				}
+			case "env":
+				if inCommandline {
+					if env, ok := parseEnvAttrs(t); ok {
+						envs = append(envs, env)
+					}
+				}
+			}
+		case xml.EndElement:
+			if t.Name.Space == qemuNamespace && t.Name.Local == "commandline" {
+				inCommandline = false
+			}
+		}
 	}
+
+	return args, envs, hasCommandline
+}
+
+func parseArgAttrs(t xml.StartElement) api.Arg {
+	for _, attr := range t.Attr {
+		if attr.Name.Local == "value" {
+			return api.Arg{Value: attr.Value}
+		}
+	}
+	return api.Arg{}
+}
+
+func parseEnvAttrs(t xml.StartElement) (api.Env, bool) {
+	var env api.Env
+	for _, attr := range t.Attr {
+		switch attr.Name.Local {
+		case "name":
+			env.Name = attr.Value
+		case "value":
+			env.Value = attr.Value
+		}
+	}
+	if env.Name == "" {
+		return api.Env{}, false
+	}
+	return env, true
 }

--- a/pkg/virt-launcher/virtwrap/converter/translate/translate_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/translate/translate_test.go
@@ -206,6 +206,146 @@ var _ = Describe("Domain translation", func() {
 		})
 	})
 
+	Context("TransferQEMUCommandline", func() {
+		It("should extract args and envs from domain XML", func() {
+			domainXML := `<domain type="kvm" xmlns:qemu="http://libvirt.org/schemas/domain/qemu/1.0">
+				<name>test-vm</name>
+				<qemu:commandline>
+					<qemu:arg value="-fw_cfg"/>
+					<qemu:arg value="name=opt/com.coreos/config,file=/data.ign"/>
+					<qemu:env name="QEMU_AUDIO_DRV" value="none"/>
+				</qemu:commandline>
+			</domain>`
+
+			spec := &api.DomainSpec{}
+			TransferQEMUCommandline(domainXML, spec)
+
+			Expect(spec.XmlNS).To(Equal("http://libvirt.org/schemas/domain/qemu/1.0"))
+			Expect(spec.QEMUCmd).NotTo(BeNil())
+			Expect(spec.QEMUCmd.QEMUArg).To(HaveLen(2))
+			Expect(spec.QEMUCmd.QEMUArg[0].Value).To(Equal("-fw_cfg"))
+			Expect(spec.QEMUCmd.QEMUArg[1].Value).To(Equal("name=opt/com.coreos/config,file=/data.ign"))
+			Expect(spec.QEMUCmd.QEMUEnv).To(HaveLen(1))
+			Expect(spec.QEMUCmd.QEMUEnv[0].Name).To(Equal("QEMU_AUDIO_DRV"))
+			Expect(spec.QEMUCmd.QEMUEnv[0].Value).To(Equal("none"))
+		})
+
+		It("should set XmlNS but not QEMUCmd for empty commandline", func() {
+			domainXML := `<domain type="kvm" xmlns:qemu="http://libvirt.org/schemas/domain/qemu/1.0">
+				<name>test-vm</name>
+				<qemu:commandline></qemu:commandline>
+			</domain>`
+
+			spec := &api.DomainSpec{}
+			TransferQEMUCommandline(domainXML, spec)
+
+			Expect(spec.XmlNS).To(Equal("http://libvirt.org/schemas/domain/qemu/1.0"))
+			Expect(spec.QEMUCmd).To(BeNil())
+		})
+
+		It("should not modify spec when no qemu namespace is present", func() {
+			domainXML := `<domain type="kvm">
+				<name>test-vm</name>
+				<devices><disk type="file"/></devices>
+			</domain>`
+
+			spec := &api.DomainSpec{}
+			TransferQEMUCommandline(domainXML, spec)
+
+			Expect(spec.XmlNS).To(BeEmpty())
+			Expect(spec.QEMUCmd).To(BeNil())
+		})
+
+		It("should handle envs without value attribute", func() {
+			domainXML := `<domain type="kvm" xmlns:qemu="http://libvirt.org/schemas/domain/qemu/1.0">
+				<name>test-vm</name>
+				<qemu:commandline>
+					<qemu:env name="DISPLAY"/>
+				</qemu:commandline>
+			</domain>`
+
+			spec := &api.DomainSpec{}
+			TransferQEMUCommandline(domainXML, spec)
+
+			Expect(spec.QEMUCmd).NotTo(BeNil())
+			Expect(spec.QEMUCmd.QEMUEnv).To(HaveLen(1))
+			Expect(spec.QEMUCmd.QEMUEnv[0].Name).To(Equal("DISPLAY"))
+			Expect(spec.QEMUCmd.QEMUEnv[0].Value).To(BeEmpty())
+		})
+
+		It("should skip env entries without a name attribute", func() {
+			domainXML := `<domain type="kvm" xmlns:qemu="http://libvirt.org/schemas/domain/qemu/1.0">
+				<name>test-vm</name>
+				<qemu:commandline>
+					<qemu:env value="orphan"/>
+					<qemu:env name="VALID" value="yes"/>
+				</qemu:commandline>
+			</domain>`
+
+			spec := &api.DomainSpec{}
+			TransferQEMUCommandline(domainXML, spec)
+
+			Expect(spec.QEMUCmd).NotTo(BeNil())
+			Expect(spec.QEMUCmd.QEMUEnv).To(HaveLen(1))
+			Expect(spec.QEMUCmd.QEMUEnv[0].Name).To(Equal("VALID"))
+		})
+
+		It("should include arg with empty value attribute", func() {
+			domainXML := `<domain type="kvm" xmlns:qemu="http://libvirt.org/schemas/domain/qemu/1.0">
+				<name>test-vm</name>
+				<qemu:commandline>
+					<qemu:arg value=""/>
+					<qemu:arg value="-nographic"/>
+				</qemu:commandline>
+			</domain>`
+
+			spec := &api.DomainSpec{}
+			TransferQEMUCommandline(domainXML, spec)
+
+			Expect(spec.QEMUCmd).NotTo(BeNil())
+			Expect(spec.QEMUCmd.QEMUArg).To(HaveLen(2))
+			Expect(spec.QEMUCmd.QEMUArg[0].Value).To(BeEmpty())
+			Expect(spec.QEMUCmd.QEMUArg[1].Value).To(Equal("-nographic"))
+		})
+
+		It("should aggregate args across multiple commandline blocks", func() {
+			domainXML := `<domain type="kvm" xmlns:qemu="http://libvirt.org/schemas/domain/qemu/1.0">
+				<name>test-vm</name>
+				<qemu:commandline>
+					<qemu:arg value="-fw_cfg"/>
+				</qemu:commandline>
+				<qemu:commandline>
+					<qemu:arg value="-device"/>
+				</qemu:commandline>
+			</domain>`
+
+			spec := &api.DomainSpec{}
+			TransferQEMUCommandline(domainXML, spec)
+
+			Expect(spec.QEMUCmd).NotTo(BeNil())
+			Expect(spec.QEMUCmd.QEMUArg).To(HaveLen(2))
+			Expect(spec.QEMUCmd.QEMUArg[0].Value).To(Equal("-fw_cfg"))
+			Expect(spec.QEMUCmd.QEMUArg[1].Value).To(Equal("-device"))
+		})
+
+		It("should skip qemu elements outside commandline block", func() {
+			domainXML := `<domain type="kvm" xmlns:qemu="http://libvirt.org/schemas/domain/qemu/1.0">
+				<name>test-vm</name>
+				<qemu:arg value="stray"/>
+				<qemu:commandline>
+					<qemu:arg value="real"/>
+				</qemu:commandline>
+			</domain>`
+
+			spec := &api.DomainSpec{}
+			TransferQEMUCommandline(domainXML, spec)
+
+			Expect(spec.QEMUCmd).NotTo(BeNil())
+			Expect(spec.QEMUCmd.QEMUArg).To(HaveLen(1))
+			Expect(spec.QEMUCmd.QEMUArg[0].Value).To(Equal("real"))
+		})
+	})
+
 	Context("Round-trip fidelity", func() {
 		It("should round-trip a DomainSpec with metadata", func() {
 			spec := api.NewMinimalDomainSpec("test-vm")

--- a/pkg/virt-launcher/virtwrap/util/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/util/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//pkg/virt-launcher/virtwrap/cli:go_default_library",
         "//pkg/virt-launcher/virtwrap/converter/compute:go_default_library",
+        "//pkg/virt-launcher/virtwrap/converter/translate:go_default_library",
         "//pkg/virt-launcher/virtwrap/plugins:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/api/plugin/v1alpha1:go_default_library",

--- a/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
+++ b/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
@@ -22,6 +22,7 @@ import (
 	"libvirt.org/go/libvirt"
 
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter/compute"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter/translate"
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
@@ -152,6 +153,12 @@ func ApplySidecarHooks(vmi *v1.VirtualMachineInstance, wantedSpec *api.DomainSpe
 		return "", err
 	}
 	domainSpecObj.DeepCopyInto(wantedSpec)
+
+	// Go's encoding/xml cannot unmarshal namespace-prefixed struct tags
+	// (e.g. xml:"qemu:commandline"), so QEMUCmd is silently lost during
+	// the round-trip above. Re-extract it from the hook-returned XML
+	// using namespace-aware token parsing.
+	translate.TransferQEMUCommandline(domainSpec, wantedSpec)
 
 	return domainSpec, nil
 }

--- a/pkg/virt-launcher/virtwrap/util/libvirt_helper_test.go
+++ b/pkg/virt-launcher/virtwrap/util/libvirt_helper_test.go
@@ -276,6 +276,146 @@ var _ = Describe("LibvirtHelper", func() {
 		Expect(wantedSpec.Devices.Disks).To(Equal(mutatedSpec.Devices.Disks))
 	})
 
+	Context("QEMUCmd preservation across sidecar hooks", func() {
+		var (
+			vmi             *v1.VirtualMachineInstance
+			ctrl            *gomock.Controller
+			mockHookManager *hooks.MockManager
+		)
+
+		BeforeEach(func() {
+			ctrl = gomock.NewController(GinkgoT())
+			vmi = api2.NewMinimalVMIWithNS("test-namespace", "test-vmi")
+			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
+			mockHookManager = hooks.NewMockManager(ctrl)
+			getHookManager = func() hooks.Manager {
+				return mockHookManager
+			}
+		})
+
+		AfterEach(func() {
+			getHookManager = hooks.GetManager
+		})
+
+		marshalSpec := func(spec *api.DomainSpec, _ *v1.VirtualMachineInstance) (string, error) {
+			xmlBytes, err := xml.MarshalIndent(spec, "", "\t")
+			if err != nil {
+				return "", err
+			}
+			return string(xmlBytes), nil
+		}
+
+		It("should preserve QEMUCmd args and envs across the round-trip", func() {
+			wantedSpec := &api.DomainSpec{
+				Type:  "kvm",
+				XmlNS: "http://libvirt.org/schemas/domain/qemu/1.0",
+				Name:  "test-vm",
+				QEMUCmd: &api.Commandline{
+					QEMUArg: []api.Arg{
+						{Value: "-fw_cfg"},
+						{Value: "name=opt/com.coreos/config,file=/var/run/test/data.ign"},
+					},
+					QEMUEnv: []api.Env{
+						{Name: "QEMU_AUDIO_DRV", Value: "none"},
+					},
+				},
+			}
+
+			mockHookManager.EXPECT().OnDefineDomain(wantedSpec, vmi).DoAndReturn(marshalSpec)
+
+			_, err := ApplySidecarHooks(vmi, wantedSpec)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(wantedSpec.QEMUCmd).NotTo(BeNil())
+			Expect(wantedSpec.QEMUCmd.QEMUArg).To(HaveLen(2))
+			Expect(wantedSpec.QEMUCmd.QEMUArg[0].Value).To(Equal("-fw_cfg"))
+			Expect(wantedSpec.QEMUCmd.QEMUArg[1].Value).To(
+				Equal("name=opt/com.coreos/config,file=/var/run/test/data.ign"))
+			Expect(wantedSpec.QEMUCmd.QEMUEnv).To(HaveLen(1))
+			Expect(wantedSpec.QEMUCmd.QEMUEnv[0].Name).To(Equal("QEMU_AUDIO_DRV"))
+			Expect(wantedSpec.QEMUCmd.QEMUEnv[0].Value).To(Equal("none"))
+		})
+
+		It("should not introduce QEMUCmd when the spec has none", func() {
+			wantedSpec := &api.DomainSpec{
+				Type: "kvm",
+				Name: "test-vm",
+			}
+
+			mockHookManager.EXPECT().OnDefineDomain(wantedSpec, vmi).DoAndReturn(marshalSpec)
+
+			_, err := ApplySidecarHooks(vmi, wantedSpec)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(wantedSpec.QEMUCmd).To(BeNil())
+		})
+
+		It("should capture hook-added QEMUCmd args", func() {
+			wantedSpec := &api.DomainSpec{
+				Type:  "kvm",
+				XmlNS: "http://libvirt.org/schemas/domain/qemu/1.0",
+				Name:  "test-vm",
+				QEMUCmd: &api.Commandline{
+					QEMUArg: []api.Arg{
+						{Value: "-fw_cfg"},
+						{Value: "name=opt/com.coreos/config,file=/var/run/test/data.ign"},
+					},
+				},
+			}
+
+			mockHookManager.EXPECT().OnDefineDomain(wantedSpec, vmi).DoAndReturn(
+				func(spec *api.DomainSpec, _ *v1.VirtualMachineInstance) (string, error) {
+					modified := spec.DeepCopy()
+					modified.QEMUCmd.QEMUArg = append(modified.QEMUCmd.QEMUArg,
+						api.Arg{Value: "-device"},
+						api.Arg{Value: "virtio-rng"},
+					)
+					xmlBytes, err := xml.MarshalIndent(modified, "", "\t")
+					if err != nil {
+						return "", err
+					}
+					return string(xmlBytes), nil
+				},
+			)
+
+			_, err := ApplySidecarHooks(vmi, wantedSpec)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(wantedSpec.QEMUCmd).NotTo(BeNil())
+			Expect(wantedSpec.QEMUCmd.QEMUArg).To(HaveLen(4))
+			Expect(wantedSpec.QEMUCmd.QEMUArg[2].Value).To(Equal("-device"))
+			Expect(wantedSpec.QEMUCmd.QEMUArg[3].Value).To(Equal("virtio-rng"))
+		})
+
+		It("should not restore QEMUCmd when the hook removed it", func() {
+			wantedSpec := &api.DomainSpec{
+				Type:  "kvm",
+				XmlNS: "http://libvirt.org/schemas/domain/qemu/1.0",
+				Name:  "test-vm",
+				QEMUCmd: &api.Commandline{
+					QEMUArg: []api.Arg{
+						{Value: "-fw_cfg"},
+						{Value: "name=opt/com.coreos/config,file=/var/run/test/data.ign"},
+					},
+				},
+			}
+
+			mockHookManager.EXPECT().OnDefineDomain(wantedSpec, vmi).DoAndReturn(
+				func(spec *api.DomainSpec, _ *v1.VirtualMachineInstance) (string, error) {
+					stripped := spec.DeepCopy()
+					stripped.QEMUCmd = nil
+					stripped.XmlNS = ""
+					xmlBytes, err := xml.MarshalIndent(stripped, "", "\t")
+					if err != nil {
+						return "", err
+					}
+					return string(xmlBytes), nil
+				},
+			)
+
+			_, err := ApplySidecarHooks(vmi, wantedSpec)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(wantedSpec.QEMUCmd).To(BeNil())
+		})
+	})
+
 	Context("getLibvirtLogFilters()", func() {
 
 		DescribeTable("should return customLogFilters if defined and not empty with", func(libvirtLogVerbosityEnvVar *string, libvirtDebugLogsEnvVarDefined bool) {


### PR DESCRIPTION
### What this PR does
Fixes the XML round-trip bug where Go's `encoding/xml` silently drops `qemu:commandline` elements during the `xml.Unmarshal` → `DeepCopyInto` cycle in `ApplySidecarHooks`.

After the round-trip, `QEMUCmd` is re-extracted from the hook-returned XML using `xml.Decoder` with token-level parsing, which resolves namespace URIs correctly. This captures hook modifications and works with any well-formed XML regardless of schema strictness.

#### Before this PR:
- `ApplySidecarHooks` corrupts the in-memory `DomainSpec` by dropping `QEMUCmd` on every call
- Any code that re-defines the domain using the same `DomainSpec` pointer produces a domain without `<qemu:commandline>`, losing QEMU arguments like `-fw_cfg` (Ignition) or `-device` (SeaBIOS debug)

#### After this PR:
- `QEMUCmd` is preserved through the round-trip by re-parsing the hook-returned XML with namespace-aware token parsing
- Hook modifications to `QEMUCmd` (additions, changes, removals) are correctly captured since the source of truth is the hook-processed XML

### References
- Fixes https://github.com/kubevirt/kubevirt/issues/16901
- Unblocks https://github.com/kubevirt/kubevirt/pull/17605 (PCI hotplug PR that exposed this latent bug)
- Related: `pkg/virt-launcher/virtwrap/converter/translate/translate.go` documents the same Go limitation with an existing workaround for the `libvirtxml.Domain` case

### Release note
```release-note
Fix sidecar hooks silently dropping QEMU command-line arguments (qemu:commandline) during XML round-trip
```