### PR TITLE
tests: remove flaky e2e test_id:1655, add unit tests

### DIFF
--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -599,6 +599,53 @@ var _ = Describe("VirtualMachineInstance", func() {
 			testutils.ExpectEvent(recorder, VMIStopping)
 		})
 
+		Context("when VMI has DeletionTimestamp and domain has grace period", func() {
+			var vmi *v1.VirtualMachineInstance
+			var domain *api.Domain
+
+			BeforeEach(func() {
+				vmi = api2.NewMinimalVMI("testvmi")
+				vmi.UID = vmiTestUUID
+				vmi.Status.Phase = v1.Running
+				now := metav1.Now()
+				vmi.DeletionTimestamp = &now
+
+				domain = api.NewMinimalDomainWithUUID("testvmi", vmiTestUUID)
+				domain.Status.Status = api.Running
+			})
+
+			It("should attempt graceful shutdown", func() {
+				initGracePeriodHelper(5, vmi, domain)
+
+				client.EXPECT().ShutdownVirtualMachine(gomock.Any())
+				addVMI(vmi, domain)
+
+				sanityExecute()
+				testutils.ExpectEvent(recorder, VMIGracefulShutdown)
+			})
+
+			It("should force kill when grace period expired", func() {
+				initGracePeriodHelper(1, vmi, domain)
+				expired := metav1.Time{Time: time.Unix(time.Now().UTC().Unix()-3, 0)}
+				domain.Spec.Metadata.KubeVirt.GracePeriod.DeletionTimestamp = &expired
+
+				client.EXPECT().KillVirtualMachine(gomock.Any())
+				addVMI(vmi, domain)
+
+				sanityExecute()
+				testutils.ExpectEvent(recorder, VMIStopping)
+			})
+
+			It("should skip shutdown signal when domain is already shutting down", func() {
+				domain.Status.Status = api.Shutdown
+				initGracePeriodHelper(5, vmi, domain)
+
+				addVMI(vmi, domain)
+
+				sanityExecute()
+			})
+		})
+
 		It("should re-enqueue if the Key is unparseable", func() {
 			Expect(mockQueue.Len()).Should(Equal(0))
 			mockQueue.Add("a/b/c/d/e")

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -1393,35 +1393,6 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				Entry("[test_id:1654]with default grace period seconds", decorators.Conformance, withoutTerminationGracePeriodSeconds, v1.DefaultGracePeriodSeconds),
 			)
 		})
-		Context("with grace period greater than 0", func() {
-			It("[test_id:1655]should run graceful shutdown", decorators.Conformance, decorators.WgS390x, func() {
-				By("Setting a VirtualMachineInstance termination grace period to 5")
-				vmi := libvmifact.NewAlpineWithTestTooling(libvmi.WithTerminationGracePeriod(5))
-
-				By("Creating the VirtualMachineInstance")
-				vmi = libvmops.RunVMIAndExpectLaunch(vmi, startupTimeout)
-
-				// Delete the VirtualMachineInstance and wait for the confirmation of the delete
-				By("Deleting the VirtualMachineInstance")
-				Expect(kubevirt.Client().VirtualMachineInstance(vmi.Namespace).Delete(context.Background(), vmi.Name, metav1.DeleteOptions{})).To(Succeed(), "Should delete VMI gracefully")
-
-				ctx, cancel := context.WithCancel(context.Background())
-				defer cancel()
-
-				// Check if the graceful shutdown was logged
-				By("Checking that virt-handler logs VirtualMachineInstance graceful shutdown")
-				event := watcher.New(vmi).Timeout(30*time.Second).SinceWatchedObjectResourceVersion().WaitFor(ctx, watcher.NormalEvent, "ShuttingDown")
-				Expect(event).ToNot(BeNil(), "There should be a graceful shutdown")
-
-				// Verify VirtualMachineInstance is killed after grace period expires
-				// 5 seconds is grace period, doubling to prevent flakiness
-				By("Checking that the VirtualMachineInstance does not exist after grace period")
-				event = watcher.New(vmi).Timeout(10*time.Second).SinceWatchedObjectResourceVersion().WaitFor(ctx, watcher.NormalEvent, "Deleted")
-				Expect(event).ToNot(BeNil(), "There should be a graceful shutdown")
-
-				Eventually(matcher.ThisVMI(vmi)).WithTimeout(15 * time.Second).WithPolling(time.Second).Should(matcher.BeGone())
-			})
-		})
 	})
 
 	Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:component]Killed VirtualMachineInstance", Serial, decorators.WgS390x, func() {


### PR DESCRIPTION
### What this PR does

Removes the flaky e2e test `[test_id:1655] should run graceful shutdown` and replaces its coverage with targeted unit tests in `pkg/virt-handler/vm_test.go`.

#### Before this PR:
- Test 1655 causes 5 of 29 CI failures (17%) in the [sig-compute weekly report](https://storage.googleapis.com/kubevirt-prow/reports/sig-failure-reports/sig-compute-failure-report.html), failing with `Timed out after 15s, expected object to be gone` across main, release-1.9, and release-1.8 branches
- The test has been modified 14 times over 9 years, cycling through 5 VM images (registry-disk, Cirros, Alpine, Fedora, AlpineWithTestTooling)
- The test name says "should run graceful shutdown" but it actually asserts the `Deleted` event (grace period expired, VM force-killed) - the opposite of graceful shutdown succeeding
- The final `BeGone` assertion tests virt-controller finalizer/pod GC timing, not graceful shutdown
- The test uses `AlpineWithTestTooling` which includes qemu-guest-agent; `DOMAIN_SHUTDOWN_DEFAULT` (flag 0) tries guest agent first, so the ACPI path implied by the parent context is not exercised

#### After this PR:
- The flaky e2e test is removed. Graceful shutdown e2e coverage is preserved by sibling tests 1653/1654 which use Fedora and properly assert `Succeeded` phase
- Three new unit tests in `pkg/virt-handler/vm_test.go` cover the virt-handler shutdown decision paths that test 1655 was attempting to validate:
  1. VMI with `DeletionTimestamp` + running domain + active grace period triggers `ShutdownVirtualMachine` (graceful signal sent)
  2. VMI with `DeletionTimestamp` + expired grace period triggers `KillVirtualMachine` (force kill) with `Deleted` event
  3. Domain already in `Shutdown` status skips redundant shutdown signal
- Unit tests are deterministic, run in milliseconds, and don't depend on VM boot, guest agent behavior, pod GC, or informer cache propagation

### References

CI failure examples from the [sig-compute report (2026-07-02 to 2026-07-09)](https://storage.googleapis.com/kubevirt-prow/reports/sig-failure-reports/sig-compute-failure-report.html):
- `pull-kubevirt-e2e-k8s-1.35-sig-compute` (main, PR #18319): `Timed out after 15.00Xs. expected object to be gone, but it still exists`
- `pull-kubevirt-e2e-k8s-1.36-sig-compute-1.9` (release-1.9, PR #18405): same timeout
- `pull-kubevirt-e2e-k8s-1.35-sig-compute-1.8` (release-1.8, PR #18363): same timeout

All failures show VMI phase `Failed`, finalizer `kubevirt.io/foregroundDeleteVirtualMachine` still present, reason `PodTerminating` - the VMI cleanup chain (virt-launcher exit -> monitor log dump -> kubelet pod GC -> informer cache update -> virt-controller finalizer removal) exceeds the 15s timeout under CI load.

### Release note
```release-note
NONE
```