### PR TITLE
virt-controller: Decouple VMI controller from vsock package

### DIFF
--- a/pkg/virt-controller/watch/BUILD.bazel
+++ b/pkg/virt-controller/watch/BUILD.bazel
@@ -43,6 +43,7 @@ go_library(
         "//pkg/virt-controller/watch/topology:go_default_library",
         "//pkg/virt-controller/watch/vm:go_default_library",
         "//pkg/virt-controller/watch/vmi:go_default_library",
+        "//pkg/virt-controller/watch/vsock:go_default_library",
         "//pkg/virt-controller/watch/workload-updater:go_default_library",
         "//staging/src/kubevirt.io/api/backup/v1alpha1:go_default_library",
         "//staging/src/kubevirt.io/api/clone/v1beta1:go_default_library",

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -95,6 +95,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"
 	"kubevirt.io/kubevirt/pkg/virt-controller/watch/drain/disruptionbudget"
 	"kubevirt.io/kubevirt/pkg/virt-controller/watch/drain/evacuation"
+	"kubevirt.io/kubevirt/pkg/virt-controller/watch/vsock"
 	workloadupdater "kubevirt.io/kubevirt/pkg/virt-controller/watch/workload-updater"
 
 	netadmitter "kubevirt.io/kubevirt/pkg/network/admitter"
@@ -745,6 +746,7 @@ func (vca *VirtControllerApp) initCommon() {
 			return netadmitter.ValidateCreation(field, vmiSpec, clusterCfg)
 		},
 		netmigration.NewEvaluator(),
+		vsock.NewCIDsMap(),
 		vca.additionalLauncherAnnotationsSync,
 		vca.additionalLauncherLabelsSync,
 	)

--- a/pkg/virt-controller/watch/application_test.go
+++ b/pkg/virt-controller/watch/application_test.go
@@ -163,6 +163,7 @@ var _ = Describe("Application", func() {
 				return nil
 			},
 			stubMigrationEvaluator{},
+			stubVSOCKAllocator{},
 			[]string{},
 			[]string{},
 		)
@@ -389,6 +390,14 @@ var _ = Describe("Application", func() {
 		})
 	})
 })
+
+type stubVSOCKAllocator struct{}
+
+func (stubVSOCKAllocator) Sync(_ []*v1.VirtualMachineInstance) {}
+
+func (stubVSOCKAllocator) Allocate(_ *v1.VirtualMachineInstance) error { return nil }
+
+func (stubVSOCKAllocator) Remove(_ string) {}
 
 type stubMigrationEvaluator struct{}
 

