### PR TITLE
net, e2e: Ping ref VMI instead of ref pod in migration tests

### DIFF
--- a/tests/network/vmi_networking.go
+++ b/tests/network/vmi_networking.go
@@ -580,23 +580,21 @@ var _ = Describe(SIG("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:
 
 				var err error
 
-				By("Create client pod")
-				clientPod := libpod.RenderPod("test-conn", []string{"/bin/sh", "-c", "sleep 360"}, []string{})
-				clientPod, err = virtClient.CoreV1().Pods(testsuite.GetTestNamespace(nil)).Create(context.Background(), clientPod, metav1.CreateOptions{})
+				By("Create ref VMI")
+				refVMI := conformanceVMI()
+				refVMI, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), refVMI, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
 				By("Create VMI")
 				vmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Create(context.Background(), testVMI, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
+
+				refVMI = libwait.WaitUntilVMIReady(refVMI, console.LoginToAlpine)
 				vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToAlpine)
 
-				Eventually(matcher.ThisPod(clientPod)).WithTimeout(120 * time.Second).WithPolling(time.Second).Should(matcher.BeRunning())
-				clientPod, err = virtClient.CoreV1().Pods(clientPod.Namespace).Get(context.Background(), clientPod.Name, metav1.GetOptions{})
-				Expect(err).ToNot(HaveOccurred())
-
 				By("Check connectivity")
-				podIP := libnet.GetPodIPByFamily(clientPod, k8sv1.IPv4Protocol)
-				Expect(ping(podIP)).To(Succeed())
+				refIP := libnet.GetVmiPrimaryIPByFamily(refVMI, k8sv1.IPv4Protocol)
+				Expect(ping(refIP)).To(Succeed())
 
 				By("starting the migration")
 				migration := libmigration.New(vmi.Name, vmi.Namespace)
@@ -606,7 +604,7 @@ var _ = Describe(SIG("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:
 				Expect(err).ToNot(HaveOccurred())
 				Expect(vmi.Status.Phase).To(Equal(v1.Running))
 
-				Expect(ping(podIP)).To(Succeed())
+				Expect(ping(refIP)).To(Succeed())
 
 				By("Initiating DHCP client request after migration")
 
@@ -616,8 +614,8 @@ var _ = Describe(SIG("[rfe_id:694][crit:medium][vendor:cnv-qe@redhat.com][level:
 				Expect(console.RunCommand(vmi, "kill -USR1 $(cat /var/run/udhcpc.eth0.pid)\n", 15*time.Second)).To(Succeed(), "failed to renew dhcp client")
 
 				Eventually(func() error {
-					return ping(podIP)
-				}, 30*time.Second, 1*time.Second).Should(Succeed(), "expected pod to be reachable after DHCP renew")
+					return ping(refIP)
+				}, 30*time.Second, 1*time.Second).Should(Succeed(), "expected ref VMI to be reachable after DHCP renew")
 			},
 				Entry("without explicit ports specification", conformanceVMI()),
 				Entry("with explicit ports used by live migration", decorators.InterfacePorts,


### PR DESCRIPTION
### What this PR does

Currently this test uses a reference pod that the VMI under test pings
before and after migration to verify connectivity. It does so by
fetching the pod IP and pinging it.
However in clusters where pod network is not the default network, the
pod IP is in a different network than the VMI. So the ping fails.

This PR changes the ref pod to a ref VMI. It takes up relatively
more resources, but can be now used in clusters where pod network is not
the default network.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
Tested on a cluster without default pod network

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated IPv4 migration connectivity validation to use a dedicated virtual machine as the connectivity target.
  * Added readiness and IPv4 address checks for the virtual machine before and after migration.
  * Removed reliance on a separate client pod for connectivity verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->