### PR TITLE
virt-api: resolve the virt-launcher pod IP in the portforward subresource (VEP-405)

### DIFF
--- a/pkg/virt-api/rest/dialers.go
+++ b/pkg/virt-api/rest/dialers.go
@@ -27,7 +27,9 @@ import (
 	"github.com/gorilla/websocket"
 
 	"github.com/emicklei/go-restful/v3"
+	k8sv1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	netutils "k8s.io/utils/net"
 
 	v1 "kubevirt.io/api/core/v1"
@@ -40,6 +42,7 @@ import (
 
 type netDial struct {
 	request *restful.Request
+	app     *SubresourceAPIApp
 }
 
 type handlerDial struct {
@@ -74,7 +77,7 @@ func (n netDial) Dial(vmi *v1.VirtualMachineInstance) (*websocket.Conn, *k8serro
 func (n netDial) DialUnderlying(vmi *v1.VirtualMachineInstance) (net.Conn, *k8serrors.StatusError) {
 	logger := log.Log.Object(vmi)
 
-	targetIP, err := getTargetInterfaceIP(vmi)
+	targetIP, err := n.resolveTargetIP(vmi)
 	if err != nil {
 		logger.Reason(err).Error("Can't establish TCP tunnel.")
 		return nil, k8serrors.NewBadRequest(err.Error())
@@ -129,6 +132,62 @@ func (app *SubresourceAPIApp) getVirtHandlerConnForVMI(vmi *v1.VirtualMachineIns
 		return nil, errors.New(fmt.Sprintf("Unable to connect to VirtualMachineInstance because phase is %s instead of %s or %s", vmi.Status.Phase, v1.Running, v1.Scheduled))
 	}
 	return kubecli.NewVirtHandlerClient(app.virtCli, app.handlerHttpClient).Port(app.consoleServerPort).ForNode(vmi.Status.NodeName), nil
+}
+
+// resolveTargetIP returns the IP virt-api should dial to reach the VMI. It
+// prefers the current virt-launcher pod IP, which is always routable from the
+// pod network, and falls back to the first reported guest interface IP. The
+// guest interface IP may not be routable from the pod network (for example
+// when the VM is attached to a VPC network), so it is only used when the
+// launcher pod IP cannot be determined.
+func (n netDial) resolveTargetIP(vmi *v1.VirtualMachineInstance) (string, error) {
+	if podIP := n.launcherPodIP(vmi); podIP != "" {
+		return podIP, nil
+	}
+	return getTargetInterfaceIP(vmi)
+}
+
+// launcherPodIP looks up the IP of the virt-launcher pod currently backing the
+// VMI. It returns an empty string (rather than an error) when the pod cannot be
+// found or has no IP yet, so the caller can fall back to the interface IP.
+func (n netDial) launcherPodIP(vmi *v1.VirtualMachineInstance) string {
+	if n.app == nil {
+		return ""
+	}
+	pods, err := n.app.virtCli.CoreV1().Pods(vmi.Namespace).List(
+		n.request.Request.Context(),
+		metav1.ListOptions{LabelSelector: fmt.Sprintf("%s=%s", v1.AppLabel, "virt-launcher")},
+	)
+	if err != nil {
+		log.Log.Object(vmi).Reason(err).Warning("failed to list virt-launcher pods; falling back to the VMI interface IP")
+		return ""
+	}
+	if pod := currentLauncherPod(vmi, pods.Items); pod != nil {
+		return pod.Status.PodIP
+	}
+	return ""
+}
+
+// currentLauncherPod selects the virt-launcher pod backing the VMI right now:
+// the most recently created pod owned by the VMI and scheduled to the VMI's
+// node. This mirrors the selection performed by controller.CurrentVMIPod and
+// ensures that during a migration the target pod is only chosen once the VMI
+// node has been handed over.
+func currentLauncherPod(vmi *v1.VirtualMachineInstance, pods []k8sv1.Pod) *k8sv1.Pod {
+	var current *k8sv1.Pod
+	for i := range pods {
+		pod := &pods[i]
+		if !metav1.IsControlledBy(pod, vmi) {
+			continue
+		}
+		if vmi.Status.NodeName != "" && vmi.Status.NodeName != pod.Spec.NodeName {
+			continue
+		}
+		if current == nil || current.CreationTimestamp.Before(&pod.CreationTimestamp) {
+			current = pod
+		}
+	}
+	return current
 }
 
 // get the first available interface IP

--- a/pkg/virt-api/rest/dialers_test.go
+++ b/pkg/virt-api/rest/dialers_test.go
@@ -31,7 +31,9 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
+	k8sv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
@@ -62,12 +64,35 @@ var _ = Describe("NetDialer", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      vmName,
 				Namespace: vmNamespace,
+				UID:       "1234",
 			},
 			Spec: v1.VirtualMachineInstanceSpec{},
 			Status: v1.VirtualMachineInstanceStatus{
 				Interfaces: interfaces,
 			},
 		}
+	}
+
+	launcherPodForVMI := func(vmi *v1.VirtualMachineInstance, node, podIP string) *k8sv1.Pod {
+		return &k8sv1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            vmi.Name + "-launcher",
+				Namespace:       vmi.Namespace,
+				Labels:          map[string]string{v1.AppLabel: "virt-launcher"},
+				OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(vmi, v1.VirtualMachineInstanceGroupVersionKind)},
+			},
+			Spec:   k8sv1.PodSpec{NodeName: node},
+			Status: k8sv1.PodStatus{PodIP: podIP},
+		}
+	}
+
+	newAppWithObjects := func(objs ...runtime.Object) *SubresourceAPIApp {
+		ctrl := gomock.NewController(GinkgoT())
+		virtClient := kubecli.NewMockKubevirtClient(ctrl)
+		k8sfakeClient := fake.NewSimpleClientset(objs...)
+		virtClient.EXPECT().CoreV1().Return(k8sfakeClient.CoreV1()).AnyTimes()
+		config, _, _ := testutils.NewFakeClusterConfigUsingKV(&v1.KubeVirt{})
+		return NewSubresourceAPIApp(virtClient, 0, nil, config)
 	}
 
 	It("Should fail if vmi has no network interfaces", func() {
@@ -150,4 +175,58 @@ var _ = Describe("NetDialer", func() {
 		Entry("with ipv4 ip address", "127.0.0.1"),
 		Entry("with ipv6 ip address", "[::1]"),
 	)
+
+	It("Should prefer the launcher pod IP over the guest interface IP", func() {
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		Expect(err).NotTo(HaveOccurred())
+		defer ln.Close()
+		tcpAddr := ln.Addr().(*net.TCPAddr)
+		request.PathParameters()["port"] = strconv.FormatInt(int64(tcpAddr.Port), 10)
+
+		// The guest interface IP is not routable; dialing it would fail.
+		vmi := makeVMIWithInterfaceStatus([]v1.VirtualMachineInstanceNetworkInterface{{IP: "192.0.2.1"}})
+		vmi.Status.NodeName = "node1"
+		pod := launcherPodForVMI(vmi, "node1", tcpAddr.IP.String())
+
+		dialer := netDial{request: request, app: newAppWithObjects(pod)}
+		conn, statusErr := dialer.DialUnderlying(vmi)
+		Expect(statusErr).NotTo(HaveOccurred())
+		Expect(conn).NotTo(BeNil())
+	})
+
+	It("Should fall back to the interface IP when no launcher pod is found", func() {
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		Expect(err).NotTo(HaveOccurred())
+		defer ln.Close()
+		tcpAddr := ln.Addr().(*net.TCPAddr)
+		request.PathParameters()["port"] = strconv.FormatInt(int64(tcpAddr.Port), 10)
+
+		vmi := makeVMIWithInterfaceStatus([]v1.VirtualMachineInstanceNetworkInterface{{IP: tcpAddr.IP.String()}})
+		vmi.Status.NodeName = "node1"
+
+		// Client is present but has no launcher pod for the VMI.
+		dialer := netDial{request: request, app: newAppWithObjects()}
+		conn, statusErr := dialer.DialUnderlying(vmi)
+		Expect(statusErr).NotTo(HaveOccurred())
+		Expect(conn).NotTo(BeNil())
+	})
+
+	It("Should not select a launcher pod scheduled to a different node", func() {
+		ln, err := net.Listen("tcp", "127.0.0.1:0")
+		Expect(err).NotTo(HaveOccurred())
+		defer ln.Close()
+		tcpAddr := ln.Addr().(*net.TCPAddr)
+		request.PathParameters()["port"] = strconv.FormatInt(int64(tcpAddr.Port), 10)
+
+		// The VMI runs on node1 (reachable listener), but a stale pod on node2
+		// carries a non-routable IP. The node filter must skip the node2 pod.
+		vmi := makeVMIWithInterfaceStatus([]v1.VirtualMachineInstanceNetworkInterface{{IP: tcpAddr.IP.String()}})
+		vmi.Status.NodeName = "node1"
+		stalePod := launcherPodForVMI(vmi, "node2", "192.0.2.1")
+
+		dialer := netDial{request: request, app: newAppWithObjects(stalePod)}
+		conn, statusErr := dialer.DialUnderlying(vmi)
+		Expect(statusErr).NotTo(HaveOccurred())
+		Expect(conn).NotTo(BeNil())
+	})
 })

--- a/pkg/virt-api/rest/dialers_test.go
+++ b/pkg/virt-api/rest/dialers_test.go
@@ -20,19 +20,24 @@
 package rest
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strconv"
+	"time"
 
 	"github.com/emicklei/go-restful/v3"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
+	k8sv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/testing"
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 
@@ -62,12 +67,38 @@ var _ = Describe("NetDialer", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      vmName,
 				Namespace: vmNamespace,
+				UID:       "1234",
 			},
 			Spec: v1.VirtualMachineInstanceSpec{},
 			Status: v1.VirtualMachineInstanceStatus{
 				Interfaces: interfaces,
 			},
 		}
