### PR TITLE
Revert "tests: remove flaky e2e test_id:1655, add unit tests"

### DIFF
--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -1393,6 +1393,35 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				Entry("[test_id:1654]with default grace period seconds", decorators.Conformance, withoutTerminationGracePeriodSeconds, v1.DefaultGracePeriodSeconds),
 			)
 		})
+		Context("with grace period greater than 0", func() {
+			It("[test_id:1655]should run graceful shutdown", decorators.Conformance, decorators.WgS390x, func() {
+				By("Setting a VirtualMachineInstance termination grace period to 5")
+				vmi := libvmifact.NewAlpineWithTestTooling(libvmi.WithTerminationGracePeriod(5))
+
+				By("Creating the VirtualMachineInstance")
+				vmi = libvmops.RunVMIAndExpectLaunch(vmi, startupTimeout)
+
+				// Delete the VirtualMachineInstance and wait for the confirmation of the delete
+				By("Deleting the VirtualMachineInstance")
+				Expect(kubevirt.Client().VirtualMachineInstance(vmi.Namespace).Delete(context.Background(), vmi.Name, metav1.DeleteOptions{})).To(Succeed(), "Should delete VMI gracefully")
+
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+
+				// Check if the graceful shutdown was logged
+				By("Checking that virt-handler logs VirtualMachineInstance graceful shutdown")
+				event := watcher.New(vmi).Timeout(30*time.Second).SinceWatchedObjectResourceVersion().WaitFor(ctx, watcher.NormalEvent, "ShuttingDown")
+				Expect(event).ToNot(BeNil(), "There should be a graceful shutdown")
+
+				// Verify VirtualMachineInstance is killed after grace period expires
+				// 5 seconds is grace period, doubling to prevent flakiness
+				By("Checking that the VirtualMachineInstance does not exist after grace period")
+				event = watcher.New(vmi).Timeout(10*time.Second).SinceWatchedObjectResourceVersion().WaitFor(ctx, watcher.NormalEvent, "Deleted")
+				Expect(event).ToNot(BeNil(), "There should be a graceful shutdown")
+
+				Eventually(matcher.ThisVMI(vmi)).WithTimeout(15 * time.Second).WithPolling(time.Second).Should(matcher.BeGone())
+			})
+		})
 	})
 
 	Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:component]Killed VirtualMachineInstance", Serial, decorators.WgS390x, func() {


### PR DESCRIPTION
### What this PR does

Partially reverts #18504 - restores the conformance e2e test (test_id:1655) while keeping the unit tests added by the original PR.

The e2e test provides end-to-end coverage for the graceful shutdown flow that unit tests alone do not fully replace - VM boot, shutdown signal delivery, domain lifecycle, pod cleanup, and VMI finalizer removal.

### Release note
```release-note
NONE
```