### PR TITLE
tests: fix HTTP/2 transport mismatch in Prometheus port-forward test helper

### DIFF
--- a/tests/libmonitoring/prometheus.go
+++ b/tests/libmonitoring/prometheus.go
@@ -44,6 +44,9 @@ const (
 	defaultAlertWaitTimeout         = 5 * time.Minute
 	defaultMetricsPort              = 8443
 	prometheusPortForwardTargetPort = 9090
+	prometheusPortForwardTimeout    = 90 * time.Second
+	prometheusRequestTimeout        = 30 * time.Second
+	prometheusHTTPTimeout           = 10 * time.Second
 )
 
 var (
@@ -221,7 +224,9 @@ func DoPrometheusHTTPRequest(cli kubecli.KubevirtClient, endpoint string) []byte
 	var result []byte
 	if checks.IsOpenShift() {
 		promURL := getPrometheusURLForOpenShift()
-		result = doHTTPRequest(promURL, endpoint, token)
+		var err error
+		result, err = doHTTPRequest(promURL, endpoint, token)
+		Expect(err).ShouldNot(HaveOccurred())
 	} else {
 		Eventually(func() error {
 			_, cmd, cmdErr := clientcmd.CreateCommandWithNS(monitoringNs, "kubectl",
@@ -240,9 +245,10 @@ func DoPrometheusHTTPRequest(cli kubecli.KubevirtClient, endpoint string) []byte
 			sourcePort := WaitForPortForwardCmd(stdout)
 
 			promURL := fmt.Sprintf("http://localhost:%d", sourcePort)
-			result = doHTTPRequest(promURL, endpoint, token)
-			return nil
-		}, 10*time.Second, time.Second).ShouldNot(HaveOccurred())
+			var err error
+			result, err = doHTTPRequest(promURL, endpoint, token)
+			return err
+		}, prometheusPortForwardTimeout, time.Second).ShouldNot(HaveOccurred())
 	}
 	return result
 }
@@ -260,38 +266,56 @@ func getPrometheusURLForOpenShift() string {
 	return fmt.Sprintf("https://%s", route.Spec.Host)
 }
 
