### PR TITLE
Support raw ORAS artifacts in imageVolume containerDisk path

### DIFF
--- a/pkg/virt-controller/services/rendervolumes.go
+++ b/pkg/virt-controller/services/rendervolumes.go
@@ -253,7 +253,8 @@ func withImageVolumes(vmi *v1.VirtualMachineInstance) VolumeRendererOption {
 			renderer.addKernelBootVolumeMount()
 		}
 
-		if shouldAddLauncherBinaryVolume(vmi, renderer.imageIDs) {
+		if vmi.Annotations[v1.ImageVolumeSkipDigestResolutionAnnotation] != "true" &&
+			shouldAddLauncherBinaryVolume(vmi, renderer.imageIDs) {
 			renderer.addLauncherBinaryVolume()
 		}
 

--- a/pkg/virt-controller/services/rendervolumes_test.go
+++ b/pkg/virt-controller/services/rendervolumes_test.go
@@ -427,6 +427,33 @@ var _ = Describe("Container spec renderer", func() {
 			Entry("PullNever", k8sv1.PullNever),
 			Entry("PullIfNotPresent", k8sv1.PullIfNotPresent),
 		)
+
+		It("should not add launcher binary volume when skip-digest-resolution annotation is set", func() {
+			const imageVolumeFeatureGateEnabled = true
+			vmi := libvmi.New(
+				libvmi.WithContainerDisk("test-disk", "registry/image:tag"),
+				libvmi.WithAnnotation(v1.ImageVolumeSkipDigestResolutionAnnotation, "true"),
+			)
+
+			var err error
+			vsr, err = NewVolumeRenderer(
+				stubImagePullPolicyGetter{imagePullPolicy: k8sv1.PullAlways},
+				imageVolumeFeatureGateEnabled,
+				launcherImage,
+				make(map[string]string),
+				namespace,
+				ephemeralDisk,
+				containerDisk,
+				virtShareDir,
+				withImageVolumes(vmi),
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			for _, vol := range vsr.Volumes() {
+				Expect(vol.Name).ToNot(Equal(containerdisk.LauncherVolume),
+					"should not create launcher binary volume when digest resolution is skipped")
+			}
+		})
 	})
 })
 

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -658,7 +658,7 @@ func (t *TemplateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 		if kernelBootInitContainer != nil {
 			initContainers = append(initContainers, *kernelBootInitContainer)
 		}
-	} else if t.clusterConfig.ImageVolumeEnabled() {
+	} else if t.clusterConfig.ImageVolumeEnabled() && vmi.Annotations[v1.ImageVolumeSkipDigestResolutionAnnotation] != "true" {
 		// TODO: Once the KEP https://github.com/kubernetes/enhancements/pull/5375 is fully implemented and stable
 		// in all Kubernetes versions supported by KubeVirt, this entire init containers logic should be removed,
 		// and the digest can be fetched directly from the Pod volume status.

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -4306,6 +4306,25 @@ var _ = Describe("Template", func() {
 				),
 			)
 
+			It("should skip init containers and launcher volume when skip-digest-resolution annotation is set", func() {
+				vmi := libvmi.New(
+					libvmi.WithNamespace("default"),
+					libvmi.WithContainerDisk("r0", "someImage"),
+					libvmi.WithAnnotation(v1.ImageVolumeSkipDigestResolutionAnnotation, "true"),
+				)
+				pod, err := svc.RenderLaunchManifest(vmi)
+				Expect(err).ToNot(HaveOccurred())
+
+				for _, vol := range pod.Spec.Volumes {
+					Expect(vol.Name).ToNot(Equal(containerdisk.LauncherVolume),
+						"should not create launcher binary volume when digest resolution is skipped")
+				}
+				for _, c := range pod.Spec.InitContainers {
+					Expect(c.Name).ToNot(HavePrefix("volume"),
+						"should not create digest-resolving init containers when annotation is set")
+				}
+			})
+
 			DescribeTable("should use image digest extracted from source pod during migration and avoid adding init container for container disks ", func(vmi *v1.VirtualMachineInstance, sourcePod *k8sv1.Pod, expectedVolumes []k8sv1.Volume) {
 				// Create a mock migration object
 				migration := &v1.VirtualMachineInstanceMigration{

--- a/pkg/virt-launcher/virtwrap/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/BUILD.bazel
@@ -119,6 +119,7 @@ go_test(
         "//pkg/os/disk:go_default_library",
         "//pkg/pointer:go_default_library",
         "//pkg/testutils:go_default_library",
+        "//pkg/unsafepath:go_default_library",
         "//pkg/util:go_default_library",
         "//pkg/util/heap:go_default_library",
         "//pkg/util/migrations:go_default_library",

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -2945,17 +2945,40 @@ func getDiskTargetPathFromImageVolumeView(volumeIndex int, volumePath string) (*
 	if volumePath != "" {
 		return safepath.JoinAndResolveWithRelativeRoot(kutil.VirtImageVolumeDir, fmt.Sprintf("disk_%d", volumeIndex), volumePath)
 	}
-	imageVolumeDir := filepath.Join(kutil.VirtImageVolumeDir, fmt.Sprintf("disk_%d", volumeIndex), osdisk.DiskSourceFallbackPath)
-	files, err := os.ReadDir(imageVolumeDir)
+
+	baseDir := filepath.Join(kutil.VirtImageVolumeDir, fmt.Sprintf("disk_%d", volumeIndex))
+	return findDiskFileInImageVolume(baseDir)
+}
+
+func findDiskFileInImageVolume(baseDir string) (*safepath.Path, error) {
+	files, err := os.ReadDir(baseDir)
 	if err != nil {
-		return nil, fmt.Errorf("failed to check ImageVolume path %s: %v", imageVolumeDir, err)
+		return nil, fmt.Errorf("failed to read image volume directory %s: %v", baseDir, err)
 	}
-	if len(files) == 0 {
-		return nil, fmt.Errorf("no file found in folder %s, no disk present", imageVolumeDir)
-	} else if len(files) > 1 {
-		return nil, fmt.Errorf("more than one file found in folder %s, only one disk is allowed", imageVolumeDir)
+
+	// Prefer single file at the root (common case for ORAS-pushed artifacts)
+	if len(files) == 1 && !files[0].IsDir() {
+		log.Log.Infof("Using single file from root of image volume: %s", files[0].Name())
+		return safepath.JoinAndResolveWithRelativeRoot(baseDir, files[0].Name())
 	}
-	return safepath.JoinAndResolveWithRelativeRoot(imageVolumeDir, files[0].Name())
+
+	// Fallback to legacy /disk behavior for backward compatibility with classic container images
+	diskDir := filepath.Join(baseDir, osdisk.DiskSourceFallbackPath)
+	stat, err := os.Stat(diskDir)
+	if err != nil || !stat.IsDir() {
+		return nil, fmt.Errorf("could not determine disk file in image volume root %s (found %d entries, no %s directory)", baseDir, len(files), osdisk.DiskSourceFallbackPath)
+	}
+
+	diskFiles, err := os.ReadDir(diskDir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read legacy /disk directory %s: %v", diskDir, err)
+	}
+	if len(diskFiles) != 1 || diskFiles[0].IsDir() {
+		return nil, fmt.Errorf("could not determine disk file in %s (expected exactly one non-directory entry, found %d)", diskDir, len(diskFiles))
+	}
+
+	log.Log.Infof("Using single file from /disk fallback in image volume: %s", diskFiles[0].Name())
+	return safepath.JoinAndResolveWithRelativeRoot(diskDir, diskFiles[0].Name())
 }
 
 func getKernelBootArtifactPathFromImageVolumeView(artifact string) (*safepath.Path, error) {

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -55,6 +55,7 @@ import (
 	osdisk "kubevirt.io/kubevirt/pkg/os/disk"
 	virtpointer "kubevirt.io/kubevirt/pkg/pointer"
 	"kubevirt.io/kubevirt/pkg/testutils"
+	"kubevirt.io/kubevirt/pkg/unsafepath"
 	"kubevirt.io/kubevirt/pkg/util"
 	"kubevirt.io/kubevirt/pkg/util/net/ip"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
@@ -4823,4 +4824,63 @@ var _ = Describe("Cross-architecture emulation helpers", func() {
 		Entry("uses host arch when guest arch matches host", true, runtime.GOARCH, runtime.GOARCH),
 		Entry("uses guest arch for cross-arch emulation", true, crossArch, crossArch),
 	)
+})
+
+var _ = Describe("findDiskFileInImageVolume", func() {
+	var baseDir string
+
+	BeforeEach(func() {
+		baseDir = GinkgoT().TempDir()
+	})
+
+	It("should use single file at root for ORAS-style artifacts", func() {
+		Expect(os.WriteFile(filepath.Join(baseDir, "fedora.qcow2"), []byte("fake-disk"), 0644)).To(Succeed())
+
+		result, err := findDiskFileInImageVolume(baseDir)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(unsafepath.UnsafeAbsolute(result.Raw())).To(HaveSuffix("/fedora.qcow2"))
+	})
+
+	It("should fallback to /disk for classic container images", func() {
+		diskDir := filepath.Join(baseDir, osdisk.DiskSourceFallbackPath)
+		Expect(os.MkdirAll(diskDir, 0755)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(diskDir, "disk.img"), []byte("fake-disk"), 0644)).To(Succeed())
+
+		result, err := findDiskFileInImageVolume(baseDir)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(unsafepath.UnsafeAbsolute(result.Raw())).To(HaveSuffix("/disk/disk.img"))
+	})
+
+	It("should use /disk fallback when root has both a file and a directory", func() {
+		Expect(os.WriteFile(filepath.Join(baseDir, "image.raw"), []byte("fake-disk"), 0644)).To(Succeed())
+
+		diskDir := filepath.Join(baseDir, osdisk.DiskSourceFallbackPath)
+		Expect(os.MkdirAll(diskDir, 0755)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(diskDir, "disk.img"), []byte("fake-disk"), 0644)).To(Succeed())
+
+		result, err := findDiskFileInImageVolume(baseDir)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(unsafepath.UnsafeAbsolute(result.Raw())).To(HaveSuffix("/disk/disk.img"))
+	})
+
+	It("should fail when directory is empty", func() {
+		_, err := findDiskFileInImageVolume(baseDir)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("could not determine disk file"))
+	})
+
+	It("should fail when multiple files at root and no /disk fallback", func() {
+		Expect(os.WriteFile(filepath.Join(baseDir, "disk1.qcow2"), []byte("fake"), 0644)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(baseDir, "disk2.qcow2"), []byte("fake"), 0644)).To(Succeed())
+
+		_, err := findDiskFileInImageVolume(baseDir)
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("could not determine disk file"))
+	})
+
+	It("should fail when directory does not exist", func() {
+		_, err := findDiskFileInImageVolume(filepath.Join(baseDir, "nonexistent"))
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("failed to read image volume directory"))
+	})
 })

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -1166,6 +1166,12 @@ const (
 	// Internal use only.
 	OwnerVMINameAnnotation string = "kubevirt.io/owner-vmi-name"
 	OwnerVMIUIDAnnotation  string = "kubevirt.io/owner-vmi-uid"
+	// ImageVolumeSkipDigestResolutionAnnotation skips the digest-resolving init
+	// containers for containerDisk volumes when the ImageVolume feature gate is
+	// enabled. Required for OCI artifacts (e.g. raw disk images pushed with ORAS)
+	// that are not valid container images. Will be removed once VEP #117 / KEP 5365
+	// provides digest resolution via Pod volume status.
+	ImageVolumeSkipDigestResolutionAnnotation string = "kubevirt.io/image-volume-skip-digest-resolution"
 	// This label is used to indicate that this pod is the target of a migration job.
 	MigrationJobLabel string = "kubevirt.io/migrationJobUID"
 	// This label indicates the migration name that a PDB is protecting.

--- a/tests/container_disk_test.go
+++ b/tests/container_disk_test.go
@@ -211,6 +211,46 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 		})
 	})
 
