### PR TITLE
VEP-199 Followup - validate Grace prerequisites before domain conversion

### DIFF
--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -1142,10 +1142,6 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 		}
 	}
 
-	if err := validateGraceIOVirtualizationConversion(vmi, c); err != nil {
-		return err
-	}
-
 	if vmi.Spec.Domain.CPU != nil && vmi.IsCPUDedicated() {
 		// Adjust guest vcpu config. Currently will handle vCPUs to pCPUs pinning
 		if err := vcpu.AdjustDomainForTopologyAndCPUSet(domain, vmi, c.Topology, c.CPUSet); err != nil {
@@ -1190,38 +1186,6 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 		}
 	}
 
-	return nil
-}
-
-func graceIOVirtualizationRequested(c *convertertypes.ConverterContext) bool {
-	return c != nil && len(c.GraceHostDeviceAliases) > 0
-}
-
-func validateGraceIOVirtualizationConversion(vmi *v1.VirtualMachineInstance, c *convertertypes.ConverterContext) error {
-	if !graceIOVirtualizationRequested(c) {
-		return nil
-	}
-	if !c.GraceIOVirtualizationEnabled {
-		return fmt.Errorf("GraceIOVirtualization conversion requested without the GraceIOVirtualization feature gate")
-	}
-	if !c.PCINUMAAwareTopologyEnabled {
-		return fmt.Errorf("GraceIOVirtualization requires PCINUMAAwareTopology for PCI placement")
-	}
-	if !c.IOMMUFDEnabled {
-		return fmt.Errorf("GraceIOVirtualization requires an IOMMUFD file descriptor in virt-launcher")
-	}
-	if vmi.Spec.Domain.CPU == nil || !vmi.IsCPUDedicated() {
-		return fmt.Errorf("GraceIOVirtualization requires dedicated CPU placement")
-	}
-	if !c.Architecture.SupportPCIePlacement() {
-		return fmt.Errorf("GraceIOVirtualization requires PCIe placement support on architecture %s", c.Architecture.GetArchitecture())
-	}
-	if vmi.Annotations[v1.DisablePCIHole64] == "true" {
-		return fmt.Errorf("GraceIOVirtualization requires the 64-bit PCI hole")
-	}
-	if vmi.Annotations[v1.PlacePCIDevicesOnRootComplex] == "true" {
-		return fmt.Errorf("GraceIOVirtualization cannot be combined with PCI root-complex placement")
-	}
 	return nil
 }
 

