### PR TITLE
automation: Fold SR-IOV e2e tests into the penultimate provider

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -85,6 +85,7 @@ case "$TARGET" in
     export KUBEVIRT_DEPLOY_NETWORK_RESOURCES_INJECTOR=true
     export KUBEVIRT_PROVIDER=${TARGET/-sig-network*/}
     if [[ "${KUBEVIRT_PROVIDER}" == "${SIG_NETWORK_SRIOV_PROVIDER}" ]]; then
+      export KUBEVIRT_NUM_VCPU=8
       export KUBEVIRT_WITH_SRIOV=true
       export KUBEVIRT_DEPLOY_NETWORK_RESOURCES_INJECTOR=true
       export KUBEVIRT_FUNC_TEST_SUITE_ARGS="${KUBEVIRT_FUNC_TEST_SUITE_ARGS} -emulated-sriov=true"
@@ -92,6 +93,7 @@ case "$TARGET" in
     fi
     ;;
   *emulated-igb*)
+    export KUBEVIRT_NUM_VCPU=8
     export KUBEVIRT_PROVIDER=${TARGET/-emulated-igb*/}
     export KUBEVIRT_FUNC_TEST_SUITE_ARGS="${KUBEVIRT_FUNC_TEST_SUITE_ARGS} -emulated-sriov=true"
     export KUBEVIRT_WITH_SRIOV=true

--- a/automation/test.sh
+++ b/automation/test.sh
@@ -56,11 +56,20 @@ add_feature_gate() {
   fi
 }
 
+get_sig_network_sriov_provider() {
+  local provider_dirs=()
+  mapfile -t provider_dirs < <(printf '%s\n' kubevirtci/cluster-up/cluster/k8s-*/ | sort -V)
+  basename "${provider_dirs[-2]}"
+}
+
 export KUBEVIRT_DEPLOY_CDI=true
 if [[ ! $TARGET =~ .*kind.* ]]; then
   add_feature_gate "NodeRestriction"
   export KUBEVIRT_PSA="true"
 fi
+
+# auto detect the penultimate provider
+readonly SIG_NETWORK_SRIOV_PROVIDER="$(get_sig_network_sriov_provider)"
 
 case "$TARGET" in
   *windows*)
@@ -75,6 +84,12 @@ case "$TARGET" in
     export KUBEVIRT_DEPLOY_ISTIO=true
     export KUBEVIRT_DEPLOY_NETWORK_RESOURCES_INJECTOR=true
     export KUBEVIRT_PROVIDER=${TARGET/-sig-network*/}
+    if [[ "${KUBEVIRT_PROVIDER}" == "${SIG_NETWORK_SRIOV_PROVIDER}" ]]; then
+      export KUBEVIRT_WITH_SRIOV=true
+      export KUBEVIRT_DEPLOY_NETWORK_RESOURCES_INJECTOR=true
+      export KUBEVIRT_FUNC_TEST_SUITE_ARGS="${KUBEVIRT_FUNC_TEST_SUITE_ARGS} -emulated-sriov=true"
+      add_feature_gate "ExternalNetResourceInjection"
+    fi
     ;;
   *emulated-igb*)
     export KUBEVIRT_PROVIDER=${TARGET/-emulated-igb*/}
@@ -542,8 +557,9 @@ if [[ -z ${KUBEVIRT_E2E_FOCUS} && -z ${KUBEVIRT_E2E_SKIP} && -z ${label_filter} 
     label_filter='(Windows)'
   elif [[ $TARGET =~ sig-network ]]; then
     label_filter='(sig-network,netCustomBindingPlugins)'
-    # SR-IOV tests runs on dedicated lane (matching the pattern: *kind-sriov*)
-    add_to_label_filter "(!SRIOV)" "&&"
+    if [[ "${KUBEVIRT_PROVIDER}" != "${SIG_NETWORK_SRIOV_PROVIDER}" ]]; then
+      add_to_label_filter "(!SRIOV)" "&&"
+    fi
     if [[ $KUBEVIRT_WITH_DYN_NET_CTRL == "true" ]]; then
       add_to_label_filter "(!migration-based-hotplug-NICs)" "&&"
     else

--- a/tests/network/sriov.go
+++ b/tests/network/sriov.go
@@ -116,7 +116,7 @@ var _ = Describe(SIG("SRIOV", Serial, decorators.SRIOV, func() {
 		It("should have cloud-init meta_data with tagged interface and aligned cpus to sriov interface numa node for VMIs with dedicatedCPUs", decorators.RequiresNodeWithCPUManager, func() {
 			vmi := libvmifact.NewFedora(
 				libvmi.WithCloudInitConfigDrive(libvmici.WithConfigDriveNetworkData(defaultCloudInitNetworkData())),
-				libvmi.WithCPUCount(4, 0, 0),
+				libvmi.WithCPUCount(5, 0, 0),
 				libvmi.WithDedicatedCPUPlacement(),
 				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Derive the provider from the available k8s cluster directories so the lane wiring follows version bumps with one less manual update.

This allows running SR-IOV tests on phase 2, saving precious CI time.
Even with kind-sriov we didn't always run on latest k8s. It should not affect, and can be improved in the future according needs.

Adapt one of the tests to be compatible to folded run.

With this, we can drop the separate lane
https://github.com/kubevirt/project-infra/pull/5295

Next step is to make the tests run in parallel.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
We almost always have just vm based providers named k8s-x.yz, i.e without additional suffix.
The current code assumes that.
In case it changed, we will need to fix it, but it is very rare.
If desire we can assert this is the case.

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

