### PR TITLE
virt-handler: don't overwrite valid SELinux context on reconcile

### DIFF
--- a/pkg/virt-handler/BUILD.bazel
+++ b/pkg/virt-handler/BUILD.bazel
@@ -68,6 +68,7 @@ go_library(
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/github.com/opencontainers/cgroups:go_default_library",
+        "//vendor/github.com/opencontainers/selinux/go-selinux:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -35,6 +35,7 @@ import (
 	"time"
 
 	"github.com/opencontainers/cgroups"
+	goselinux "github.com/opencontainers/selinux/go-selinux"
 	"libvirt.org/go/libvirtxml"
 
 	k8sv1 "k8s.io/api/core/v1"
@@ -1031,6 +1032,10 @@ func (c *VirtualMachineController) updateIsoSizeStatus(vmi *v1.VirtualMachineIns
 }
 
 func (c *VirtualMachineController) updateSELinuxContext(vmi *v1.VirtualMachineInstance) error {
+	if selinuxContextHasCategories(vmi.Status.SelinuxContext) {
+		return nil
+	}
+
 	_, present, err := selinux.NewSELinux()
 	if err != nil {
 		return err
@@ -1046,6 +1051,24 @@ func (c *VirtualMachineController) updateSELinuxContext(vmi *v1.VirtualMachineIn
 	}
 
 	return nil
+}
+
+// selinuxContextHasCategories returns true when the context contains an MCS
+// level with categories (e.g. "s0:c1,c2"). A container's SELinux context is
+// immutable for its lifetime, so once we have observed categories there is no
+// reason to re-read from the filesystem.
+func selinuxContextHasCategories(ctx string) bool {
+	if ctx == "" || ctx == "none" {
+		return false
+	}
+	parsed, err := goselinux.NewContext(ctx)
+	if err != nil {
+		return false
+	}
+	level := parsed["level"]
+	// The ":c" check mirrors the upstream go-selinux mcsAdd function,
+	// which uses the same pattern to detect MCS categories in a level.
+	return strings.Contains(level, ":c")
 }
 
 func (c *VirtualMachineController) updateMemoryInfo(vmi *v1.VirtualMachineInstance, domain *api.Domain) error {

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -3661,3 +3661,18 @@ func withFilesystemDevice(deviceName string) libvmi.Option {
 		})
 	}
 }
+
+var _ = Describe("selinuxContextHasCategories", func() {
+	DescribeTable("should detect MCS categories correctly",
+		func(ctx string, expected bool) {
+			Expect(selinuxContextHasCategories(ctx)).To(Equal(expected))
+		},
+		Entry("full context with categories", "system_u:object_r:container_file_t:s0:c1,c2", true),
+		Entry("full context without categories", "system_u:object_r:container_file_t:s0", false),
+		Entry("empty context", "", false),
+		Entry("none context", "none", false),
+		Entry("context with high categories", "system_u:system_r:container_t:s0:c123,c456", true),
+		Entry("context with single category", "system_u:system_r:container_t:s0:c7", true),
+		Entry("three-part context", "user:role:type", false),
+	)
+})


### PR DESCRIPTION
### What this PR does
updateSELinuxContext re-reads the virt-launcher SELinux context from /proc on every reconcile and unconditionally overwrites vmi.Status.SelinuxContext. If the xattr read ever returns a truncated value (e.g. "s0" without MCS categories), the good context is clobbered, and a subsequent migration uses the wrong level.

Skip the read when we already have a context with MCS categories. The context is immutable for the container's lifetime, so re-reading after a successful observation is unnecessary. The ":c" category check mirrors go-selinux's own mcsAdd.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
