### PR TITLE
Add check in handleVolumeUpdateRequest function to determine whether VMI already has migratedVolumes

### DIFF
--- a/pkg/virt-controller/watch/vm/vm.go
+++ b/pkg/virt-controller/watch/vm/vm.go
@@ -905,6 +905,21 @@ func (c *Controller) handleVolumeUpdateRequest(vm *virtv1.VirtualMachine, vmi *v
 		*vm.Spec.UpdateVolumesStrategy == virtv1.UpdateVolumesStrategyReplacement:
 		log.Log.Object(vm).V(4).Infof("not handling replacement update volumes strategy")
 	case vm.Spec.UpdateVolumesStrategy != nil && *vm.Spec.UpdateVolumesStrategy == virtv1.UpdateVolumesStrategyMigration:
+		// Idempotency: if VMI has migratedVolumes the VM doesn't have yet,
+		// propagate them to the VM status (recovery from partial failure).
+		vmHasMigratedVolumes := vm.Status.VolumeUpdateState != nil &&
+			vm.Status.VolumeUpdateState.VolumeMigrationState != nil &&
+			equality.Semantic.DeepEqual(vm.Status.VolumeUpdateState.VolumeMigrationState.MigratedVolumes, vmi.Status.MigratedVolumes)
+		if len(vmi.Status.MigratedVolumes) > 0 && !vmHasMigratedVolumes &&
+			volumemig.MigratedVolumesMatchVMSpec(vmi.Status.MigratedVolumes, &vm.Spec.Template.Spec) {
+			if vm.Status.VolumeUpdateState == nil {
+				vm.Status.VolumeUpdateState = &virtv1.VolumeUpdateState{}
+			}
+			vm.Status.VolumeUpdateState.VolumeMigrationState = &virtv1.VolumeMigrationState{
+				MigratedVolumes: vmi.Status.MigratedVolumes,
+			}
+		}
+
 		if !volumemig.PersistentVolumesUpdated(&vm.Spec.Template.Spec, &vmi.Spec) {
 			log.Log.Object(vm).V(4).Infof("No persistent volumes updated")
 			return nil

--- a/pkg/virt-controller/watch/vm/vm_test.go
+++ b/pkg/virt-controller/watch/vm/vm_test.go
@@ -6101,6 +6101,72 @@ var _ = Describe("VirtualMachine", func() {
 					Expect(cond.Message).To(ContainSubstring("invalid volumes to update with migration:"))
 				})
 
+				migVols := func(src, dst string) []v1.StorageMigratedVolumeInfo {
+					return []v1.StorageMigratedVolumeInfo{{
+						VolumeName:         diskName,
+						SourcePVCInfo:      &v1.PersistentVolumeClaimInfo{ClaimName: src},
+						DestinationPVCInfo: &v1.PersistentVolumeClaimInfo{ClaimName: dst},
+					}}
+				}
+				migState := func(src, dst string) *v1.VolumeMigrationState {
+					return &v1.VolumeMigrationState{MigratedVolumes: migVols(src, dst)}
+				}
+				volUpdateState := func(src, dst string) *v1.VolumeUpdateState {
+					return &v1.VolumeUpdateState{VolumeMigrationState: migState(src, dst)}
+				}
+
+				DescribeTable("should handle migratedVolumes propagation from VMI to VM", func(
+					volClaim string,
+					vmiMigratedVols []v1.StorageMigratedVolumeInfo,
+					vmVolumeUpdateState *v1.VolumeUpdateState,
+					expectedVolumeMigrationState *v1.VolumeMigrationState,
+				) {
+					testutils.UpdateFakeKubeVirtClusterConfig(kvStore, &v1.KubeVirt{
+						Spec: v1.KubeVirtSpec{
+							Configuration: v1.KubeVirtConfiguration{
+								VMRolloutStrategy: &liveUpdate,
+							},
+						},
+					})
+
+					vmi := libvmi.New(libvmi.WithNamespace(ns), libvmi.WithDataVolume(diskName, volClaim))
+					vm := libvmi.NewVirtualMachine(
+						libvmi.New(libvmi.WithNamespace(ns), libvmi.WithDataVolume(diskName, volClaim)),
+						libvmi.WithUpdateVolumeStrategy(v1.UpdateVolumesStrategyMigration),
+					)
+
+					vmi.Status.MigratedVolumes = vmiMigratedVols
+					vm.Status.VolumeUpdateState = vmVolumeUpdateState
+
+					controller.handleVolumeUpdateRequest(vm, vmi)
+
+					if expectedVolumeMigrationState == nil {
+						if vm.Status.VolumeUpdateState == nil {
+							return
+						}
+						Expect(vm.Status.VolumeUpdateState.VolumeMigrationState).To(BeNil())
+					} else {
+						Expect(vm.Status.VolumeUpdateState).ToNot(BeNil())
+						Expect(vm.Status.VolumeUpdateState.VolumeMigrationState).To(Equal(expectedVolumeMigrationState))
+					}
+				},
+					Entry("should propagate when VM status update previously failed",
+						"dv1", migVols("dv0", "dv1"), nil, migState("dv0", "dv1"),
+					),
+					Entry("should not update when VM already has matching migratedVolumes",
+						"dv1", migVols("dv0", "dv1"), volUpdateState("dv0", "dv1"), migState("dv0", "dv1"),
+					),
+					Entry("should not update when VMI has no migratedVolumes",
+						"dv1", nil, nil, nil,
+					),
+					Entry("should not propagate stale migratedVolumes from cancelled migration",
+						"dv0", migVols("dv0", "dv1"), nil, nil,
+					),
+					Entry("should overwrite with new migratedVolumes during chained migration",
+						"dv2", migVols("dv1", "dv2"), volUpdateState("dv0", "dv1"), migState("dv1", "dv2"),
+					),
+				)
+
 				DescribeTable("should return an error", func(setup func() (*v1.VirtualMachineInstance, *v1.VirtualMachine)) {
 					testutils.UpdateFakeKubeVirtClusterConfig(kvStore, &v1.KubeVirt{
 						Spec: v1.KubeVirtSpec{

--- a/pkg/virt-controller/watch/volume-migration/volume-migration.go
+++ b/pkg/virt-controller/watch/volume-migration/volume-migration.go
@@ -466,6 +466,26 @@ func PatchVMIVolumes(clientset kubecli.KubevirtClient, vmi *virtv1.VirtualMachin
 	return clientset.VirtualMachineInstance(vmi.Namespace).Patch(context.Background(), vmi.Name, types.JSONPatchType, patch, metav1.PatchOptions{})
 }
 
+// MigratedVolumesMatchVMSpec is a helper to determine if the destination in the migrated volumes match VM spec
+func MigratedVolumesMatchVMSpec(migratedVols []virtv1.StorageMigratedVolumeInfo, vmSpec *virtv1.VirtualMachineInstanceSpec) bool {
+	vmVols := make(map[string]string)
+	for _, v := range vmSpec.Volumes {
+		if claim := storagetypes.PVCNameFromVirtVolume(&v); claim != "" {
+			vmVols[v.Name] = claim
+		}
+	}
+	for _, mv := range migratedVols {
+		if mv.DestinationPVCInfo == nil {
+			return false
+		}
+		vmClaim, ok := vmVols[mv.VolumeName]
+		if !ok || vmClaim != mv.DestinationPVCInfo.ClaimName {
+			return false
+		}
+	}
+	return true
+}
+
 // ValidateVolumesUpdateMigration checks if the VMI can be update with the volume migration. For example, for certain VMs, the migration is not allowed for other reasons then the storage
 func ValidateVolumesUpdateMigration(vmi *virtv1.VirtualMachineInstance, vm *virtv1.VirtualMachine, migVolsInfo []virtv1.StorageMigratedVolumeInfo) error {
 	if vmi == nil {

--- a/pkg/virt-controller/watch/volume-migration/volume-migration_test.go
+++ b/pkg/virt-controller/watch/volume-migration/volume-migration_test.go
@@ -410,7 +410,89 @@ var _ = Describe("Volume Migration", func() {
 			Entry("without any update", []string{"vol0"}, []string{"vol0"}, map[string]migVolumes{}),
 		)
 
+		It("should generate correct migrated volumes for two sequential migrations", func() {
+			// Migration 1: disk0 moves from pvc-a → pvc-b
+			shouldAddPVCsIntoTheStore([]string{"pvc-a"}, []string{"pvc-b"})
+			vmi := libvmi.New(append(addVMIOptionsForVolumes([]string{"pvc-a"}), libvmi.WithNamespace(ns))...)
+			vm := libvmi.NewVirtualMachine(libvmi.New(append(addVMIOptionsForVolumes([]string{"pvc-b"}), libvmi.WithNamespace(ns))...))
+			_, err := fakeClientset.KubevirtV1().VirtualMachineInstances(ns).Create(context.TODO(), vmi, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			migVols1, err := volumemigration.GenerateMigratedVolumes(pvcStore, vmi, vm)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(migVols1).To(HaveLen(1))
+			Expect(migVols1[0].SourcePVCInfo.ClaimName).To(Equal("pvc-a"))
+			Expect(migVols1[0].DestinationPVCInfo.ClaimName).To(Equal("pvc-b"))
+
+			Expect(volumemigration.PatchVMIStatusWithMigratedVolumes(virtClient, migVols1, vmi)).To(Succeed())
+			updatedVMI, err := fakeClientset.KubevirtV1().VirtualMachineInstances(ns).Get(context.TODO(), vmi.Name, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updatedVMI.Status.MigratedVolumes).To(HaveLen(1))
+
+			// Simulate migration 1 completing: VMI volumes are now pvc-b
+			// and VMI still has migratedVolumes from migration 1
+			updatedVMI.Spec.Volumes = vm.Spec.Template.Spec.Volumes
+
+			// Migration 2: disk0 moves from pvc-b → pvc-c
+			shouldAddPVCsIntoTheStore([]string{"pvc-b"}, []string{"pvc-c"})
+			vm2 := libvmi.NewVirtualMachine(libvmi.New(append(addVMIOptionsForVolumes([]string{"pvc-c"}), libvmi.WithNamespace(ns))...))
+
+			migVols2, err := volumemigration.GenerateMigratedVolumes(pvcStore, updatedVMI, vm2)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(migVols2).To(HaveLen(1))
+			Expect(migVols2[0].SourcePVCInfo.ClaimName).To(Equal("pvc-b"),
+				"Migration 2 should use pvc-b as source, not stale pvc-a from migration 1")
+			Expect(migVols2[0].DestinationPVCInfo.ClaimName).To(Equal("pvc-c"),
+				"Migration 2 should use pvc-c as destination")
+		})
 	})
+
+	// helper for the DescribeTable below
+	vmiSpecWithVolumes := func(pvcNames []string) *v1.VirtualMachineInstanceSpec {
+		return &libvmi.New(addVMIOptionsForVolumes(pvcNames)...).Spec
+	}
+
+	DescribeTable("MigratedVolumesMatchVMSpec", func(migratedVols []v1.StorageMigratedVolumeInfo, vmSPec *v1.VirtualMachineInstanceSpec, expected bool) {
+		Expect(volumemigration.MigratedVolumesMatchVMSpec(migratedVols, vmSPec)).To(Equal(expected))
+	},
+
+		Entry("should match when destinatons align with VM spec",
+			[]v1.StorageMigratedVolumeInfo{{
+				VolumeName:         "disk0",
+				SourcePVCInfo:      &v1.PersistentVolumeClaimInfo{ClaimName: "pvc-a"},
+				DestinationPVCInfo: &v1.PersistentVolumeClaimInfo{ClaimName: "pvc-b"},
+			}},
+			vmiSpecWithVolumes([]string{"pvc-b"}),
+			true,
+		),
+		Entry("should not match when destination doesn't align (canceled migration)",
+			[]v1.StorageMigratedVolumeInfo{{
+				VolumeName:         "disk0",
+				SourcePVCInfo:      &v1.PersistentVolumeClaimInfo{ClaimName: "pvc-a"},
+				DestinationPVCInfo: &v1.PersistentVolumeClaimInfo{ClaimName: "pvc-b"},
+			}},
+			vmiSpecWithVolumes([]string{"pvc-a"}),
+			false,
+		),
+		Entry("should not match when DestinationPVCInfo is nil",
+			[]v1.StorageMigratedVolumeInfo{{
+				VolumeName:         "disk0",
+				SourcePVCInfo:      &v1.PersistentVolumeClaimInfo{ClaimName: "pvc-a"},
+				DestinationPVCInfo: nil,
+			}},
+			vmiSpecWithVolumes([]string{"pvc-b"}),
+			false,
+		),
+		Entry("should not match when volume name is not found in VM spec",
+			[]v1.StorageMigratedVolumeInfo{{
+				VolumeName:         "disk99",
+				SourcePVCInfo:      &v1.PersistentVolumeClaimInfo{ClaimName: "pvc-a"},
+				DestinationPVCInfo: &v1.PersistentVolumeClaimInfo{ClaimName: "pvc-b"},
+			}},
+			vmiSpecWithVolumes([]string{"pvc-b"}),
+			false,
+		),
+	)
 
 	Context("ValidateVolumesUpdateMigration", func() {
 		DescribeTable("should validate if the VMI can be migrate due to a volume update", func(vmi *v1.VirtualMachineInstance, exectedRes error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
This PR fixes an idempotency issue in the volume migration reconciliation loop that caused flaky test failures in the sig-storage suite.

When a volume migration is initiated, the controller patches the VMI status and volumes, then updates the VM status. If the VM status update fails (e.g., due to a resource version conflict or server load), the sync loop retries. However, on retry, `PersistentVolumesUpdated` returns `false` because the VMI volumes were already swapped to match the VM, causing `handleVolumeUpdateRequest` to bail out early. The VM status is never updated with MigratedVolumes, and since there is no error, the VM is removed from the work queue permanently.

#### Before this PR:
When a volume migration is initiated, the controller patches the VMI status and volumes, then updates the VM status. If the VM status update fails (e.g., due to a resource version conflict or server load), the sync loop retries. However, on retry, `PersistentVolumesUpdated` returns false because the VMI volumes were already swapped to match the VM, causing `handleVolumeUpdateRequest` to bail out early. The VM status is never updated with MigratedVolumes, and since there is no error, the VM is removed from the work queue permanently.

#### After this PR:
Before the `PersistentVolumesUpdated` gate, `handleVolumeUpdateRequest` now checks whether the VMI has `migratedVolumes` that the VM doesn't have yet (or that differ from the VM's current state). It also validates that the destination PVCs in the VMI's `migratedVolumes` match the current VM spec volumes via `MigratedVolumesMatchVMSpec`, preventing stale data from a cancelled migration from being propagated. If both conditions are met, it propagates the `migratedVolumes` to the VM's in-memory status. The `PersistentVolumesUpdated` gate then returns nil as before, and the updated status is persisted by `updateStatus()`. This keeps the gate and the rest of the migration logic completely untouched. The fix is a standalone pre-check that only handles the partial failure recovery case.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:
None

The following alternatives were considered:
None

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->
Internal team slack

### Special notes for your reviewer
Looking for feedback as an intern.

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

