### PR TITLE
virt-api: count an unset ramFB.enabled as enabled in the ramfb check

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -527,10 +527,14 @@ func validateLiveMigration(field *k8sfield.Path, spec *v1.VirtualMachineInstance
 func countConfiguredMDEVRamFBs(spec *v1.VirtualMachineInstanceSpec) int {
 	count := 0
 	for _, device := range spec.Domain.Devices.GPUs {
+		// Treat an unset Display.Enabled or RamFB.Enabled as enabled, per the
+		// "Defaults to true" API contract on both fields. RamFB.Enabled gets
+		// that default from SetDefaults_FeatureState; Display.Enabled has no
+		// defaulter and is enabled-when-unset by convention.
 		if device.VirtualGPUOptions != nil &&
 			device.VirtualGPUOptions.Display != nil &&
 			(device.VirtualGPUOptions.Display.Enabled == nil || *device.VirtualGPUOptions.Display.Enabled) &&
-			(device.VirtualGPUOptions.Display.RamFB == nil || (device.VirtualGPUOptions.Display.RamFB.Enabled != nil && *device.VirtualGPUOptions.Display.RamFB.Enabled)) {
+			(device.VirtualGPUOptions.Display.RamFB == nil || device.VirtualGPUOptions.Display.RamFB.Enabled == nil || *device.VirtualGPUOptions.Display.RamFB.Enabled) {
 			count++
 		}
 	}

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -1261,6 +1261,54 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			Expect(causes[0].Field).To(Equal("fake.GPUs"))
 		})
 
+		vgpuRamfbSpec := func(displays ...*v1.VGPUDisplayOptions) *v1.VirtualMachineInstanceSpec {
+			vmi := api.NewMinimalVMI("testvm")
+			for i, display := range displays {
+				vmi.Spec.Domain.Devices.GPUs = append(vmi.Spec.Domain.Devices.GPUs, v1.GPU{
+					Name:              fmt.Sprintf("gpu%d", i),
+					DeviceName:        fmt.Sprintf("vendor.com/gpu%d", i),
+					VirtualGPUOptions: &v1.VGPUOptions{Display: display},
+				})
+			}
+			return &vmi.Spec
+		}
+
+		DescribeTable("rejecting more than one vGPU display that enables ramfb", func(displays ...*v1.VGPUDisplayOptions) {
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), vgpuRamfbSpec(displays...), config)
+			Expect(causes).To(HaveLen(1))
+			Expect(causes[0].Field).To(Equal("fake.GPUs"))
+		},
+			Entry("two vGPUs whose ramFB is present with enabled unset",
+				&v1.VGPUDisplayOptions{Enabled: pointer.P(true), RamFB: &v1.FeatureState{}},
+				&v1.VGPUDisplayOptions{Enabled: pointer.P(true), RamFB: &v1.FeatureState{}}),
+			Entry("an unset ramFB alongside an absent ramFB",
+				&v1.VGPUDisplayOptions{Enabled: pointer.P(true), RamFB: &v1.FeatureState{}},
+				&v1.VGPUDisplayOptions{Enabled: pointer.P(true), RamFB: nil}),
+			Entry("an unset ramFB alongside an explicitly enabled ramFB",
+				&v1.VGPUDisplayOptions{Enabled: pointer.P(true), RamFB: &v1.FeatureState{}},
+				&v1.VGPUDisplayOptions{Enabled: pointer.P(true), RamFB: &v1.FeatureState{Enabled: pointer.P(true)}}),
+			Entry("an unset display defaults to enabled so its ramFB is counted",
+				&v1.VGPUDisplayOptions{Enabled: nil, RamFB: &v1.FeatureState{}},
+				&v1.VGPUDisplayOptions{Enabled: nil, RamFB: &v1.FeatureState{}}),
+		)
+
+		DescribeTable("allowing at most one vGPU display that enables ramfb", func(displays ...*v1.VGPUDisplayOptions) {
+			causes := ValidateVirtualMachineInstanceSpec(k8sfield.NewPath("fake"), vgpuRamfbSpec(displays...), config)
+			Expect(causes).To(BeEmpty())
+		},
+			Entry("a single vGPU whose ramFB is present with enabled unset",
+				&v1.VGPUDisplayOptions{Enabled: pointer.P(true), RamFB: &v1.FeatureState{}}),
+			Entry("two vGPUs with ramFB explicitly disabled",
+				&v1.VGPUDisplayOptions{Enabled: pointer.P(true), RamFB: &v1.FeatureState{Enabled: pointer.P(false)}},
+				&v1.VGPUDisplayOptions{Enabled: pointer.P(true), RamFB: &v1.FeatureState{Enabled: pointer.P(false)}}),
+			Entry("a disabled display is not counted even with ramFB enabled",
+				&v1.VGPUDisplayOptions{Enabled: pointer.P(false), RamFB: &v1.FeatureState{Enabled: pointer.P(true)}},
+				&v1.VGPUDisplayOptions{Enabled: pointer.P(false), RamFB: &v1.FeatureState{Enabled: pointer.P(true)}}),
+			Entry("a disabled display is not counted even with ramFB unset",
+				&v1.VGPUDisplayOptions{Enabled: pointer.P(false), RamFB: &v1.FeatureState{}},
+				&v1.VGPUDisplayOptions{Enabled: pointer.P(false), RamFB: nil}),
+		)
+
 		It("should accept legacy GPU devices if PermittedHostDevices aren't set", func() {
 			vmi := api.NewMinimalVMI("testvm")
 			vmi.Spec.Domain.Devices.GPUs = []v1.GPU{

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmirs-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmirs-admitter_test.go
@@ -33,6 +33,7 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 
+	"kubevirt.io/kubevirt/pkg/pointer"
 	"kubevirt.io/kubevirt/pkg/testutils"
 	"kubevirt.io/kubevirt/pkg/virt-api/webhooks"
 )
@@ -140,6 +141,41 @@ var _ = Describe("Validating VMIRS Admitter", func() {
 
 		resp := vmirsAdmitter.Admit(context.Background(), ar)
 		Expect(resp.Allowed).To(BeTrue())
+	})
+
+	It("should reject a template with more than one unset-enabled ramFB display", func() {
+		template := newVirtualMachineBuilder().
+			WithDisk(v1.Disk{Name: "testdisk"}).
+			WithVolume(v1.Volume{
+				Name: "testdisk",
+				VolumeSource: v1.VolumeSource{
+					ContainerDisk: testutils.NewFakeContainerDiskSource(),
+				},
+			}).
+			WithLabel("match", "me").
+			BuildTemplate()
+		template.Spec.Domain.Devices.GPUs = []v1.GPU{
+			{Name: "gpu0", DeviceName: "vendor.com/gpu0", VirtualGPUOptions: &v1.VGPUOptions{Display: &v1.VGPUDisplayOptions{Enabled: pointer.P(true), RamFB: &v1.FeatureState{}}}},
+			{Name: "gpu1", DeviceName: "vendor.com/gpu1", VirtualGPUOptions: &v1.VGPUOptions{Display: &v1.VGPUDisplayOptions{Enabled: pointer.P(true), RamFB: &v1.FeatureState{}}}},
+		}
+		vmirs := &v1.VirtualMachineInstanceReplicaSet{
+			Spec: v1.VirtualMachineInstanceReplicaSetSpec{
+				Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"match": "me"}},
+				Template: template,
+			},
+		}
+		vmirsBytes, _ := json.Marshal(&vmirs)
+
+		ar := &admissionv1.AdmissionReview{
+			Request: &admissionv1.AdmissionRequest{
+				Resource: webhooks.VirtualMachineInstanceReplicaSetGroupVersionResource,
+				Object:   runtime.RawExtension{Raw: vmirsBytes},
+			},
+		}
+
+		resp := vmirsAdmitter.Admit(context.Background(), ar)
+		Expect(resp.Allowed).To(BeFalse())
+		Expect(resp.Result.Details.Causes).To(ContainElement(WithTransform(func(c metav1.StatusCause) string { return c.Field }, Equal("spec.template.spec.GPUs"))))
 	})
 })
 

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter_test.go
@@ -185,6 +185,31 @@ var _ = Describe("Validating VM Admitter", func() {
 			Expect(resp.Result.Details.Causes).To(HaveLen(1))
 			Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.template.spec.domain.devices.disks[0].name"))
 		})