--- a/pkg/virt-controller/watch/vmi/BUILD.bazel
+++ b/pkg/virt-controller/watch/vmi/BUILD.bazel
@@ -28,7 +28,6 @@ go_library(
         "//pkg/virt-controller/watch/common:go_default_library",
         "//pkg/virt-controller/watch/descheduler:go_default_library",
         "//pkg/virt-controller/watch/topology:go_default_library",
-        "//pkg/virt-controller/watch/vsock:go_default_library",
         "//pkg/virtiofs:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",

--- a/pkg/virt-controller/watch/vmi/vmi.go
+++ b/pkg/virt-controller/watch/vmi/vmi.go
@@ -210,6 +210,12 @@ type migrationEvaluator interface {
 	Evaluate(vmi *virtv1.VirtualMachineInstance, pod *k8sv1.Pod) k8sv1.ConditionStatus
 }
 
+type vsockAllocator interface {
+	Sync(vmis []*virtv1.VirtualMachineInstance)
+	Allocate(vmi *virtv1.VirtualMachineInstance) error
+	Remove(key string)
+}
+
 type Controller struct {
 	templateService                   templateService
 	clientset                         kubecli.KubevirtClient
@@ -228,7 +234,7 @@ type Controller struct {
 	cdiStore                          cache.Store
 	cdiConfigStore                    cache.Store
 	clusterConfig                     *virtconfig.ClusterConfig
-	cidsMap                           vsock.Allocator
+	cidsMap                           vsockAllocator
 	backendStorage                    *backendstorage.BackendStorage
 	hasSynced                         func() bool
 	netAnnotationsGenerator           annotationsGenerator

--- a/pkg/virt-controller/watch/vmi/vmi.go
+++ b/pkg/virt-controller/watch/vmi/vmi.go
@@ -45,7 +45,6 @@ import (
 	traceUtils "kubevirt.io/kubevirt/pkg/util/trace"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/pkg/virt-controller/watch/topology"
-	"kubevirt.io/kubevirt/pkg/virt-controller/watch/vsock"
 )
 
 const (
@@ -74,6 +73,7 @@ func NewController(templateService templateService,
 	netStatusUpdater statusUpdater,
 	netSpecValidator specValidator,
 	netMigrationEvaluator migrationEvaluator,
+	vsockCIDAllocator vsockAllocator,
 	additionalLauncherAnnotationsSync []string,
 	additionalLauncherLabelsSync []string,
 ) (*Controller, error) {
@@ -99,7 +99,7 @@ func NewController(templateService templateService,
 		cdiConfigStore:                    cdiConfigInformer.GetStore(),
 		clusterConfig:                     clusterConfig,
 		topologyHinter:                    topologyHinter,
-		cidsMap:                           vsock.NewCIDsMap(),
+		cidsMap:                           vsockCIDAllocator,
 		backendStorage:                    backendstorage.NewBackendStorage(clientset, clusterConfig, storageClassInformer.GetStore(), storageProfileInformer.GetStore(), pvcInformer.GetIndexer()),
 		netAnnotationsGenerator:           netAnnotationsGenerator,
 		storageAnnotationsGenerator:       storageAnnotationsGenerator,

--- a/pkg/virt-controller/watch/vmi/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi/vmi_test.go
@@ -252,6 +252,7 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			stubNetStatusUpdate,
 			validateNetVMISpecStub(),
 			stubMigrationEvaluator{result: k8sv1.ConditionUnknown},
+			&fakeAllocator{},
 			[]string{},
 			[]string{},
 		)
@@ -5623,8 +5624,10 @@ func (alc *fakeAllocator) Sync(_ []*virtv1.VirtualMachineInstance) {
 	alc.calls = append(alc.calls, "Sync")
 }
 
-func (alc *fakeAllocator) Allocate(_ *virtv1.VirtualMachineInstance) error {
+func (alc *fakeAllocator) Allocate(vmi *virtv1.VirtualMachineInstance) error {
 	alc.calls = append(alc.calls, "Allocate")
+	cid := uint32(3)
+	vmi.Status.VSOCKCID = &cid
 	return nil
 }
 

--- a/pkg/virt-controller/watch/vsock/vsock.go
+++ b/pkg/virt-controller/watch/vsock/vsock.go
@@ -11,12 +11,6 @@ import (
 	"kubevirt.io/kubevirt/pkg/controller"
 )
 
-type Allocator interface {
-	Sync(vmis []*virtv1.VirtualMachineInstance)
-	Allocate(vmi *virtv1.VirtualMachineInstance) error
-	Remove(key string)
-}
-
 type randCIDFunc func() uint32
 type nextCIDFunc func(uint32) uint32
 

--- a/pkg/virt-controller/watch/vsock/vsock.go
+++ b/pkg/virt-controller/watch/vsock/vsock.go
@@ -20,7 +20,7 @@ type Allocator interface {
 type randCIDFunc func() uint32
 type nextCIDFunc func(uint32) uint32
 
-type cidsMap struct {
+type CIDsMap struct {
 	mu      sync.Mutex
 	cids    map[string]uint32
 	reverse map[uint32]string
@@ -28,8 +28,8 @@ type cidsMap struct {
 	nextCID nextCIDFunc
 }
 
-func NewCIDsMap() *cidsMap {
-	return &cidsMap{
+func NewCIDsMap() *CIDsMap {
+	return &CIDsMap{
 		cids:    make(map[string]uint32),
 		reverse: make(map[uint32]string),
 		randCID: func() uint32 {
@@ -50,7 +50,7 @@ func NewCIDsMap() *cidsMap {
 }
 
 // Sync loads the allocated CIDs from VMIs.
-func (m *cidsMap) Sync(vmis []*virtv1.VirtualMachineInstance) {
+func (m *CIDsMap) Sync(vmis []*virtv1.VirtualMachineInstance) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	for _, vmi := range vmis {
@@ -64,7 +64,7 @@ func (m *cidsMap) Sync(vmis []*virtv1.VirtualMachineInstance) {
 }
 
 // Allocate select a new CID and set it to the status of the given VMI.
-func (m *cidsMap) Allocate(vmi *virtv1.VirtualMachineInstance) error {
+func (m *CIDsMap) Allocate(vmi *virtv1.VirtualMachineInstance) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	key := controller.VirtualMachineInstanceKey(vmi)
@@ -91,7 +91,7 @@ func (m *cidsMap) Allocate(vmi *virtv1.VirtualMachineInstance) error {
 }
 
 // Remove cleans the CID for given VMI.
-func (m *cidsMap) Remove(key string) {
+func (m *CIDsMap) Remove(key string) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if cid, exist := m.cids[key]; exist {

--- a/pkg/virt-controller/watch/vsock/vsock_test.go
+++ b/pkg/virt-controller/watch/vsock/vsock_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 var _ = Describe("VSOCK", func() {
-	var m *cidsMap
+	var m *CIDsMap
 
 	newRandomVMIsWithORWithoutVSOCK := func(totalVMINum, vsockVMINum int) []*virtv1.VirtualMachineInstance {
 		var vmis []*virtv1.VirtualMachineInstance


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
The VMI controller imported the vsock package to create its CID allocator and to reference the Allocator interface. This PR removes that dependency by exporting the concrete CIDsMap type, moving the interface to the  consumer, and injecting the allocator through the constructor.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The vsock package is an implementation detail that the VMI controller shouldn't depend on directly. Defining the interface at the consumer follows the Go convention and makes the controller testable with simple stubs instead of importing vsock internals.

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

