### PR TITLE
Fix premature domain deletion during slow QEMU startup

### DIFF
--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -1517,8 +1517,17 @@ func (c *VirtualMachineController) sync(key string,
 	}
 
 	if !domainAlive && domainExists && !vmi.IsFinal() {
-		c.logger.Object(vmi).V(3).Info("Deleting inactive domain for vmi.")
-		shouldDelete = true
+		isAmbiguousStartup := domain.Status.Reason == api.ReasonUnknown || domain.Status.Reason == ""
+		if domain.Status.Status == api.Shutoff && vmi.IsScheduled() && isAmbiguousStartup &&
+			!hasExceededSlowStartupDeferralWindow(vmi) {
+			c.logger.Object(vmi).V(3).Info(
+				"Domain is Shutoff with no reason yet but VMI is Scheduled; " +
+					"deferring deletion as domain may still be starting.")
+			c.queue.AddAfter(key, 5*time.Second)
+		} else {
+			c.logger.Object(vmi).V(3).Info("Deleting inactive domain for vmi.")
+			shouldDelete = true
+		}
 	}
 
 	// Determine if an active (or about to be active) VirtualMachineInstance should be updated.
@@ -1662,6 +1671,16 @@ func (c *VirtualMachineController) processVmShutdown(vmi *v1.VirtualMachineInsta
 }
 
 const firstGracefulShutdownAttempt = -1
+
+func hasExceededSlowStartupDeferralWindow(vmi *v1.VirtualMachineInstance) bool {
+	const slowStartupDeferralTimeout = 5 * time.Minute
+	for _, transition := range vmi.Status.PhaseTransitionTimestamps {
+		if transition.Phase == v1.Scheduled {
+			return time.Since(transition.PhaseTransitionTimestamp.Time) > slowStartupDeferralTimeout
+		}
+	}
+	return time.Since(vmi.CreationTimestamp.Time) > slowStartupDeferralTimeout
+}
 
 // Determines if a domain's grace period has expired during shutdown.
 // If the grace period has started but not expired, timeLeft represents

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -389,6 +389,113 @@ var _ = Describe("VirtualMachineInstance", func() {
 			testutils.ExpectEvent(recorder, VMISignalDeletion)
 		})
 
