### PR TITLE
Cover most virt-launcher converter sub-packages with the linter

### DIFF
--- a/hack/linter/lint-paths.txt
+++ b/hack/linter/lint-paths.txt
@@ -68,6 +68,7 @@ pkg/virt-launcher/virtwrap/access-credentials
 pkg/virt-launcher/virtwrap/agent-poller
 pkg/virt-launcher/virtwrap/converter/compute
 pkg/virt-launcher/virtwrap/converter/metadata
+pkg/virt-launcher/virtwrap/converter/mshv
 pkg/virt-launcher/virtwrap/converter/network
 pkg/virt-launcher/virtwrap/converter/storage
 pkg/virt-launcher/virtwrap/converter/types

--- a/hack/linter/lint-paths.txt
+++ b/hack/linter/lint-paths.txt
@@ -70,6 +70,7 @@ pkg/virt-launcher/virtwrap/converter/compute
 pkg/virt-launcher/virtwrap/converter/metadata
 pkg/virt-launcher/virtwrap/converter/network
 pkg/virt-launcher/virtwrap/converter/storage
+pkg/virt-launcher/virtwrap/converter/types
 pkg/virt-launcher/virtwrap/converter/virtio
 pkg/virt-launcher/virtwrap/network
 pkg/virt-launcher/virtwrap/statsconv/util

--- a/hack/linter/lint-paths.txt
+++ b/hack/linter/lint-paths.txt
@@ -67,6 +67,7 @@ pkg/virt-launcher/premigration-hook-server/network
 pkg/virt-launcher/virtwrap/access-credentials
 pkg/virt-launcher/virtwrap/agent-poller
 pkg/virt-launcher/virtwrap/converter/compute
+pkg/virt-launcher/virtwrap/converter/kvm
 pkg/virt-launcher/virtwrap/converter/metadata
 pkg/virt-launcher/virtwrap/converter/mshv
 pkg/virt-launcher/virtwrap/converter/network

--- a/hack/linter/lint-paths.txt
+++ b/hack/linter/lint-paths.txt
@@ -68,6 +68,7 @@ pkg/virt-launcher/virtwrap/access-credentials
 pkg/virt-launcher/virtwrap/agent-poller
 pkg/virt-launcher/virtwrap/converter/arch
 pkg/virt-launcher/virtwrap/converter/compute
+pkg/virt-launcher/virtwrap/converter/iothreads
 pkg/virt-launcher/virtwrap/converter/kvm
 pkg/virt-launcher/virtwrap/converter/metadata
 pkg/virt-launcher/virtwrap/converter/mshv

--- a/hack/linter/lint-paths.txt
+++ b/hack/linter/lint-paths.txt
@@ -66,6 +66,7 @@ pkg/virt-launcher/metadata
 pkg/virt-launcher/premigration-hook-server/network
 pkg/virt-launcher/virtwrap/access-credentials
 pkg/virt-launcher/virtwrap/agent-poller
+pkg/virt-launcher/virtwrap/converter/arch
 pkg/virt-launcher/virtwrap/converter/compute
 pkg/virt-launcher/virtwrap/converter/kvm
 pkg/virt-launcher/virtwrap/converter/metadata

--- a/hack/linter/lint-paths.txt
+++ b/hack/linter/lint-paths.txt
@@ -74,6 +74,7 @@ pkg/virt-launcher/virtwrap/converter/metadata
 pkg/virt-launcher/virtwrap/converter/mshv
 pkg/virt-launcher/virtwrap/converter/network
 pkg/virt-launcher/virtwrap/converter/storage
+pkg/virt-launcher/virtwrap/converter/translate
 pkg/virt-launcher/virtwrap/converter/types
 pkg/virt-launcher/virtwrap/converter/virtio
 pkg/virt-launcher/virtwrap/network

