### PR TITLE
virt-operator: make cert Secret volume mounts required

### DIFF
--- a/pkg/virt-operator/resource/generate/components/deployments.go
+++ b/pkg/virt-operator/resource/generate/components/deployments.go
@@ -219,14 +219,21 @@ func attachProfileVolume(spec *corev1.PodSpec) {
 
 }
 
+func attachOptionalCertificateSecret(spec *corev1.PodSpec, secretName string, mountPath string) {
+	attachCertificateSecretWithOptions(spec, secretName, mountPath, pointer.P(true))
+}
+
 func attachCertificateSecret(spec *corev1.PodSpec, secretName string, mountPath string) {
-	True := true
+	attachCertificateSecretWithOptions(spec, secretName, mountPath, nil)
+}
+
+func attachCertificateSecretWithOptions(spec *corev1.PodSpec, secretName string, mountPath string, optional *bool) {
 	secretVolume := corev1.Volume{
 		Name: secretName,
 		VolumeSource: corev1.VolumeSource{
 			Secret: &corev1.SecretVolumeSource{
 				SecretName: secretName,
-				Optional:   &True,
+				Optional:   optional,
 			},
 		},
 	}
@@ -656,7 +663,7 @@ func NewOperatorDeployment(namespace, repository, imagePrefix, version, verbosit
 		deployment.Spec.Template.Spec.Containers[0].Env = append(deployment.Spec.Template.Spec.Containers[0].Env, envVars...)
 	}
 
-	attachCertificateSecret(&deployment.Spec.Template.Spec, VirtOperatorCertSecretName, "/etc/virt-operator/certificates")
+	attachOptionalCertificateSecret(&deployment.Spec.Template.Spec, VirtOperatorCertSecretName, "/etc/virt-operator/certificates")
 	attachProfileVolume(&deployment.Spec.Template.Spec)
 	placement.InjectPlacementMetadata(nil, &deployment.Spec.Template.Spec, placement.RequireControlPlanePreferNonWorker)
 

--- a/pkg/virt-operator/resource/generate/components/deployments.go
+++ b/pkg/virt-operator/resource/generate/components/deployments.go
@@ -219,14 +219,21 @@ func attachProfileVolume(spec *corev1.PodSpec) {
 
 }
 
+func attachOptionalCertificateSecret(spec *corev1.PodSpec, secretName string, mountPath string) {
+	attachCertificateSecretWithOptions(spec, secretName, mountPath, true)
+}
+
 func attachCertificateSecret(spec *corev1.PodSpec, secretName string, mountPath string) {
-	True := true
+	attachCertificateSecretWithOptions(spec, secretName, mountPath, false)
+}
+
+func attachCertificateSecretWithOptions(spec *corev1.PodSpec, secretName string, mountPath string, optional bool) {
 	secretVolume := corev1.Volume{
 		Name: secretName,
 		VolumeSource: corev1.VolumeSource{
 			Secret: &corev1.SecretVolumeSource{
 				SecretName: secretName,
-				Optional:   &True,
+				Optional:   &optional,
 			},
 		},
 	}
@@ -656,7 +663,7 @@ func NewOperatorDeployment(namespace, repository, imagePrefix, version, verbosit
 		deployment.Spec.Template.Spec.Containers[0].Env = append(deployment.Spec.Template.Spec.Containers[0].Env, envVars...)
 	}
 
-	attachCertificateSecret(&deployment.Spec.Template.Spec, VirtOperatorCertSecretName, "/etc/virt-operator/certificates")
+	attachOptionalCertificateSecret(&deployment.Spec.Template.Spec, VirtOperatorCertSecretName, "/etc/virt-operator/certificates")
 	attachProfileVolume(&deployment.Spec.Template.Spec)
 	placement.InjectPlacementMetadata(nil, &deployment.Spec.Template.Spec, placement.RequireControlPlanePreferNonWorker)
 


### PR DESCRIPTION
The Optional flag on cert Secret volume mounts was introduced in April
2020 (commit 1a4ad7dea4) when operator-managed cert rotation was first
added. At that point virt-api had no operator-provided cert volumes at
all; making the new volume optional allowed existing pods to keep running
during the one-time upgrade from self-managed certs.

That upgrade path no longer exists. The reconcile loop always creates
cert Secrets before creating or updating Deployments, so the Secret is
available on the API server before any new pod is scheduled. Marking the
volume as required reflects this: a component should not start without
its TLS certificates.

virt-operator's own cert volume remains Optional, since virt-operator is
the component that creates its own cert Secret — requiring it would
create a deadlock where virt-operator cannot start without a Secret that
only virt-operator can create.

Assisted-By: Claude Sonnet 4.6

```release-note
NONE
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Certificate secrets are now required when mounting them into deployments, preventing workloads from starting without the necessary certificate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->