### PR TITLE
config: filter kubelet atomic writer entries from ISO source directories

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	ephemeraldiskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
 
@@ -102,6 +103,9 @@ func getFilesLayout(dirPath string) ([]string, error) {
 	}
 	for _, file := range files {
 		fileName := file.Name()
+		if strings.HasPrefix(fileName, "..") {
+			continue
+		}
 		filesPath = append(filesPath, fileName+"="+filepath.Join(dirPath, fileName))
 	}
 	return filesPath, nil

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -77,5 +77,14 @@ var _ = Describe("Creating config images", func() {
 			_, err = os.Stat(imgPath)
 			Expect(err).NotTo(HaveOccurred())
 		})
+
+		It("Should filter out kubernetes atomic writer entries", func() {
+			os.MkdirAll(filepath.Join(tempConfDir, "..2026_07_26_10_00_00.12345"), 0755)
+			os.Symlink("..2026_07_26_10_00_00.12345", filepath.Join(tempConfDir, "..data"))
+
+			fsLayout, err := getFilesLayout(tempConfDir)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(fsLayout).To(Equal(expectedLayout))
+		})
 	})
 })


### PR DESCRIPTION
### What this PR does

Filters out ".." prefixed entries in `getFilesLayout` when reading projected volume source directories for ISO creation.

The kubelet's [atomic writer](https://github.com/kubernetes/kubernetes/blob/master/pkg/volume/util/atomic_writer.go) uses `..data` (symlink) and `..timestamp` (directory) entries to atomically swap projected volume content on updates. When `getFilesLayout` passes these entries to `xorrisofs` with `-follow-links`, a race occurs: if the kubelet updates the volume between `os.ReadDir` and the `xorrisofs` invocation, xorrisofs follows a stale path that was deleted during the swap and fails.

#### Before this PR:
- `getFilesLayout` returns ALL entries from `os.ReadDir`, including `..data` and `..2026_07_26_timestamp` entries
- These get passed to `xorrisofs` as graft-points with `-follow-links`
- If kubelet atomically swaps the volume (DownwardAPI label update, ConfigMap/Secret change), xorrisofs tries to follow a deleted path and fails with exit status 32
- virt-handler emits a transient `SyncFailed` Warning, requeues, next attempt succeeds
- e2e tests with `FailOnWarnings: true` flake on the transient Warning

#### After this PR:
- `getFilesLayout` skips entries prefixed with `..`, passing only user-visible files to `xorrisofs`
- This matches the existing filtering in [cloud-init.go:195](https://github.com/kubevirt/kubevirt/blob/main/pkg/cloud-init/cloud-init.go#L195) and [access_credentials.go:648-649](https://github.com/kubevirt/kubevirt/blob/main/pkg/virt-launcher/virtwrap/access-credentials/access_credentials.go#L648-L649) which already skip `..` entries with the comment: *"Mounted secret directory contains directories prefixed by '..'. They are used by k8s to atomically swap all files when the secret is updated."*

### Evidence

Addresses flakes in `[test_id:790]` from [sig-compute failure report](https://storage.googleapis.com/kubevirt-prow/reports/sig-failure-reports/sig-compute-failure-report.html):
- main (2026-07-16): `creating DownwardAPI disks failed: exit status 32`
- release-1.9 (2026-07-20): `creating DownwardAPI disks failed: exit status 5`

### Release note
```release-note
NONE
```