--- a/pkg/virt-launcher/virtwrap/converter/arch/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/arch/converter_test.go
@@ -25,7 +25,6 @@ import (
 )
 
 var _ = Describe("Arch Converter", func() {
-
 	DescribeTable("Should create a new archConverter for the correct architecture", func(arch string, result Converter) {
 		ac := NewConverter(arch)
 

--- a/pkg/virt-launcher/virtwrap/converter/iothreads/iothreads.go
+++ b/pkg/virt-launcher/virtwrap/converter/iothreads/iothreads.go
@@ -69,7 +69,7 @@ func GetIOThreadsCountType(vmi *v1.VirtualMachineInstance) (ioThreadCount, autoT
 	}
 
 	ioThreadCount = autoThreads + dedicatedThreads
-	return
+	return ioThreadCount, autoThreads
 }
 
 func getThreadPoolLimit(vmi *v1.VirtualMachineInstance) int {
@@ -84,6 +84,7 @@ func getThreadPoolLimit(vmi *v1.VirtualMachineInstance) int {
 		if vmi.IsCPUDedicated() && vmi.Spec.Domain.CPU.IsolateEmulatorThread {
 			return 1
 		}
+		const ioThreadsPerCPU = 2
 		numCPUs := 1
 		// Requested CPU's is guaranteed to be no greater than the limit
 		if req, ok := vmi.Spec.Domain.Resources.Requests[k8sv1.ResourceCPU]; ok {
@@ -91,7 +92,7 @@ func getThreadPoolLimit(vmi *v1.VirtualMachineInstance) int {
 		} else if lim, ok := vmi.Spec.Domain.Resources.Limits[k8sv1.ResourceCPU]; ok {
 			numCPUs = int(lim.Value())
 		}
-		return numCPUs * 2
+		return numCPUs * ioThreadsPerCPU
 	default:
 		return 0
 	}

--- a/pkg/virt-launcher/virtwrap/converter/kvm/configurator.go
+++ b/pkg/virt-launcher/virtwrap/converter/kvm/configurator.go
@@ -56,7 +56,7 @@ type KvmDomainConfigurator struct {
 }
 
 // NewKvmDomainConfigurator creates a new hypervisor domain configurator
-func NewKvmDomainConfigurator(allowEmulation bool, kvmAvailable bool) KvmDomainConfigurator {
+func NewKvmDomainConfigurator(allowEmulation, kvmAvailable bool) KvmDomainConfigurator {
 	return KvmDomainConfigurator{
 		allowEmulation: allowEmulation,
 		kvmAvailable:   kvmAvailable,
@@ -64,7 +64,10 @@ func NewKvmDomainConfigurator(allowEmulation bool, kvmAvailable bool) KvmDomainC
 }
 
 // NewKvmDomainConfiguratorWithCrossArch creates a new hypervisor domain configurator with cross-architecture emulation support
-func NewKvmDomainConfiguratorWithCrossArch(allowEmulation, kvmAvailable, allowCrossArchEmulation bool, hostArchitecture string) KvmDomainConfigurator {
+func NewKvmDomainConfiguratorWithCrossArch(
+	allowEmulation, kvmAvailable, allowCrossArchEmulation bool,
+	hostArchitecture string,
+) KvmDomainConfigurator {
 	return KvmDomainConfigurator{
 		allowEmulation:          allowEmulation,
 		kvmAvailable:            kvmAvailable,

--- a/pkg/virt-launcher/virtwrap/converter/kvm/configurator_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/kvm/configurator_test.go
@@ -53,7 +53,6 @@ var _ = Describe("Hypervisor Domain Configurator", func() {
 			Expect(configurator.Configure(vmi, &domain)).To(Succeed())
 			Expect(domain.Spec.Type).To(Equal(""))
 			Expect(domain).To(Equal(api.Domain{}))
-
 		})
 
 		It("Should not modify domain type even when emulation is allowed", func() {

--- a/pkg/virt-launcher/virtwrap/converter/mshv/configurator.go
+++ b/pkg/virt-launcher/virtwrap/converter/mshv/configurator.go
@@ -34,7 +34,7 @@ type MshvDomainConfigurator struct {
 }
 
 // NewMshvDomainConfigurator creates a new MSHV domain configurator
-func NewMshvDomainConfigurator(allowEmulation bool, mshvAvailable bool) MshvDomainConfigurator {
+func NewMshvDomainConfigurator(allowEmulation, mshvAvailable bool) MshvDomainConfigurator {
 	return MshvDomainConfigurator{
 		allowEmulation: allowEmulation,
 		mshvAvailable:  mshvAvailable,

--- a/pkg/virt-launcher/virtwrap/converter/translate/translate_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/translate/translate_test.go
@@ -31,7 +31,6 @@ import (
 )
 
 var _ = Describe("Domain translation", func() {
-
 	Context("ToLibvirtDomain", func() {
 		It("should convert a minimal DomainSpec", func() {
 			spec := api.NewMinimalDomainSpec("test-vm")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Most converter sub-packages were not covered by the linter configuration. This PR adds them to `lint-paths.txt` and fixes the handful of findings so the linter passes.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
The `vcpu` sub-package is not included here because it has a larger set of findings that warrants a separate PR.
<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

