### PR TITLE
Revert "Guard plugin ValidatingAdmissionPolicies behind Plugins feature gate"

### DIFF
--- a/pkg/virt-operator/kubevirt_test.go
+++ b/pkg/virt-operator/kubevirt_test.go
@@ -92,8 +92,8 @@ const (
 	NAMESPACE = "kubevirt-test"
 
 	// +1 for ContainerPathVolumes webhook (always enabled in tests)
-	resourceCount = 96 + virtTemplateResourceCount
-	patchCount    = 64 + virtTemplatePatchCount
+	resourceCount = 104 + virtTemplateResourceCount
+	patchCount    = 72 + virtTemplatePatchCount
 	updateCount   = 33 + virtTemplateUpdateCount
 
 	// 1 because a temporary validation webhook is created to block new CRDs until api server is deployed
@@ -1400,12 +1400,10 @@ func (k *KubeVirtTestData) addAllWithExclusionMap(config *util.KubeVirtDeploymen
 
 	userName := fmt.Sprintf("system:serviceaccount:%s:%s", config.GetNamespace(), components.HandlerServiceAccountName)
 	all = append(all, vap.NewHandlerV1ValidatingAdmissionPolicy(userName), vap.NewHandlerV1ValidatingAdmissionPolicyBinding())
-	if config.PluginsEnabled() {
-		all = append(all, vap.NewPluginValidatingAdmissionPolicy(), vap.NewPluginValidatingAdmissionPolicyBinding())
-		all = append(all, vap.NewPluginWarningAdmissionPolicy(), vap.NewPluginWarningAdmissionPolicyBinding())
-		all = append(all, vap.NewSidecarSubPathValidatingAdmissionPolicy(), vap.NewSidecarSubPathValidatingAdmissionPolicyBinding())
-		all = append(all, vap.NewPluginSocketPathValidatingAdmissionPolicy(), vap.NewPluginSocketPathValidatingAdmissionPolicyBinding())
-	}
+	all = append(all, vap.NewPluginValidatingAdmissionPolicy(), vap.NewPluginValidatingAdmissionPolicyBinding())
+	all = append(all, vap.NewPluginWarningAdmissionPolicy(), vap.NewPluginWarningAdmissionPolicyBinding())
+	all = append(all, vap.NewSidecarSubPathValidatingAdmissionPolicy(), vap.NewSidecarSubPathValidatingAdmissionPolicyBinding())
+	all = append(all, vap.NewPluginSocketPathValidatingAdmissionPolicy(), vap.NewPluginSocketPathValidatingAdmissionPolicyBinding())
 
 	if config.VirtTemplateDeploymentEnabled() {
 		resources, err := components.NewVirtTemplateResources(config)

--- a/pkg/virt-operator/resource/generate/install/strategy.go
+++ b/pkg/virt-operator/resource/generate/install/strategy.go
@@ -633,18 +633,16 @@ func GenerateCurrentInstallStrategy(config *operatorutil.KubeVirtDeploymentConfi
 	virtHandlerServiceAccount := getVirtHandlerServiceAccount(config.GetNamespace())
 	strategy.validatingAdmissionPolicies = append(strategy.validatingAdmissionPolicies, vap.NewHandlerV1ValidatingAdmissionPolicy(virtHandlerServiceAccount))
 
-	if config.PluginsEnabled() {
-		strategy.validatingAdmissionPolicyBindings = append(strategy.validatingAdmissionPolicyBindings, vap.NewPluginValidatingAdmissionPolicyBinding())
-		strategy.validatingAdmissionPolicies = append(strategy.validatingAdmissionPolicies, vap.NewPluginValidatingAdmissionPolicy())
-		strategy.validatingAdmissionPolicyBindings = append(strategy.validatingAdmissionPolicyBindings, vap.NewPluginWarningAdmissionPolicyBinding())
-		strategy.validatingAdmissionPolicies = append(strategy.validatingAdmissionPolicies, vap.NewPluginWarningAdmissionPolicy())
+	strategy.validatingAdmissionPolicyBindings = append(strategy.validatingAdmissionPolicyBindings, vap.NewPluginValidatingAdmissionPolicyBinding())
+	strategy.validatingAdmissionPolicies = append(strategy.validatingAdmissionPolicies, vap.NewPluginValidatingAdmissionPolicy())
+	strategy.validatingAdmissionPolicyBindings = append(strategy.validatingAdmissionPolicyBindings, vap.NewPluginWarningAdmissionPolicyBinding())
+	strategy.validatingAdmissionPolicies = append(strategy.validatingAdmissionPolicies, vap.NewPluginWarningAdmissionPolicy())
 
-		strategy.validatingAdmissionPolicyBindings = append(strategy.validatingAdmissionPolicyBindings, vap.NewSidecarSubPathValidatingAdmissionPolicyBinding())
-		strategy.validatingAdmissionPolicies = append(strategy.validatingAdmissionPolicies, vap.NewSidecarSubPathValidatingAdmissionPolicy())
+	strategy.validatingAdmissionPolicyBindings = append(strategy.validatingAdmissionPolicyBindings, vap.NewSidecarSubPathValidatingAdmissionPolicyBinding())
+	strategy.validatingAdmissionPolicies = append(strategy.validatingAdmissionPolicies, vap.NewSidecarSubPathValidatingAdmissionPolicy())
 
-		strategy.validatingAdmissionPolicyBindings = append(strategy.validatingAdmissionPolicyBindings, vap.NewPluginSocketPathValidatingAdmissionPolicyBinding())
-		strategy.validatingAdmissionPolicies = append(strategy.validatingAdmissionPolicies, vap.NewPluginSocketPathValidatingAdmissionPolicy())
-	}
+	strategy.validatingAdmissionPolicyBindings = append(strategy.validatingAdmissionPolicyBindings, vap.NewPluginSocketPathValidatingAdmissionPolicyBinding())
+	strategy.validatingAdmissionPolicies = append(strategy.validatingAdmissionPolicies, vap.NewPluginSocketPathValidatingAdmissionPolicy())
 
 	instancetypes, err := components.NewClusterInstancetypes()
 	if err != nil {

--- a/pkg/virt-operator/util/config.go
+++ b/pkg/virt-operator/util/config.go
@@ -104,9 +104,6 @@ const (
 	AdditionalPropertiesVMStatsCollectorEnabled = "VMStatsCollectorEnabled"
 
 	// lookup key in AdditionalProperties
-	AdditionalPropertiesPluginsEnabled = "PluginsEnabled"
-
-	// lookup key in AdditionalProperties
 	AdditionalPropertiesSynchronizationPort       = "SynchronizationPort"
 	DefaultSynchronizationPort              int32 = 9185
 
@@ -211,10 +208,6 @@ func GetTargetConfigFromKVWithEnvVarManager(kv *v1.KubeVirt, envVarManager EnvVa
 
 	if isFeatureGateEnabledInKvConfig(&kv.Spec.Configuration, featuregate.VMStatsCollector) {
 		additionalProperties[AdditionalPropertiesVMStatsCollectorEnabled] = ""
-	}
-
-	if isFeatureGateEnabledInKvConfig(&kv.Spec.Configuration, featuregate.PluginsGate) {
-		additionalProperties[AdditionalPropertiesPluginsEnabled] = ""
 	}
 
 	if isFeatureGateEnabledInKvConfig(&kv.Spec.Configuration, featuregate.OptOutRoleAggregation) {
@@ -588,11 +581,6 @@ func (c *KubeVirtDeploymentConfig) VMStatsCollectorEnabled() bool {
 
 func (c *KubeVirtDeploymentConfig) OptOutRoleAggregationEnabled() bool {
 	_, enabled := c.AdditionalProperties[AdditionalPropertiesOptOutRoleAggregation]
-	return enabled
-}
-
-func (c *KubeVirtDeploymentConfig) PluginsEnabled() bool {
-	_, enabled := c.AdditionalProperties[AdditionalPropertiesPluginsEnabled]
 	return enabled
 }
 


### PR DESCRIPTION
### What this PR does
#### Before this PR:

PR #18457 added `PluginsEnabled` to the operator's `AdditionalProperties` and
gated plugin VAP creation behind it. This caused the install strategy hash to
change every time the Plugins feature gate was toggled, triggering a full
operator rollout of all components (~2.5 min each).

The plugin functional tests toggle this gate in `BeforeEach` (enable) and
restore the default config after each test (disable) - two rollouts per test.
With 18 plugin tests, this added ~90 minutes to the compute-serial lane
(2h30m → 4h00m on both main and release-1.9).

#### After this PR:

Plugin VAPs are deployed unconditionally, as they were before #18457. They are
harmless when plugins are disabled since they validate plugin-related resources
that don't exist without the feature gate.

### References

- Fixes the compute-serial lane regression introduced by #18457

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- ~~Design: A VEP was considered~~ - revert, not applicable
- ~~Refactor~~ - revert
- ~~Upgrade~~ - restores previous behavior
- ~~Testing~~ - revert restores previous test behavior
- ~~Documentation~~ - not applicable
- ~~Community~~ - not applicable
- [x] AI Contributions: The PR abides by the KubeVirt AI Contribution Policy.

### Release note

```release-note
NONE
```