-func doHTTPRequest(promURL, endpoint, token string) []byte {
-	var result []byte
+func doHTTPRequest(promURL, endpoint, token string) ([]byte, error) {
 	client := &http.Client{
 		Transport: &http.Transport{
 			TLSClientConfig:   &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
-			ForceAttemptHTTP2: true,
+			DisableKeepAlives: true,
 		},
 	}
-	Eventually(func() error {
+
+	var lastErr error
+	deadline := time.Now().Add(prometheusRequestTimeout)
+	for time.Now().Before(deadline) {
+		ctx, cancel := context.WithTimeout(context.Background(), prometheusHTTPTimeout)
+
 		req, err := http.NewRequestWithContext(
-			context.Background(),
+			ctx,
 			"GET",
-			fmt.Sprintf("%s/api/v1/%s", promURL, endpoint),
+			fmt.Sprintf("%s/api/v1/%s", promURL, strings.TrimLeft(endpoint, "/")),
 			http.NoBody,
 		)
 		if err != nil {
-			return err
+			cancel()
+			return nil, fmt.Errorf("creating request: %w", err)
 		}
 		req.Header.Add("Authorization", "Bearer "+token)
+
 		resp, err := client.Do(req)
 		if err != nil {
-			return err
+			cancel()
+			lastErr = err
+			time.Sleep(time.Second)
+			continue
 		}
-		defer resp.Body.Close()
-		if resp.StatusCode != http.StatusOK {
-			return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
-		}
-		result, err = io.ReadAll(resp.Body)
-		return err
-	}, 10*time.Second, 1*time.Second).Should(Not(HaveOccurred()))
 
-	return result
+		result, readErr := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		cancel()
+
+		if resp.StatusCode != http.StatusOK {
+			lastErr = fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+			time.Sleep(time.Second)
+			continue
+		}
+		if readErr != nil {
+			lastErr = readErr
+			time.Sleep(time.Second)
+			continue
+		}
+		return result, nil
+	}
+	return nil, fmt.Errorf("timed out after %s: %w", prometheusRequestTimeout, lastErr)
 }
 
 func getAuthorizationToken(cli kubecli.KubevirtClient, monitoringNs string) string {

--- a/tests/libmonitoring/prometheus.go
+++ b/tests/libmonitoring/prometheus.go
@@ -37,13 +37,17 @@ import (
 )
 
 const (
-	statusSuccess                   = "success"
-	defaultGomegaOffset             = 2
-	readBufferSize                  = 1024
-	defaultAlertTimeout             = 120 * time.Second
-	defaultAlertWaitTimeout         = 5 * time.Minute
-	defaultMetricsPort              = 8443
-	prometheusPortForwardTargetPort = 9090
+	statusSuccess                     = "success"
+	defaultGomegaOffset               = 2
+	readBufferSize                    = 1024
+	defaultAlertTimeout               = 120 * time.Second
+	defaultAlertWaitTimeout           = 5 * time.Minute
+	defaultMetricsPort                = 8443
+	prometheusPortForwardTargetPort   = 9090
+	prometheusPortForwardTimeout      = 90 * time.Second
+	prometheusPortForwardReadyTimeout = 30 * time.Second
+	prometheusRequestTimeout          = 30 * time.Second
+	prometheusHTTPTimeout             = 10 * time.Second
 )
 
 var (
@@ -221,7 +225,9 @@ func DoPrometheusHTTPRequest(cli kubecli.KubevirtClient, endpoint string) []byte
 	var result []byte
 	if checks.IsOpenShift() {
 		promURL := getPrometheusURLForOpenShift()
-		result = doHTTPRequest(promURL, endpoint, token)
+		var err error
+		result, err = doHTTPRequest(promURL, endpoint, token)
+		Expect(err).ShouldNot(HaveOccurred())
 	} else {
 		Eventually(func() error {
 			_, cmd, cmdErr := clientcmd.CreateCommandWithNS(monitoringNs, "kubectl",
@@ -237,12 +243,16 @@ func DoPrometheusHTTPRequest(cli kubecli.KubevirtClient, endpoint string) []byte
 				return startErr
 			}
 			defer func() { _ = KillPortForwardCommand(cmd) }()
-			sourcePort := WaitForPortForwardCmd(stdout)
+			sourcePort, waitErr := WaitForPortForwardCmd(stdout)
+			if waitErr != nil {
+				return waitErr
+			}
 
 			promURL := fmt.Sprintf("http://localhost:%d", sourcePort)
-			result = doHTTPRequest(promURL, endpoint, token)
-			return nil
-		}, 10*time.Second, time.Second).ShouldNot(HaveOccurred())
+			var err error
+			result, err = doHTTPRequest(promURL, endpoint, token)
+			return err
+		}, prometheusPortForwardTimeout, time.Second).ShouldNot(HaveOccurred())
 	}
 	return result
 }
@@ -260,38 +270,59 @@ func getPrometheusURLForOpenShift() string {
 	return fmt.Sprintf("https://%s", route.Spec.Host)
 }
 
