### PR TITLE
network, netstat: log unexpected pod interface cache read failures

### DIFF
--- a/pkg/network/setup/netstat.go
+++ b/pkg/network/setup/netstat.go
@@ -20,9 +20,11 @@
 package network
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"net/netip"
+	"os"
 	"slices"
 	"strings"
 	"sync"
@@ -31,6 +33,7 @@ import (
 	netutils "k8s.io/utils/net"
 
 	v1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/log"
 
 	"kubevirt.io/kubevirt/pkg/network/cache"
 	"kubevirt.io/kubevirt/pkg/network/deviceinfo"
@@ -240,8 +243,11 @@ func (c *NetStat) getPodInterfacefromFileCache(vmi *v1.VirtualMachineInstance, i
 
 	podInterface := &cache.PodIfaceCacheData{}
 	if data, err := cache.ReadPodInterfaceCache(c.cacheCreator, string(vmi.UID), ifaceName); err == nil {
-		//FIXME error handling?
 		podInterface = data
+	} else if !errors.Is(err, os.ErrNotExist) {
+		// A missing cache file is expected while the pod interface is still being configured.
+		// Any other error is unexpected and worth surfacing, even though it is not fatal here.
+		log.Log.Object(vmi).Reason(err).Warningf("failed to read pod interface cache for interface %s", ifaceName)
 	}
 
 	c.podInterfaceVolatileCache.Store(vmiInterfaceKey(vmi.UID, ifaceName), podInterface)


### PR DESCRIPTION
Motivation:
Issue kubevirt#17334 asked for a test around pod interface cache read
failures in virt-handler's netstat reconciliation. Investigation showed
getPodInterfacefromFileCache() (pkg/network/setup/netstat.go) silently
swallowed every cache.ReadPodInterfaceCache() error behind a long-standing
"//FIXME error handling?" comment, including genuine I/O or corruption
errors, giving operators no signal when something other than "the cache
file isn't written yet" goes wrong. A near-identical fix was previously
proposed in PR kubevirt#16974, but that PR bundled three unrelated fixes
together and was auto-closed for inactivity before it could be split up
and merged; this change carries forward only its netstat-specific part.

Note: the pod interface volatile cache is a memoize-once cache by design
(see the comment above getPodInterfacefromFileCache: once an interface's
data is read, it is cached for the lifetime of the VMI/interface pair and
is not re-read on subsequent reconciliations). So this is not a "retry on
next reconcile" fix, and no such behavior is added or implied.

Approach:
Distinguish an expected "cache file not written yet" condition
(os.ErrNotExist, e.g. while the pod interface is still being configured)
from any other read error, using the same errors.Is(err, os.ErrNotExist)
idiom already used by the sibling ConfigStateCache.Read/Write/Delete in
pkg/network/setup/configstatecache.go for the identical
cache.ReadPodInterfaceCache() call. Unexpected errors are now logged via
log.Log.Object(vmi).Reason(err).Warningf(...).

This is a pure observability change: no return value, error propagation,
or caching behavior changes in any branch. Before and after this change,
UpdateStatus() succeeds and reports an empty IP when the pod interface
cache can't be read, for both the "file missing" and "unexpected read
error" cases; the only user-visible difference is a new warning-level log
line for the latter, which previously vanished with no trace of what went
wrong.

This PR does not add tests: the two specs added during review were
dropped after feedback that they either duplicated existing coverage or
only exercised a log-only branch with no behavioral change (see PR
discussion), so the diff is now limited to netstat.go.

Whether a warning log is the right amount of handling here (vs. a real
error-handling codepath, or vs. no log at all given existing log-noise
concerns) is still an open question raised in review; see the PR
discussion.

Validation:
- GOOS=linux go build ./pkg/network/setup/... ./pkg/network/cache/...
- GOOS=linux go vet ./pkg/network/setup/... ./pkg/network/cache/...
All of the above pass. This development sandbox is macOS with no
Docker/VM available, and this package transitively imports a Linux-only
CNI netns package, so tests could not be executed locally (they compile
cleanly with `go test -c`, but the resulting binary can't run on this
host); this needs a Linux host or this repo's own CI to actually run.

Fixes #17334

```release-note
NONE
```

Assisted-by: Claude <noreply@anthropic.com>
Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>
