### PR TITLE
pkg/storage/admitters: move vmexport_test to external test package

### DIFF
--- a/pkg/storage/admitters/vmexport_test.go
+++ b/pkg/storage/admitters/vmexport_test.go
@@ -17,7 +17,7 @@
  *
  */
 
-package admitters
+package admitters_test
 
 import (
 	"context"
@@ -34,6 +34,7 @@ import (
 	exportv1 "kubevirt.io/api/export/v1"
 	templateapi "kubevirt.io/virt-template-api/core"
 
+	"kubevirt.io/kubevirt/pkg/storage/admitters"
 	"kubevirt.io/kubevirt/pkg/virt-api/webhooks"
 )
 
@@ -52,7 +53,7 @@ var _ = Describe("Validating VirtualMachineExport Admitter", func() {
 				},
 			}
 
-			resp := createTestVMExportAdmitter(stubVMExportConfigChecker{}).Admit(context.Background(), ar)
+			resp := admitters.NewVMExportAdmitter(stubVMExportConfigChecker{}).Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeFalse())
 			Expect(resp.Result.Message).Should(ContainSubstring("unexpected resource"))
 		})
@@ -60,7 +61,7 @@ var _ = Describe("Validating VirtualMachineExport Admitter", func() {
 		createBlankPVCObjectRef := func() corev1.TypedLocalObjectReference {
 			return corev1.TypedLocalObjectReference{
 				APIGroup: &apiGroup,
-				Kind:     pvc,
+				Kind:     "PersistentVolumeClaim",
 				Name:     "",
 			}
 		}
@@ -68,7 +69,7 @@ var _ = Describe("Validating VirtualMachineExport Admitter", func() {
 		createBlankVMSnapshotObjectRef := func() corev1.TypedLocalObjectReference {
 			return corev1.TypedLocalObjectReference{
 				APIGroup: &kubevirtApiGroup,
-				Kind:     vmSnapshotKind,
+				Kind:     "VirtualMachineSnapshot",
 				Name:     "",
 			}
 		}
@@ -76,7 +77,7 @@ var _ = Describe("Validating VirtualMachineExport Admitter", func() {
 		createBlankVMObjectRef := func() corev1.TypedLocalObjectReference {
 			return corev1.TypedLocalObjectReference{
 				APIGroup: &kubevirtApiGroup,
-				Kind:     vmKind,
+				Kind:     "VirtualMachine",
 				Name:     "",
 			}
 		}
@@ -84,7 +85,7 @@ var _ = Describe("Validating VirtualMachineExport Admitter", func() {
 		createBlankVMBackupObjectRef := func() corev1.TypedLocalObjectReference {
 			return corev1.TypedLocalObjectReference{
 				APIGroup: &backupApiGroup,
-				Kind:     vmBackupKind,
+				Kind:     "VirtualMachineBackup",
 				Name:     "",
 			}
 		}
@@ -92,7 +93,7 @@ var _ = Describe("Validating VirtualMachineExport Admitter", func() {
 		createBlankVMTemplateObjectRef := func() corev1.TypedLocalObjectReference {
 			return corev1.TypedLocalObjectReference{
 				APIGroup: &templateApiGroup,
-				Kind:     vmTemplateKind,
+				Kind:     "VirtualMachineTemplate",
 				Name:     "",
 			}
 		}
@@ -104,7 +105,7 @@ var _ = Describe("Validating VirtualMachineExport Admitter", func() {
 				},
 			}
 			ar := createExportAdmissionReview(export)
-			resp := createTestVMExportAdmitter(stubVMExportConfigChecker{}).Admit(context.Background(), ar)
+			resp := admitters.NewVMExportAdmitter(stubVMExportConfigChecker{}).Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeFalse())
 			Expect(resp.Result.Message).Should(ContainSubstring(errorString))
 		},
@@ -125,7 +126,7 @@ var _ = Describe("Validating VirtualMachineExport Admitter", func() {
 				},
 			}
 			ar := createExportAdmissionReview(export)
-			resp := createTestVMExportAdmitter(clusterConfig).Admit(context.Background(), ar)
+			resp := admitters.NewVMExportAdmitter(clusterConfig).Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeFalse())
 			Expect(resp.Result.Message).Should(ContainSubstring("VirtualMachineTemplate name must not be empty"))
 		})
@@ -137,7 +138,7 @@ var _ = Describe("Validating VirtualMachineExport Admitter", func() {
 				},
 			}
 			ar := createExportAdmissionReview(export)
-			resp := createTestVMExportAdmitter(clusterConfig).Admit(context.Background(), ar)
+			resp := admitters.NewVMExportAdmitter(clusterConfig).Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeFalse())
 			Expect(resp.Result.Message).Should(ContainSubstring("OCIExport feature gate and virt-template deployment"))
 		},
@@ -155,13 +156,13 @@ var _ = Describe("Validating VirtualMachineExport Admitter", func() {
 				Spec: exportv1.VirtualMachineExportSpec{
 					Source: corev1.TypedLocalObjectReference{
 						APIGroup: &templateApiGroup,
-						Kind:     vmTemplateKind,
+						Kind:     "VirtualMachineTemplate",
 						Name:     "test-template",
 					},
 				},
 			}
 			ar := createExportAdmissionReview(export)
-			resp := createTestVMExportAdmitter(clusterConfig).Admit(context.Background(), ar)
+			resp := admitters.NewVMExportAdmitter(clusterConfig).Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeTrue())
 		})
 
@@ -177,7 +178,7 @@ var _ = Describe("Validating VirtualMachineExport Admitter", func() {
 			}
 
 			ar := createExportAdmissionReview(export)
-			resp := createTestVMExportAdmitter(stubVMExportConfigChecker{}).Admit(context.Background(), ar)
+			resp := admitters.NewVMExportAdmitter(stubVMExportConfigChecker{}).Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeFalse())
 			Expect(resp.Result.Details.Causes).To(HaveLen(1))
 			Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.source.kind"))
@@ -188,7 +189,7 @@ var _ = Describe("Validating VirtualMachineExport Admitter", func() {
 				Spec: exportv1.VirtualMachineExportSpec{
 					Source: corev1.TypedLocalObjectReference{
 						APIGroup: &apiGroup,
-						Kind:     pvc,
+						Kind:     "PersistentVolumeClaim",
 						Name:     "test",
 					},
 				},
@@ -198,14 +199,14 @@ var _ = Describe("Validating VirtualMachineExport Admitter", func() {
 				Spec: exportv1.VirtualMachineExportSpec{
 					Source: corev1.TypedLocalObjectReference{
 						APIGroup: &apiGroup,
-						Kind:     pvc,
+						Kind:     "PersistentVolumeClaim",
 						Name:     "baz",
 					},
 				},
 			}
 
 			ar := createExportUpdateAdmissionReview(oldExport, export)
-			resp := createTestVMExportAdmitter(stubVMExportConfigChecker{}).Admit(context.Background(), ar)
+			resp := admitters.NewVMExportAdmitter(stubVMExportConfigChecker{}).Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeFalse())
 			Expect(resp.Result.Details.Causes).To(HaveLen(1))
 			Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec"))
@@ -216,7 +217,7 @@ var _ = Describe("Validating VirtualMachineExport Admitter", func() {
 				Spec: exportv1.VirtualMachineExportSpec{
 					Source: corev1.TypedLocalObjectReference{
 						APIGroup: &apiGroup,
-						Kind:     pvc,
+						Kind:     "PersistentVolumeClaim",
 						Name:     "test",
 					},
 				},
@@ -229,14 +230,14 @@ var _ = Describe("Validating VirtualMachineExport Admitter", func() {
 				Spec: exportv1.VirtualMachineExportSpec{
 					Source: corev1.TypedLocalObjectReference{
 						APIGroup: &apiGroup,
-						Kind:     pvc,
+						Kind:     "PersistentVolumeClaim",
 						Name:     "test",
 					},
 				},
 			}
 
 			ar := createExportUpdateAdmissionReview(oldExport, export)
-			resp := createTestVMExportAdmitter(stubVMExportConfigChecker{}).Admit(context.Background(), ar)
+			resp := admitters.NewVMExportAdmitter(stubVMExportConfigChecker{}).Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeTrue())
 		})
 
@@ -252,12 +253,12 @@ var _ = Describe("Validating VirtualMachineExport Admitter", func() {
 			}
 
 			ar := createExportAdmissionReview(export)
-			resp := createTestVMExportAdmitter(stubVMExportConfigChecker{}).Admit(context.Background(), ar)
+			resp := admitters.NewVMExportAdmitter(stubVMExportConfigChecker{}).Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeTrue(), "should allow APIGroup: %s, Kind: %s", apiGroup, kind)
 		},
-			Entry("persistent volume claim blank", "", pvc),
-			Entry("virtual machine snapshot", snapshotApiGroup, vmSnapshotKind),
-			Entry("virtual machine", kubevirtApiGroup, vmKind),
+			Entry("persistent volume claim blank", "", "PersistentVolumeClaim"),
+			Entry("virtual machine snapshot", snapshotApiGroup, "VirtualMachineSnapshot"),
+			Entry("virtual machine", kubevirtApiGroup, "VirtualMachine"),
 		)
 
 		DescribeTable("it should reject invalid apigroups", func(apiGroup, kind string) {
@@ -272,13 +273,13 @@ var _ = Describe("Validating VirtualMachineExport Admitter", func() {
 			}
 
 			ar := createExportAdmissionReview(export)
-			resp := createTestVMExportAdmitter(stubVMExportConfigChecker{}).Admit(context.Background(), ar)
+			resp := admitters.NewVMExportAdmitter(stubVMExportConfigChecker{}).Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeFalse(), "should reject APIGroup: %s, Kind: %s", apiGroup, kind)
 		},
-			Entry("persistent volume claim", "invalid", pvc),
-			Entry("virtual machine snapshot", "invalid", vmSnapshotKind),
-			Entry("virtual machine", "invalid", vmKind),
-			Entry("virtual machine backup", "invalid", vmBackupKind),
+			Entry("persistent volume claim", "invalid", "PersistentVolumeClaim"),
+			Entry("virtual machine snapshot", "invalid", "VirtualMachineSnapshot"),
+			Entry("virtual machine", "invalid", "VirtualMachine"),
+			Entry("virtual machine backup", "invalid", "VirtualMachineBackup"),
 		)
 
 		It("should reject invalid VMTemplate apigroup", func() {
@@ -291,13 +292,13 @@ var _ = Describe("Validating VirtualMachineExport Admitter", func() {
 				Spec: exportv1.VirtualMachineExportSpec{
 					Source: corev1.TypedLocalObjectReference{
 						APIGroup: &invalidGroup,
-						Kind:     vmTemplateKind,
+						Kind:     "VirtualMachineTemplate",
 						Name:     "test",
 					},
 				},
 			}
 			ar := createExportAdmissionReview(export)
-			resp := createTestVMExportAdmitter(clusterConfig).Admit(context.Background(), ar)
+			resp := admitters.NewVMExportAdmitter(clusterConfig).Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeFalse())
 		})
 	})
@@ -345,10 +346,6 @@ func createExportUpdateAdmissionReview(old, current *exportv1.VirtualMachineExpo
 	}
 
 	return ar
-}
-
-func createTestVMExportAdmitter(config vmExportConfigChecker) *VMExportAdmitter {
-	return &VMExportAdmitter{config: config}
 }
 
 type stubVMExportConfigChecker struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Move `vmexport_test.go` from package `admitters` to `admitters_test` to test the API like a consumer would. Testing only the externally observed behaviour allows internal changes to production code without affecting the tests.

Use the `NewVMExportAdmitter` constructor instead of direct struct construction, and inline the unexported kind constants as string literals.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

