### PR TITLE
Fix hugepages validation panics and reject non-representable page sizes

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -1064,14 +1064,29 @@ func validateHugepagesMemoryRequests(field *k8sfield.Path, spec *v1.VirtualMachi
 		})
 		return causes
 	}
+	// pageSize is used as an int64 divisor below, so reject any value that is not
+	// a positive whole byte equal to its Value(); CmpInt64 catches zero/negative/overflow/fractional.
+	pageSizeField := field.Child("domain", "memory", "hugepages", "pageSize").String()
+	pageSize := hugepagesSize.Value()
+	if pageSize <= 0 || hugepagesSize.CmpInt64(pageSize) != 0 {
+		causes = append(causes, metav1.StatusCause{
+			Type: metav1.CauseTypeFieldValueInvalid,
+			Message: fmt.Sprintf("%s '%s' must be a positive whole-byte value representable as int64",
+				pageSizeField,
+				spec.Domain.Memory.Hugepages.PageSize,
+			),
+			Field: pageSizeField,
+		})
+		return causes
+	}
 	vmMemory := spec.Domain.Resources.Requests.Memory().Value()
-	if vmMemory == 0 && spec.Domain.Memory != nil {
+	if vmMemory == 0 && spec.Domain.Memory.Guest != nil {
 		vmMemory = spec.Domain.Memory.Guest.Value()
 	}
 	if vmMemory == 0 {
 		vmMemory = spec.Domain.Resources.Limits.Memory().Value()
 	}
-	if vmMemory != 0 && vmMemory < hugepagesSize.Value() {
+	if vmMemory != 0 && vmMemory < pageSize {
 		causes = append(causes, metav1.StatusCause{
 			Type: metav1.CauseTypeFieldValueInvalid,
 			Message: fmt.Sprintf("%s '%s' must be equal to or larger than page size %s '%s'",
@@ -1082,7 +1097,7 @@ func validateHugepagesMemoryRequests(field *k8sfield.Path, spec *v1.VirtualMachi
 			),
 			Field: field.Child("domain", "resources", "requests", "memory").String(),
 		})
-	} else if vmMemory%hugepagesSize.Value() != 0 {
+	} else if vmMemory%pageSize != 0 {
 		causes = append(causes, metav1.StatusCause{
 			Type: metav1.CauseTypeFieldValueInvalid,
 			Message: fmt.Sprintf("%s '%s' is not a multiple of the page size %s '%s'",

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -1068,14 +1068,29 @@ func validateHugepagesMemoryRequests(field *k8sfield.Path, spec *v1.VirtualMachi
 		})
 		return causes
 	}
+	// pageSize is used as an int64 divisor below, so reject any value that is not
+	// a positive whole byte equal to its Value(); CmpInt64 catches zero/negative/overflow/fractional.
+	pageSizeField := field.Child("domain", "memory", "hugepages", "pageSize").String()
+	pageSize := hugepagesSize.Value()
+	if pageSize <= 0 || hugepagesSize.CmpInt64(pageSize) != 0 {
+		causes = append(causes, metav1.StatusCause{
+			Type: metav1.CauseTypeFieldValueInvalid,
+			Message: fmt.Sprintf("%s '%s' must be a positive whole-byte value representable as int64",
+				pageSizeField,
+				spec.Domain.Memory.Hugepages.PageSize,
+			),
+			Field: pageSizeField,
+		})
+		return causes
+	}
 	vmMemory := spec.Domain.Resources.Requests.Memory().Value()
-	if vmMemory == 0 && spec.Domain.Memory != nil {
+	if vmMemory == 0 && spec.Domain.Memory.Guest != nil {
 		vmMemory = spec.Domain.Memory.Guest.Value()
 	}
 	if vmMemory == 0 {
 		vmMemory = spec.Domain.Resources.Limits.Memory().Value()
 	}
-	if vmMemory != 0 && vmMemory < hugepagesSize.Value() {
+	if vmMemory != 0 && vmMemory < pageSize {
 		causes = append(causes, metav1.StatusCause{
 			Type: metav1.CauseTypeFieldValueInvalid,
 			Message: fmt.Sprintf("%s '%s' must be equal to or larger than page size %s '%s'",
@@ -1086,7 +1101,7 @@ func validateHugepagesMemoryRequests(field *k8sfield.Path, spec *v1.VirtualMachi
 			),
 			Field: field.Child("domain", "resources", "requests", "memory").String(),
 		})
-	} else if vmMemory%hugepagesSize.Value() != 0 {
+	} else if vmMemory%pageSize != 0 {
 		causes = append(causes, metav1.StatusCause{
 			Type: metav1.CauseTypeFieldValueInvalid,
 			Message: fmt.Sprintf("%s '%s' is not a multiple of the page size %s '%s'",

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -4466,3 +4466,65 @@ func newValidateStub(statusCauses ...metav1.StatusCause) SpecValidator {
 		return statusCauses
 	}
 }
+
+var _ = Describe("validateHugepagesMemoryRequests", func() {
+	newHugepagesSpec := func(pageSize string, guest *resource.Quantity, requestMemory string) *v1.VirtualMachineInstanceSpec {
+		spec := &v1.VirtualMachineInstanceSpec{}
+		spec.Domain.Memory = &v1.Memory{
+			Hugepages: &v1.Hugepages{PageSize: pageSize},
+			Guest:     guest,
+		}
+		if requestMemory != "" {
+			spec.Domain.Resources.Requests = k8sv1.ResourceList{
+				k8sv1.ResourceMemory: resource.MustParse(requestMemory),
+			}
+		}
+		return spec
+	}
+
+	It("does not panic and returns no error when guest memory is nil and no memory request is set", func() {
+		spec := newHugepagesSpec("2Mi", nil, "")
+		var causes []metav1.StatusCause
+		Expect(func() {
+			causes = validateHugepagesMemoryRequests(k8sfield.NewPath("spec"), spec)
+		}).ToNot(Panic())
+		Expect(causes).To(BeEmpty())
+	})
+
+	It("accepts a valid page size with a matching memory request", func() {
+		spec := newHugepagesSpec("2Mi", nil, "64Mi")
+		Expect(validateHugepagesMemoryRequests(k8sfield.NewPath("spec"), spec)).To(BeEmpty())
+	})
+
+	It("does not reject a MaxInt64 page size as non-representable", func() {
+		spec := newHugepagesSpec("9223372036854775807", nil, "64Mi")
+		for _, cause := range validateHugepagesMemoryRequests(k8sfield.NewPath("spec"), spec) {
+			Expect(cause.Message).NotTo(ContainSubstring("representable"))
+		}
+	})
+
+	It("accepts a realistic decimal page size that is a whole number of bytes (10.1M = 10,100,000, with a matching request)", func() {
+		spec := newHugepagesSpec("10.1M", nil, "101M")
+		Expect(validateHugepagesMemoryRequests(k8sfield.NewPath("spec"), spec)).To(BeEmpty())
+	})
+
+	DescribeTable("rejects an invalid page size with a field-scoped error instead of panicking or bypassing validation",
+		func(pageSize string) {
+			spec := newHugepagesSpec(pageSize, nil, "64Mi")
+			var causes []metav1.StatusCause
+			Expect(func() {
+				causes = validateHugepagesMemoryRequests(k8sfield.NewPath("spec"), spec)
+			}).ToNot(Panic())
+			Expect(causes).To(HaveLen(1))
+			Expect(causes[0].Type).To(Equal(metav1.CauseTypeFieldValueInvalid))
+			Expect(causes[0].Field).To(Equal("spec.domain.memory.hugepages.pageSize"))
+			Expect(causes[0].Message).To(ContainSubstring("representable"))
+		},
+		Entry("zero", "0"),
+		Entry("negative", "-2Mi"),
+		Entry("overflows int64 to zero", "10E"),
+		Entry("overflows int64 aliasing to a small value", "18446744073711648768"),
+		Entry("fractional byte value", "0.1"),
+		Entry("fractional bytes from a binary suffix", "10.1Mi"),
+	)
+})

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -4514,3 +4514,93 @@ func newValidateStub(statusCauses ...metav1.StatusCause) SpecValidator {
 		return statusCauses
 	}
 }
+
+var _ = Describe("validateHugepagesMemoryRequests", func() {
+	newHugepagesSpec := func(pageSize string, guest *resource.Quantity, requestMemory string) *v1.VirtualMachineInstanceSpec {
+		spec := &v1.VirtualMachineInstanceSpec{}
+		spec.Domain.Memory = &v1.Memory{
+			Hugepages: &v1.Hugepages{PageSize: pageSize},
+			Guest:     guest,
+		}
+		if requestMemory != "" {
+			spec.Domain.Resources.Requests = k8sv1.ResourceList{
+				k8sv1.ResourceMemory: resource.MustParse(requestMemory),
+			}
+		}
+		return spec
+	}
+
+	It("does not panic and returns no error when guest memory is nil and no memory request is set", func() {
+		spec := newHugepagesSpec("2Mi", nil, "")
+		var causes []metav1.StatusCause
+		Expect(func() {
+			causes = validateHugepagesMemoryRequests(k8sfield.NewPath("spec"), spec)
+		}).ToNot(Panic())
+		Expect(causes).To(BeEmpty())
+	})
+
+	It("accepts a valid page size with a matching memory request", func() {
+		spec := newHugepagesSpec("2Mi", nil, "64Mi")
+		Expect(validateHugepagesMemoryRequests(k8sfield.NewPath("spec"), spec)).To(BeEmpty())
+	})
+
+	It("keeps a MaxInt64 page size representable and goes on validating against it", func() {
+		spec := newHugepagesSpec("9223372036854775807", nil, "64Mi")
+
+		causes := validateHugepagesMemoryRequests(k8sfield.NewPath("spec"), spec)
+
+		Expect(causes).To(HaveLen(1))
+		Expect(causes[0].Type).To(Equal(metav1.CauseTypeFieldValueInvalid))
+		Expect(causes[0].Field).To(Equal("spec.domain.resources.requests.memory"))
+		Expect(causes[0].Message).NotTo(ContainSubstring("representable"))
+		Expect(causes[0].Message).To(ContainSubstring("must be equal to or larger"))
+	})
+
+	// The limit is the last source the validator falls back to, and reaching it used
+	// to dereference an unset guest.
+	DescribeTable("uses the memory limit when there is no request and guest is unset",
+		func(limit string, wantCause bool) {
+			spec := newHugepagesSpec("2Mi", nil, "")
+			spec.Domain.Resources.Limits = k8sv1.ResourceList{
+				k8sv1.ResourceMemory: resource.MustParse(limit),
+			}
+
+			causes := validateHugepagesMemoryRequests(k8sfield.NewPath("spec"), spec)
+
+			if !wantCause {
+				Expect(causes).To(BeEmpty())
+				return
+			}
+			Expect(causes).To(HaveLen(1))
+			Expect(causes[0].Type).To(Equal(metav1.CauseTypeFieldValueInvalid))
+			Expect(causes[0].Message).To(ContainSubstring("not a multiple"))
+		},
+		Entry("an aligned limit", "64Mi", false),
+		Entry("a limit that is not a multiple of the page size", "65Mi", true),
+	)
+
+	It("accepts a realistic decimal page size that is a whole number of bytes (10.1M = 10,100,000, with a matching request)", func() {
+		spec := newHugepagesSpec("10.1M", nil, "101M")
+		Expect(validateHugepagesMemoryRequests(k8sfield.NewPath("spec"), spec)).To(BeEmpty())
+	})
+
+	DescribeTable("rejects an invalid page size with a field-scoped error instead of panicking or bypassing validation",
+		func(pageSize string) {
+			spec := newHugepagesSpec(pageSize, nil, "64Mi")
+			var causes []metav1.StatusCause
+			Expect(func() {
+				causes = validateHugepagesMemoryRequests(k8sfield.NewPath("spec"), spec)
+			}).ToNot(Panic())
+			Expect(causes).To(HaveLen(1))
+			Expect(causes[0].Type).To(Equal(metav1.CauseTypeFieldValueInvalid))
+			Expect(causes[0].Field).To(Equal("spec.domain.memory.hugepages.pageSize"))
+			Expect(causes[0].Message).To(ContainSubstring("representable"))
+		},
+		Entry("zero", "0"),
+		Entry("negative", "-2Mi"),
+		Entry("overflows int64 to zero", "10E"),
+		Entry("overflows int64 aliasing to a small value", "18446744073711648768"),
+		Entry("fractional byte value", "0.1"),
+		Entry("fractional bytes from a binary suffix", "10.1Mi"),
+	)
+})

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmirs-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmirs-admitter_test.go
@@ -108,6 +108,60 @@ var _ = Describe("Validating VMIRS Admitter", func() {
 			"spec.selector",
 		}),
 	)
+	// The hugepage validator reads the memory sources in turn and used to dereference
+	// an unset guest on the way to the limit. Both operations reach it through Admit.
+	DescribeTable("validates hugepages in the template with no guest memory set", func(operation admissionv1.Operation, pageSize string, expectedField string) {
+		template := newVirtualMachineBuilder().
+			WithDisk(v1.Disk{
+				Name: "testdisk",
+			}).
+			WithVolume(v1.Volume{
+				Name: "testdisk",
+				VolumeSource: v1.VolumeSource{
+					ContainerDisk: testutils.NewFakeContainerDiskSource(),
+				},
+			}).
+			WithLabel("match", "me").
+			BuildTemplate()
+		template.Spec.Domain.Memory = &v1.Memory{Hugepages: &v1.Hugepages{PageSize: pageSize}}
+		template.Spec.Domain.Resources.Requests = nil
+
+		vmirs := &v1.VirtualMachineInstanceReplicaSet{
+			Spec: v1.VirtualMachineInstanceReplicaSetSpec{
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"match": "me"},
+				},
+				Template: template,
+			},
+		}
+		vmirsBytes, _ := json.Marshal(&vmirs)
+
+		ar := &admissionv1.AdmissionReview{
+			Request: &admissionv1.AdmissionRequest{
+				Operation: operation,
+				Resource:  webhooks.VirtualMachineInstanceReplicaSetGroupVersionResource,
+				Object: runtime.RawExtension{
+					Raw: vmirsBytes,
+				},
+			},
+		}
+
+		resp := vmirsAdmitter.Admit(context.Background(), ar)
+
+		if expectedField == "" {
+			Expect(resp.Allowed).To(BeTrue())
+			return
+		}
+		Expect(resp.Allowed).To(BeFalse())
+		Expect(resp.Result.Details.Causes).To(HaveLen(1))
+		Expect(resp.Result.Details.Causes[0].Field).To(Equal(expectedField))
+	},
+		Entry("accepting a valid page size on create", admissionv1.Create, "2Mi", ""),
+		Entry("accepting a valid page size on update", admissionv1.Update, "2Mi", ""),
+		Entry("rejecting a zero page size on create", admissionv1.Create, "0", "spec.template.spec.domain.memory.hugepages.pageSize"),
+		Entry("rejecting a zero page size on update", admissionv1.Update, "0", "spec.template.spec.domain.memory.hugepages.pageSize"),
+	)
+
 	It("should accept valid vmi spec", func() {
 		vmirs := &v1.VirtualMachineInstanceReplicaSet{
 			Spec: v1.VirtualMachineInstanceReplicaSetSpec{


### PR DESCRIPTION
### What this PR does
#### Before this PR:
`validateHugepagesMemoryRequests`, in the shared VMI spec validator `ValidateVirtualMachineInstanceSpec`, could panic on two hugepages inputs and separately accepted some invalid page sizes.

It read `spec.Domain.Memory.Guest.Value()` after checking only `Memory != nil`, so a spec with hugepages, no memory request and an unset `guest` dereferenced a nil pointer. `Memory` is already guaranteed non-nil earlier in the function, so that check was doing nothing.

`pageSize` is a free-form string used below as an int64 divisor and comparison bound, but the code trusted `Quantity.Value()`. `"0"` and decimal values that overflow int64 to zero, such as `"10E"`, divide by zero. A value equal to `2^64 + 2Mi` has a `Value()` that overflows to `2Mi`, so it was silently accepted as a valid 2Mi page size. Fractional values such as `"0.1"` were silently rounded up to one byte.

#### After this PR:
The nil check is on `Guest`, which is what was intended. The page size is rejected unless it is positive and exactly representable as int64, compared with `CmpInt64` against the original quantity rather than the overflowed `Value()`, and the validated value is reused for the comparison and the modulo.

### References
- Fixes #18495

### Why we need it and why it was done in this way
The panics are recovered per request by the HTTP server, so virt-api stays up, but the affected admission request is rejected with an internal error instead of a normal validation response.

Which admitters actually reach the unset `guest` is worth being precise about, because it decides where the regression test belongs. The VM admitter runs `SetDefaultVirtualMachineInstanceSpec` on its copy before validating, and that fills `guest` through `setGuestMemory`, so it cannot reach the dereference; its existing "missing spec.template.spec.domain.memory.guest" case also sets a memory request, so it would not have reached it either way. The VirtualMachineInstanceReplicaSet admitter does no defaulting and hands the template spec straight to the shared validator, on create and on update, so it is affected, and so is a direct call.

### Special notes for your reviewer
The change is limited to `validateHugepagesMemoryRequests`. The tests are in `vmi-create-admitter_test.go` and `vmirs-admitter_test.go`; the latter goes through `Admit`, so it covers the entry point rather than the helper alone.

I checked that the tests discriminate rather than only asserting the panic is gone. Restoring the `Memory != nil` check reddens the VMIRS regression and the limit case and nothing else. Removing the limit fallback reddens exactly the limit case. Reverting the page size guard to a plain `Value() <= 0` reddens exactly the overflow-aliasing entry and the two fractional entries, so the suite pins the `CmpInt64` behaviour rather than the rounding.

Two edge cases I looked at and left unchanged. A binarySI page size above `MaxInt64` such as `8Ei` canonicalizes to `MaxInt64` at parse time, so it passes the representability check; it does not panic and is caught by the existing lower-bound check against a non-zero memory request. The requested memory is still read through `Value()` as before, which is a separate path and out of scope for this fix.

This change was developed with AI assistance (Claude Code). The affected package's unit tests were run and pass.

### Release note
```release-note
Fixed virt-api validating webhook panics and an accepted-but-invalid hugepage page size, caused by missing guest memory or a page size that is not a positive value representable as int64.
```
