### PR TITLE
fix: rewrite source domain name in target disk source paths

### DIFF
--- a/pkg/virt-controller/watch/migration/decentralized.go
+++ b/pkg/virt-controller/watch/migration/decentralized.go
@@ -48,6 +48,7 @@ func (c *Controller) initializeMigrateSourceState(migration *v1.VirtualMachineIn
 	vmi.Status.MigrationState.SourceState.MigrationUID = migration.UID
 	vmi.Status.MigrationState.SourceState.VirtualMachineInstanceUID = &vmi.UID
 	vmi.Status.MigrationState.SourceState.DomainNamespace = &vmi.Namespace
+	vmi.Status.MigrationState.SourceState.DomainName = &vmi.Name
 
 	vmi.Status.MigrationState.TargetState.SyncAddress = &migration.Spec.SendTo.ConnectURL
 }

--- a/pkg/virt-launcher/premigration-hook-server/disk/BUILD.bazel
+++ b/pkg/virt-launcher/premigration-hook-server/disk/BUILD.bazel
@@ -24,6 +24,7 @@ go_test(
         ":go_default_library",
         "//pkg/libvmi:go_default_library",
         "//pkg/libvmi/status:go_default_library",
+        "//pkg/pointer:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",

--- a/pkg/virt-launcher/premigration-hook-server/disk/source_path.go
+++ b/pkg/virt-launcher/premigration-hook-server/disk/source_path.go
@@ -30,7 +30,7 @@ import (
 )
 
 // DiskSourcePathHook updates disk source file paths in the domain XML by
-// replacing the source domain namespace with the target domain namespace.
+// replacing the source domain namespace/name with the target domain namespace/name.
 // This is the target-side equivalent of the source-side
 // updateFilePathsToNewDomain() + convertDisks() functions.
 func DiskSourcePathHook(_ *convertertypes.ConverterContext, vmi *v1.VirtualMachineInstance, domain *libvirtxml.Domain) error {
@@ -40,51 +40,133 @@ func DiskSourcePathHook(_ *convertertypes.ConverterContext, vmi *v1.VirtualMachi
 
 	sourceDomainNamespace := getSourceDomainNamespace(vmi)
 	targetDomainNamespace := getTargetDomainNamespace(vmi)
-	if targetDomainNamespace == "" || sourceDomainNamespace == targetDomainNamespace {
+	sourceDomainName := getSourceDomainName(vmi)
+	targetDomainName := getTargetDomainName(vmi)
+
+	nsUnchanged := targetDomainNamespace == "" || sourceDomainNamespace == "" || sourceDomainNamespace == targetDomainNamespace
+	nameUnchanged := targetDomainName == "" || sourceDomainName == "" || sourceDomainName == targetDomainName
+	if nsUnchanged && nameUnchanged {
 		return nil
 	}
-
-	oldSegment := "/" + sourceDomainNamespace + "/"
-	newSegment := "/" + targetDomainNamespace + "/"
 
 	for i := range domain.Devices.Disks {
 		disk := &domain.Devices.Disks[i]
 		if disk.Source == nil {
 			continue
 		}
-		if disk.Source.File != nil && strings.Contains(disk.Source.File.File, oldSegment) {
+		if disk.Source.File != nil {
 			oldPath := disk.Source.File.File
-			newPath := strings.Replace(oldPath, oldSegment, newSegment, 1)
-			log.Log.Object(vmi).V(4).Infof("diskSourcePathHook: updating disk file path from %s to %s", oldPath, newPath)
-			disk.Source.File.File = newPath
+			newPath := rewriteDomainPath(oldPath, sourceDomainNamespace, targetDomainNamespace, sourceDomainName, targetDomainName)
+			if newPath != oldPath {
+				log.Log.Object(vmi).V(4).Infof("diskSourcePathHook: updating disk file path from %s to %s", oldPath, newPath)
+				disk.Source.File.File = newPath
+			}
 		}
 		if disk.Source.DataStore != nil && disk.Source.DataStore.Source != nil &&
-			disk.Source.DataStore.Source.File != nil &&
-			strings.Contains(disk.Source.DataStore.Source.File.File, oldSegment) {
+			disk.Source.DataStore.Source.File != nil {
 			oldPath := disk.Source.DataStore.Source.File.File
-			newPath := strings.Replace(oldPath, oldSegment, newSegment, 1)
-			log.Log.Object(vmi).V(4).Infof("diskSourcePathHook: updating datastore file path from %s to %s", oldPath, newPath)
-			disk.Source.DataStore.Source.File.File = newPath
+			newPath := rewriteDomainPath(oldPath, sourceDomainNamespace, targetDomainNamespace, sourceDomainName, targetDomainName)
+			if newPath != oldPath {
+				log.Log.Object(vmi).V(4).Infof("diskSourcePathHook: updating datastore file path from %s to %s", oldPath, newPath)
+				disk.Source.DataStore.Source.File.File = newPath
+			}
 		}
 	}
 
 	return nil
 }
 
+// rewriteDomainPath replaces /{sourceNS}/{sourceName} path segments with the
+// target equivalents. The contiguous ns/name pair is rewritten first so a
+// targetNS that equals sourceName cannot be matched by a subsequent name
+// replacement (e.g. foo/bar → bar/baz stays bar/baz). Individual segment
+// replacement is used only when the pair is not present. A segment at the end
+// of the path (no trailing slash) is also rewritten.
+func rewriteDomainPath(path, sourceNS, targetNS, sourceName, targetName string) string {
+	if rewritten, ok := replacePathPair(path, sourceNS, sourceName, targetNS, targetName); ok {
+		return rewritten
+	}
+	newPath := replacePathSegment(path, sourceNS, targetNS)
+	return replacePathSegment(newPath, sourceName, targetName)
+}
+
+// replacePathPair rewrites the first contiguous /{oldNS}/{oldName} pair.
+// Matches either "/{oldNS}/{oldName}/" mid-path or "/{oldNS}/{oldName}" at the end.
+func replacePathPair(path, oldNS, oldName, newNS, newName string) (string, bool) {
+	if oldNS == "" || oldName == "" || newNS == "" || newName == "" {
+		return path, false
+	}
+	if oldNS == newNS && oldName == newName {
+		return path, false
+	}
+	pairOld := "/" + oldNS + "/" + oldName
+	pairNew := "/" + newNS + "/" + newName
+	if mid := pairOld + "/"; strings.Contains(path, mid) {
+		return strings.Replace(path, mid, pairNew+"/", 1), true
+	}
+	if strings.HasSuffix(path, pairOld) {
+		return strings.TrimSuffix(path, pairOld) + pairNew, true
+	}
+	return path, false
+}
+
+// replacePathSegment rewrites the first path segment matching oldSeg to newSeg.
+// Matches either "/{oldSeg}/" mid-path or "/{oldSeg}" at the end of the path.
+func replacePathSegment(path, oldSeg, newSeg string) string {
+	if oldSeg == "" || newSeg == "" || oldSeg == newSeg {
+		return path
+	}
+	mid := "/" + oldSeg + "/"
+	if strings.Contains(path, mid) {
+		return strings.Replace(path, mid, "/"+newSeg+"/", 1)
+	}
+	suffix := "/" + oldSeg
+	if strings.HasSuffix(path, suffix) {
+		return strings.TrimSuffix(path, oldSeg) + newSeg
+	}
+	return path
+}
+
 func getSourceDomainNamespace(vmi *v1.VirtualMachineInstance) string {
 	if vmi.Status.MigrationState != nil &&
 		vmi.Status.MigrationState.SourceState != nil &&
-		vmi.Status.MigrationState.SourceState.DomainNamespace != nil {
+		vmi.Status.MigrationState.SourceState.DomainNamespace != nil &&
+		*vmi.Status.MigrationState.SourceState.DomainNamespace != "" {
 		return *vmi.Status.MigrationState.SourceState.DomainNamespace
 	}
-	return vmi.Namespace
+	// Do not fall back to vmi.Namespace: on the target this hook runs against the
+	// target VMI, whose Namespace is the destination, not the source embedded in DestXML.
+	return ""
 }
 
 func getTargetDomainNamespace(vmi *v1.VirtualMachineInstance) string {
 	if vmi.Status.MigrationState != nil &&
 		vmi.Status.MigrationState.TargetState != nil &&
-		vmi.Status.MigrationState.TargetState.DomainNamespace != nil {
+		vmi.Status.MigrationState.TargetState.DomainNamespace != nil &&
+		*vmi.Status.MigrationState.TargetState.DomainNamespace != "" {
 		return *vmi.Status.MigrationState.TargetState.DomainNamespace
 	}
 	return ""
+}
+
+func getSourceDomainName(vmi *v1.VirtualMachineInstance) string {
+	if vmi.Status.MigrationState != nil &&
+		vmi.Status.MigrationState.SourceState != nil &&
+		vmi.Status.MigrationState.SourceState.DomainName != nil &&
+		*vmi.Status.MigrationState.SourceState.DomainName != "" {
+		return *vmi.Status.MigrationState.SourceState.DomainName
+	}
+	// Do not fall back to vmi.Name: on the target this hook runs against the target VMI,
+	// whose Name is the destination name, not the source name embedded in DestXML paths.
+	return ""
+}
+
+func getTargetDomainName(vmi *v1.VirtualMachineInstance) string {
+	if vmi.Status.MigrationState != nil &&
+		vmi.Status.MigrationState.TargetState != nil &&
+		vmi.Status.MigrationState.TargetState.DomainName != nil &&
+		*vmi.Status.MigrationState.TargetState.DomainName != "" {
+		return *vmi.Status.MigrationState.TargetState.DomainName
+	}
+	return vmi.Name
 }

--- a/pkg/virt-launcher/premigration-hook-server/disk/source_path_test.go
+++ b/pkg/virt-launcher/premigration-hook-server/disk/source_path_test.go
@@ -28,83 +28,50 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
 	libvmistatus "kubevirt.io/kubevirt/pkg/libvmi/status"
+	"kubevirt.io/kubevirt/pkg/pointer"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/premigration-hook-server/disk"
 )
 
 const (
-	sourceNamespace      = "source-ns"
-	targetNamespace      = "target-ns"
-	cloudInitPathWithSrc = "/var/run/libvirt/cloud-init-dir/source-ns/vmi-test/noCloud.iso"
-	cloudInitPathWithDst = "/var/run/libvirt/cloud-init-dir/target-ns/vmi-test/noCloud.iso"
-	pvcDiskPath          = "/var/run/kubevirt-private/vmi-disks/pvc/disk.img"
+	sourceNamespace       = "source-ns"
+	targetNamespace       = "target-ns"
+	sourceName            = "source-vm"
+	targetName            = "target-vm"
+	cloudInitPathWithSrc  = "/var/run/kubevirt-ephemeral-disks/cloud-init-data/source-ns/source-vm/noCloud.iso"
+	cloudInitPathWithDst  = "/var/run/kubevirt-ephemeral-disks/cloud-init-data/target-ns/target-vm/noCloud.iso"
+	cloudInitPathNsOnly   = "/var/run/kubevirt-ephemeral-disks/cloud-init-data/target-ns/source-vm/noCloud.iso"
+	cloudInitPathNameOnly = "/var/run/kubevirt-ephemeral-disks/cloud-init-data/source-ns/target-vm/noCloud.iso"
+	pathEndingWithSrc     = "/var/run/kubevirt-ephemeral-disks/cloud-init-data/source-ns/source-vm"
+	pathEndingWithDst     = "/var/run/kubevirt-ephemeral-disks/cloud-init-data/target-ns/target-vm"
+	pvcDiskPath           = "/var/run/kubevirt-private/vmi-disks/pvc/disk.img"
 )
 
 var _ = Describe("DiskSourcePathHook", func() {
 	var vmi *v1.VirtualMachineInstance
 
 	BeforeEach(func() {
-		sourceNs := sourceNamespace
-		targetNs := targetNamespace
-		vmi = libvmi.New(
-			libvmi.WithNamespace(sourceNamespace),
-			libvmistatus.WithStatus(libvmistatus.New(
-				libvmistatus.WithMigrationState(v1.VirtualMachineInstanceMigrationState{
-					SourceState: &v1.VirtualMachineInstanceMigrationSourceState{
-						VirtualMachineInstanceCommonMigrationState: v1.VirtualMachineInstanceCommonMigrationState{
-							DomainNamespace: &sourceNs,
-						},
-					},
-					TargetState: &v1.VirtualMachineInstanceMigrationTargetState{
-						VirtualMachineInstanceCommonMigrationState: v1.VirtualMachineInstanceCommonMigrationState{
-							DomainNamespace: &targetNs,
-						},
-					},
-				}),
-			)),
-		)
+		vmi = newMigrationTargetVMI(sourceNamespace, sourceName, targetNamespace, targetName)
 	})
 
-	It("should replace namespace in file paths", func() {
-		domain := &libvirtxml.Domain{
-			Devices: &libvirtxml.DomainDeviceList{
-				Disks: []libvirtxml.DomainDisk{
-					{
-						Alias: &libvirtxml.DomainAlias{Name: "ua-cloudinit"},
-						Source: &libvirtxml.DomainDiskSource{
-							File: &libvirtxml.DomainDiskSourceFile{
-								File: cloudInitPathWithSrc,
-							},
-						},
-					},
-				},
-			},
-		}
+	DescribeTable("file path rewriting",
+		func(sourceNS, sourceVM, targetNS, targetVM, inputPath, expectedPath string) {
+			vmi = newMigrationTargetVMI(sourceNS, sourceVM, targetNS, targetVM)
+			domain := domainWithCloudInitDisk(inputPath)
+			Expect(disk.DiskSourcePathHook(nil, vmi, domain)).To(Succeed())
+			Expect(domain.Devices.Disks[0].Source.File.File).To(Equal(expectedPath))
+		},
+		Entry("replaces namespace and name", sourceNamespace, sourceName, targetNamespace, targetName, cloudInitPathWithSrc, cloudInitPathWithDst),
+		Entry("replaces only namespace when names match", sourceNamespace, sourceName, targetNamespace, sourceName, cloudInitPathWithSrc, cloudInitPathNsOnly),
+		Entry("replaces only name when namespaces match", sourceNamespace, sourceName, sourceNamespace, targetName, cloudInitPathWithSrc, cloudInitPathNameOnly),
+		Entry("replaces namespace and name when they are the final path segments", sourceNamespace, sourceName, targetNamespace, targetName, pathEndingWithSrc, pathEndingWithDst),
+		Entry("does not let target namespace collide with source name", "foo", "bar", "bar", "baz",
+			"/var/run/kubevirt-ephemeral-disks/cloud-init-data/foo/bar/noCloud.iso",
+			"/var/run/kubevirt-ephemeral-disks/cloud-init-data/bar/baz/noCloud.iso"),
+		Entry("does not modify unrelated paths", sourceNamespace, sourceName, targetNamespace, targetName, pvcDiskPath, pvcDiskPath),
+		Entry("does not modify when source and target are identical", sourceNamespace, sourceName, sourceNamespace, sourceName, cloudInitPathWithSrc, cloudInitPathWithSrc),
+	)
 
-		Expect(disk.DiskSourcePathHook(nil, vmi, domain)).To(Succeed())
-		Expect(domain.Devices.Disks[0].Source.File.File).To(Equal(cloudInitPathWithDst))
-	})
-
-	It("should not modify paths that don't contain the namespace", func() {
-		domain := &libvirtxml.Domain{
-			Devices: &libvirtxml.DomainDeviceList{
-				Disks: []libvirtxml.DomainDisk{
-					{
-						Alias: &libvirtxml.DomainAlias{Name: "ua-pvc"},
-						Source: &libvirtxml.DomainDiskSource{
-							File: &libvirtxml.DomainDiskSourceFile{
-								File: pvcDiskPath,
-							},
-						},
-					},
-				},
-			},
-		}
-
-		Expect(disk.DiskSourcePathHook(nil, vmi, domain)).To(Succeed())
-		Expect(domain.Devices.Disks[0].Source.File.File).To(Equal(pvcDiskPath))
-	})
-
-	It("should replace namespace in datastore file paths", func() {
+	It("should replace namespace and name in datastore file paths", func() {
 		domain := &libvirtxml.Domain{
 			Devices: &libvirtxml.DomainDeviceList{
 				Disks: []libvirtxml.DomainDisk{
@@ -132,10 +99,30 @@ var _ = Describe("DiskSourcePathHook", func() {
 		Expect(disk.DiskSourcePathHook(nil, vmi, &libvirtxml.Domain{})).To(Succeed())
 	})
 
+	It("should not rewrite the name without SourceState.DomainName", func() {
+		vmi.Status.MigrationState.SourceState.DomainName = nil
+		domain := domainWithCloudInitDisk(cloudInitPathWithSrc)
+
+		Expect(disk.DiskSourcePathHook(nil, vmi, domain)).To(Succeed())
+		Expect(domain.Devices.Disks[0].Source.File.File).To(Equal(cloudInitPathNsOnly))
+	})
+
+	It("should not treat target namespace as source when SourceState.DomainNamespace is unset", func() {
+		// Hook runs on the target VMI; falling back to vmi.Namespace would wrongly
+		// skip namespace rewrite. Without SourceState.DomainNamespace, only the name
+		// segment (from SourceState.DomainName) may be rewritten.
+		vmi.Status.MigrationState.SourceState.DomainNamespace = nil
+		domain := domainWithCloudInitDisk(cloudInitPathWithSrc)
+
+		Expect(disk.DiskSourcePathHook(nil, vmi, domain)).To(Succeed())
+		Expect(domain.Devices.Disks[0].Source.File.File).To(Equal(cloudInitPathNameOnly))
+	})
+
 	Context("early-return when migration state is incomplete", func() {
 		It("should return nil when MigrationState is nil", func() {
 			vmi = libvmi.New(
-				libvmi.WithNamespace(sourceNamespace),
+				libvmi.WithNamespace(targetNamespace),
+				libvmi.WithName(targetName),
 				libvmistatus.WithStatus(libvmistatus.New()),
 			)
 			domain := domainWithCloudInitDisk(cloudInitPathWithSrc)
@@ -146,7 +133,8 @@ var _ = Describe("DiskSourcePathHook", func() {
 
 		It("should return nil when TargetState is nil", func() {
 			vmi = libvmi.New(
-				libvmi.WithNamespace(sourceNamespace),
+				libvmi.WithNamespace(targetNamespace),
+				libvmi.WithName(targetName),
 				libvmistatus.WithStatus(libvmistatus.New(
 					libvmistatus.WithMigrationState(v1.VirtualMachineInstanceMigrationState{
 						TargetState: nil,
@@ -159,14 +147,21 @@ var _ = Describe("DiskSourcePathHook", func() {
 			Expect(domain.Devices.Disks[0].Source.File.File).To(Equal(cloudInitPathWithSrc))
 		})
 
-		It("should return nil when DomainNamespace is nil", func() {
+		It("should return nil when DomainNamespace is nil and names match", func() {
 			vmi = libvmi.New(
 				libvmi.WithNamespace(sourceNamespace),
+				libvmi.WithName(sourceName),
 				libvmistatus.WithStatus(libvmistatus.New(
 					libvmistatus.WithMigrationState(v1.VirtualMachineInstanceMigrationState{
+						SourceState: &v1.VirtualMachineInstanceMigrationSourceState{
+							VirtualMachineInstanceCommonMigrationState: v1.VirtualMachineInstanceCommonMigrationState{
+								DomainName: pointer.P(sourceName),
+							},
+						},
 						TargetState: &v1.VirtualMachineInstanceMigrationTargetState{
 							VirtualMachineInstanceCommonMigrationState: v1.VirtualMachineInstanceCommonMigrationState{
 								DomainNamespace: nil,
+								DomainName:      pointer.P(sourceName),
 							},
 						},
 					}),
@@ -178,27 +173,31 @@ var _ = Describe("DiskSourcePathHook", func() {
 			Expect(domain.Devices.Disks[0].Source.File.File).To(Equal(cloudInitPathWithSrc))
 		})
 
-		It("should return nil when source and target namespace are the same", func() {
-			sameNs := sourceNamespace
-			vmi = libvmi.New(
-				libvmi.WithNamespace(sourceNamespace),
-				libvmistatus.WithStatus(libvmistatus.New(
-					libvmistatus.WithMigrationState(v1.VirtualMachineInstanceMigrationState{
-						TargetState: &v1.VirtualMachineInstanceMigrationTargetState{
-							VirtualMachineInstanceCommonMigrationState: v1.VirtualMachineInstanceCommonMigrationState{
-								DomainNamespace: &sameNs,
-							},
-						},
-					}),
-				)),
-			)
-			domain := domainWithCloudInitDisk(cloudInitPathWithSrc)
-
-			Expect(disk.DiskSourcePathHook(nil, vmi, domain)).To(Succeed())
-			Expect(domain.Devices.Disks[0].Source.File.File).To(Equal(cloudInitPathWithSrc))
-		})
 	})
 })
+
+func newMigrationTargetVMI(sourceNS, sourceVM, targetNS, targetVM string) *v1.VirtualMachineInstance {
+	return libvmi.New(
+		libvmi.WithNamespace(targetNS),
+		libvmi.WithName(targetVM),
+		libvmistatus.WithStatus(libvmistatus.New(
+			libvmistatus.WithMigrationState(v1.VirtualMachineInstanceMigrationState{
+				SourceState: &v1.VirtualMachineInstanceMigrationSourceState{
+					VirtualMachineInstanceCommonMigrationState: v1.VirtualMachineInstanceCommonMigrationState{
+						DomainNamespace: pointer.P(sourceNS),
+						DomainName:      pointer.P(sourceVM),
+					},
+				},
+				TargetState: &v1.VirtualMachineInstanceMigrationTargetState{
+					VirtualMachineInstanceCommonMigrationState: v1.VirtualMachineInstanceCommonMigrationState{
+						DomainNamespace: pointer.P(targetNS),
+						DomainName:      pointer.P(targetVM),
+					},
+				},
+			}),
+		)),
+	)
+}
 
 func domainWithCloudInitDisk(path string) *libvirtxml.Domain {
 	return &libvirtxml.Domain{


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
With libvirt hooks enabled, decentralized migrations skip source-side path conversion, so
the target hook must rewrite both namespace and VMI name. Also populate SourceState.DomainName
for the hook to use.

#### Before this PR:
decentralized live migrations would fail because the hooks are enabled by default now, and the source rewrite is no longer happening.

#### After this PR:
decentralized live migrations work because we modify the domain xml on the target to the appropriate values.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [X] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [X] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [X] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [X] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Decentralized live migrations now work in combination with libvirt hooks
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved migration disk path handling by correctly rewriting both domain namespaces and domain names.
  * Prevented incorrect path changes when migration source or target details are incomplete.
  * Updated cloud-init disk path handling to support the current storage path layout.
  * Added coverage for namespace-only, name-only, combined, and non-matching path scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->