--- a/pkg/virt-launcher/virtwrap/converter/grace.go
+++ b/pkg/virt-launcher/virtwrap/converter/grace.go
@@ -30,8 +30,11 @@ import (
 	"strconv"
 	"strings"
 
+	v1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/util/hardware"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
+	convertertypes "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter/types"
 )
 
 const (
@@ -109,6 +112,40 @@ var graceRuntimeInfo graceRuntimeInfoProvider = sysfsGraceRuntimeInfoProvider{
 	pciDevicesPath: sysfsPCIDevicesPath,
 	nodePath:       sysfsNodePath,
 	iommuClassPath: sysfsIOMMUClassPath,
+}
+
+func graceIOVirtualizationRequested(c *convertertypes.ConverterContext) bool {
+	return c != nil && len(c.GraceHostDeviceAliases) > 0
+}
+
+// ValidateGraceIOVirtualizationConversion verifies that a completed converter
+// context can support Grace IO virtualization.
+func ValidateGraceIOVirtualizationConversion(vmi *v1.VirtualMachineInstance, c *convertertypes.ConverterContext) error {
+	if !graceIOVirtualizationRequested(c) {
+		return nil
+	}
+	if !c.GraceIOVirtualizationEnabled {
+		return fmt.Errorf("GraceIOVirtualization conversion requested without the GraceIOVirtualization feature gate")
+	}
+	if !c.PCINUMAAwareTopologyEnabled {
+		return fmt.Errorf("GraceIOVirtualization requires PCINUMAAwareTopology for PCI placement")
+	}
+	if !c.IOMMUFDEnabled {
+		return fmt.Errorf("GraceIOVirtualization requires an IOMMUFD file descriptor in virt-launcher")
+	}
+	if vmi.Spec.Domain.CPU == nil || !vmi.IsCPUDedicated() {
+		return fmt.Errorf("GraceIOVirtualization requires dedicated CPU placement")
+	}
+	if !c.Architecture.SupportPCIePlacement() {
+		return fmt.Errorf("GraceIOVirtualization requires PCIe placement support on architecture %s", c.Architecture.GetArchitecture())
+	}
+	if vmi.Annotations[v1.DisablePCIHole64] == "true" {
+		return fmt.Errorf("GraceIOVirtualization requires the 64-bit PCI hole")
+	}
+	if vmi.Annotations[v1.PlacePCIDevicesOnRootComplex] == "true" {
+		return fmt.Errorf("GraceIOVirtualization cannot be combined with PCI root-complex placement")
+	}
+	return nil
 }
 
 func configureGraceIOVirtualization(domainSpec *api.DomainSpec, expectedAliases []string, iommufdAvailable bool) error {

--- a/pkg/virt-launcher/virtwrap/converter/grace_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/grace_test.go
@@ -214,25 +214,25 @@ var _ = Describe("Grace conversion preflight", func() {
 		c := newGraceContext()
 		c.IOMMUFDEnabled = false
 
-		err := validateGraceIOVirtualizationConversion(newGraceVMI(), c)
+		err := ValidateGraceIOVirtualizationConversion(newGraceVMI(), c)
 
 		Expect(err).To(MatchError(ContainSubstring("requires an IOMMUFD file descriptor")))
 	})
 
-	It("rejects disabling the 64-bit PCI hole before domain mutation", func() {
+	It("rejects disabling the 64-bit PCI hole", func() {
 		vmi := newGraceVMI()
 		vmi.Annotations[v1.DisablePCIHole64] = "true"
 
-		err := validateGraceIOVirtualizationConversion(vmi, newGraceContext())
+		err := ValidateGraceIOVirtualizationConversion(vmi, newGraceContext())
 
 		Expect(err).To(MatchError(ContainSubstring("requires the 64-bit PCI hole")))
 	})
 
-	It("rejects root-complex placement before domain mutation", func() {
+	It("rejects root-complex placement", func() {
 		vmi := newGraceVMI()
 		vmi.Annotations[v1.PlacePCIDevicesOnRootComplex] = "true"
 
-		err := validateGraceIOVirtualizationConversion(vmi, newGraceContext())
+		err := ValidateGraceIOVirtualizationConversion(vmi, newGraceContext())
 
 		Expect(err).To(MatchError(ContainSubstring("root-complex placement")))
 	})

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -1416,6 +1416,9 @@ func (l *LibvirtDomainManager) generateConverterContext(vmi *v1.VirtualMachineIn
 		}
 	}
 	c.IOMMUFDEnabled = l.iommuFD != -1
+	if err := converter.ValidateGraceIOVirtualizationConversion(vmi, c); err != nil {
+		return nil, err
+	}
 	return c, nil
 }
 

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -3258,10 +3258,36 @@ var _ = Describe("Manager", func() {
 		})
 
 		It("should set Grace conversion flags and expected aliases from options", func() {
+			vmi.Spec.Domain.CPU = &v1.CPU{DedicatedCPUPlacement: true}
+			iommuFDFile, err := os.CreateTemp(GinkgoT().TempDir(), "iommufd-test")
+			Expect(err).ToNot(HaveOccurred())
+			DeferCleanup(iommuFDFile.Close)
+
 			options := &cmdv1.VirtualMachineOptions{
 				VirtualMachineSMBios: &cmdv1.SMBios{},
 				ClusterConfig: &cmdv1.ClusterConfig{
 					GraceIOVirtualizationEnabled: true,
+					PCINUMAAwareTopologyEnabled:  true,
+				},
+				GraceHostDeviceAliases: []string{"gpu-gpu0"},
+			}
+
+			libvirtManager := manager.(*LibvirtDomainManager)
+			libvirtManager.iommuFD = int(iommuFDFile.Fd())
+			converterContext, err := libvirtManager.generateConverterContext(vmi, true, options, false)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(converterContext.GraceIOVirtualizationEnabled).To(BeTrue())
+			Expect(converterContext.GraceHostDeviceAliases).To(Equal([]string{"gpu-gpu0"}))
+		})
+
+		It("should reject Grace conversion when the IOMMUFD file descriptor is unavailable", func() {
+			vmi.Spec.Domain.CPU = &v1.CPU{DedicatedCPUPlacement: true}
+			options := &cmdv1.VirtualMachineOptions{
+				VirtualMachineSMBios: &cmdv1.SMBios{},
+				ClusterConfig: &cmdv1.ClusterConfig{
+					GraceIOVirtualizationEnabled: true,
+					PCINUMAAwareTopologyEnabled:  true,
 				},
 				GraceHostDeviceAliases: []string{"gpu-gpu0"},
 			}
@@ -3269,9 +3295,8 @@ var _ = Describe("Manager", func() {
 			libvirtManager := manager.(*LibvirtDomainManager)
 			converterContext, err := libvirtManager.generateConverterContext(vmi, true, options, false)
 
-			Expect(err).ToNot(HaveOccurred())
-			Expect(converterContext.GraceIOVirtualizationEnabled).To(BeTrue())
-			Expect(converterContext.GraceHostDeviceAliases).To(Equal([]string{"gpu-gpu0"}))
+			Expect(err).To(MatchError(ContainSubstring("requires an IOMMUFD file descriptor")))
+			Expect(converterContext).To(BeNil())
 		})
 	})
 


### PR DESCRIPTION
### What this PR does

#### Before this PR:

Grace virtualization conversion prerequisites were validated late in the domain conversion flow, after generic conversion had already mutated the domain. A failed preflight could therefore leave a partially converted in-memory domain.

#### After this PR:

Grace virtualization prerequisites are validated during converter-context generation, after the API-visible configuration and node-local runtime state—including IOMMUFD file descriptor availability—have been populated, and before domain conversion begins.
The actual Grace domain configuration remains later in the conversion flow because it depends on the converted CPU and NUMA topology.
Regression coverage verifies that context generation fails and returns no converter context when a required Grace runtime prerequisite is unavailable.

### References

- Follow-up to https://github.com/kubevirt/kubevirt/pull/18011
- Review discussion: https://github.com/kubevirt/kubevirt/pull/18011#discussion_r3549511779
- VEP 199: https://github.com/kubevirt/enhancements/blob/main/veps/sig-compute/199-nvidia-grace-virtualization-support/199-nvidia-grace-virtualization-support.md

### Why we need it and why it was done in this way

virt-launcher must reject an invalid Grace converter context before invoking domain conversion.

Admission-only validation is insufficient because admission can validate the VMI specification and feature-gate configuration, but it cannot determine whether the selected `virt-launcher` pod actually received an IOMMUFD file descriptor.

The following tradeoffs were made:

- Some validation overlaps with admission as defense in depth for stale objects, configuration changes, and component skew.
- Only the preflight validation is moved. Grace domain configuration remains after generic CPU and NUMA conversion because it requires the resulting domain topology.

The following alternatives were considered:

- Performing all validation during admission was rejected because node-local runtime resources are not available at admission time.
- Moving Grace domain configuration to the beginning was rejected because it depends on topology produced later in the conversion flow.
- Leaving the validation late was rejected because failures could occur after partial domain mutation.

Links to places where the discussion took place:

- https://github.com/kubevirt/kubevirt/pull/18011#discussion_r3549511779

### Special notes for your reviewer

This change does not modify the VMI API, generated XML for valid workloads, or admission behavior. It moves Grace prerequisite validation into converter-context generation so invalid configurations fail before domain construction begins.

### Checklist

- [x] Design: Covered by VEP 199
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: The change is narrowly scoped to converter-context validation
- [x] Refactor: Grace validation now runs before domain conversion
- [x] Upgrade: No upgrade-flow impact
- [x] Testing: Manager coverage verifies that missing runtime prerequisites prevent converter-context generation
- [x] Documentation: No user-facing API or behavior change requiring documentation
- [x] Community: No announcement required
- [ ] AI Contributions: The PR abides by the KubeVirt AI Contribution Policy

### Release note

```release-note
NONE
```