+		DescribeTable("should not delete a Shutoff domain while the VMI is still Scheduled", func(reason api.StateChangeReason) {
+			vmi := api2.NewMinimalVMI("testvmi")
+			vmi.UID = vmiTestUUID
+			vmi.ObjectMeta.ResourceVersion = "1"
+			vmi.Status.Phase = v1.Scheduled
+			vmi.CreationTimestamp = metav1.Now()
+			vmi = addActivePods(vmi, podTestUUID, host)
+
+			domain := api.NewMinimalDomainWithUUID("testvmi", vmiTestUUID)
+			domain.Status.Status = api.Shutoff
+			domain.Status.Reason = reason
+
+			client.EXPECT().SyncVirtualMachine(vmi, gomock.Any())
+			client.EXPECT().DeleteDomain(gomock.Any()).Times(0)
+			mockHotplugVolumeMounter.EXPECT().Mount(gomock.Any(), mockCgroupManager).Return(nil)
+
+			addVMI(vmi, domain)
+
+			sanityExecute()
+
+			Expect(mockQueue.GetAddAfterEnqueueCount()).To(BeNumerically(">", 0))
+		},
+			Entry("with empty reason", api.StateChangeReason("")),
+			Entry("with Unknown reason", api.ReasonUnknown),
+		)
+
+		It("should delete a Shutoff domain once the Scheduled deferral window has expired", func() {
+			vmi := api2.NewMinimalVMI("testvmi")
+			vmi.UID = vmiTestUUID
+			vmi.ObjectMeta.ResourceVersion = "1"
+			vmi.Status.Phase = v1.Scheduled
+			vmi.Status.PhaseTransitionTimestamps = []v1.VirtualMachineInstancePhaseTransitionTimestamp{
+				{
+					Phase:                    v1.Scheduled,
+					PhaseTransitionTimestamp: metav1.NewTime(time.Now().Add(-10 * time.Minute)),
+				},
+			}
+			vmi = addActivePods(vmi, podTestUUID, host)
+
+			domain := api.NewMinimalDomainWithUUID("testvmi", vmiTestUUID)
+			domain.Status.Status = api.Shutoff
+
+			mockHotplugVolumeMounter.EXPECT().UnmountAll(gomock.Any(), mockCgroupManager).Return(nil)
+			client.EXPECT().DeleteDomain(gomock.Any())
+			addVMI(vmi, domain)
+
+			sanityExecuteNoDomain()
+
+			testutils.ExpectEvent(recorder, VMISignalDeletion)
+		})
+
+		It("should delete a Shutoff domain using CreationTimestamp fallback when PhaseTransitionTimestamps are missing", func() {
+			vmi := api2.NewMinimalVMI("testvmi")
+			vmi.UID = vmiTestUUID
+			vmi.ObjectMeta.ResourceVersion = "1"
+			vmi.Status.Phase = v1.Scheduled
+			vmi.CreationTimestamp = metav1.NewTime(time.Now().Add(-10 * time.Minute))
+			vmi = addActivePods(vmi, podTestUUID, host)
+
+			domain := api.NewMinimalDomainWithUUID("testvmi", vmiTestUUID)
+			domain.Status.Status = api.Shutoff
+
+			mockHotplugVolumeMounter.EXPECT().UnmountAll(gomock.Any(), mockCgroupManager).Return(nil)
+			client.EXPECT().DeleteDomain(gomock.Any())
+			addVMI(vmi, domain)
+
+			sanityExecuteNoDomain()
+
+			testutils.ExpectEvent(recorder, VMISignalDeletion)
+		})
+
+		It("should delete a Shutoff domain with a definitive Failed reason even while the VMI is still Scheduled", func() {
+			vmi := api2.NewMinimalVMI("testvmi")
+			vmi.UID = vmiTestUUID
+			vmi.ObjectMeta.ResourceVersion = "1"
+			vmi.Status.Phase = v1.Scheduled
+			vmi = addActivePods(vmi, podTestUUID, host)
+
+			domain := api.NewMinimalDomainWithUUID("testvmi", vmiTestUUID)
+			domain.Status.Status = api.Shutoff
+			domain.Status.Reason = api.ReasonFailed
+
+			mockHotplugVolumeMounter.EXPECT().UnmountAll(gomock.Any(), mockCgroupManager).Return(nil)
+			client.EXPECT().DeleteDomain(gomock.Any())
+			addVMI(vmi, domain)
+
+			sanityExecuteNoDomain()
+
+			testutils.ExpectEvent(recorder, VMISignalDeletion)
+		})
+
+		It("should delete a Shutoff domain when the VMI was previously Running", func() {
+			vmi := api2.NewMinimalVMI("testvmi")
+			vmi.UID = vmiTestUUID
+			vmi.Status.Phase = v1.Running
+
+			domain := api.NewMinimalDomainWithUUID("testvmi", vmiTestUUID)
+			domain.Status.Status = api.Shutoff
+
+			mockHotplugVolumeMounter.EXPECT().UnmountAll(gomock.Any(), mockCgroupManager).Return(nil)
+			client.EXPECT().DeleteDomain(gomock.Any())
+			addVMI(vmi, domain)
+
+			sanityExecuteNoDomain()
+			testutils.ExpectEvent(recorder, VMISignalDeletion)
+		})
+
 		It("should attempt graceful shutdown of Domain if no cluster wide equivalent exists", func() {
 			vmi := api2.NewMinimalVMI("testvmi")
 			vmi.UID = vmiTestUUID

--- a/tests/compute/BUILD.bazel
+++ b/tests/compute/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "pcihole64.go",
         "vm_lifecycle.go",
         "vmi_memory_overhead.go",
+        "vmi_slow_startup.go",
         "vmidefaults.go",
     ],
     importpath = "kubevirt.io/kubevirt/tests/compute",

--- a/tests/compute/vmi_slow_startup.go
+++ b/tests/compute/vmi_slow_startup.go
@@ -1,0 +1,125 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package compute
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	k8sv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/kubecli"
+
+	"kubevirt.io/kubevirt/pkg/libvmi"
+	"kubevirt.io/kubevirt/tests/exec"
+	"kubevirt.io/kubevirt/tests/framework/kubevirt"
+	"kubevirt.io/kubevirt/tests/framework/matcher"
+	"kubevirt.io/kubevirt/tests/libnode"
+	"kubevirt.io/kubevirt/tests/libpod"
+	"kubevirt.io/kubevirt/tests/libvmifact"
+	"kubevirt.io/kubevirt/tests/testsuite"
+)
+
+var _ = Describe(SIG("Slow QEMU startup", func() {
+	It("should not prematurely delete a domain when qemu startup is delayed", Serial, func() {
+		virtClient := kubevirt.Client()
+		namespace := testsuite.GetTestNamespace(nil)
+
+		By("Selecting a schedulable node")
+		nodes := libnode.GetAllSchedulableNodes(virtClient)
+		Expect(nodes.Items).ToNot(BeEmpty())
+		targetNode := nodes.Items[0].Name
+
+		By("Launching a privileged interceptor pod that SIGSTOPs qemu on the target node")
+		interceptorPod := createQemuInterceptorPod(virtClient, targetNode)
+
+		By("Creating a guestless VMI pinned to the target node")
+		vmi := libvmifact.NewGuestless(libvmi.WithNodeAffinityFor(targetNode))
+		vmi, err := virtClient.VirtualMachineInstance(namespace).Create(context.Background(), vmi, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Waiting for the interceptor to catch and stop qemu")
+		Eventually(func(g Gomega) {
+			pod, err := virtClient.CoreV1().Pods(interceptorPod.Namespace).Get(
+				context.Background(), interceptorPod.Name, metav1.GetOptions{})
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(pod.Status.Phase).To(Equal(k8sv1.PodSucceeded))
+		}).WithTimeout(120 * time.Second).WithPolling(2 * time.Second).Should(Succeed())
+
+		By("Verifying the VMI is not deleted across multiple virt-handler reconcile cycles")
+		Consistently(func(g Gomega) {
+			current, err := virtClient.VirtualMachineInstance(namespace).Get(
+				context.Background(), vmi.Name, metav1.GetOptions{})
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(current.Status.Phase).ToNot(Equal(v1.Failed))
+			g.Expect(current.DeletionTimestamp).To(BeNil())
+		}).WithTimeout(60 * time.Second).WithPolling(5 * time.Second).Should(Succeed())
+
+		By("Verifying no SignalDeletion event was emitted")
+		eventList, err := virtClient.CoreV1().Events(namespace).List(context.Background(),
+			metav1.ListOptions{
+				FieldSelector: fmt.Sprintf("involvedObject.name=%s,reason=SignalDeletion", vmi.Name),
+			})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(eventList.Items).To(BeEmpty())
+
+		By("Resuming qemu-kvm via virt-handler exec")
+		virtHandlerPod, err := libnode.GetVirtHandlerPod(virtClient, targetNode)
+		Expect(err).ToNot(HaveOccurred())
+		_, err = exec.ExecuteCommandOnPod(virtHandlerPod, "virt-handler",
+			[]string{"sh", "-c", "pgrep -u 107 qemu-kvm | xargs -r kill -CONT"})
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Waiting for the VMI to reach Running after resume")
+		Eventually(matcher.ThisVMI(vmi)).WithTimeout(180 * time.Second).WithPolling(2 * time.Second).Should(matcher.BeRunning())
+	})
+}))
+
+func createQemuInterceptorPod(virtClient kubecli.KubevirtClient, nodeName string) *k8sv1.Pod {
+	const script = `while true; do
+  PIDS=$(pgrep -u 107 qemu-kvm 2>/dev/null)
+  if [ -n "$PIDS" ]; then
+    for PID in $PIDS; do kill -STOP $PID 2>/dev/null; done
+    exit 0
+  fi
+  sleep 0.05
+done`
+	pod := libpod.RenderPrivilegedPod("qemu-interceptor-", []string{"/bin/bash", "-c"}, []string{script})
+	pod.Spec.NodeName = nodeName
+
+	pod, err := virtClient.CoreV1().Pods(pod.Namespace).Create(
+		context.Background(), pod, metav1.CreateOptions{})
+	ExpectWithOffset(1, err).ToNot(HaveOccurred())
+
+	EventuallyWithOffset(1, func(g Gomega) {
+		p, err := virtClient.CoreV1().Pods(pod.Namespace).Get(
+			context.Background(), pod.Name, metav1.GetOptions{})
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(p.Status.Phase).To(Equal(k8sv1.PodRunning))
+	}).WithTimeout(60 * time.Second).WithPolling(time.Second).Should(Succeed())
+
+	return pod
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
When `CreateWithFlags` took longer than the SyncVMI gRPC timeout (common for large-memory VFIO VMs), virt-handler treated a Shutoff domain on a Scheduled VMI as inactive and called DeleteVMI. Undefining raced with startup and left the domain running as transient (`Persistent: no`). Later hotplug failed with libvirt Code=55 ("transient domains do not have any persistent config").

#### After this PR:
virt-handler defers deletion while the VMI is still Scheduled and the domain is Shutoff, requeueing so startup can finish.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
- Bug tracker: https://redhat.atlassian.net/browse/CNV-93613

### Why we need it and why it was done in this way
The following tradeoffs were made:
- Prefer a targeted guard on the shouldDelete path over raising the SyncVMI gRPC timeout. A longer timeout would affect unrelated RPCs and still would not cover worst-case VFIO memory allocation times (1-3 minutes is normal).

The following alternatives were considered:
- Increase `longTimeout` for SyncVMI only: blunt, delays detection of genuinely stuck launchers.
- Destroy-before-undefine in DeleteVMI as a safety net: dropped, because `dom.GetState` / destroy can hang while libvirt still holds the monitor lock for an in-progress create.
- Rely only on HugePages / smaller memory as a workaround: valid ops workaround, but does not fix the race in code.

Links to places where the discussion took place:
- https://redhat.atlassian.net/browse/CNV-93613

### Special notes for your reviewer
- Reproducer without VFIO hardware (from CNV-93613): pin a VM, pause qemu-kvm early with `kill -STOP` until CreateWithFlags has been blocked >20s, then `kill -CONT`. Without the fix, `virsh dominfo` shows `Persistent: no`.
- Unit tests cover the shouldDelete guard. An e2e test is still outstanding (reason this PR is opened as draft). Happy to add one before marking ready for review.
- AI assistance was used for exploration and drafting; the commit includes a `Co-authored-by: Cursor` trailer and DCO `Signed-off-by`.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix premature domain undefine during slow QEMU startup that left VMs transient and broke hotplug
```