### PR TITLE
backend-storage: increase PVC size for CBT-enabled VMs

### DIFF
--- a/pkg/storage/backend-storage/BUILD.bazel
+++ b/pkg/storage/backend-storage/BUILD.bazel
@@ -54,6 +54,7 @@ go_test(
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/storage/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/fake:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",

--- a/pkg/storage/backend-storage/backend-storage.go
+++ b/pkg/storage/backend-storage/backend-storage.go
@@ -532,6 +532,11 @@ func (bs *BackendStorage) createPVC(vmi *corev1.VirtualMachineInstance, labels m
 	// This helps avoid issues with provisioners that reject the hardcoded 10Mi PVC size used here.
 	labels[storagetypes.LabelApplyStorageProfile] = "true"
 
+	pvcSize := resource.MustParse(PVCSize)
+	if cbt.HasCBTStateEnabled(vmi.Status.ChangedBlockTracking) {
+		pvcSize.Add(resource.MustParse(cbt.CBTBackendStateOverhead))
+	}
+
 	pvc := &v1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName:    basePVC(vmi) + "-",
@@ -541,7 +546,7 @@ func (bs *BackendStorage) createPVC(vmi *corev1.VirtualMachineInstance, labels m
 		Spec: v1.PersistentVolumeClaimSpec{
 			AccessModes: []v1.PersistentVolumeAccessMode{accessMode},
 			Resources: v1.VolumeResourceRequirements{
-				Requests: v1.ResourceList{v1.ResourceStorage: resource.MustParse(PVCSize)},
+				Requests: v1.ResourceList{v1.ResourceStorage: pvcSize},
 			},
 			StorageClassName: &storageClass,
 			VolumeMode:       &mode,

--- a/pkg/storage/backend-storage/backend-storage_test.go
+++ b/pkg/storage/backend-storage/backend-storage_test.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 
@@ -269,7 +270,10 @@ var _ = Describe("Backend Storage", func() {
 	})
 
 	Context("createPVC", func() {
-		var k8sClient *k8sfake.Clientset
+		var (
+			k8sClient *k8sfake.Clientset
+			sc        storagev1.StorageClass
+		)
 		const (
 			nsName  = "testns"
 			vmiName = "testvmi"
@@ -279,6 +283,14 @@ var _ = Describe("Backend Storage", func() {
 		BeforeEach(func() {
 			k8sClient = k8sfake.NewSimpleClientset()
 			virtClient.EXPECT().CoreV1().Return(k8sClient.CoreV1()).AnyTimes()
+			sc = storagev1.StorageClass{
+				ObjectMeta: k8smetav1.ObjectMeta{
+					Name:        "sc",
+					Annotations: map[string]string{"storageclass.kubernetes.io/is-default-class": "true"},
+				},
+			}
+			err := storageClassStore.Add(&sc)
+			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("Should create a PVC with the correct labels", func() {
@@ -289,19 +301,31 @@ var _ = Describe("Backend Storage", func() {
 				},
 			}
 
-			sc := storagev1.StorageClass{
-				ObjectMeta: k8smetav1.ObjectMeta{
-					Name:        "sc",
-					Annotations: map[string]string{"storageclass.kubernetes.io/is-default-class": "true"},
-				},
-			}
-			err := storageClassStore.Add(&sc)
-			Expect(err).NotTo(HaveOccurred())
-
 			pvc, err := backendStorage.createPVC(vmi, map[string]string{})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(pvc).NotTo(BeNil())
 			Expect(pvc.Labels).To(HaveKeyWithValue(storagetypes.LabelApplyStorageProfile, "true"))
+		})
+
+		It("Should create a PVC with overhead if CBT is enabled for the VM", func() {
+			vmi := &virtv1.VirtualMachineInstance{
+				ObjectMeta: k8smetav1.ObjectMeta{
+					Name:      vmiName,
+					Namespace: nsName,
+				},
+				Status: virtv1.VirtualMachineInstanceStatus{
+					ChangedBlockTracking: &virtv1.ChangedBlockTrackingStatus{
+						State: virtv1.ChangedBlockTrackingInitializing,
+					},
+				},
+			}
+
+			pvc, err := backendStorage.createPVC(vmi, map[string]string{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(pvc).NotTo(BeNil())
+			pvcSize := resource.MustParse(PVCSize)
+			pvcSize.Add(resource.MustParse(cbt.CBTBackendStateOverhead))
+			Expect(pvc.Spec.Resources.Requests.Storage().Cmp(pvcSize)).To(Equal(0))
 		})
 	})
 

--- a/pkg/storage/cbt/cbt.go
+++ b/pkg/storage/cbt/cbt.go
@@ -37,6 +37,24 @@ import (
 var (
 	CBTKey   = "changedBlockTracking"
 	CBTLabel = map[string]string{"changedBlockTracking": "true"}
+
+	// The backend state PVC overhead is sized for a high-end scenario:
+	// 5 disks x 500GiB, 256KiB clusters, 10 bitmaps each, 64KiB bitmap granularity.
+	//
+	// Per qcow2 overlay (data-file-raw forces PREALLOC_MODE_METADATA):
+	//   V = virtual disk size (500 GiB)
+	//   S = qcow2 cluster size (256 KiB)
+	//   G = bitmap granularity (64 KiB)
+	//   N = number of bitmaps per disk (10)
+	//
+	//   L2 tables: V x 8 / S = 500GiB x 8 / 256KiB ~= 15.75 MiB
+	//   Bitmap data: N x [V/G/8 / S] x S = 10 x 4 x 256KiB = 10 MiB
+	//   Bitmap tables: N x S = 10 x 256KiB = 2.5 MiB
+	//   Fixed (header, L1, refcount): ~= 1.25 MiB
+	//   Total ~= 29.5  MiB
+	//
+	//   5 overlays (1 per disk) ~= 148 MiB.
+	CBTBackendStateOverhead = "512Mi"
 )
 
 func CBTState(status *v1.ChangedBlockTrackingStatus) v1.ChangedBlockTrackingState {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
The persistent state PVC for VMs that required it (including TPM and CBT) was created with a storage request size of 10Mi which was insufficient for the vast majority of CBT usecases.

#### 
This PR adds a 512Mi overhead for VMs with CBT enabled required to accommodate the associated qcow2 overlays' metadata and stored bitmaps.


### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/25
- Partially addresses #18352

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
The actual space consumed by qcow2 overlays depends on the number of disks, their size, and the number of incremental backups. The 1Gi overhead is a conservative default that covers common configurations. Finer control over PVC sizing and bitmap retention policies are planned for future PRs.

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Backend storage PVC size is increased by 1Gi for VMs with CBT enabled.
```

