### PR TITLE
Safepath: Make sure the whole path doesn't have symlink

### DIFF
--- a/pkg/safepath/safepath.go
+++ b/pkg/safepath/safepath.go
@@ -122,7 +122,18 @@ func OpenAtNoFollow(path *Path) (file *File, err error) {
 		}
 		fd = newfd
 	}
-	return &File{fd: fd, path: path}, nil
+	file = &File{fd: fd, path: path}
+	fstat, err := os.Stat(file.SafePath())
+	if err != nil {
+		_ = file.Close()
+		return nil, err
+	}
+	if fstat.Mode()&os.ModeSymlink != 0 {
+		_ = file.Close()
+		return nil, fmt.Errorf("%s: the pathname is symlink", path)
+	}
+
+	return file, nil
 }
 
 func ChmodAtNoFollow(path *Path, mode os.FileMode) error {

--- a/pkg/safepath/safepath_test.go
+++ b/pkg/safepath/safepath_test.go
@@ -263,6 +263,40 @@ var _ = Describe("safepath", func() {
 		Expect(unsafepath.UnsafeRelative(child.Raw())).To(Equal("/test"))
 	})
 
+	It("should fail on symlink as base", func() {
+		baseDir := GinkgoT().TempDir()
+		// Create dir acting as root
+		Expect(os.MkdirAll(filepath.Join(baseDir, "root"), os.ModePerm)).To(Succeed())
+
+		root, err := JoinAndResolveWithRelativeRoot(filepath.Join(baseDir, "root"))
+		Expect(err).ToNot(HaveOccurred())
+
+		// create dir and file within root
+		Expect(os.MkdirAll(filepath.Join(baseDir, "root", "dir"), os.ModePerm)).To(Succeed())
+		f, err := os.Create(filepath.Join(baseDir, "root", "dir", "file"))
+		Expect(err).ToNot(HaveOccurred())
+		Expect(f.Close()).ToNot(HaveOccurred())
+
+		// create symlinks to dir & file
+		Expect(os.Symlink(filepath.Join(baseDir, "root", "dir"),
+			filepath.Join(baseDir, "root", "symtodir"))).
+			To(Succeed())
+		Expect(os.Symlink(filepath.Join(baseDir, "root", "dir", "file"),
+			filepath.Join(baseDir, "root", "symtofile"))).
+			To(Succeed())
+
+		// Test
+		_, err = JoinNoFollow(root, "symtodir")
+		Expect(err).To(MatchError(ContainSubstring("symlink")))
+
+		_, err = NewPathNoFollow(filepath.Join(baseDir, "root", "symtodir"))
+		Expect(err).To(MatchError(ContainSubstring("symlink")))
+
+		_, err = NewFileNoFollow(filepath.Join(baseDir, "root", "symtofile"))
+		Expect(err).To(MatchError(ContainSubstring("symlink")))
+
+	})
+
 	It("should append new relative root components to the relative path", func() {
 		baseDir := GinkgoT().TempDir()
 		root, err := JoinAndResolveWithRelativeRoot(baseDir)


### PR DESCRIPTION
### What this PR does
The `safepath` package contains a bug where the last part of the path can be symlink and the package doesn't handle it.
The context can be found in manpage of `openat`:
```
If pathname is a symbolic link and the O_NOFOLLOW flag is also specified, then the call returns a file descriptor referring to the symbolic link.
```
This PR fixes it by performing `stat` on the `safepath` that will result in getting the metadata of the symlink (symlink is not followed). 

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

