### PR TITLE
DNM: profile etcd storage during sig-operator to investigate #18309

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -149,6 +149,7 @@ case "$TARGET" in
     export KUBEVIRT_PROVIDER=${TARGET/-sig-operator*/}
     export KUBEVIRT_WITH_CNAO=true
     export KUBEVIRT_NUM_SECONDARY_NICS=1
+    export KUBEVIRT_PROFILE_ETCD=true
     ;;
   *sig-monitoring*)
     export KUBEVIRT_PROVIDER=${TARGET/-sig-monitoring/}

--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -106,6 +106,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libwait"
 	"kubevirt.io/kubevirt/tests/operator/resourcefiles"
 	"kubevirt.io/kubevirt/tests/operator/version"
+	"kubevirt.io/kubevirt/tests/reporter"
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
@@ -3000,6 +3001,11 @@ func deleteVMIs(vmis []*v1.VirtualMachineInstance) {
 
 func deleteAllKvAndWait(ignoreOriginal bool, originalKvName string) {
 	GinkgoHelper()
+
+	if p := reporter.ActiveEtcdProfiler; p != nil {
+		p.MonitorRanges("deleteAllKvAndWait", 5*time.Second)
+		defer p.StopMonitor()
+	}
 
 	virtClient := kubevirt.Client()
 	Eventually(func(g Gomega) {

--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -1046,8 +1046,8 @@ var _ = Describe("[sig-operator]Operator", Serial, decorators.SigOperator, func(
 			By("Deleting KubeVirt object")
 			deleteAllKvAndWait(false, originalKv.Name)
 		},
-			Entry("[QUARANTINE]from previous y release by patching KubeVirt CR", decorators.Quarantine, fromY, false),
-			Entry("[QUARANTINE]from previous y release by updating virt-operator", decorators.Quarantine, fromY, true),
+			Entry("from previous y release by patching KubeVirt CR", fromY, false),
+			Entry("from previous y release by updating virt-operator", fromY, true),
 			Entry("from previous z release by patching KubeVirt CR", fromZ, false),
 			Entry("from previous z release by updating virt-operator", fromZ, true),
 		)

--- a/tests/reporter/BUILD.bazel
+++ b/tests/reporter/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 go_library(
     name = "go_default_library",
     srcs = [
+        "etcd.go",
         "kubernetes.go",
         "outputenricher.go",
         "vmlog_reporter.go",

--- a/tests/reporter/etcd.go
+++ b/tests/reporter/etcd.go
@@ -1,0 +1,344 @@
+package reporter
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/onsi/ginkgo/v2/types"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"kubevirt.io/kubevirt/tests/exec"
+	"kubevirt.io/kubevirt/tests/framework/kubevirt"
+	"kubevirt.io/kubevirt/tests/libnode"
+)
+
+const (
+	etcdContainerName = "etcd"
+	etcdCACert        = "/etc/kubernetes/pki/etcd/ca.crt"
+	etcdCert          = "/etc/kubernetes/pki/etcd/server.crt"
+	etcdKey           = "/etc/kubernetes/pki/etcd/server.key"
+)
+
+type EtcdSnapshot struct {
+	DBSizeBytes      int64  `json:"dbSizeBytes"`
+	DBSizeInUseBytes int64  `json:"dbSizeInUseBytes"`
+	Revision         int64  `json:"revision"`
+	TmpfsUsedBytes   int64  `json:"tmpfsUsedBytes"`
+	TmpfsTotalBytes  int64  `json:"tmpfsTotalBytes"`
+	TmpfsAvailBytes  int64  `json:"tmpfsAvailBytes"`
+	WALSizeBytes     int64  `json:"walSizeBytes"`
+	SnapSizeBytes    int64  `json:"snapSizeBytes"`
+	Error            string `json:"error,omitempty"`
+}
+
+type EtcdSpecRecord struct {
+	SpecName        string       `json:"specName"`
+	Before          EtcdSnapshot `json:"before"`
+	After           EtcdSnapshot `json:"after"`
+	DeltaDBSize     int64        `json:"deltaDBSizeBytes"`
+	DeltaTmpfsUsed  int64        `json:"deltaTmpfsUsedBytes"`
+	DeltaRevision   int64        `json:"deltaRevision"`
+	Passed          bool         `json:"passed"`
+	DurationSeconds float64      `json:"durationSeconds"`
+}
+
+type EtcdProfiler struct {
+	artifactsDir   string
+	mu             sync.Mutex
+	records        []EtcdSpecRecord
+	currentSnap    *EtcdSnapshot
+	etcdPod        *v1.Pod
+	virtHandlerPod *v1.Pod
+}
+
+func NewEtcdProfiler(artifactsDir string) *EtcdProfiler {
+	return &EtcdProfiler{
+		artifactsDir: artifactsDir,
+	}
+}
+
+func (p *EtcdProfiler) getEtcdPod() (*v1.Pod, error) {
+	if p.etcdPod != nil {
+		return p.etcdPod, nil
+	}
+
+	virtCli := kubevirt.Client()
+	pods, err := virtCli.CoreV1().Pods("kube-system").List(context.Background(), metav1.ListOptions{
+		LabelSelector: "component=etcd",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list etcd pods: %v", err)
+	}
+	if len(pods.Items) == 0 {
+		return nil, fmt.Errorf("no etcd pods found")
+	}
+
+	p.etcdPod = &pods.Items[0]
+	return p.etcdPod, nil
+}
+
+func (p *EtcdProfiler) collectSnapshot() EtcdSnapshot {
+	snap := EtcdSnapshot{}
+
+	pod, err := p.getEtcdPod()
+	if err != nil {
+		snap.Error = err.Error()
+		return snap
+	}
+
+	p.collectEndpointStatus(pod, &snap)
+	p.collectDfOutput(pod, &snap)
+	p.collectDirSizes(pod, &snap)
+
+	return snap
+}
+
+func (p *EtcdProfiler) collectEndpointStatus(pod *v1.Pod, snap *EtcdSnapshot) {
+	cmd := []string{
+		"etcdctl",
+		"endpoint", "status",
+		"--write-out=json",
+		"--cacert=" + etcdCACert,
+		"--cert=" + etcdCert,
+		"--key=" + etcdKey,
+	}
+
+	stdout, err := exec.ExecuteCommandOnPod(pod, etcdContainerName, cmd)
+	if err != nil {
+		snap.Error = appendError(snap.Error, fmt.Sprintf("etcdctl endpoint status: %v", err))
+		return
+	}
+
+	// etcdctl returns an array of endpoint statuses
+	var statuses []struct {
+		Status struct {
+			DBSize      int64 `json:"dbSize"`
+			DBSizeInUse int64 `json:"dbSizeInUse"`
+			Header      struct {
+				Revision int64 `json:"revision"`
+			} `json:"header"`
+		} `json:"Status"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &statuses); err != nil {
+		snap.Error = appendError(snap.Error, fmt.Sprintf("failed to parse etcdctl output: %v", err))
+		return
+	}
+
+	if len(statuses) > 0 {
+		snap.DBSizeBytes = statuses[0].Status.DBSize
+		snap.DBSizeInUseBytes = statuses[0].Status.DBSizeInUse
+		snap.Revision = statuses[0].Status.Header.Revision
+	}
+}
+
+func (p *EtcdProfiler) getVirtHandlerPod(nodeName string) (*v1.Pod, error) {
+	if p.virtHandlerPod != nil {
+		return p.virtHandlerPod, nil
+	}
+
+	virtCli := kubevirt.Client()
+	pod, err := libnode.GetVirtHandlerPod(virtCli, nodeName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get virt-handler pod on node %s: %v", nodeName, err)
+	}
+
+	p.virtHandlerPod = pod
+	return p.virtHandlerPod, nil
+}
+
+// execOnNode runs a command on the host via nsenter through the virt-handler pod.
+func (p *EtcdProfiler) execOnNode(nodeName string, command string) (string, error) {
+	pod, err := p.getVirtHandlerPod(nodeName)
+	if err != nil {
+		return "", err
+	}
+
+	cmd := []string{"sh", "-c", "nsenter -t 1 -m -- " + command}
+	stdout, err := exec.ExecuteCommandOnPod(pod, virtHandlerName, cmd)
+	if err != nil {
+		// Invalidate cached pod in case it was recycled by a test
+		p.virtHandlerPod = nil
+		return "", err
+	}
+	return stdout, nil
+}
+
+func (p *EtcdProfiler) collectDfOutput(etcdPod *v1.Pod, snap *EtcdSnapshot) {
+	stdout, err := p.execOnNode(etcdPod.Spec.NodeName, "df -k /var/lib/etcd | tail -1")
+	if err != nil {
+		snap.Error = appendError(snap.Error, fmt.Sprintf("df: %v", err))
+		return
+	}
+
+	// Parse df output: Filesystem 1K-blocks Used Available Use% Mounted
+	fields := strings.Fields(strings.TrimSpace(stdout))
+	if len(fields) >= 4 {
+		if total, err := strconv.ParseInt(fields[1], 10, 64); err == nil {
+			snap.TmpfsTotalBytes = total * 1024
+		}
+		if used, err := strconv.ParseInt(fields[2], 10, 64); err == nil {
+			snap.TmpfsUsedBytes = used * 1024
+		}
+		if avail, err := strconv.ParseInt(fields[3], 10, 64); err == nil {
+			snap.TmpfsAvailBytes = avail * 1024
+		}
+	}
+}
+
+func (p *EtcdProfiler) collectDirSizes(etcdPod *v1.Pod, snap *EtcdSnapshot) {
+	stdout, err := p.execOnNode(etcdPod.Spec.NodeName, "du -sb /var/lib/etcd/member/wal /var/lib/etcd/member/snap 2>/dev/null")
+	if err != nil {
+		snap.Error = appendError(snap.Error, fmt.Sprintf("du: %v", err))
+		return
+	}
+
+	for _, line := range strings.Split(strings.TrimSpace(stdout), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		size, err := strconv.ParseInt(fields[0], 10, 64)
+		if err != nil {
+			continue
+		}
+		if strings.Contains(fields[1], "/wal") {
+			snap.WALSizeBytes = size
+		} else if strings.Contains(fields[1], "/snap") {
+			snap.SnapSizeBytes = size
+		}
+	}
+}
+
+// RecordBeforeSpec captures etcd state before a spec runs.
+func (p *EtcdProfiler) RecordBeforeSpec() {
+	snap := p.collectSnapshot()
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.currentSnap = &snap
+}
+
+// RecordSpec captures etcd state after a spec runs and stores the record.
+func (p *EtcdProfiler) RecordSpec(specReport types.SpecReport) {
+	after := p.collectSnapshot()
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	before := EtcdSnapshot{}
+	if p.currentSnap != nil {
+		before = *p.currentSnap
+		p.currentSnap = nil
+	}
+
+	record := EtcdSpecRecord{
+		SpecName:        specReport.FullText(),
+		Before:          before,
+		After:           after,
+		DeltaDBSize:     after.DBSizeBytes - before.DBSizeBytes,
+		DeltaTmpfsUsed:  after.TmpfsUsedBytes - before.TmpfsUsedBytes,
+		DeltaRevision:   after.Revision - before.Revision,
+		Passed:          !specReport.Failed(),
+		DurationSeconds: specReport.RunTime.Seconds(),
+	}
+
+	p.records = append(p.records, record)
+
+	printInfo("etcd profiler: spec=%q dbSize=%d tmpfsUsed=%d/%d deltaDB=%d deltaTmpfs=%d rev=%d walSize=%d snapSize=%d",
+		specReport.FullText(),
+		after.DBSizeBytes,
+		after.TmpfsUsedBytes,
+		after.TmpfsTotalBytes,
+		record.DeltaDBSize,
+		record.DeltaTmpfsUsed,
+		after.Revision,
+		after.WALSizeBytes,
+		after.SnapSizeBytes,
+	)
+}
+
+// Finalize writes the collected records to the artifacts directory.
+func (p *EtcdProfiler) Finalize() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if len(p.records) == 0 {
+		return
+	}
+
+	if err := os.MkdirAll(p.artifactsDir, 0777); err != nil {
+		printError("etcd profiler: failed to create artifacts dir: %v", err)
+		return
+	}
+
+	// Write summary
+	summary := p.buildSummary()
+	data, err := json.MarshalIndent(summary, "", "  ")
+	if err != nil {
+		printError("etcd profiler: failed to marshal summary: %v", err)
+		return
+	}
+
+	outPath := filepath.Join(p.artifactsDir, "etcd-storage-profile.json")
+	if err := os.WriteFile(outPath, data, 0644); err != nil {
+		printError("etcd profiler: failed to write %s: %v", outPath, err)
+		return
+	}
+
+	printInfo("etcd profiler: wrote %d records to %s", len(p.records), outPath)
+}
+
+type etcdProfileSummary struct {
+	CollectedAt     string           `json:"collectedAt"`
+	TotalSpecs      int              `json:"totalSpecs"`
+	FinalDBSize     int64            `json:"finalDBSizeBytes"`
+	FinalTmpfsUsed  int64            `json:"finalTmpfsUsedBytes"`
+	FinalTmpfsTotal int64            `json:"finalTmpfsTotalBytes"`
+	FinalWALSize    int64            `json:"finalWALSizeBytes"`
+	FinalSnapSize   int64            `json:"finalSnapSizeBytes"`
+	PeakTmpfsUsed   int64            `json:"peakTmpfsUsedBytes"`
+	PeakDBSize      int64            `json:"peakDBSizeBytes"`
+	Records         []EtcdSpecRecord `json:"records"`
+}
+
+func (p *EtcdProfiler) buildSummary() etcdProfileSummary {
+	s := etcdProfileSummary{
+		CollectedAt: time.Now().UTC().Format(time.RFC3339),
+		TotalSpecs:  len(p.records),
+		Records:     p.records,
+	}
+
+	for _, r := range p.records {
+		if r.After.TmpfsUsedBytes > s.PeakTmpfsUsed {
+			s.PeakTmpfsUsed = r.After.TmpfsUsedBytes
+		}
+		if r.After.DBSizeBytes > s.PeakDBSize {
+			s.PeakDBSize = r.After.DBSizeBytes
+		}
+	}
+
+	if len(p.records) > 0 {
+		last := p.records[len(p.records)-1].After
+		s.FinalDBSize = last.DBSizeBytes
+		s.FinalTmpfsUsed = last.TmpfsUsedBytes
+		s.FinalTmpfsTotal = last.TmpfsTotalBytes
+		s.FinalWALSize = last.WALSizeBytes
+		s.FinalSnapSize = last.SnapSizeBytes
+	}
+
+	return s
+}
+
+func appendError(existing, new string) string {
+	if existing == "" {
+		return new
+	}
+	return existing + "; " + new
+}

--- a/tests/reporter/etcd.go
+++ b/tests/reporter/etcd.go
@@ -273,7 +273,7 @@ func (p *EtcdProfiler) Finalize() {
 		return
 	}
 
-	if err := os.MkdirAll(p.artifactsDir, 0777); err != nil {
+	if err := os.MkdirAll(p.artifactsDir, 0755); err != nil {
 		printError("etcd profiler: failed to create artifacts dir: %v", err)
 		return
 	}

--- a/tests/reporter/etcd.go
+++ b/tests/reporter/etcd.go
@@ -27,16 +27,25 @@ const (
 	etcdKey           = "/etc/kubernetes/pki/etcd/server.key"
 )
 
+type EtcdRangeProbe struct {
+	Prefix     string  `json:"prefix"`
+	KeyCount   int64   `json:"keyCount"`
+	DurationMs float64 `json:"durationMs"`
+	SizeBytes  int64   `json:"sizeBytes"`
+	Error      string  `json:"error,omitempty"`
+}
+
 type EtcdSnapshot struct {
-	DBSizeBytes      int64  `json:"dbSizeBytes"`
-	DBSizeInUseBytes int64  `json:"dbSizeInUseBytes"`
-	Revision         int64  `json:"revision"`
-	TmpfsUsedBytes   int64  `json:"tmpfsUsedBytes"`
-	TmpfsTotalBytes  int64  `json:"tmpfsTotalBytes"`
-	TmpfsAvailBytes  int64  `json:"tmpfsAvailBytes"`
-	WALSizeBytes     int64  `json:"walSizeBytes"`
-	SnapSizeBytes    int64  `json:"snapSizeBytes"`
-	Error            string `json:"error,omitempty"`
+	DBSizeBytes      int64            `json:"dbSizeBytes"`
+	DBSizeInUseBytes int64            `json:"dbSizeInUseBytes"`
+	Revision         int64            `json:"revision"`
+	TmpfsUsedBytes   int64            `json:"tmpfsUsedBytes"`
+	TmpfsTotalBytes  int64            `json:"tmpfsTotalBytes"`
+	TmpfsAvailBytes  int64            `json:"tmpfsAvailBytes"`
+	WALSizeBytes     int64            `json:"walSizeBytes"`
+	SnapSizeBytes    int64            `json:"snapSizeBytes"`
+	RangeProbes      []EtcdRangeProbe `json:"rangeProbes,omitempty"`
+	Error            string           `json:"error,omitempty"`
 }
 
 type EtcdSpecRecord struct {
@@ -50,14 +59,32 @@ type EtcdSpecRecord struct {
 	DurationSeconds float64      `json:"durationSeconds"`
 }
 
+type EtcdRangeMonitorSample struct {
+	Timestamp string           `json:"timestamp"`
+	ElapsedMs float64          `json:"elapsedMs"`
+	Probes    []EtcdRangeProbe `json:"probes"`
+}
+
+type EtcdRangeMonitorRecord struct {
+	Label   string                   `json:"label"`
+	Samples []EtcdRangeMonitorSample `json:"samples"`
+}
+
 type EtcdProfiler struct {
 	artifactsDir   string
 	mu             sync.Mutex
 	records        []EtcdSpecRecord
+	monitorRecords []EtcdRangeMonitorRecord
 	currentSnap    *EtcdSnapshot
 	etcdPod        *v1.Pod
 	virtHandlerPod *v1.Pod
+	monitorStop    chan struct{}
+	monitorDone    chan struct{}
 }
+
+// ActiveEtcdProfiler holds the current profiler instance so that test
+// helpers outside the suite file can access it for live monitoring.
+var ActiveEtcdProfiler *EtcdProfiler
 
 func NewEtcdProfiler(artifactsDir string) *EtcdProfiler {
 	return &EtcdProfiler{
@@ -85,6 +112,25 @@ func (p *EtcdProfiler) getEtcdPod() (*v1.Pod, error) {
 	return p.etcdPod, nil
 }
 
+var kubevirtEtcdPrefixes = []string{
+	"/registry/kubevirt.io/virtualmachineinstances/",
+	"/registry/kubevirt.io/virtualmachines/",
+	"/registry/kubevirt.io/virtualmachineinstancemigrations/",
+	"/registry/kubevirt.io/virtualmachineinstancereplicasets/",
+	"/registry/kubevirt.io/virtualmachineinstancepresets/",
+	"/registry/clone.kubevirt.io/virtualmachineclones/",
+	"/registry/snapshot.kubevirt.io/virtualmachinesnapshots/",
+	"/registry/snapshot.kubevirt.io/virtualmachinesnapshotcontents/",
+	"/registry/snapshot.kubevirt.io/virtualmachinerestores/",
+	"/registry/export.kubevirt.io/virtualmachineexports/",
+	"/registry/pool.kubevirt.io/virtualmachinepools/",
+	"/registry/migrations.kubevirt.io/migrationpolicies/",
+	"/registry/instancetype.kubevirt.io/virtualmachineinstancetypes/",
+	"/registry/instancetype.kubevirt.io/virtualmachineclusterinstancetypes/",
+	"/registry/instancetype.kubevirt.io/virtualmachinepreferences/",
+	"/registry/instancetype.kubevirt.io/virtualmachineclusterpreferences/",
+}
+
 func (p *EtcdProfiler) collectSnapshot() EtcdSnapshot {
 	snap := EtcdSnapshot{}
 
@@ -97,6 +143,7 @@ func (p *EtcdProfiler) collectSnapshot() EtcdSnapshot {
 	p.collectEndpointStatus(pod, &snap)
 	p.collectDfOutput(pod, &snap)
 	p.collectDirSizes(pod, &snap)
+	p.collectRangeProbes(pod, &snap)
 
 	return snap
 }
@@ -217,6 +264,140 @@ func (p *EtcdProfiler) collectDirSizes(etcdPod *v1.Pod, snap *EtcdSnapshot) {
 	}
 }
 
+func (p *EtcdProfiler) collectRangeProbes(pod *v1.Pod, snap *EtcdSnapshot) {
+	for _, prefix := range kubevirtEtcdPrefixes {
+		snap.RangeProbes = append(snap.RangeProbes, p.probeRange(pod, prefix))
+	}
+}
+
+// MonitorRanges starts a background goroutine that samples Range durations
+// for all KubeVirt CRD prefixes at the given interval. Call StopMonitor to
+// stop sampling and store the results. This is intended to capture Range
+// latency during active CRD deletion when the CRD finalizer is running.
+func (p *EtcdProfiler) MonitorRanges(label string, interval time.Duration) {
+	p.mu.Lock()
+	if p.monitorStop != nil {
+		p.mu.Unlock()
+		return
+	}
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	p.monitorStop = stop
+	p.monitorDone = done
+	p.mu.Unlock()
+
+	pod, err := p.getEtcdPod()
+	if err != nil {
+		printError("etcd monitor: failed to get etcd pod: %v", err)
+		close(done)
+		return
+	}
+
+	go func() {
+		defer close(done)
+		start := time.Now()
+		var samples []EtcdRangeMonitorSample
+
+		for {
+			select {
+			case <-stop:
+				p.mu.Lock()
+				p.monitorRecords = append(p.monitorRecords, EtcdRangeMonitorRecord{
+					Label:   label,
+					Samples: samples,
+				})
+				p.mu.Unlock()
+				printInfo("etcd monitor [%s]: stopped after %d samples", label, len(samples))
+				return
+			default:
+			}
+
+			var probes []EtcdRangeProbe
+			for _, prefix := range kubevirtEtcdPrefixes {
+				probe := p.probeRange(pod, prefix)
+				probes = append(probes, probe)
+			}
+
+			sample := EtcdRangeMonitorSample{
+				Timestamp: time.Now().UTC().Format(time.RFC3339Nano),
+				ElapsedMs: float64(time.Since(start).Milliseconds()),
+				Probes:    probes,
+			}
+			samples = append(samples, sample)
+
+			for _, probe := range probes {
+				if probe.KeyCount > 0 || probe.DurationMs > 100 {
+					printInfo("etcd monitor [%s]: %s keys=%d duration=%.1fms size=%d elapsed=%.0fms",
+						label, probe.Prefix, probe.KeyCount, probe.DurationMs, probe.SizeBytes, sample.ElapsedMs)
+				}
+			}
+
+			time.Sleep(interval)
+		}
+	}()
+}
+
+// StopMonitor stops the background Range monitor and waits for it to finish.
+func (p *EtcdProfiler) StopMonitor() {
+	p.mu.Lock()
+	stop := p.monitorStop
+	done := p.monitorDone
+	p.monitorStop = nil
+	p.monitorDone = nil
+	p.mu.Unlock()
+
+	if stop != nil {
+		close(stop)
+	}
+	if done != nil {
+		<-done
+	}
+}
+
+func (p *EtcdProfiler) probeRange(pod *v1.Pod, prefix string) EtcdRangeProbe {
+	probe := EtcdRangeProbe{Prefix: prefix}
+
+	cmd := []string{
+		"etcdctl",
+		"get", prefix,
+		"--prefix",
+		"--keys-only",
+		"--write-out=json",
+		"--cacert=" + etcdCACert,
+		"--cert=" + etcdCert,
+		"--key=" + etcdKey,
+	}
+
+	start := time.Now()
+	stdout, err := exec.ExecuteCommandOnPod(pod, etcdContainerName, cmd)
+	probe.DurationMs = float64(time.Since(start).Microseconds()) / 1000.0
+
+	if err != nil {
+		probe.Error = fmt.Sprintf("etcdctl get: %v", err)
+		return probe
+	}
+
+	var result struct {
+		Header struct {
+			Revision int64 `json:"revision"`
+		} `json:"header"`
+		Kvs   []json.RawMessage `json:"kvs"`
+		Count int64             `json:"count"`
+	}
+	if err := json.Unmarshal([]byte(stdout), &result); err != nil {
+		probe.Error = fmt.Sprintf("parse: %v", err)
+		return probe
+	}
+
+	if result.Count > 0 {
+		probe.KeyCount = result.Count
+	} else {
+		probe.KeyCount = int64(len(result.Kvs))
+	}
+	probe.SizeBytes = int64(len(stdout))
+	return probe
+}
+
 // RecordBeforeSpec captures etcd state before a spec runs.
 func (p *EtcdProfiler) RecordBeforeSpec() {
 	snap := p.collectSnapshot()
@@ -251,7 +432,13 @@ func (p *EtcdProfiler) RecordSpec(specReport types.SpecReport) {
 
 	p.records = append(p.records, record)
 
-	printInfo("etcd profiler: spec=%q dbSize=%d tmpfsUsed=%d/%d deltaDB=%d deltaTmpfs=%d rev=%d walSize=%d snapSize=%d",
+	rangeInfo := ""
+	for _, probe := range after.RangeProbes {
+		if probe.KeyCount > 0 || probe.Error != "" {
+			rangeInfo += fmt.Sprintf(" %s(keys=%d, %.1fms)", probe.Prefix, probe.KeyCount, probe.DurationMs)
+		}
+	}
+	printInfo("etcd profiler: spec=%q dbSize=%d tmpfsUsed=%d/%d deltaDB=%d deltaTmpfs=%d rev=%d walSize=%d snapSize=%d%s",
 		specReport.FullText(),
 		after.DBSizeBytes,
 		after.TmpfsUsedBytes,
@@ -261,15 +448,19 @@ func (p *EtcdProfiler) RecordSpec(specReport types.SpecReport) {
 		after.Revision,
 		after.WALSizeBytes,
 		after.SnapSizeBytes,
+		rangeInfo,
 	)
 }
 
 // Finalize writes the collected records to the artifacts directory.
 func (p *EtcdProfiler) Finalize() {
+	// Stop any running monitor so its samples are flushed to monitorRecords
+	p.StopMonitor()
+
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	if len(p.records) == 0 {
+	if len(p.records) == 0 && len(p.monitorRecords) == 0 {
 		return
 	}
 
@@ -296,16 +487,17 @@ func (p *EtcdProfiler) Finalize() {
 }
 
 type etcdProfileSummary struct {
-	CollectedAt     string           `json:"collectedAt"`
-	TotalSpecs      int              `json:"totalSpecs"`
-	FinalDBSize     int64            `json:"finalDBSizeBytes"`
-	FinalTmpfsUsed  int64            `json:"finalTmpfsUsedBytes"`
-	FinalTmpfsTotal int64            `json:"finalTmpfsTotalBytes"`
-	FinalWALSize    int64            `json:"finalWALSizeBytes"`
-	FinalSnapSize   int64            `json:"finalSnapSizeBytes"`
-	PeakTmpfsUsed   int64            `json:"peakTmpfsUsedBytes"`
-	PeakDBSize      int64            `json:"peakDBSizeBytes"`
-	Records         []EtcdSpecRecord `json:"records"`
+	CollectedAt     string                   `json:"collectedAt"`
+	TotalSpecs      int                      `json:"totalSpecs"`
+	FinalDBSize     int64                    `json:"finalDBSizeBytes"`
+	FinalTmpfsUsed  int64                    `json:"finalTmpfsUsedBytes"`
+	FinalTmpfsTotal int64                    `json:"finalTmpfsTotalBytes"`
+	FinalWALSize    int64                    `json:"finalWALSizeBytes"`
+	FinalSnapSize   int64                    `json:"finalSnapSizeBytes"`
+	PeakTmpfsUsed   int64                    `json:"peakTmpfsUsedBytes"`
+	PeakDBSize      int64                    `json:"peakDBSizeBytes"`
+	Records         []EtcdSpecRecord         `json:"records"`
+	MonitorRecords  []EtcdRangeMonitorRecord `json:"monitorRecords,omitempty"`
 }
 
 func (p *EtcdProfiler) buildSummary() etcdProfileSummary {
@@ -332,6 +524,8 @@ func (p *EtcdProfiler) buildSummary() etcdProfileSummary {
 		s.FinalWALSize = last.WALSizeBytes
 		s.FinalSnapSize = last.SnapSizeBytes
 	}
+
+	s.MonitorRecords = p.monitorRecords
 
 	return s
 }

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -66,6 +66,7 @@ import (
 
 var afterSuiteReporters = []Reporter{}
 var k8sReporter *reporter.KubernetesReporter
+var etcdProfiler *reporter.EtcdProfiler
 
 func TestTests(t *testing.T) {
 	flags.NormalizeFlags()
@@ -95,6 +96,14 @@ func TestTests(t *testing.T) {
 
 	k8sReporter = reporter.NewKubernetesReporter(artifactsPath, maxFails, alwaysCollect)
 	k8sReporter.Cleanup()
+
+	if os.Getenv("KUBEVIRT_PROFILE_ETCD") == "true" {
+		etcdProfilerPath := filepath.Join(flags.ArtifactsDir, "etcd-profiler")
+		if suiteConfig.ParallelTotal > 1 {
+			etcdProfilerPath = filepath.Join(etcdProfilerPath, strconv.Itoa(GinkgoParallelProcess()))
+		}
+		etcdProfiler = reporter.NewEtcdProfiler(etcdProfilerPath)
+	}
 
 	vmsgeneratorutils.DockerPrefix = flags.KubeVirtUtilityRepoPrefix
 	vmsgeneratorutils.DockerTag = flags.KubeVirtVersionTag
@@ -159,6 +168,12 @@ func getAlwaysCollectFromEnv() bool {
 	return alwaysCollect
 }
 
+var _ = ReportAfterSuite("Etcd storage profile", func(_ Report) {
+	if etcdProfiler != nil {
+		etcdProfiler.Finalize()
+	}
+})
+
 var _ = ReportAfterSuite("Collect cluster data", func(report Report) {
 	artifactPath := filepath.Join(flags.ArtifactsDir, "k8s-reporter", "suite")
 	kvReport := reporter.NewKubernetesReporter(artifactPath, 1, false)
@@ -177,6 +192,12 @@ var _ = ReportBeforeSuite(func(report Report) {
 	k8sReporter.ConfigurePerSpecReporting(report)
 })
 
+var _ = BeforeEach(func() {
+	if etcdProfiler != nil {
+		etcdProfiler.RecordBeforeSpec()
+	}
+})
+
 // CRITICAL ORDER: These two JustAfterEach blocks must remain in this order!
 // 1. First JustAfterEach checks VM logs and may call ginkgo.Fail() to mark spec as failed.
 // 2. Second one collects logs based on failure status, hence it must run after the first block
@@ -192,6 +213,9 @@ var _ = JustAfterEach(func() {
 		return
 	}
 	k8sReporter.ReportSpec(CurrentSpecReport())
+	if etcdProfiler != nil {
+		etcdProfiler.RecordSpec(CurrentSpecReport())
+	}
 })
 
 func testCleanup() {

--- a/tests/tests_suite_test.go
+++ b/tests/tests_suite_test.go
@@ -103,6 +103,7 @@ func TestTests(t *testing.T) {
 			etcdProfilerPath = filepath.Join(etcdProfilerPath, strconv.Itoa(GinkgoParallelProcess()))
 		}
 		etcdProfiler = reporter.NewEtcdProfiler(etcdProfilerPath)
+		reporter.ActiveEtcdProfiler = etcdProfiler
 	}
 
 	vmsgeneratorutils.DockerPrefix = flags.KubeVirtUtilityRepoPrefix


### PR DESCRIPTION
### What this PR does
#### Before this PR:

No visibility into etcd storage state during the CRD finalizer timeout investigated in #18309.

#### After this PR:

Reverts the test quarantine from #18420 and introduces the opt-in etcd storage profiler from #17035 to capture etcd DB size, tmpfs usage, WAL/snapshot sizes, and revision count before and after each spec during sig-operator runs.

### References

- Partially addresses #18309
- Reverts #18420 (test quarantine)
- Introduces #17035 (etcd profiler)

### Why we need it and why it was done in this way

We need to understand why the etcd Range call for the VMI key space exceeds the 60-second `PollUntilContextTimeout` in the k8s CRD finalizer on k8s 1.35/1.36 but not on k8s 1.34. The root cause is not yet clear — the CRD finalizer timeout, kubevirtci provider configs, etcd versions, and apiserver storage layer are all functionally identical across versions. This PR enables the etcd profiler to collect data during the failure window.

**DO NOT MERGE** — this is a diagnostic PR to collect etcd profiling data from sig-operator CI runs.

### Special notes for your reviewer

Trigger sig-operator runs with:
```
/test pull-kubevirt-e2e-k8s-1.34-sig-operator
/test pull-kubevirt-e2e-k8s-1.35-sig-operator
/test pull-kubevirt-e2e-k8s-1.36-sig-operator
```

The etcd profiler needs `KUBEVIRT_PROFILE_ETCD=true` to activate. Check whether the prowjob config passes this through or if it needs to be hardcoded as default-on for this run.

### Checklist

- [ ] PR: The PR description is expressive enough and will help future contributors
- [x] AI Contributions: The PR abides by the KubeVirt AI Contribution Policy.

### Release note
```release-note
NONE
```