+	}
+
+	launcherPodForVMI := func(vmi *v1.VirtualMachineInstance, node, podIP string) *k8sv1.Pod {
+		return &k8sv1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            vmi.Name + "-launcher",
+				Namespace:       vmi.Namespace,
+				Labels:          map[string]string{v1.AppLabel: "virt-launcher"},
+				OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(vmi, v1.VirtualMachineInstanceGroupVersionKind)},
+			},
+			Spec:   k8sv1.PodSpec{NodeName: node},
+			Status: k8sv1.PodStatus{PodIP: podIP},
+		}
+	}
+
+	newAppWithClient := func(k8sfakeClient *fake.Clientset) *SubresourceAPIApp {
+		ctrl := gomock.NewController(GinkgoT())
+		virtClient := kubecli.NewMockKubevirtClient(ctrl)
+		virtClient.EXPECT().CoreV1().Return(k8sfakeClient.CoreV1()).AnyTimes()
+		config, _, _ := testutils.NewFakeClusterConfigUsingKV(&v1.KubeVirt{})
+		return NewSubresourceAPIApp(virtClient, 0, nil, config)
+	}
+
+	newAppWithObjects := func(objs ...runtime.Object) *SubresourceAPIApp {
+		return newAppWithClient(fake.NewSimpleClientset(objs...))
 	}
 
 	It("Should fail if vmi has no network interfaces", func() {
@@ -150,4 +181,129 @@ var _ = Describe("NetDialer", func() {
 		Entry("with ipv4 ip address", "127.0.0.1"),
 		Entry("with ipv6 ip address", "[::1]"),
 	)
+
+	Context("with launcher pod IP resolution", func() {
+		const (
+			nodeName    = "node1"
+			podIP       = "10.244.0.10"
+			interfaceIP = "192.0.2.1"
+		)
+
+		var vmi *v1.VirtualMachineInstance
+
+		BeforeEach(func() {
+			vmi = makeVMIWithInterfaceStatus([]v1.VirtualMachineInstanceNetworkInterface{{IP: interfaceIP}})
+			vmi.Status.NodeName = nodeName
+		})
+
+		DescribeTable("Should select the current launcher pod", func(pods func(vmi *v1.VirtualMachineInstance) []runtime.Object, expectedIP string) {
+			dialer := netDial{request: request, app: newAppWithObjects(pods(vmi)...)}
+			Expect(dialer.resolveTargetIP(vmi)).To(Equal(expectedIP))
+		},
+			Entry("preferring the pod IP over the interface IP",
+				func(vmi *v1.VirtualMachineInstance) []runtime.Object {
+					return []runtime.Object{launcherPodForVMI(vmi, nodeName, podIP)}
+				}, podIP),
+			Entry("preferring the most recently created pod on the VMI node",
+				func(vmi *v1.VirtualMachineInstance) []runtime.Object {
+					oldPod := launcherPodForVMI(vmi, nodeName, "10.244.0.9")
+					oldPod.Name = "old-launcher"
+					oldPod.CreationTimestamp = metav1.NewTime(time.Now().Add(-time.Hour))
+					newPod := launcherPodForVMI(vmi, nodeName, podIP)
+					newPod.CreationTimestamp = metav1.NewTime(time.Now())
+					return []runtime.Object{oldPod, newPod}
+				}, podIP),
+			Entry("falling back to the interface IP when there is no launcher pod",
+				func(_ *v1.VirtualMachineInstance) []runtime.Object {
+					return nil
+				}, interfaceIP),
+			Entry("falling back to the interface IP when the pod has no IP yet",
+				func(vmi *v1.VirtualMachineInstance) []runtime.Object {
+					return []runtime.Object{launcherPodForVMI(vmi, nodeName, "")}
+				}, interfaceIP),
+			Entry("ignoring a pod scheduled to a different node",
+				func(vmi *v1.VirtualMachineInstance) []runtime.Object {
+					return []runtime.Object{launcherPodForVMI(vmi, "node2", podIP)}
+				}, interfaceIP),
+			Entry("ignoring a pod not controlled by the VMI",
+				func(vmi *v1.VirtualMachineInstance) []runtime.Object {
+					pod := launcherPodForVMI(vmi, nodeName, podIP)
+					pod.OwnerReferences[0].UID = "other-vmi"
+					return []runtime.Object{pod}
+				}, interfaceIP),
+			Entry("ignoring a pod without the virt-launcher label",
+				func(vmi *v1.VirtualMachineInstance) []runtime.Object {
+					pod := launcherPodForVMI(vmi, nodeName, podIP)
+					pod.Labels = nil
+					return []runtime.Object{pod}
+				}, interfaceIP),
+			Entry("ignoring a pod in a different namespace",
+				func(vmi *v1.VirtualMachineInstance) []runtime.Object {
+					pod := launcherPodForVMI(vmi, nodeName, podIP)
+					pod.Namespace = "other-namespace"
+					return []runtime.Object{pod}
+				}, interfaceIP),
+		)
+
+		It("Should accept a pod on any node when the VMI has no node yet", func() {
+			vmi.Status.NodeName = ""
+			dialer := netDial{request: request, app: newAppWithObjects(launcherPodForVMI(vmi, "node2", podIP))}
+			Expect(dialer.resolveTargetIP(vmi)).To(Equal(podIP))
+		})
+
+		It("Should use the pod IP when no interface IP has been reported yet", func() {
+			vmi.Status.Interfaces = []v1.VirtualMachineInstanceNetworkInterface{{IP: ""}}
+			dialer := netDial{request: request, app: newAppWithObjects(launcherPodForVMI(vmi, nodeName, podIP))}
+			Expect(dialer.resolveTargetIP(vmi)).To(Equal(podIP))
+		})
+
+		It("Should use the pod IP when the VMI reports no interfaces", func() {
+			vmi.Status.Interfaces = nil
+			dialer := netDial{request: request, app: newAppWithObjects(launcherPodForVMI(vmi, nodeName, podIP))}
+			Expect(dialer.resolveTargetIP(vmi)).To(Equal(podIP))
+		})
+
+		It("Should fail when neither a launcher pod nor an interface is present", func() {
+			vmi.Status.Interfaces = nil
+			dialer := netDial{request: request, app: newAppWithObjects()}
+			_, err := dialer.resolveTargetIP(vmi)
+			Expect(err).To(MatchError("no network interfaces are present"))
+		})
+
+		It("Should fall back to the interface IP when listing pods fails", func() {
+			k8sfakeClient := fake.NewSimpleClientset(launcherPodForVMI(vmi, nodeName, podIP))
+			k8sfakeClient.Fake.PrependReactor("list", "pods", func(_ testing.Action) (bool, runtime.Object, error) {
+				return true, nil, errors.New("list failed")
+			})
+			dialer := netDial{request: request, app: newAppWithClient(k8sfakeClient)}
+			Expect(dialer.resolveTargetIP(vmi)).To(Equal(interfaceIP))
+		})
+
+		It("Should fall back to the interface IP when no client is available", func() {
+			dialer := netDial{request: request}
+			Expect(dialer.resolveTargetIP(vmi)).To(Equal(interfaceIP))
+		})
+
+		DescribeTable("Should dial the launcher pod IP", func(ipAddr, unreachableIP string) {
+			ln, err := net.Listen("tcp", fmt.Sprintf("%s:0", ipAddr))
+			Expect(err).NotTo(HaveOccurred())
+			defer ln.Close()
+			tcpAddr := ln.Addr().(*net.TCPAddr)
+			request.PathParameters()["port"] = strconv.FormatInt(int64(tcpAddr.Port), 10)
+
+			// Nothing listens on the interface IP; the listener is only reachable via the pod IP.
+			vmi.Status.Interfaces = []v1.VirtualMachineInstanceNetworkInterface{{IP: unreachableIP}}
+			pod := launcherPodForVMI(vmi, nodeName, tcpAddr.IP.String())
+			dialer := netDial{request: request, app: newAppWithObjects(pod)}
+
+			conn, statusErr := dialer.DialUnderlying(vmi)
+			Expect(statusErr).NotTo(HaveOccurred())
+			Expect(conn).NotTo(BeNil())
+			defer conn.Close()
+			Expect(conn.RemoteAddr().String()).To(Equal(ln.Addr().String()))
+		},
+			Entry("with ipv4 ip address", "127.0.0.1", "::1"),
+			Entry("with ipv6 ip address", "[::1]", "127.0.0.1"),
+		)
+	})
 })

--- a/pkg/virt-api/rest/portforward.go
+++ b/pkg/virt-api/rest/portforward.go
@@ -41,7 +41,7 @@ func (app *SubresourceAPIApp) PortForwardRequestHandler(fetcher vmiFetcher) rest
 		streamer := NewWebsocketStreamer(
 			fetcher,
 			validateVMIForPortForward,
-			netDial{request: request},
+			netDial{request: request, app: app},
 		)
 
 		streamer.Handle(request, response)


### PR DESCRIPTION
### What this PR does
#### Before this PR:

virt-api's `portforward` subresource dials `vmi.status.interfaces[0].IP` — the
guest's own interface IP. For multihomed virt-launcher pods, where the guest's
primary interface is attached to a network other than the cluster pod network
(a VPC, a primary user-defined network), that address is not routable from
virt-api and the tunnel fails:

```
Internal error occurred: dialing VM: dial tcp 10.88.0.2:22: connect: connection timed out
```

`virtctl ssh` and `virtctl port-forward`, as clients of the subresource, fail
on such networks.

#### After this PR:

The subresource resolves the current virt-launcher pod at dial time — via the
API client already held by `SubresourceAPIApp`, with the same selection
predicate as `controller.CurrentVMIPod` (owned by the VMI, on the VMI's node,
most recently created) — and dials `pod.status.podIP`, falling back to the
first interface IP when the pod IP cannot be determined. The launcher pod IP is
on the cluster network, the only network virt-api and virt-launcher are
guaranteed to share.

### References

- Partially addresses #18399
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/405
- VEP PR: https://github.com/kubevirt/enhancements/pull/406

### Why we need it and why it was done in this way
The following tradeoffs were made:

- The pod is resolved with one namespace-scoped pod list per tunnel
  establishment rather than a shared informer — the same cost class as the
  virt-handler pod lookup the console/VNC path already performs per connection.
- The client is injected into the `netDial` struct at its single construction
  site, mirroring `handlerDial`; the `dialer` interface is unchanged.
- Pod-selection failure degrades to today's behavior (interface IP) instead of
  erroring, so configurations that work today keep working.

The following alternatives were considered:

- Publishing the launcher pod IP as a new `vmi.status.podIP` field populated by
  virt-controller (prototype: https://github.com/kubevirt/kubevirt/compare/main...lllamnyp:kubevirt:vmi-pod-ip).
  Set aside per SIG-network preference to avoid growing VMI status (#18399).
- Extending the network-binding-plugin API to declare a tunnel endpoint. Set
  aside: the cluster network is the only network virt-api and virt-launcher
  must share, so resolving the launcher pod IP is needed regardless.

Links to places where the discussion took place: #18399,
https://github.com/kubevirt/enhancements/pull/406

### Special notes for your reviewer

Draft: reference implementation for VEP 405, published for early review while
the VEP is under discussion. Before marking ready:

- add the feature gate the VEP proposes (`TunnelToLauncherPod`, naming open) —
  the change is currently unconditional;
- e2e coverage per the VEP's functional testing section (live migration —
  a newly opened tunnel must reach the guest on the target pod; regression for
  masquerade and pod-network bridge);
- whether the guest is reachable at the launcher pod IP is binding-dependent
  (see the VEP's per-binding matrix); this PR only changes the dial target.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present: https://github.com/kubevirt/enhancements/pull/406
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
virt-api's portforward subresource (used by virtctl ssh and virtctl port-forward) now dials the virt-launcher pod IP, falling back to the first interface IP, so tunnels work when the VM's primary interface is on a network not routable from the pod network
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
