### PR TITLE
hotfix: Protect unprotected stall detector code paths

### DIFF
--- a/pkg/virt-handler/cmd-client/client.go
+++ b/pkg/virt-handler/cmd-client/client.go
@@ -88,8 +88,7 @@ type MigrationOptions struct {
 	AllowPostCopy            bool
 	ParallelMigrationThreads *uint
 	AllowWorkloadDisruption  bool
-	StallDetectionEnabled    bool
-	StallDetectorOptions     StallDetectorOptions
+	StallDetectorOptions     *StallDetectorOptions
 	Compression              *string
 }
 

--- a/pkg/virt-handler/migration-source.go
+++ b/pkg/virt-handler/migration-source.go
@@ -532,25 +532,6 @@ func (c *MigrationSourceController) migrateVMI(vmi *v1.VirtualMachineInstance, d
 	if migrationConfiguration.MaxDowntimeMs == nil {
 		migrationConfiguration.MaxDowntimeMs = pointer.P(virtconfig.DefaultMigrationMaxDowntimeMs)
 	}
-	applyExperimentalMigrationDefaults(migrationConfiguration)
-
-	stallDetector := migrationConfiguration.ExperimentalMigrationOptions.StallDetector
-	ewmaAlpha, err := virtconfig.ParseFactor(*stallDetector.EwmaAlpha, virtconfig.StallDetectorFactorPrecision)
-	if err != nil {
-		return fmt.Errorf("invalid ewmaAlpha: %w", err)
-	}
-	precopyPossibleFactor, err := virtconfig.ParseFactor(*stallDetector.PrecopyPossibleFactor, virtconfig.StallDetectorFactorPrecision)
-	if err != nil {
-		return fmt.Errorf("invalid precopyPossibleFactor: %w", err)
-	}
-	patienceWindowDecayFactor, err := virtconfig.ParseFactor(*stallDetector.PatienceWindowDecayFactor, virtconfig.StallDetectorFactorPrecision)
-	if err != nil {
-		return fmt.Errorf("invalid patienceWindowDecayFactor: %w", err)
-	}
-	completionTimeoutFactor, err := virtconfig.ParseFactor(*stallDetector.CompletionTimeoutFactor, virtconfig.StallDetectorFactorPrecision)
-	if err != nil {
-		return fmt.Errorf("invalid completionTimeoutFactor: %w", err)
-	}
 
 	options := &cmdclient.MigrationOptions{
 		Bandwidth:               *migrationConfiguration.BandwidthPerMigration,
@@ -561,8 +542,28 @@ func (c *MigrationSourceController) migrateVMI(vmi *v1.VirtualMachineInstance, d
 		AllowAutoConverge:       *migrationConfiguration.AllowAutoConverge,
 		AllowPostCopy:           *migrationConfiguration.AllowPostCopy,
 		AllowWorkloadDisruption: *migrationConfiguration.AllowWorkloadDisruption,
-		StallDetectionEnabled:   c.clusterConfig.MigrationStallDetectionEnabled(),
-		StallDetectorOptions: cmdclient.StallDetectorOptions{
+	}
+
+	if c.clusterConfig.MigrationStallDetectionEnabled() {
+		applyExperimentalMigrationDefaults(migrationConfiguration)
+		stallDetector := migrationConfiguration.ExperimentalMigrationOptions.StallDetector
+		ewmaAlpha, err := virtconfig.ParseFactor(*stallDetector.EwmaAlpha, virtconfig.StallDetectorFactorPrecision)
+		if err != nil {
+			return fmt.Errorf("invalid ewmaAlpha: %w", err)
+		}
+		precopyPossibleFactor, err := virtconfig.ParseFactor(*stallDetector.PrecopyPossibleFactor, virtconfig.StallDetectorFactorPrecision)
+		if err != nil {
+			return fmt.Errorf("invalid precopyPossibleFactor: %w", err)
+		}
+		patienceWindowDecayFactor, err := virtconfig.ParseFactor(*stallDetector.PatienceWindowDecayFactor, virtconfig.StallDetectorFactorPrecision)
+		if err != nil {
+			return fmt.Errorf("invalid patienceWindowDecayFactor: %w", err)
+		}
+		completionTimeoutFactor, err := virtconfig.ParseFactor(*stallDetector.CompletionTimeoutFactor, virtconfig.StallDetectorFactorPrecision)
+		if err != nil {
+			return fmt.Errorf("invalid completionTimeoutFactor: %w", err)
+		}
+		options.StallDetectorOptions = &cmdclient.StallDetectorOptions{
 			StallMargin:               float64(*stallDetector.StallMargin) / 100,
 			StallProgressTimeout:      *stallDetector.StallProgressTimeout,
 			SwitchoverTimeout:         *stallDetector.SwitchoverTimeout,
@@ -571,7 +572,7 @@ func (c *MigrationSourceController) migrateVMI(vmi *v1.VirtualMachineInstance, d
 			PatienceWindowDecayFactor: patienceWindowDecayFactor,
 			SearchLocalMinima:         *stallDetector.SearchLocalMinima,
 			CompletionTimeoutFactor:   completionTimeoutFactor,
-		},
+		}
 	}
 
 	if exp := migrationConfiguration.ExperimentalMigrationOptions; exp != nil && exp.Compression != nil {

--- a/pkg/virt-handler/migration-source_test.go
+++ b/pkg/virt-handler/migration-source_test.go
@@ -301,18 +301,8 @@ var _ = Describe("VirtualMachineInstance migration target", func() {
 				AllowPostCopy:            true,
 				AllowWorkloadDisruption:  true,
 				AllowAutoConverge:        false,
-				StallDetectionEnabled:    false,
+				StallDetectorOptions:     nil,
 				ParallelMigrationThreads: pointer.P(parallelMultifdMigrationThreads),
-				StallDetectorOptions: cmdclient.StallDetectorOptions{
-					StallMargin:               float64(virtconfig.DefaultStallMargin) / 100,
-					StallProgressTimeout:      virtconfig.DefaultStallProgressTimeout,
-					SwitchoverTimeout:         virtconfig.DefaultSwitchoverTimeout,
-					EwmaAlpha:                 parseDefaultStallDetectorFactor(virtconfig.DefaultEwmaAlpha),
-					PrecopyPossibleFactor:     parseDefaultStallDetectorFactor(virtconfig.DefaultPrecopyPossibleFactor),
-					PatienceWindowDecayFactor: parseDefaultStallDetectorFactor(virtconfig.DefaultPatienceWindowDecayFactor),
-					SearchLocalMinima:         virtconfig.DefaultSearchLocalMinima,
-					CompletionTimeoutFactor:   parseDefaultStallDetectorFactor(virtconfig.DefaultCompletionTimeoutFactor),
-				},
 			}
 			client.EXPECT().MigrateVirtualMachine(vmi, expectedOptions)
 			sanityExecute()
@@ -595,7 +585,7 @@ var _ = Describe("VirtualMachineInstance migration target", func() {
 		})
 	})
 
-	It("should set StallDetectionEnabled to true when MigrationStallDetection feature gate is enabled", func() {
+	It("should put StallDetectorOptions on the wire when MigrationStallDetection feature gate is enabled", func() {
 		kv := &v1.KubeVirtConfiguration{
 			DeveloperConfiguration: &v1.DeveloperConfiguration{
 				FeatureGates: []string{featuregate.PasstBinding, featuregate.MigrationStallDetection},
@@ -634,7 +624,17 @@ var _ = Describe("VirtualMachineInstance migration target", func() {
 		}
 		addVMI(vmi, domain)
 		client.EXPECT().MigrateVirtualMachine(gomock.Any(), gomock.Any()).Do(func(_ *v1.VirtualMachineInstance, options *cmdclient.MigrationOptions) {
-			Expect(options.StallDetectionEnabled).To(BeTrue())
+			Expect(options.StallDetectorOptions).ToNot(BeNil())
+			Expect(options.StallDetectorOptions).To(Equal(&cmdclient.StallDetectorOptions{
+				StallMargin:               float64(virtconfig.DefaultStallMargin) / 100,
+				StallProgressTimeout:      virtconfig.DefaultStallProgressTimeout,
+				SwitchoverTimeout:         virtconfig.DefaultSwitchoverTimeout,
+				EwmaAlpha:                 parseDefaultStallDetectorFactor(virtconfig.DefaultEwmaAlpha),
+				PrecopyPossibleFactor:     parseDefaultStallDetectorFactor(virtconfig.DefaultPrecopyPossibleFactor),
+				PatienceWindowDecayFactor: parseDefaultStallDetectorFactor(virtconfig.DefaultPatienceWindowDecayFactor),
+				SearchLocalMinima:         virtconfig.DefaultSearchLocalMinima,
+				CompletionTimeoutFactor:   parseDefaultStallDetectorFactor(virtconfig.DefaultCompletionTimeoutFactor),
+			}))
 		}).Times(1).Return(nil)
 
 		sanityExecute()
@@ -680,16 +680,6 @@ var _ = Describe("VirtualMachineInstance migration target", func() {
 			UnsafeMigration:          virtconfig.DefaultUnsafeMigrationOverride,
 			AllowPostCopy:            virtconfig.MigrationAllowPostCopy,
 			ParallelMigrationThreads: pointer.P(parallelMultifdMigrationThreads),
-			StallDetectorOptions: cmdclient.StallDetectorOptions{
-				StallMargin:               float64(virtconfig.DefaultStallMargin) / 100,
-				StallProgressTimeout:      virtconfig.DefaultStallProgressTimeout,
-				SwitchoverTimeout:         virtconfig.DefaultSwitchoverTimeout,
-				EwmaAlpha:                 parseDefaultStallDetectorFactor(virtconfig.DefaultEwmaAlpha),
-				PrecopyPossibleFactor:     parseDefaultStallDetectorFactor(virtconfig.DefaultPrecopyPossibleFactor),
-				PatienceWindowDecayFactor: parseDefaultStallDetectorFactor(virtconfig.DefaultPatienceWindowDecayFactor),
-				SearchLocalMinima:         virtconfig.DefaultSearchLocalMinima,
-				CompletionTimeoutFactor:   parseDefaultStallDetectorFactor(virtconfig.DefaultCompletionTimeoutFactor),
-			},
 		}
 		client.EXPECT().MigrateVirtualMachine(vmi, options)
 		sanityExecute()

--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -438,6 +438,7 @@ func (l *LibvirtDomainManager) setMigrationAbortStatus(abortStatus v1.MigrationA
 }
 
 func newMigrationMonitor(vmi *v1.VirtualMachineInstance, l *LibvirtDomainManager, options *cmdclient.MigrationOptions, migrationDone <-chan struct{}) *migrationMonitor {
+	stallDetectorEnabled := options.StallDetectorOptions != nil
 	monitor := &migrationMonitor{
 		l:                        l,
 		vmi:                      vmi,
@@ -447,15 +448,15 @@ func newMigrationMonitor(vmi *v1.VirtualMachineInstance, l *LibvirtDomainManager
 		remainingData:            0,
 		progressTimeout:          options.ProgressTimeout,
 		acceptableCompletionTime: options.CompletionTimeoutPerGiB * getVMIMigrationDataSize(vmi, l.ephemeralDiskDir),
-		stallDetectionEnabled:    options.StallDetectionEnabled,
+		stallDetectionEnabled:    stallDetectorEnabled,
 		logger:                   log.Log.Object(vmi),
 	}
 
-	if options.StallDetectionEnabled {
+	if stallDetectorEnabled {
 		monitor.iterationCh = make(chan int, 16)
 		monitor.switchOverDeadline = monitor.acceptableCompletionTime
 		monitor.stallDetector = &stallDetector{
-			stallDetectorOptions:    options.StallDetectorOptions,
+			stallDetectorOptions:    *options.StallDetectorOptions,
 			maxDowntimeMs:           options.MaxDowntimeMs,
 			allowPostCopy:           options.AllowPostCopy,
 			allowWorkloadDisruption: options.AllowWorkloadDisruption,
@@ -464,7 +465,7 @@ func newMigrationMonitor(vmi *v1.VirtualMachineInstance, l *LibvirtDomainManager
 		monitor.logger.V(3).Infof(
 			"initialized migration monitor: stallDetection=%t progressTimeout=%ds completionTimeoutPerGiB=%d maxDowntimeMs=%d allowPostCopy=%t allowWorkloadDisruption=%t "+
 				"stallMargin=%.2f stallProgressTimeout=%ds switchoverTimeout=%ds preCopyPossibleFactor=%.2f patienceWindowDecayFactor=%.2f bandwidthEWMAAlpha=%.2f searchLocalMinima=%t completionTimeoutFactor=%.2f",
-			options.StallDetectionEnabled,
+			stallDetectorEnabled,
 			options.ProgressTimeout,
 			options.CompletionTimeoutPerGiB,
 			options.MaxDowntimeMs,

--- a/pkg/virt-launcher/virtwrap/live-migration-source_test.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source_test.go
@@ -890,7 +890,7 @@ var _ = Describe("Live migration source", func() {
 
 		BeforeEach(func() {
 			options := &cmdclient.MigrationOptions{
-				StallDetectorOptions: cmdclient.StallDetectorOptions{
+				StallDetectorOptions: &cmdclient.StallDetectorOptions{
 					StallMargin:               float64(4) / 100,
 					StallProgressTimeout:      25,
 					SwitchoverTimeout:         testSwitchoverTimeout,
@@ -903,7 +903,7 @@ var _ = Describe("Live migration source", func() {
 				MaxDowntimeMs: testMaxDowntimeMs,
 			}
 			sd = &stallDetector{
-				stallDetectorOptions: options.StallDetectorOptions,
+				stallDetectorOptions: *options.StallDetectorOptions,
 				maxDowntimeMs:        options.MaxDowntimeMs,
 			}
 			monitor = &migrationMonitor{
@@ -1650,9 +1650,8 @@ var _ = Describe("Live migration source", func() {
 
 		It("newMigrationMonitor should pass StallDetectorOptions to the stall detector", func() {
 			customOptions := &cmdclient.MigrationOptions{
-				StallDetectionEnabled: true,
-				MaxDowntimeMs:         testMaxDowntimeMs,
-				StallDetectorOptions: cmdclient.StallDetectorOptions{
+				MaxDowntimeMs: testMaxDowntimeMs,
+				StallDetectorOptions: &cmdclient.StallDetectorOptions{
 					StallMargin:             0.08,
 					StallProgressTimeout:    10,
 					SwitchoverTimeout:       42,
@@ -1663,7 +1662,7 @@ var _ = Describe("Live migration source", func() {
 				},
 			}
 			m := newMigrationMonitor(vmi, libvirtDomainManager, customOptions, make(chan struct{}, 1))
-			Expect(m.stallDetector.stallDetectorOptions).To(Equal(customOptions.StallDetectorOptions))
+			Expect(m.stallDetector.stallDetectorOptions).To(Equal(*customOptions.StallDetectorOptions))
 			Expect(m.stallDetector.maxDowntimeMs).To(Equal(customOptions.MaxDowntimeMs))
 		})
 	})


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

Some of the stall detector code paths are unguarded and run unconditionally. The worst offender here is StallDetectorOptions which unconditionally encodes into migration options with default parameterization. This is a problem since this is an alpha feature and any changes to stall detector options could thus cause backward compatability concerns and break upgrades even in cases where Stall Detector was never enabled.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
https://github.com/kubevirt/enhancements/issues/248
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

* This PR must merge before the v1.9 release as it contains breaking changes.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

