### PR TITLE
nominate Barakmor1 for SIG compute approver

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -115,6 +115,7 @@ aliases:
   # And everything on the cluster level such as RBAC, controller, …
   #
   sig-compute-approvers:
+    - Barakmor1
     - jean-edouard
     - iholder101
     - fossedihelm


### PR DESCRIPTION
### What this PR does

  Nominating [@Barakmor1](https://github.com/Barakmor1) for SIG compute approver.

  Barak has been an active KubeVirt contributor for several years and has served as sig-compute reviewer since [PR
  #13517](https://github.com/kubevirt/kubevirt/pull/13517) (merged December 2024, ~7 months ago). Since then he has consistently authored substantial SIG compute changes, led multiple VEP implementations end-to-end, and provided deep, high-quality reviews across launcher, handler, migration, CPU, and API lifecycle topics.

  Barak has demonstrated holistic sig-compute ownership - not only authoring features, but driving them through design,
  implementation, testing, feature-gate graduation, and cross-component review (virt-launcher, virt-handler, virt-controller, API, and e2e/unit test strategy). He has contributed across several sig-compute areas including CPU topology & node labeller, live migration, API lifecycle & deprecation, and VEP implementation & graduation.

  Barak is primary owner of the following sig-compute VEPs:
  - [VEP-16: Use ImageVolume to mount OCI images as volumes in virt-launcher](https://github.com/kubevirt/enhancements/issues/16)
  - [VEP-118: Use Volume status to extract digest during live migration](https://github.com/kubevirt/enhancements/issues/118)
  - [VEP-141: Target-Side Pre-Migration Hooks for Domain XML Modification](https://github.com/kubevirt/enhancements/issues/141)
  - [VEP-156: Expose Memory Overhead on VMI Status](https://github.com/kubevirt/enhancements/issues/156) 

  Barak has authored over [150 merged PRs](https://github.com/kubevirt/kubevirt/pulls?q=is%3Apr+author%3ABarakmor1+is%3Amerged), reviewed [187+ closed PRs](https://github.com/kubevirt/kubevirt/pulls?q=is%3Apr+reviewed-by%3ABarakmor1+is%3Aclosed), and has been actively involved in [289+ sig-compute
  PRs](https://github.com/kubevirt/kubevirt/pulls?q=repo%3Akubevirt%2Fkubevirt+commenter%3ABarakmor1+sig%2Fcompute+is%3Aclosed).

  I think Barak has enough contributions, demonstrated deep sig-compute knowledge, and guided other contributors through reviews and VEP ownership, which qualifies him to be a sig-compute approver.


### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