-func doHTTPRequest(promURL, endpoint, token string) []byte {
-	var result []byte
+func doHTTPRequest(promURL, endpoint, token string) ([]byte, error) {
 	client := &http.Client{
 		Transport: &http.Transport{
 			TLSClientConfig:   &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
-			ForceAttemptHTTP2: true,
+			DisableKeepAlives: true,
+			// Do NOT set ForceAttemptHTTP2. kubectl port-forward speaks
+			// plain HTTP/1.1; forcing HTTP/2 without h2c causes
+			// "malformed HTTP status code" errors on the response.
 		},
 	}
-	Eventually(func() error {
+
+	var lastErr error
+	deadline := time.Now().Add(prometheusRequestTimeout)
+	for time.Now().Before(deadline) {
+		ctx, cancel := context.WithTimeout(context.Background(), prometheusHTTPTimeout)
+
 		req, err := http.NewRequestWithContext(
-			context.Background(),
+			ctx,
 			"GET",
-			fmt.Sprintf("%s/api/v1/%s", promURL, endpoint),
+			fmt.Sprintf("%s/api/v1/%s", promURL, strings.TrimLeft(endpoint, "/")),
 			http.NoBody,
 		)
 		if err != nil {
-			return err
+			cancel()
+			return nil, fmt.Errorf("creating request: %w", err)
 		}
 		req.Header.Add("Authorization", "Bearer "+token)
+
 		resp, err := client.Do(req)
 		if err != nil {
-			return err
+			cancel()
+			lastErr = err
+			time.Sleep(time.Second)
+			continue
 		}
-		defer resp.Body.Close()
-		if resp.StatusCode != http.StatusOK {
-			return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
-		}
-		result, err = io.ReadAll(resp.Body)
-		return err
-	}, 10*time.Second, 1*time.Second).Should(Not(HaveOccurred()))
 
-	return result
+		result, readErr := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		cancel()
+
+		if resp.StatusCode != http.StatusOK {
+			lastErr = fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+			time.Sleep(time.Second)
+			continue
+		}
+		if readErr != nil {
+			lastErr = readErr
+			time.Sleep(time.Second)
+			continue
+		}
+		return result, nil
+	}
+	return nil, fmt.Errorf("timed out after %s: %w", prometheusRequestTimeout, lastErr)
 }
 
 func getAuthorizationToken(cli kubecli.KubevirtClient, monitoringNs string) string {
@@ -338,18 +369,30 @@ func getMonitoringNs() string {
 // WaitForPortForwardCmd reads kubectl's stdout until it sees the "Forwarding from"
 // readiness line, then returns the OS-assigned local port number.
 // kubectl prints "Forwarding from 127.0.0.1:<localPort> -> <targetPort>" once the tunnel is ready.
-func WaitForPortForwardCmd(stdout io.ReadCloser) int {
-	var m []string
-	Eventually(func() []string {
-		tmp := make([]byte, readBufferSize)
-		_, err := stdout.Read(tmp)
-		Expect(err).NotTo(HaveOccurred())
-		m = portForwardRe.FindStringSubmatch(string(tmp))
-		return m
-	}, 30*time.Second, 1*time.Second).ShouldNot(BeEmpty())
-	port, err := strconv.Atoi(m[1])
-	Expect(err).NotTo(HaveOccurred())
-	return port
+// Returns an error instead of failing the test so callers can retry with a fresh
+// port-forward.
+func WaitForPortForwardCmd(stdout io.ReadCloser) (int, error) {
+	deadline := time.Now().Add(prometheusPortForwardReadyTimeout)
+	buf := make([]byte, 0, readBufferSize)
+	tmp := make([]byte, readBufferSize)
+	for time.Now().Before(deadline) {
+		n, err := stdout.Read(tmp)
+		if n > 0 {
+			buf = append(buf, tmp[:n]...)
+			if m := portForwardRe.FindStringSubmatch(string(buf)); len(m) > 1 {
+				port, convErr := strconv.Atoi(m[1])
+				if convErr != nil {
+					return 0, fmt.Errorf("parsing port-forward port: %w", convErr)
+				}
+				return port, nil
+			}
+		}
+		if err != nil {
+			return 0, fmt.Errorf("reading port-forward stdout: %w", err)
+		}
+		time.Sleep(time.Second)
+	}
+	return 0, fmt.Errorf("timed out waiting for port-forward readiness")
 }
 
 func KillPortForwardCommand(portForwardCmd *exec.Cmd) error {


### PR DESCRIPTION
Fix issues in `DoPrometheusHTTPRequest` and `doHTTPRequest` that caused intermittent sig-monitoring test failures:

1. Replace nested `gomega.Eventually` with a plain Go retry loop in `doHTTPRequest`. Nested Eventually blocks fail because the inner assertion calls `ginkgo.Fail()`, which is terminal and prevents the outer loop from retrying with a fresh port-forward. The new retry loop returns an error so the outer Eventually can properly retry.

2. Do **not** set `ForceAttemptHTTP2` on the transport. Port-forwarded connections use plain HTTP, where HTTP/2 requires h2c. Forcing HTTP/2 causes "malformed HTTP status code" errors. A transport comment documents this so it is not re-added.

3. Disable keep-alives on the transport so each retry gets a fresh TCP connection.

4. Fix double-slash in URL construction via `strings.TrimLeft` before `"%s/api/v1/%s"`.

5. Layered timeouts: port-forward lifecycle 90s, HTTP retry budget 30s, per-request 10s.

6. Make `WaitForPortForwardCmd` return an error instead of failing via Gomega so the outer Eventually can retry when readiness fails.

### Release note
```release-note
NONE
```