### PR TITLE
tests: guard kvm-pit assertion by VMI arch instead of skipping entire test

### DIFF
--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -1217,7 +1217,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 				By("Checking if pod memory usage is > 80Mi")
 				Expect(m).To(BeNumerically(">", 83886080), "83886080 B = 80 Mi")
 			})
-			DescribeTable("[test_id:4023]should start a vmi with dedicated cpus and isolated emulator thread", decorators.RequiresAMD64, func(resources *v1.ResourceRequirements) {
+			DescribeTable("[test_id:4023]should start a vmi with dedicated cpus and isolated emulator thread", func(resources *v1.ResourceRequirements) {
 				cpuVmi := libvmifact.NewAlpine()
 				cpuVmi.Spec.Domain.CPU = &v1.CPU{
 					Cores:                 2,
@@ -1295,23 +1295,26 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 					&expect.BExp{R: "2"},
 				}, 15)).To(Succeed())
 
-				domSpec, err := libdomain.GetRunningVMIDomainSpec(vmi)
-				Expect(err).ToNot(HaveOccurred())
+				// KVM PIT (i8254) is x86-only; ARM64 uses the Generic Timer
+				if vmi.Spec.Architecture == "amd64" {
+					domSpec, err := libdomain.GetRunningVMIDomainSpec(vmi)
+					Expect(err).ToNot(HaveOccurred())
 
-				emulator := filepath.Base(domSpec.Devices.Emulator)
-				pidCmd := []string{"pidof", emulator}
-				qemuPid, err := exec.ExecuteCommandOnPod(readyPod, "compute", pidCmd)
-				// do not check for kvm-pit thread if qemu is not in use
-				if err != nil {
-					return
+					emulator := filepath.Base(domSpec.Devices.Emulator)
+					pidCmd := []string{"pidof", emulator}
+					qemuPid, err := exec.ExecuteCommandOnPod(readyPod, "compute", pidCmd)
+					// do not check for kvm-pit thread if qemu is not in use
+					if err != nil {
+						return
+					}
+					kvmpitmask, err := getKvmPitMask(strings.TrimSpace(qemuPid), node)
+					Expect(err).ToNot(HaveOccurred())
+
+					vcpuzeromask, err := getVcpuMask(readyPod, emulator, "0")
+					Expect(err).ToNot(HaveOccurred())
+
+					Expect(kvmpitmask).To(Equal(vcpuzeromask))
 				}
-				kvmpitmask, err := getKvmPitMask(strings.TrimSpace(qemuPid), node)
-				Expect(err).ToNot(HaveOccurred())
-
-				vcpuzeromask, err := getVcpuMask(readyPod, emulator, "0")
-				Expect(err).ToNot(HaveOccurred())
-
-				Expect(kvmpitmask).To(Equal(vcpuzeromask))
 			},
 				Entry(" with explicit resources set", &v1.ResourceRequirements{
 					Requests: k8sv1.ResourceList{

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -1170,7 +1170,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 					&expect.BExp{R: console.RetValue("pass")},
 				}, 15)).To(Succeed())
 			})
-			DescribeTable("[test_id:4023]should start a vmi with dedicated cpus and isolated emulator thread", decorators.RequiresAMD64, func(resources *v1.ResourceRequirements) {
+			DescribeTable("[test_id:4023]should start a vmi with dedicated cpus and isolated emulator thread", func(resources *v1.ResourceRequirements) {
 				cpuVmi := libvmifact.NewAlpine()
 				cpuVmi.Spec.Domain.CPU = &v1.CPU{
 					Cores:                 2,
@@ -1248,23 +1248,26 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 					&expect.BExp{R: "2"},
 				}, 15)).To(Succeed())
 
-				domSpec, err := libdomain.GetRunningVMIDomainSpec(vmi)
-				Expect(err).ToNot(HaveOccurred())
+				// KVM PIT (i8254) is x86-only; ARM64 uses the Generic Timer
+				if vmi.Spec.Architecture == "amd64" {
+					domSpec, err := libdomain.GetRunningVMIDomainSpec(vmi)
+					Expect(err).ToNot(HaveOccurred())
 
-				emulator := filepath.Base(domSpec.Devices.Emulator)
-				pidCmd := []string{"pidof", emulator}
-				qemuPid, err := exec.ExecuteCommandOnPod(readyPod, "compute", pidCmd)
-				// do not check for kvm-pit thread if qemu is not in use
-				if err != nil {
-					return
+					emulator := filepath.Base(domSpec.Devices.Emulator)
+					pidCmd := []string{"pidof", emulator}
+					qemuPid, err := exec.ExecuteCommandOnPod(readyPod, "compute", pidCmd)
+					// do not check for kvm-pit thread if qemu is not in use
+					if err != nil {
+						return
+					}
+					kvmpitmask, err := getKvmPitMask(strings.TrimSpace(qemuPid), node)
+					Expect(err).ToNot(HaveOccurred())
+
+					vcpuzeromask, err := getVcpuMask(readyPod, strings.TrimSpace(qemuPid), "0")
+					Expect(err).ToNot(HaveOccurred())
+
+					Expect(kvmpitmask).To(Equal(vcpuzeromask))
 				}
-				kvmpitmask, err := getKvmPitMask(strings.TrimSpace(qemuPid), node)
-				Expect(err).ToNot(HaveOccurred())
-
-				vcpuzeromask, err := getVcpuMask(readyPod, strings.TrimSpace(qemuPid), "0")
-				Expect(err).ToNot(HaveOccurred())
-
-				Expect(kvmpitmask).To(Equal(vcpuzeromask))
 			},
 				Entry(" with explicit resources set", &v1.ResourceRequirements{
 					Requests: k8sv1.ResourceList{


### PR DESCRIPTION
### What this PR does
Replaces the `RequiresAMD64` decorator on `test_id:4023` with a conditional guard on `vmi.Spec.Architecture` around only the kvm-pit CPU mask assertion.

#### Before this PR:
- The entire DescribeTable is skipped on ARM64 clusters via `decorators.RequiresAMD64` (added in #18292)
- ARM64 gets zero coverage for isolated emulator thread behavior

#### After this PR:
- The arch-independent checks (QOS, cpuset pinning, cgroup thread inspection, guest /proc/cpuinfo) run on all architectures
- Only the kvm-pit mask assertion is conditionally skipped on non-amd64, since KVM PIT (i8254) is x86-only hardware and ARM64 uses the Generic Timer
- Uses `vmi.Spec.Architecture` (set by the mutating webhook) rather than `testsuite.Arch` which is unreliable on heterogeneous clusters

### References
- Supersedes the approach in #18292
- Relates-To: https://github.com/kubevirt/kubevirt/issues/18030

### Release note
```release-note
NONE
```