### PR TITLE
Console: Use JoinNoFollow for console socket path

### DIFF
--- a/pkg/virt-handler/rest/console.go
+++ b/pkg/virt-handler/rest/console.go
@@ -25,6 +25,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"path/filepath"
 	"strconv"
 	"sync"
 
@@ -265,7 +266,7 @@ func (t *ConsoleHandler) getUnixSocketPath(vmi *v1.VirtualMachineInstance, socke
 	if err != nil {
 		return nil, err
 	}
-	return root.AppendAndResolveWithRelativeRoot("run", "kubevirt-private", string(vmi.GetUID()), socketName)
+	return safepath.JoinNoFollow(root, filepath.Join("run", "kubevirt-private", string(vmi.GetUID()), socketName))
 }
 
 func unixSocketDialer(vmi *v1.VirtualMachineInstance, socketPath *safepath.Path) func() (net.Conn, error) {


### PR DESCRIPTION
### What this PR does
Replace AppendAndResolveWithRelativeRoot with safepath.JoinNoFollow to resolve the console unix socket path without following symlinks.


Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

