### PR TITLE
hostdevice: Default ramfb to enabled when display is set

### DIFF
--- a/pkg/virt-launcher/virtwrap/device/hostdevice/hostdev.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/hostdev.go
@@ -63,11 +63,10 @@ func isVgpuDisplayExplicitlyEnabled(display *v1.VGPUDisplayOptions) bool {
 }
 
 func isRamFBSet(hostDeviceMetadata HostDeviceMetaData) bool {
-	return hostDeviceMetadata.VirtualGPUOptions != nil &&
-		hostDeviceMetadata.VirtualGPUOptions.Display != nil &&
-		hostDeviceMetadata.VirtualGPUOptions.Display.RamFB != nil &&
-		hostDeviceMetadata.VirtualGPUOptions.Display.RamFB.Enabled != nil &&
-		*hostDeviceMetadata.VirtualGPUOptions.Display.RamFB.Enabled
+	return isVgpuDisplaySet(hostDeviceMetadata) &&
+		(hostDeviceMetadata.VirtualGPUOptions.Display.RamFB == nil ||
+			hostDeviceMetadata.VirtualGPUOptions.Display.RamFB.Enabled == nil ||
+			*hostDeviceMetadata.VirtualGPUOptions.Display.RamFB.Enabled)
 }
 func isVgpuDisplaySetIn(hostDevicesData []HostDeviceMetaData) bool {
 	for _, hostDeviceData := range hostDevicesData {

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/hostdev_test.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/hostdev_test.go
@@ -203,7 +203,7 @@ var _ = Describe("HostDevice", func() {
 			Expect(hostDevices, err).To(Equal([]api.HostDevice{basePCIDevice}))
 		})
 
-		It("sets display on when explicitly enabled, without ramfb", func() {
+		It("sets display on when explicitly enabled, with ramfb", func() {
 			hostDevicesMetaData := []hostdevice.HostDeviceMetaData{
 				{AliasPrefix: aliasPrefix, Name: devName0, ResourceName: resourceName0,
 					VirtualGPUOptions: &v1.VGPUOptions{
@@ -217,6 +217,7 @@ var _ = Describe("HostDevice", func() {
 			hostDevices, err := hostdevice.CreatePCIHostDevices(hostDevicesMetaData, pool)
 			expected := basePCIDevice
 			expected.Display = "on"
+			expected.RamFB = "on"
 
 			Expect(hostDevices, err).To(Equal([]api.HostDevice{expected}))
 		})
@@ -264,7 +265,7 @@ var _ = Describe("HostDevice", func() {
 			Expect(hostDevices, err).To(Equal([]api.HostDevice{expected}))
 		})
 
-		It("does not set ramfb when RamFB is present but Enabled is nil", func() {
+		It("does  set ramfb when RamFB is present but Enabled is nil", func() {
 			hostDevicesMetaData := []hostdevice.HostDeviceMetaData{
 				{AliasPrefix: aliasPrefix, Name: devName0, ResourceName: resourceName0,
 					VirtualGPUOptions: &v1.VGPUOptions{
@@ -279,6 +280,7 @@ var _ = Describe("HostDevice", func() {
 			hostDevices, err := hostdevice.CreatePCIHostDevices(hostDevicesMetaData, pool)
 			expected := basePCIDevice
 			expected.Display = "on"
+			expected.RamFB = "on"
 
 			Expect(hostDevices, err).To(Equal([]api.HostDevice{expected}))
 		})


### PR DESCRIPTION
### What this PR does
Change isRamFBSet to enable ramfb by default when vGPU display is configured. Previously, ramfb was only enabled when explicitly set to true. Now it is enabled unless explicitly disabled, which aligns with the expected behavior for PCI host devices with display support.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->
https://github.com/kubevirt/kubevirt/pull/18112/changes/BASE..a7d142fb95f70cf236b3ac6e31fb71a7b6dd9764#r3568797219

### Special notes for your reviewer

<!-- optional -->

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