+	// TODO: Once all containerDisk images are migrated to ORAS (see VEP 392),
+	// these dedicated ORAS tests can be dropped since the existing containerDisk
+	// tests would implicitly cover ORAS artifact support.
+	Describe("Starting a VMI from a raw ORAS artifact", decorators.ImageVolume, func() {
+		BeforeEach(func() {
+			v, err := checks.GetKubernetesVersion()
+			Expect(err).ToNot(HaveOccurred())
+			if v < "1.35" {
+				Fail("this test requires Kubernetes version >= 1.35")
+			}
+			if !checks.HasFeature(featuregate.ImageVolume) {
+				Fail("ImageVolume feature gate is not enabled")
+			}
+		})
+
+		It("should boot, live migrate, and login to a VMI using a raw ORAS artifact", func() {
+			vmi := libvmi.New(
+				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+				libvmi.WithNetwork(v1.DefaultPodNetwork()),
+				libvmi.WithResourceMemory("256Mi"),
+				libvmi.WithContainerDiskAndPullPolicy("rootdisk", flags.OrasTestArtifactImage, k8sv1.PullAlways),
+				libvmi.WithAnnotation(v1.ImageVolumeSkipDigestResolutionAnnotation, "true"),
+			)
+			vmi = libvmops.RunVMIAndExpectLaunch(vmi, flags.StartupTimeoutSecondsLarge())
+
+			By("Logging into the VM")
+			Expect(console.LoginToAlpine(vmi)).To(Succeed())
+
+			By("Starting live migration")
+			migration := libmigration.New(vmi.Name, vmi.Namespace)
+			migration = libmigration.RunMigrationAndExpectToCompleteWithDefaultTimeout(virtClient, migration)
+
+			By("Verifying the VMI is still running after migration")
+			vmi = libmigration.ConfirmVMIPostMigration(virtClient, vmi, migration)
+
+			By("Logging in after migration")
+			Expect(console.LoginToAlpine(vmi)).To(Succeed())
+		})
+	})
+
 	Describe("Simulate an upgrade from a version where ImageVolume was disabled to a version where it is enabled", Serial, decorators.ImageVolume, decorators.NoFlakeCheck, func() {
 		BeforeEach(func() {
 			v, err := checks.GetKubernetesVersion()

--- a/tests/flags/flags.go
+++ b/tests/flags/flags.go
@@ -61,6 +61,7 @@ var MigrationNetworkNIC = "eth1"
 var MigrationNetworkName string
 var EmulatedSRIOV bool
 var PrimaryNetworkBindingPlugin string
+var OrasTestArtifactImage = "quay.io/vladikr/alpine-oras-artifact:devel"
 
 func init() {
 	kubecli.Init()
@@ -97,6 +98,7 @@ func init() {
 	flag.StringVar(&MigrationNetworkName, "migration-network-name", "", "name of the NetworkAttachmentDefinition CR to be used for dedicated migration network tests")
 	flag.BoolVar(&EmulatedSRIOV, "emulated-sriov", false, "Run SR-IOV tests in emulated mode")
 	flag.StringVar(&PrimaryNetworkBindingPlugin, "primary-network-binding-plugin", "", "Name of a pre-registered network binding plugin to use instead of masquerade in conformance tests")
+	flag.StringVar(&OrasTestArtifactImage, "oras-test-artifact-image", OrasTestArtifactImage, "OCI artifact image for ORAS functional tests")
 }
 
 func NormalizeFlags() {


### PR DESCRIPTION
### What this PR does
#### Before this PR:

When the ImageVolume feature gate is enabled, KubeVirt creates no-op init containers from each containerDisk image to force the CRI to pull the image and expose its resolved sha256 digest in `pod.status.initContainerStatuses[].imageID`. This works for standard container disk images, but raw OCI artifacts pushed with ORAS (e.g. `quay.io/agentil/qcow:fedora44`) are **not valid container images** — they have no rootfs layers, so the CRI cannot create a container from them, resulting in `CreateContainerError`. This blocks all ORAS-based containerDisk usage.

Additionally, the disk file discovery in virt-launcher only looks in the `/disk` subdirectory, which doesn't exist for ORAS artifacts that place the file at the image root.

#### After this PR:

1. **Disk file discovery** (`manager.go`): When no explicit `path:` is specified, first check if the volume root contains a single file (the common layout for ORAS-pushed artifacts). Fall back to the legacy `/disk` subdirectory for classic container disk images.

2. **Annotation to skip init containers** (`template.go`, `rendervolumes.go`): When the annotation `kubevirt.io/image-volume-skip-digest-resolution: "true"` is set on the VMI, the digest-resolving init containers and launcher binary volume are not created. This allows ORAS artifacts (which CRI-O cannot create containers from) to work as containerDisk sources. Without the annotation, the default behavior is preserved — init containers are created for digest pinning during live migration.

Example usage:
```yaml
apiVersion: kubevirt.io/v1
kind: VirtualMachineInstance
metadata:
  name: my-oras-vm
  annotations:
    kubevirt.io/image-volume-skip-digest-resolution: "true"
spec:
  domain:
    resources:
      requests:
        memory: 512Mi
    devices:
      disks:
      - name: rootdisk
        disk:
          bus: virtio
  volumes:
  - name: rootdisk
    containerDisk:
      image: quay.io/agentil/qcow:fedora44
```

### Why we need it and why it was done in this way

**Why an annotation instead of removing init containers entirely:**

The digest-resolving init containers were introduced in PR #6535 to ensure that migration target pods pull the exact same image as the source. Removing them entirely would break digest pinning for live migration with tag-based container disk images — if someone updates the tag while a VMI is running, migration could silently use a different image.

The annotation approach preserves the safe default while allowing users who need ORAS artifacts to opt in explicitly. Users of ORAS artifacts accept the trade-off that tag-based references won't be digest-pinned during migration.

The annotation will be removed once VEP #117 (which depends on KEP 5365, targeting beta in k8s 1.38) graduates and digests are available via Pod volume status.

**The following alternatives were considered:**

- Removing init containers entirely when ImageVolume is enabled — rejected because it breaks digest pinning for regular container disks during live migration.
- Resolving the digest in virt-controller by querying the registry API directly — adds complexity and requires handling pull secrets, registry auth, etc.
- Auto-detecting ORAS artifacts vs container images — no reliable way to distinguish them at the API level before the pod is created.
- Adding a new Bazel-built container disk image to the test infrastructure — rejected to avoid build infrastructure overhead for downstream consumers (per @Barakmor1's feedback).

### Special notes for your reviewer

- Demo recording: https://asciinema.org/a/jvr0DoWN5M2UA8ky
- Verified end-to-end on a k8s-1.36 cluster with 2 nodes:
  - Regular Alpine containerDisk (no annotation): init containers present, `/disk` fallback works
  - ORAS artifact with annotation: boots successfully, no init containers
  - Live migration of ORAS artifact VMI: succeeds, target pod also has no init containers
- Functional tests use an externally hosted ORAS artifact (`quay.io/vladikr/alpine-oras-artifact:devel`) — no new build infrastructure required

### Checklist

- [ ] Design: A VEP was not required — this is an incremental improvement to the existing ImageVolume path
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: The annotation approach keeps the safe default while enabling new use cases
- [x] Upgrade: No upgrade impact — ImageVolume is already Beta. Pods created before this change continue to work. The annotation is opt-in.
- [x] Testing: Unit tests for disk discovery (7 cases), annotation-based init container skip, functional e2e tests for boot and live migration with ORAS artifacts
- [ ] Documentation: A user-guide update should document the annotation and ORAS artifact support once this merges
- [ ] Community: Announcement to kubevirt-dev was considered
- [x] AI Contributions: The PR abides by the KubeVirt AI Contribution Policy

### Release note
```release-note
Add support for OCI artifacts (e.g. raw disk images pushed with ORAS) as containerDisk sources via the ImageVolume path. Set the annotation `kubevirt.io/image-volume-skip-digest-resolution: "true"` on the VMI to skip the digest-resolving init containers that are incompatible with non-container OCI artifacts. The disk file discovery now also supports images with the disk at the root directory, not just under /disk.
```