### PR TITLE
[release-1.8] tests: Use WithArchitecture when creating a guest for PanicDevice tests

### DIFF
--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -410,8 +410,11 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				kvconfig.EnableFeatureGate(featuregate.PanicDevicesGate)
 			})
 
-			DescribeTable("should be stopped and have Failed phase when a PanicDevice is provided", func(device v1.PanicDeviceModel) {
-				vmi := libvmifact.NewFedora(libvmi.WithPanicDevice(device))
+			DescribeTable("should be stopped and have Failed phase when a PanicDevice is provided", func(arch string, device v1.PanicDeviceModel) {
+				vmi := libvmifact.NewFedora(
+					libvmi.WithPanicDevice(device),
+					libvmi.WithArchitecture(arch),
+				)
 				vmi, err := kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred(), "Should create VMI successfully")
 				libwait.WaitUntilVMIReady(vmi, console.LoginToFedora)
@@ -437,8 +440,8 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				By("Checking that a GuestPanicked event was emitted")
 				events.ExpectEvent(vmi, k8sv1.EventTypeWarning, "GuestPanicked")
 			},
-				Entry("amd64", v1.Isa, decorators.RequiresAMD64),
-				Entry("arm64", v1.Pvpanic, decorators.RequiresARM64),
+				Entry("amd64", "amd64", v1.Isa, decorators.RequiresAMD64),
+				Entry("arm64", "arm64", v1.Pvpanic, decorators.RequiresARM64),
 			)
 		})
 


### PR DESCRIPTION
### What this PR does
#### Before this PR:

PanicDevice tests did not specify the guest architecture, meaning tests running in multi-arch worker environments could create invalid combinations of guest arch and PanicDeviceModel (e.g. an amd64 guest with Pvpanic).

#### After this PR:

Each PanicDevice test entry explicitly passes the architecture string and uses `libvmi.WithArchitecture` to ensure the correct guest architecture is used for the provided PanicDeviceModel.

### References

- Backport of #17874 to release-1.8

### Why we need it and why it was done in this way

Cherry-pick of #17874 with a minor conflict resolution due to the `PanicDevicesGate` feature gate not being graduated to GA on the release-1.8 branch (the `BeforeEach` enabling the gate is retained).

### Special notes for your reviewer

The only difference from the main branch version is the retained `BeforeEach` block that enables `featuregate.PanicDevicesGate`, which was removed on main by `af5cd532f4` ("Graduate PanicDevices FeatureGate to GA") but is still needed on release-1.8.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
NONE
```