### PR TITLE
add FG for migration compression

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/migrationpolicy-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/migrationpolicy-admitter.go
@@ -171,6 +171,26 @@ func (admitter *MigrationPolicyAdmitter) Admit(_ context.Context, ar *admissionv
 		)...)
 	}
 
+	if spec.ExperimentalMigrationOptions != nil && spec.ExperimentalMigrationOptions.Compression != nil {
+		var oldCompression any
+		if ar.Request.OldObject.Raw != nil {
+			oldPolicy := &migrationsv1.MigrationPolicy{}
+			if err := json.Unmarshal(ar.Request.OldObject.Raw, oldPolicy); err == nil {
+				if oldPolicy.Spec.ExperimentalMigrationOptions != nil {
+					oldCompression = oldPolicy.Spec.ExperimentalMigrationOptions.Compression
+				}
+			}
+		}
+		if !equality.Semantic.DeepEqual(oldCompression, spec.ExperimentalMigrationOptions.Compression) &&
+			!admitter.clusterConfig.MigrationCompressionEnabled() {
+			causes = append(causes, metav1.StatusCause{
+				Type:    metav1.CauseTypeFieldValueInvalid,
+				Message: fmt.Sprintf("experimental.compression cannot be modified without enabling the %s feature gate", featuregate.MigrationCompression),
+				Field:   sourceField.Child("experimental", "compression").String(),
+			})
+		}
+	}
+
 	if spec.BandwidthPerMigration != nil {
 		quantity, ok := spec.BandwidthPerMigration.AsInt64()
 		if !ok {

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/migrationpolicy-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/migrationpolicy-admitter_test.go
@@ -301,6 +301,53 @@ var _ = Describe("Validating MigrationPolicy Admitter", func() {
 		),
 	)
 
+	DescribeTable("experimental.compression feature gate validation",
+		func(gate string, isUpdate bool, oldCompression, newCompression *v1.MigrationCompression, expectAllowed bool) {
+			if gate == "" {
+				disableFeatureGates()
+			} else {
+				enableFeatureGate(gate)
+			}
+			newPolicy := kubecli.NewMinimalMigrationPolicy(policyName)
+			if newCompression != nil {
+				newPolicy.Spec.ExperimentalMigrationOptions = &v1.ExperimentalMigrationOptions{
+					Compression: newCompression,
+				}
+			}
+			if !isUpdate {
+				admitter.admitAndExpect(newPolicy, expectAllowed)
+				return
+			}
+			oldPolicy := kubecli.NewMinimalMigrationPolicy(policyName)
+			if oldCompression != nil {
+				oldPolicy.Spec.ExperimentalMigrationOptions = &v1.ExperimentalMigrationOptions{
+					Compression: oldCompression,
+				}
+			}
+			if expectAllowed {
+				newPolicy.Spec.AllowAutoConverge = pointer.P(true)
+			}
+			admitter.admitUpdateAndExpect(oldPolicy, newPolicy, expectAllowed)
+		},
+		Entry("reject on create without gate", "", false, nil, pointer.P(v1.MigrationCompressionZstd), false),
+		Entry("allow unchanged update without gate", "", true,
+			pointer.P(v1.MigrationCompressionZstd),
+			pointer.P(v1.MigrationCompressionZstd),
+			true,
+		),
+		Entry("reject changing value on update without gate", "", true,
+			pointer.P(v1.MigrationCompressionNone),
+			pointer.P(v1.MigrationCompressionZstd),
+			false,
+		),
+		Entry("allow on create with MigrationCompression", featuregate.MigrationCompression, false, nil, pointer.P(v1.MigrationCompressionZstd), true),
+		Entry("allow changing value on update with MigrationCompression", featuregate.MigrationCompression, true,
+			pointer.P(v1.MigrationCompressionNone),
+			pointer.P(v1.MigrationCompressionZstd),
+			true,
+		),
+	)
+
 })
 
 func createPolicyAdmissionReview(policy *migrationsv1.MigrationPolicy, namespace string) *admissionv1.AdmissionReview {

--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -256,3 +256,7 @@ func (config *ClusterConfig) MigrationStallDetectionEnabled() bool {
 func (config *ClusterConfig) MigrationDowntimeTuningEnabled() bool {
 	return config.isFeatureGateEnabled(featuregate.MigrationDowntimeTuning)
 }
+
+func (config *ClusterConfig) MigrationCompressionEnabled() bool {
+	return config.isFeatureGateEnabled(featuregate.MigrationCompression)
+}

--- a/pkg/virt-config/featuregate/active.go
+++ b/pkg/virt-config/featuregate/active.go
@@ -284,6 +284,13 @@ const (
 	// migration convergence via the ExperimentalMigrationOptions.DowntimeTuning field.
 	MigrationDowntimeTuning = "MigrationDowntimeTuning"
 
+	// Owner: @michalskrivanek
+	// Alpha: v1.9.0
+	//
+	// MigrationCompression enables compression of the live migration data stream
+	// via the ExperimentalMigrationOptions.Compression field.
+	MigrationCompression = "MigrationCompression"
+
 	// Owner: sig-compute / @lyarwood
 	// Alpha: v1.9.0
 	//
@@ -349,6 +356,7 @@ func init() {
 	RegisterFeatureGate(FeatureGate{Name: FirmwareAutoSelection, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: MigrationStallDetection, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: MigrationDowntimeTuning, State: Alpha})
+	RegisterFeatureGate(FeatureGate{Name: MigrationCompression, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: CrossArchitectureVirtualization, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: PortRangesSpec, State: Alpha})
 }

--- a/pkg/virt-handler/migration-source.go
+++ b/pkg/virt-handler/migration-source.go
@@ -576,7 +576,7 @@ func (c *MigrationSourceController) migrateVMI(vmi *v1.VirtualMachineInstance, d
 	}
 
 	if exp := migrationConfiguration.ExperimentalMigrationOptions; exp != nil {
-		if exp.Compression != nil {
+		if c.clusterConfig.MigrationCompressionEnabled() && exp.Compression != nil {
 			options.Compression = pointer.P(string(*exp.Compression))
 		}
 		if c.clusterConfig.MigrationDowntimeTuningEnabled() && exp.DowntimeTuning != nil {

--- a/pkg/virt-handler/migration-source_test.go
+++ b/pkg/virt-handler/migration-source_test.go
@@ -699,6 +699,64 @@ var _ = Describe("VirtualMachineInstance migration target", func() {
 		Entry("drops DowntimeTuning when gate is disabled", false),
 	)
 
+	DescribeTable("should gate Compression on MigrationCompression feature gate", func(enableGate bool) {
+		kv := &v1.KubeVirtConfiguration{
+			DeveloperConfiguration: &v1.DeveloperConfiguration{},
+		}
+		if enableGate {
+			kv.DeveloperConfiguration.FeatureGates = []string{featuregate.MigrationCompression}
+		}
+		controller.clusterConfig, _, _ = testutils.NewFakeClusterConfigUsingKVConfig(kv)
+
+		compression := v1.MigrationCompressionZstd
+		vmi := api2.NewMinimalVMI("testvmi")
+		vmi.UID = vmiTestUUID
+		vmi.ObjectMeta.ResourceVersion = "1"
+		vmi.Status.Phase = v1.Running
+		vmi.Labels = map[string]string{v1.MigrationTargetNodeNameLabel: "othernode"}
+		vmi.Status.NodeName = host
+		vmi.Status.MigrationState = &v1.VirtualMachineInstanceMigrationState{
+			TargetNode:                     "othernode",
+			TargetNodeAddress:              "127.0.0.1:12345",
+			SourceNode:                     host,
+			MigrationUID:                   "123",
+			TargetDirectMigrationNodePorts: map[string]int{"49152": 12132},
+			VMIMConfigurationOptions: &v1.VMIMConfigurationOptions{
+				BandwidthPerMigration:   pointer.P(resource.MustParse("0Mi")),
+				ProgressTimeout:         pointer.P(int64(150)),
+				CompletionTimeoutPerGiB: pointer.P(int64(150)),
+				UnsafeMigrationOverride: pointer.P(false),
+				AllowAutoConverge:       pointer.P(false),
+				AllowPostCopy:           pointer.P(false),
+				ExperimentalMigrationOptions: &v1.ExperimentalMigrationOptions{
+					Compression: &compression,
+				},
+			},
+		}
+		vmi.Status.Conditions = []v1.VirtualMachineInstanceCondition{
+			{Type: v1.VirtualMachineInstanceIsMigratable, Status: k8sv1.ConditionTrue},
+		}
+		vmi = addActivePods(vmi, podTestUUID, host)
+
+		domain := api.NewMinimalDomainWithUUID("testvmi", vmiTestUUID)
+		domain.Status.Status = api.Running
+		addVMI(vmi, domain)
+
+		client.EXPECT().MigrateVirtualMachine(gomock.Any(), gomock.Any()).Do(func(_ *v1.VirtualMachineInstance, options *cmdclient.MigrationOptions) {
+			if enableGate {
+				Expect(options.Compression).To(HaveValue(Equal("zstd")))
+			} else {
+				Expect(options.Compression).To(BeNil())
+			}
+		}).Times(1).Return(nil)
+
+		sanityExecute()
+		testutils.ExpectEvent(recorder, VMIMigrating)
+	},
+		Entry("passes Compression when gate is enabled", true),
+		Entry("drops Compression when gate is disabled", false),
+	)
+
 	It("should migrate vmi once target address is known", func() {
 		vmi := api2.NewMinimalVMI("testvmi")
 		vmi.UID = vmiTestUUID

--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -2214,6 +2214,13 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 		})
 
 		Context("with migration compression", Serial, func() {
+			BeforeEach(func() {
+				kvconfig.EnableFeatureGate(featuregate.MigrationCompression)
+			})
+			AfterEach(func() {
+				kvconfig.DisableFeatureGate(featuregate.MigrationCompression)
+			})
+
 			It("should migrate with zstd compression and confirm via API and logs", func() {
 				vmi := libvmifact.NewAlpineWithTestTooling(libnet.WithMasqueradeNetworking())
 


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
adds FG around migration compression

### References
as requested by https://github.com/kubevirt/kubevirt/pull/17509#issuecomment-5057117334
depends on https://github.com/kubevirt/enhancements/pull/408

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add `MigrationCompression` feature gate (alpha) to gate configuration of live migration stream compression.
```