+
+		It("should reject a VM template with more than one unset-enabled ramFB display", func() {
+			vmi := api.NewMinimalVMI("testvmi")
+			vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{Name: "testdisk"})
+			vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
+				Name: "testdisk",
+				VolumeSource: v1.VolumeSource{
+					ContainerDisk: testutils.NewFakeContainerDiskSource(),
+				},
+			})
+			vmi.Spec.Domain.Devices.GPUs = []v1.GPU{
+				{Name: "gpu0", DeviceName: "vendor.com/gpu0", VirtualGPUOptions: &v1.VGPUOptions{Display: &v1.VGPUDisplayOptions{Enabled: pointer.P(true), RamFB: &v1.FeatureState{}}}},
+				{Name: "gpu1", DeviceName: "vendor.com/gpu1", VirtualGPUOptions: &v1.VGPUOptions{Display: &v1.VGPUDisplayOptions{Enabled: pointer.P(true), RamFB: &v1.FeatureState{}}}},
+			}
+			vm := &v1.VirtualMachine{
+				Spec: v1.VirtualMachineSpec{
+					Running:  pointer.P(false),
+					Template: &v1.VirtualMachineInstanceTemplateSpec{Spec: vmi.Spec},
+				},
+			}
+
+			resp := admitVm(vmsAdmitter, vm)
+			Expect(resp.Allowed).To(BeFalse())
+			Expect(resp.Result.Details.Causes).To(ContainElement(WithTransform(func(c metav1.StatusCause) string { return c.Field }, Equal("spec.template.spec.GPUs"))))
+		})
 	})
 
 	It("should allow VM that is being deleted", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:

`countConfiguredMDEVRamFBs`, the check behind "configuring multiple displays with ramfb is not valid", counted a vGPU whose `ramFB` is present with `enabled` unset as not having ramfb. That disagrees with the field's default: `SetDefaults_FeatureState` sets an unset `Enabled` to true, so the field is semantically on when unset. This aligns the check with that default so an unset `enabled` counts the same way.

The user-visible effect is on VM and VMIRS templates. They are validated before the `FeatureState` default is applied (the VMIRS admitter runs no VMI defaulting, and the VM admitter's `SetDefaultVirtualMachineInstanceSpec` does not apply the nested `FeatureState` default to `Display.RamFB`), so a template with more than one such vGPU was accepted while the derived VMI was then rejected after defaulting turned both into `enabled: true`. With this change the template is rejected up front with the same "multiple displays with ramfb" cause.

**Which issue(s) this PR fixes**:

Fixes #18541

**Special notes for your reviewer**:

Regression coverage runs through all three admission entry points: a `DescribeTable` on the shared validator (`Display` and `RamFB` enabled, disabled, and unset combinations, including an unset `Display.Enabled`), a VMIRS admission test, and a VM admission test, each rejecting two vGPUs with `ramFB: {}` and allowing a single one. Reverting the one-line change fails the rejection cases across all three paths. Related to #18431, which makes the mdev builders treat an unset `enabled` as on rather than dereferencing it; this validator change stands on the API default independently of that PR.

**Release note**:

```release-note
RamFB display validation now treats a vGPU whose ramFB is present with its enabled field unset as an enabled display, matching the API default. A VirtualMachine or VirtualMachineInstanceReplicaSet template with more than one such vGPU is now rejected at creation instead of being accepted and failing later when its VMI is created.
```

/kind bug
