### PR TITLE
[DNM] tests: use write64 stress-ng method for migration tests

### DIFF
--- a/tests/libmigration/BUILD.bazel
+++ b/tests/libmigration/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//tests/console:go_default_library",
         "//tests/flags:go_default_library",
         "//tests/framework/kubevirt:go_default_library",
         "//tests/framework/matcher:go_default_library",
@@ -17,6 +18,7 @@ go_library(
         "//tests/libmonitoring:go_default_library",
         "//tests/libnode:go_default_library",
         "//tests/libpod:go_default_library",
+        "//vendor/github.com/google/goexpect:go_default_library",
         "//vendor/github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",

--- a/tests/libmigration/migration.go
+++ b/tests/libmigration/migration.go
@@ -14,6 +14,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gstruct"
 
+	expect "github.com/google/goexpect"
 	k8snetworkplumbingwgv1 "github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1"
 	k8sv1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -22,6 +23,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 
+	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/flags"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/framework/matcher"
@@ -577,4 +579,21 @@ func WaitUntilMigrationMode(virtClient kubecli.KubevirtClient, vmi *v1.VirtualMa
 		}
 		return ""
 	}, timeout, 1*time.Second).Should(Equal(expectedMode))
+}
+
+func RunStressTest(vmi *v1.VirtualMachineInstance, vmsize string) {
+	By("Run a stress test to dirty some pages and slow down the migration")
+	stressCmd := fmt.Sprintf("stress-ng --vm 4 --vm-bytes %s --vm-method write64 --vm-keep &\n", vmsize)
+	Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
+		&expect.BSnd{S: "\n"},
+		&expect.BExp{R: ""},
+		&expect.BSnd{S: "command -v stress-ng\n"},
+		&expect.BExp{R: ""},
+		&expect.BSnd{S: console.EchoLastReturnValue},
+		&expect.BExp{R: console.RetValue("0")},
+		&expect.BSnd{S: stressCmd},
+		&expect.BExp{R: ""},
+	}, 15)).To(Succeed(), "should run stress test, stress-ng is only available on Fedora images")
+
+	time.Sleep(5 * time.Second)
 }

--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -97,11 +97,10 @@ import (
 )
 
 const (
-	fedoraVMSize               = "512Mi"
-	secretDiskSerial           = "D23YZ9W6WA5DJ487"
-	stressDefaultVMSize        = "100M"
-	stressLargeVMSize          = "400M"
-	stressDefaultSleepDuration = 15
+	fedoraVMSize        = "512Mi"
+	secretDiskSerial    = "D23YZ9W6WA5DJ487"
+	stressDefaultVMSize = "100M"
+	stressLargeVMSize   = "400M"
 )
 
 var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes, func() {
@@ -3159,21 +3158,7 @@ func getCurrentKvConfig(virtClient kubecli.KubevirtClient) v1.KubeVirtConfigurat
 }
 
 func runStressTest(vmi *v1.VirtualMachineInstance, vmsize string) {
-	By("Run a stress test to dirty some pages and slow down the migration")
-	stressCmd := fmt.Sprintf("stress-ng --vm 1 --vm-bytes %s --vm-keep &\n", vmsize)
-	Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
-		&expect.BSnd{S: "\n"},
-		&expect.BExp{R: ""},
-		&expect.BSnd{S: "command -v stress-ng\n"},
-		&expect.BExp{R: ""},
-		&expect.BSnd{S: console.EchoLastReturnValue},
-		&expect.BExp{R: console.RetValue("0")},
-		&expect.BSnd{S: stressCmd},
-		&expect.BExp{R: ""},
-	}, 15)).To(Succeed(), "should run stress test, stress-ng is only available on Fedora images")
-
-	// give stress tool some time to trash more memory pages before returning control to next steps
-	time.Sleep(stressDefaultSleepDuration * time.Second)
+	libmigration.RunStressTest(vmi, vmsize)
 }
 
 func stopStressTest(vmi *v1.VirtualMachineInstance) {

--- a/tests/monitoring/vm_monitoring.go
+++ b/tests/monitoring/vm_monitoring.go
@@ -336,9 +336,8 @@ var _ = Describe("[sig-monitoring]VM Monitoring", decorators.SigMonitoring, func
 
 		It("[QUARANTINE] should ensure a stress VM has high dirty rate than a stale VM", decorators.Quarantine, func() {
 			const (
-				agentConnTimeout  = 3 * time.Minute
-				stressTestTimeout = 15
-				randStrLen        = 5
+				agentConnTimeout = 3 * time.Minute
+				randStrLen       = 5
 			)
 
 			staleVM := createRunningVM(
@@ -364,17 +363,7 @@ var _ = Describe("[sig-monitoring]VM Monitoring", decorators.SigMonitoring, func
 			Expect(console.LoginToFedora(stressedVMI)).To(Succeed())
 
 			By("Stressing the VM")
-			const stressCmd = "stress-ng --vm 1 --vm-bytes 250M --vm-keep &\n"
-			Expect(console.SafeExpectBatch(stressedVMI, []expect.Batcher{
-				&expect.BSnd{S: "\n"},
-				&expect.BExp{R: ""},
-				&expect.BSnd{S: "command -v stress-ng\n"},
-				&expect.BExp{R: ""},
-				&expect.BSnd{S: console.EchoLastReturnValue},
-				&expect.BExp{R: console.RetValue("0")},
-				&expect.BSnd{S: stressCmd},
-				&expect.BExp{R: ""},
-			}, stressTestTimeout)).To(Succeed(), "should run stress test, stress-ng is only available on Fedora images")
+			libmigration.RunStressTest(stressedVMI, "250M")
 
 			By("Validating that the stressed VM's dirty rate is higher than the stale VM's dirty rate")
 			const consistencyTimeout = 30 * time.Second


### PR DESCRIPTION
The default stress-ng --vm stressor cycles through all ~72 methods, many of which primarily read memory or do sequential access rather than dirty pages. Switch to --vm-method write64 which does pure 64-bit writes, maximizing page dirty rate. Also increase workers from 1 to 4 for higher throughput.
This better matches the actual intent of these tests: generating memory pressure to slow or prevent migration convergence.


Assisted-by: claude-4.6-opus

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:

#### After this PR:

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

