### PR TITLE
tests: enable plugins gate at lane setup to avoid rollouts

### DIFF
--- a/automation/repeated_test.sh
+++ b/automation/repeated_test.sh
@@ -239,6 +239,16 @@ add_to_label_filter() {
     fi
 }
 
+add_feature_gate() {
+  if [ -z "${FEATURE_GATES:-}" ]; then
+    export FEATURE_GATES="$1"
+  else
+    export FEATURE_GATES="$FEATURE_GATES,$1"
+  fi
+}
+
+add_feature_gate "Plugins"
+
 label_filter="${KUBEVIRT_LABEL_FILTER:-}"
 
 # skip certain tests on flake lane

--- a/automation/test.sh
+++ b/automation/test.sh
@@ -127,6 +127,7 @@ case "$TARGET" in
     ;;
   *sig-compute-serial*)
     export KUBEVIRT_PROVIDER=${TARGET/-sig-compute-serial/}
+    add_feature_gate "Plugins"
     ;;
   *sig-compute-parallel*)
     export KUBEVIRT_PROVIDER=${TARGET/-sig-compute-parallel/}

--- a/tests/decorators/decorators.go
+++ b/tests/decorators/decorators.go
@@ -96,6 +96,8 @@ var (
 	RequiresRWXFsVMStateStorageClass = Label("RequiresRWXFsVMStateStorageClass")
 	// RequiresPersistentReservation requires the Persistent Reservation to be enabled on the kubevirt level
 	RequiresPersistentReservation = Label("RequiresPersistentReservation")
+	// RequiresPlugins requires the Plugins feature gate to be enabled on the kubevirt level
+	RequiresPlugins = Label("RequiresPlugins")
 
 	// RequiresBlockStorage requires a storage class with Block storage support
 	RequiresBlockStorage = Label("RequiresBlockStorage")

--- a/tests/plugin_test.go
+++ b/tests/plugin_test.go
@@ -46,10 +46,10 @@ import (
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/flags"
+	"kubevirt.io/kubevirt/tests/framework/checks"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	. "kubevirt.io/kubevirt/tests/framework/matcher"
 	"kubevirt.io/kubevirt/tests/libdomain"
-	"kubevirt.io/kubevirt/tests/libkubevirt/config"
 	"kubevirt.io/kubevirt/tests/libmigration"
 	"kubevirt.io/kubevirt/tests/libnet"
 	"kubevirt.io/kubevirt/tests/libnode"
@@ -59,10 +59,10 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = Describe("[sig-compute]Plugin domain hooks", Serial, decorators.SigCompute, func() {
+var _ = Describe("[sig-compute]Plugin domain hooks", Serial, decorators.SigCompute, decorators.RequiresPlugins, func() {
 
 	BeforeEach(func() {
-		config.EnableFeatureGate(featuregate.PluginsGate)
+		checks.FailTestIfNoFeatureGate(featuregate.PluginsGate)
 	})
 
 	createPlugin := func(plugin *pluginv1alpha1.Plugin) {
@@ -489,12 +489,12 @@ const (
 	pluginMarkerDir  = "/var/run/kubevirt/plugin-test-markers"
 )
 
-var _ = Describe("[sig-compute]Plugin node hooks", Serial, decorators.SigCompute, func() {
+var _ = Describe("[sig-compute]Plugin node hooks", Serial, decorators.SigCompute, decorators.RequiresPlugins, func() {
 	var virtClient kubecli.KubevirtClient
 
 	BeforeEach(func() {
 		virtClient = kubevirt.Client()
-		config.EnableFeatureGate(featuregate.PluginsGate)
+		checks.FailTestIfNoFeatureGate(featuregate.PluginsGate)
 	})
 
 	It("should execute PreVMStart node hook and create a marker file", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Plugin tests were each enabling/disabling the gate, triggering a
kubevirt rollout on every test spec. Instead, enable the gate once at
sig-compute-serial lane setup and fail tests if the gate is missing.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
The plugin functional tests toggle this gate in BeforeEach (enable) and
restore the default config after each test (disable) - two rollouts per test.
With 18 plugin tests, this added ~90 minutes to the compute-serial lane
(2h30m → 4h00m on both main and release-1.9).

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

