### PR TITLE
virt-controller, virt-operator: set api version annotations via merge patch

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -21,6 +21,7 @@ package controller
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"runtime/debug"
 	"strings"
@@ -259,6 +260,22 @@ func SetLatestApiVersionAnnotation(object metav1.Object) {
 	annotations[v1.ControllerAPILatestVersionObservedAnnotation] = v1.ApiLatestVersion
 	annotations[v1.ControllerAPIStorageVersionObservedAnnotation] = v1.ApiStorageVersion
 	object.SetAnnotations(annotations)
+}
+
+// LatestApiVersionMergePatch returns a merge patch setting the latest observed
+// API version annotations. The write has no read-dependency, so the patch
+// carries no resourceVersion precondition: unlike a full-object Update from an
+// informer-cache copy it cannot conflict with concurrent writers, and it
+// leaves all other annotations and labels untouched.
+func LatestApiVersionMergePatch() ([]byte, error) {
+	return json.Marshal(map[string]interface{}{
+		"metadata": map[string]interface{}{
+			"annotations": map[string]string{
+				v1.ControllerAPILatestVersionObservedAnnotation:  v1.ApiLatestVersion,
+				v1.ControllerAPIStorageVersionObservedAnnotation: v1.ApiStorageVersion,
+			},
+		},
+	})
 }
 
 func ApplyVolumeRequestOnVMISpec(vmiSpec *v1.VirtualMachineInstanceSpec, request *v1.VirtualMachineVolumeRequest) *v1.VirtualMachineInstanceSpec {

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -20,6 +20,8 @@
 package controller_test
 
 import (
+	"encoding/json"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	gomegaTypes "github.com/onsi/gomega/types"
@@ -27,9 +29,47 @@ import (
 	k8sv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	v1 "kubevirt.io/api/core/v1"
+
 	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/pointer"
 )
+
+var _ = Describe("LatestApiVersionMergePatch", func() {
+
+	type patchMetadata struct {
+		Metadata struct {
+			Annotations     map[string]string `json:"annotations"`
+			Labels          map[string]string `json:"labels"`
+			ResourceVersion *string           `json:"resourceVersion"`
+		} `json:"metadata"`
+	}
+
+	It("should produce a patch limited to the api version annotations", func() {
+		payload, err := controller.LatestApiVersionMergePatch()
+		Expect(err).ToNot(HaveOccurred())
+
+		var patch patchMetadata
+		Expect(json.Unmarshal(payload, &patch)).To(Succeed())
+		Expect(patch.Metadata.Annotations).To(Equal(map[string]string{
+			v1.ControllerAPILatestVersionObservedAnnotation:  v1.ApiLatestVersion,
+			v1.ControllerAPIStorageVersionObservedAnnotation: v1.ApiStorageVersion,
+		}))
+		Expect(patch.Metadata.Labels).To(BeNil())
+		Expect(patch.Metadata.ResourceVersion).To(BeNil())
+
+		var topLevel map[string]json.RawMessage
+		Expect(json.Unmarshal(payload, &topLevel)).To(Succeed())
+		Expect(topLevel).To(HaveLen(1))
+		Expect(topLevel).To(HaveKey("metadata"))
+
+		var metadataKeys map[string]json.RawMessage
+		Expect(json.Unmarshal(topLevel["metadata"], &metadataKeys)).To(Succeed())
+		Expect(metadataKeys).To(HaveLen(1))
+		Expect(metadataKeys).To(HaveKey("annotations"))
+	})
+
+})
 
 var _ = Describe("Controller", func() {
 

--- a/pkg/virt-controller/watch/migration/migration.go
+++ b/pkg/virt-controller/watch/migration/migration.go
@@ -21,6 +21,7 @@ package migration
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"maps"
@@ -323,12 +324,26 @@ func (c *Controller) Execute() bool {
 	return true
 }
 
-func ensureSelectorLabelPresent(migration *virtv1.VirtualMachineInstanceMigration) {
-	if migration.Labels == nil {
-		migration.Labels = map[string]string{virtv1.MigrationSelectorLabel: migration.Spec.VMIName}
-	} else if _, exist := migration.Labels[virtv1.MigrationSelectorLabel]; !exist {
-		migration.Labels[virtv1.MigrationSelectorLabel] = migration.Spec.VMIName
+// latestApiVersionMetadataPatch returns a merge patch setting the latest
+// observed API version annotations and, when missing, the migration selector
+// label. The annotations have no read-dependency, so on their own they carry
+// no precondition. The selector label must not overwrite a live value the
+// informer has not observed yet, so when the patch includes it, it also
+// carries the cached object's resourceVersion, keeping optimistic concurrency
+// for exactly that write: on conflict the controller requeues and retries
+// from a fresher cache.
+func latestApiVersionMetadataPatch(migration *virtv1.VirtualMachineInstanceMigration) ([]byte, error) {
+	metadata := map[string]interface{}{
+		"annotations": map[string]string{
+			virtv1.ControllerAPILatestVersionObservedAnnotation:  virtv1.ApiLatestVersion,
+			virtv1.ControllerAPIStorageVersionObservedAnnotation: virtv1.ApiStorageVersion,
+		},
 	}
+	if _, exists := migration.Labels[virtv1.MigrationSelectorLabel]; !exists {
+		metadata["labels"] = map[string]string{virtv1.MigrationSelectorLabel: migration.Spec.VMIName}
+		metadata["resourceVersion"] = migration.ResourceVersion
+	}
+	return json.Marshal(map[string]interface{}{"metadata": metadata})
 }
 
 func (c *Controller) patchVMI(origVMI, newVMI *virtv1.VirtualMachineInstance) error {
@@ -387,11 +402,12 @@ func (c *Controller) execute(key string) error {
 	// this must be first step in execution. Writing the object
 	// when api version changes ensures our api stored version is updated.
 	if !controller.ObservedLatestApiVersionAnnotation(migration) {
-		migration := migration.DeepCopy()
-		controller.SetLatestApiVersionAnnotation(migration)
-		// Ensure the migration contains our selector label
-		ensureSelectorLabelPresent(migration)
-		_, err = c.clientset.VirtualMachineInstanceMigration(migration.Namespace).Update(context.Background(), migration, metav1.UpdateOptions{})
+		var patchBytes []byte
+		patchBytes, err = latestApiVersionMetadataPatch(migration)
+		if err != nil {
+			return err
+		}
+		_, err = c.clientset.VirtualMachineInstanceMigration(migration.Namespace).Patch(context.Background(), migration.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
 		return err
 	}
 

--- a/pkg/virt-controller/watch/migration/migration_test.go
+++ b/pkg/virt-controller/watch/migration/migration_test.go
@@ -21,6 +21,7 @@ package migration
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -345,6 +346,131 @@ var _ = Describe("Migration watcher", func() {
 			controller.storageClassStore, controller.storageProfileStore, controller.kubevirtStore,
 		}, Default)
 	}
+
+	Context("api version annotations", func() {
+		type mergePatchMeta struct {
+			Metadata struct {
+				Annotations     map[string]string `json:"annotations"`
+				Labels          map[string]string `json:"labels"`
+				ResourceVersion *string           `json:"resourceVersion"`
+			} `json:"metadata"`
+		}
+
+		var sentPatches [][]byte
+
+		BeforeEach(func() {
+			sentPatches = nil
+			virtClientset.Fake.PrependReactor("patch", "virtualmachineinstancemigrations", func(action testing.Action) (bool, k8sruntime.Object, error) {
+				sentPatches = append(sentPatches, action.(testing.PatchAction).GetPatch())
+				return false, nil, nil
+			})
+		})
+
+		decodePatch := func(payload []byte) mergePatchMeta {
+			var patch mergePatchMeta
+			ExpectWithOffset(1, json.Unmarshal(payload, &patch)).To(Succeed())
+			return patch
+		}
+
+		It("should add the annotations and missing selector label, keeping a resourceVersion precondition", func() {
+			migration := newMigration("testmigration", "testvmi", v1.MigrationPending)
+			delete(migration.Annotations, v1.ControllerAPILatestVersionObservedAnnotation)
+			delete(migration.Annotations, v1.ControllerAPIStorageVersionObservedAnnotation)
+			migration.ResourceVersion = "42"
+			addMigration(migration)
+
+			sanityExecute()
+
+			Expect(sentPatches).To(HaveLen(1))
+			patch := decodePatch(sentPatches[0])
+			Expect(patch.Metadata.Annotations).To(HaveKeyWithValue(v1.ControllerAPILatestVersionObservedAnnotation, v1.ApiLatestVersion))
+			Expect(patch.Metadata.Labels).To(HaveKeyWithValue(v1.MigrationSelectorLabel, "testvmi"))
+			Expect(patch.Metadata.ResourceVersion).To(HaveValue(Equal("42")))
+
+			updated, err := virtClientset.KubevirtV1().VirtualMachineInstanceMigrations(migration.Namespace).Get(context.Background(), migration.Name, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updated.Annotations).To(HaveKeyWithValue(v1.ControllerAPILatestVersionObservedAnnotation, v1.ApiLatestVersion))
+			Expect(updated.Annotations).To(HaveKeyWithValue(v1.ControllerAPIStorageVersionObservedAnnotation, v1.ApiStorageVersion))
+			Expect(updated.Labels).To(HaveKeyWithValue(v1.MigrationSelectorLabel, "testvmi"))
+		})
+
+		It("should preserve unrelated labels when adding the selector label", func() {
+			migration := newMigration("testmigration", "testvmi", v1.MigrationPending)
+			delete(migration.Annotations, v1.ControllerAPILatestVersionObservedAnnotation)
+			delete(migration.Annotations, v1.ControllerAPIStorageVersionObservedAnnotation)
+			migration.Labels = map[string]string{"unrelated": "label"}
+			addMigration(migration)
+
+			sanityExecute()
+
+			updated, err := virtClientset.KubevirtV1().VirtualMachineInstanceMigrations(migration.Namespace).Get(context.Background(), migration.Name, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updated.Labels).To(HaveKeyWithValue("unrelated", "label"))
+			Expect(updated.Labels).To(HaveKeyWithValue(v1.MigrationSelectorLabel, "testvmi"))
+			Expect(updated.Annotations).To(HaveKeyWithValue(v1.ControllerAPILatestVersionObservedAnnotation, v1.ApiLatestVersion))
+		})
+
+		It("should patch only the annotations, without precondition, when the selector label exists", func() {
+			migration := newMigration("testmigration", "testvmi", v1.MigrationPending)
+			delete(migration.Annotations, v1.ControllerAPILatestVersionObservedAnnotation)
+			delete(migration.Annotations, v1.ControllerAPIStorageVersionObservedAnnotation)
+			migration.Labels = map[string]string{v1.MigrationSelectorLabel: "custom-value"}
+			addMigration(migration)
+
+			sanityExecute()
+
+			Expect(sentPatches).To(HaveLen(1))
+			patch := decodePatch(sentPatches[0])
+			Expect(patch.Metadata.Labels).To(BeNil())
+			Expect(patch.Metadata.ResourceVersion).To(BeNil())
+
+			updated, err := virtClientset.KubevirtV1().VirtualMachineInstanceMigrations(migration.Namespace).Get(context.Background(), migration.Name, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updated.Annotations).To(HaveKeyWithValue(v1.ControllerAPILatestVersionObservedAnnotation, v1.ApiLatestVersion))
+			Expect(updated.Labels).To(HaveKeyWithValue(v1.MigrationSelectorLabel, "custom-value"))
+		})
+
+		It("should not clobber a selector label the informer has not observed yet", func() {
+			// The informer copy is stale: it lacks the selector label, while the
+			// live object already carries a custom value. The patch must ship a
+			// resourceVersion precondition so the server rejects it, protecting
+			// the live label until a retry sees fresher state.
+			stale := newMigration("testmigration", "testvmi", v1.MigrationPending)
+			delete(stale.Annotations, v1.ControllerAPILatestVersionObservedAnnotation)
+			delete(stale.Annotations, v1.ControllerAPIStorageVersionObservedAnnotation)
+			stale.ResourceVersion = "41"
+
+			live := stale.DeepCopy()
+			live.Labels = map[string]string{v1.MigrationSelectorLabel: "custom-value"}
+			live.ResourceVersion = "42"
+
+			key, err := virtcontroller.KeyFunc(stale)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(controller.migrationIndexer.Add(stale)).To(Succeed())
+			controller.Queue.Add(key)
+			_, err = virtClientset.KubevirtV1().VirtualMachineInstanceMigrations(live.Namespace).Create(context.Background(), live, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			virtClientset.Fake.PrependReactor("patch", "virtualmachineinstancemigrations", func(action testing.Action) (bool, k8sruntime.Object, error) {
+				sentPatches = append(sentPatches, action.(testing.PatchAction).GetPatch())
+				return true, nil, k8serrors.NewConflict(
+					schema.GroupResource{Group: "kubevirt.io", Resource: "virtualmachineinstancemigrations"},
+					stale.Name, errors.New("the object has been modified"))
+			})
+
+			sanityExecute()
+
+			Expect(sentPatches).To(HaveLen(1))
+			patch := decodePatch(sentPatches[0])
+			Expect(patch.Metadata.Labels).To(HaveKeyWithValue(v1.MigrationSelectorLabel, "testvmi"))
+			Expect(patch.Metadata.ResourceVersion).To(HaveValue(Equal("41")))
+
+			updated, err := virtClientset.KubevirtV1().VirtualMachineInstanceMigrations(live.Namespace).Get(context.Background(), live.Name, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updated.Labels).To(HaveKeyWithValue(v1.MigrationSelectorLabel, "custom-value"))
+			Expect(updated.Annotations).ToNot(HaveKey(v1.ControllerAPILatestVersionObservedAnnotation))
+		})
+	})
 
 	Context("Migration with hotplug volumes", func() {
 		var (

--- a/pkg/virt-controller/watch/replicaset/replicaset.go
+++ b/pkg/virt-controller/watch/replicaset/replicaset.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
@@ -169,9 +170,12 @@ func (c *Controller) execute(key string) error {
 	// this must be first step in execution. Writing the object
 	// when api version changes ensures our api stored version is updated.
 	if !controller.ObservedLatestApiVersionAnnotation(rs) {
-		rs := rs.DeepCopy()
-		controller.SetLatestApiVersionAnnotation(rs)
-		_, err = c.clientset.ReplicaSet(rs.Namespace).Update(context.Background(), rs, metav1.UpdateOptions{})
+		var patchBytes []byte
+		patchBytes, err = controller.LatestApiVersionMergePatch()
+		if err != nil {
+			return err
+		}
+		_, err = c.clientset.ReplicaSet(rs.Namespace).Patch(context.Background(), rs.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
 		return err
 	}
 

--- a/pkg/virt-controller/watch/vm/vm.go
+++ b/pkg/virt-controller/watch/vm/vm.go
@@ -374,8 +374,12 @@ func (c *Controller) execute(key string) error {
 	// this must be first step in execution. Writing the object
 	// when api version changes ensures our api stored version is updated.
 	if !controller.ObservedLatestApiVersionAnnotation(vm) {
-		controller.SetLatestApiVersionAnnotation(vm)
-		_, err = c.clientset.VirtualMachine(vm.Namespace).Update(context.Background(), vm, metav1.UpdateOptions{})
+		var patchBytes []byte
+		patchBytes, err = controller.LatestApiVersionMergePatch()
+		if err != nil {
+			return err
+		}
+		_, err = c.clientset.VirtualMachine(vm.Namespace).Patch(context.Background(), vm.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
 
 		if err != nil {
 			logger.Reason(err).Error("Updating api version annotations failed")

--- a/pkg/virt-controller/watch/vm/vm_test.go
+++ b/pkg/virt-controller/watch/vm/vm_test.go
@@ -329,6 +329,39 @@ var _ = Describe("VirtualMachine", func() {
 			}, Default)
 		}
 
+		Context("api version annotations", func() {
+			It("should be added with a merge patch that does not clobber concurrent writes", func() {
+				vm, _ := watchtesting.DefaultVirtualMachine(false)
+				delete(vm.Annotations, v1.ControllerAPILatestVersionObservedAnnotation)
+				delete(vm.Annotations, v1.ControllerAPIStorageVersionObservedAnnotation)
+
+				// The stored object carries a label from a concurrent writer
+				// that the controller's informer copy has not observed yet.
+				newer := vm.DeepCopy()
+				newer.Labels = map[string]string{"concurrent": "writer"}
+				_, err := virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Create(context.TODO(), newer, metav1.CreateOptions{})
+				Expect(err).To(Succeed())
+				addVirtualMachine(vm)
+
+				sanityExecute(vm)
+
+				patched := false
+				for _, action := range virtFakeClient.Actions() {
+					if patchAction, ok := action.(testing.PatchAction); ok && patchAction.GetResource().Resource == "virtualmachines" {
+						Expect(patchAction.GetPatchType()).To(Equal(types.MergePatchType))
+						patched = true
+					}
+				}
+				Expect(patched).To(BeTrue())
+
+				updated, err := virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
+				Expect(err).To(Succeed())
+				Expect(updated.Annotations).To(HaveKeyWithValue(v1.ControllerAPILatestVersionObservedAnnotation, v1.ApiLatestVersion))
+				Expect(updated.Annotations).To(HaveKeyWithValue(v1.ControllerAPIStorageVersionObservedAnnotation, v1.ApiStorageVersion))
+				Expect(updated.Labels).To(HaveKeyWithValue("concurrent", "writer"))
+			})
+		})
+
 		It("should update conditions when failed creating DataVolume for virtualMachineInstance", func() {
 			vm, _ := watchtesting.DefaultVirtualMachine(true)
 			vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, v1.Volume{

--- a/pkg/virt-controller/watch/vmi/vmi.go
+++ b/pkg/virt-controller/watch/vmi/vmi.go
@@ -26,6 +26,7 @@ import (
 	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
@@ -318,11 +319,14 @@ func (c *Controller) execute(key string) error {
 	// this must be first step in execution. Writing the object
 	// when api version changes ensures our api stored version is updated.
 	if !controller.ObservedLatestApiVersionAnnotation(vmi) {
-		vmi := vmi.DeepCopy()
-		controller.SetLatestApiVersionAnnotation(vmi)
+		var patchBytes []byte
+		patchBytes, err = controller.LatestApiVersionMergePatch()
+		if err != nil {
+			return err
+		}
 		key := controller.VirtualMachineInstanceKey(vmi)
 		c.vmiExpectations.SetExpectations(key, 1, 0)
-		_, err = c.clientset.VirtualMachineInstance(vmi.ObjectMeta.Namespace).Update(context.Background(), vmi, v1.UpdateOptions{})
+		_, err = c.clientset.VirtualMachineInstance(vmi.ObjectMeta.Namespace).Patch(context.Background(), vmi.Name, types.MergePatchType, patchBytes, v1.PatchOptions{})
 		if err != nil {
 			c.vmiExpectations.SetExpectations(key, 0, 0)
 			return err

--- a/pkg/virt-operator/kubevirt.go
+++ b/pkg/virt-operator/kubevirt.go
@@ -822,9 +822,12 @@ func (c *KubeVirtController) execute(key string) error {
 	// this must be first step in execution. Writing the object
 	// when api version changes ensures our api stored version is updated.
 	if !controller.ObservedLatestApiVersionAnnotation(kv) {
-		kv := kv.DeepCopy()
-		controller.SetLatestApiVersionAnnotation(kv)
-		_, err = c.virtClient.KubeVirt(kv.ObjectMeta.Namespace).Update(context.Background(), kv, metav1.UpdateOptions{})
+		var patchBytes []byte
+		patchBytes, err = controller.LatestApiVersionMergePatch()
+		if err != nil {
+			return err
+		}
+		_, err = c.virtClient.KubeVirt(kv.ObjectMeta.Namespace).Patch(context.Background(), kv.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{})
 		if err != nil {
 			logger.Reason(err).Errorf("Could not update the KubeVirt resource.")
 		}


### PR DESCRIPTION
### What this PR does

#### Before this PR:
The vm, vmi, migration, replicaset controllers and virt-operator stamp the latest-observed-api-version annotations on first reconcile via a full-object `Update()` from the informer cache. Under a concurrent writer (GitOps/platform automation) the cached copy is stale, so every object creation deterministically costs 1–2 conflict/retry cycles and error-level log lines (production data in the linked issue: 393 conflict errors over 18 days).

#### After this PR:
The annotations are set with an RFC 7386 merge patch carrying no resourceVersion precondition — it cannot conflict with concurrent writers and touches nothing but the two annotation keys. This mirrors the existing finalizer handling in the same controllers.

The migration controller also ensures its selector label in the same write, and that decision depends on observed state: an unconditional patch computed from a stale cache could overwrite a label value the informer has not seen. When (and only when) the patch includes the label, it carries the cached object's resourceVersion so the server enforces the same conflict-and-retry protection the full Update provided. The annotation-only path stays precondition-free.

Open question for reviewers: on a migration's first reconcile the label is always included, so that one write remains conflict-prone (identical to current behavior — no regression). If preferred, the label could be written unconditionally instead — its only valid value is `spec.vmiName` (immutable), so overwriting divergence is arguably self-healing — but that is a semantics change I did not want to fold into this PR.

#### Validation
- New unit tests: a concurrent-writer test on the vm controller that fails against the old code (label clobbered by the full Update) and passes with the patch; migration tests covering label-added / label-exists / stale-cache-clobber cases, asserting the precondition is present exactly when the label is written.
- Live cluster comparison (v1.7.1 backport, external writer keeping a label write permanently in flight per VM): stock logged 9 conflicts over 33 VM creations including one VM retrying 5 times; the patched controller logged 0 conflicts over 90 creations, all annotations landed, and all concurrent-writer labels survived. Migration path: 12/12 annotated, 8/8 missing labels added correctly, 4/4 pre-existing custom label values preserved.

### References
Fixes #18527

```release-note
virt-controller and virt-operator now set the latest observed API version annotations with a merge patch, eliminating spurious conflict errors and retries when other clients update the object concurrently.
```