### PR TITLE
[release-1.6] tests: decorate kvm-pit emulator thread test with RequiresAMD64

### DIFF
--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -2475,7 +2475,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 				By("Checking if pod memory usage is > 80Mi")
 				Expect(m).To(BeNumerically(">", 83886080), "83886080 B = 80 Mi")
 			})
-			DescribeTable("[test_id:4023]should start a vmi with dedicated cpus and isolated emulator thread", func(resources *v1.ResourceRequirements) {
+			DescribeTable("[test_id:4023]should start a vmi with dedicated cpus and isolated emulator thread", decorators.RequiresAMD64, func(resources *v1.ResourceRequirements) {
 				cpuVmi := libvmifact.NewCirros()
 				cpuVmi.Spec.Domain.CPU = &v1.CPU{
 					Cores:                 2,


### PR DESCRIPTION
### What this PR does
Backport of #18292 to release-1.6.

Adds `decorators.RequiresAMD64` to the `test_id:4023` DescribeTable so it is skipped on ARM64 clusters. KVM PIT (i8254) is x86-only hardware - ARM64 uses the Generic Timer and has no `kvm-pit` kernel thread, so the `pgrep -f kvm-pit` always fails on ARM64 nodes.

Cherry-picked from the release-1.7 manual backport (#18501) which applied cleanly to release-1.6.

Relates-To: https://github.com/kubevirt/kubevirt/issues/18030

### Release note
```release-note
Fix kvm-pit emulator thread e2e test failing on ARM64 clusters
```