### PR TITLE
[release-1.8] tests: remove flaky e2e test_id:1655, add unit tests

### DIFF
--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -590,6 +590,53 @@ var _ = Describe("VirtualMachineInstance", func() {
 			testutils.ExpectEvent(recorder, VMIStopping)
 		})
 
+		Context("when VMI has DeletionTimestamp and domain has grace period", func() {
+			var vmi *v1.VirtualMachineInstance
+			var domain *api.Domain
+
+			BeforeEach(func() {
+				vmi = api2.NewMinimalVMI("testvmi")
+				vmi.UID = vmiTestUUID
+				vmi.Status.Phase = v1.Running
+				now := metav1.Now()
+				vmi.DeletionTimestamp = &now
+
+				domain = api.NewMinimalDomainWithUUID("testvmi", vmiTestUUID)
+				domain.Status.Status = api.Running
+			})
+
+			It("should attempt graceful shutdown", func() {
+				initGracePeriodHelper(5, vmi, domain)
+
+				client.EXPECT().ShutdownVirtualMachine(gomock.Any())
+				addVMI(vmi, domain)
+
+				sanityExecute()
+				testutils.ExpectEvent(recorder, VMIGracefulShutdown)
+			})
+
+			It("should force kill when grace period expired", func() {
+				initGracePeriodHelper(1, vmi, domain)
+				expired := metav1.Time{Time: time.Unix(time.Now().UTC().Unix()-3, 0)}
+				domain.Spec.Metadata.KubeVirt.GracePeriod.DeletionTimestamp = &expired
+
+				client.EXPECT().KillVirtualMachine(gomock.Any())
+				addVMI(vmi, domain)
+
+				sanityExecute()
+				testutils.ExpectEvent(recorder, VMIStopping)
+			})
+
+			It("should skip shutdown signal when domain is already shutting down", func() {
+				domain.Status.Status = api.Shutdown
+				initGracePeriodHelper(5, vmi, domain)
+
+				addVMI(vmi, domain)
+
+				sanityExecute()
+			})
+		})
+
 		It("should re-enqueue if the Key is unparseable", func() {
 			Expect(mockQueue.Len()).Should(Equal(0))
 			mockQueue.Add("a/b/c/d/e")

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -1471,36 +1471,6 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				Entry("[test_id:1654]with default grace period seconds", decorators.Conformance, withoutTerminationGracePeriodSeconds, v1.DefaultGracePeriodSeconds),
 			)
 		})
-		Context("with grace period greater than 0", func() {
-			It("[test_id:1655]should run graceful shutdown", decorators.Conformance, func() {
-				By("Setting a VirtualMachineInstance termination grace period to 5")
-				// Give the VirtualMachineInstance a custom grace period
-				vmi := libvmifact.NewAlpine(libvmi.WithTerminationGracePeriod(5))
-
-				By("Creating the VirtualMachineInstance")
-				vmi = libvmops.RunVMIAndExpectLaunch(vmi, startupTimeout)
-
-				// Delete the VirtualMachineInstance and wait for the confirmation of the delete
-				By("Deleting the VirtualMachineInstance")
-				Expect(kubevirt.Client().VirtualMachineInstance(vmi.Namespace).Delete(context.Background(), vmi.Name, metav1.DeleteOptions{})).To(Succeed(), "Should delete VMI gracefully")
-
-				ctx, cancel := context.WithCancel(context.Background())
-				defer cancel()
-
-				// Check if the graceful shutdown was logged
-				By("Checking that virt-handler logs VirtualMachineInstance graceful shutdown")
-				event := watcher.New(vmi).Timeout(30*time.Second).SinceWatchedObjectResourceVersion().WaitFor(ctx, watcher.NormalEvent, "ShuttingDown")
-				Expect(event).ToNot(BeNil(), "There should be a graceful shutdown")
-
-				// Verify VirtualMachineInstance is killed after grace period expires
-				// 5 seconds is grace period, doubling to prevent flakiness
-				By("Checking that the VirtualMachineInstance does not exist after grace period")
-				event = watcher.New(vmi).Timeout(10*time.Second).SinceWatchedObjectResourceVersion().WaitFor(ctx, watcher.NormalEvent, "Deleted")
-				Expect(event).ToNot(BeNil(), "There should be a graceful shutdown")
-
-				Eventually(matcher.ThisVMI(vmi)).WithTimeout(15 * time.Second).WithPolling(time.Second).Should(matcher.BeGone())
-			})
-		})
 	})
 
 	Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:component]Killed VirtualMachineInstance", Serial, decorators.WgS390x, func() {


### PR DESCRIPTION
### What this PR does

Manual cherry-pick of #18504 to release-1.8. The automated cherry-pick failed due to a conflict in `tests/vmi_lifecycle_test.go`.

The conflict was trivial - release-1.8 has a slightly different version of the test (uses `NewAlpine` instead of `NewAlpineWithTestTooling`, no `decorators.WgS390x`). Resolution: delete the entire test block, same as main.

#### Before this PR:
- test_id:1655 flakes on release-1.8 with 3 failures in the [sig-compute report](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/18363/pull-kubevirt-e2e-k8s-1.35-sig-compute-1.8/2074193727361912832)

#### After this PR:
- Flaky e2e test removed, unit test coverage added in pkg/virt-handler/vm_test.go

### References
- Cherry-pick of #18504

### Release note
```release-note
NONE
```