### PR TITLE
Add xpivarc as sig-control-plane approver

### DIFF
--- a/OWNERS_ALIASES
+++ b/OWNERS_ALIASES
@@ -202,7 +202,8 @@ aliases:
   # SIG Control plane
   # Responsible for the development and enhancement of
   # KubeVirt control plane.
-  sig-control-plane-approvers: []
+  sig-control-plane-approvers:
+    - xpivarc
   sig-control-plane-reviewers:
     - akalenyu
     - Barakmor1


### PR DESCRIPTION
### What this PR does

Nominating [@xpivarc](https://github.com/xpivarc) as the first SIG Control Plane approver.

Lubo has been an active KubeVirt contributor and [project maintainer](https://github.com/kubevirt/community/blob/main/MAINTAINERS.md) for several years and is already a top-level approver and `sig-control-plane-reviewer`. He has consistently authored substantial control plane changes across virt-handler, virt-controller, virt-operator, and virt-api, led major refactoring efforts, driven security hardening features end-to-end, and provided deep, high-quality reviews across all SIG Control Plane components.

Lubo has demonstrated holistic control plane ownership — not only authoring features, but driving them through design, implementation, testing, and cross-component review. He has contributed across several control plane areas including virt-handler internals (domain watcher, cmd-client, launcher client, device manager, notify pipe), virt-operator lifecycle (config, strategy, certificates, canary upgrades), virt-controller (evacuation, migration), and virt-api (node restriction, subresource enforcement).

#### Substantial authored PRs in SIG Control Plane paths

- [#17354](https://github.com/kubevirt/kubevirt/pull/17354) Domainwatcher refactor
- [#16869](https://github.com/kubevirt/kubevirt/pull/16869) CMD-client refactor
- [#16287](https://github.com/kubevirt/kubevirt/pull/16287) Pipe
- [#16308](https://github.com/kubevirt/kubevirt/pull/16308) Notify, client: Remove legacy socket
- [#16055](https://github.com/kubevirt/kubevirt/pull/16055) Refactor Operator's config code
- [#15957](https://github.com/kubevirt/kubevirt/pull/15957) Introduce evacuatecancel subresource and virtctl subcommand
- [#15949](https://github.com/kubevirt/kubevirt/pull/15949) Migration cert
- [#15374](https://github.com/kubevirt/kubevirt/pull/15374) NodeRestriction: Implement source check
- [#15314](https://github.com/kubevirt/kubevirt/pull/15314) Enforce CNs for aggregated API
- [#14964](https://github.com/kubevirt/kubevirt/pull/14964) Beta: NodeRestriction
- [#15141](https://github.com/kubevirt/kubevirt/pull/15141) Evacuation controller refactor
- [#16112](https://github.com/kubevirt/kubevirt/pull/16112) vGPU: SRIOV support

#### Reviews on sig/control-plane PRs

Lubo has reviewed [28+ sig/control-plane labelled PRs](https://github.com/kubevirt/kubevirt/pulls?q=is%3Apr+is%3Aclosed+reviewed-by%3Axpivarc+label%3Asig%2Fcontrol-plane) and been actively involved in [34+ sig/control-plane PRs](https://github.com/kubevirt/kubevirt/pulls?q=repo%3Akubevirt%2Fkubevirt+commenter%3Axpivarc+sig%2Fcontrol-plane+is%3Aclosed) since the label was introduced. Across the broader project, he has reviewed [2067+ closed PRs](https://github.com/kubevirt/kubevirt/pulls?q=is%3Apr+is%3Aclosed+reviewed-by%3Axpivarc).

Notable reviews include:
- [#16759](https://github.com/kubevirt/kubevirt/pull/16759) virt-operator: refine canary flow to fully support out of band changes
- [#16234](https://github.com/kubevirt/kubevirt/pull/16234) virt-operator: Refactor components package to use KubeVirtDeploymentConfig struct
- [#16106](https://github.com/kubevirt/kubevirt/pull/16106) Decouple kv and k8s client in virt-operator
- [#17707](https://github.com/kubevirt/kubevirt/pull/17707) migration controller: cleanup old virt-launcher pods along with migration objects
- [#17455](https://github.com/kubevirt/kubevirt/pull/17455) virt-controller: migrate deprecated VMI finalizer during updateStatus
- [#17437](https://github.com/kubevirt/kubevirt/pull/17437) virt-operator: use domain-qualified KubeVirt CR finalizer
- [#16028](https://github.com/kubevirt/kubevirt/pull/16028) OWNERS: Introduce sig-control-plane ownership

#### Overall contribution stats

Lubo has authored over [328 merged PRs](https://github.com/kubevirt/kubevirt/pulls?q=is%3Apr+author%3Axpivarc+is%3Amerged) across the project, with **591 commits** specifically in the SIG Control Plane paths (`pkg/virt-controller/`, `pkg/virt-api/`, `pkg/virt-handler/`, `pkg/virt-operator/`, `cmd/virt-handler/`), ranking **4th among human contributors** in these paths:

| Path | Commits |
|------|---------|
| `pkg/virt-handler/` | 237 |
| `pkg/virt-controller/` | 227 |
| `pkg/virt-operator/` | 99 |
| `pkg/virt-api/` | 48 |
| `cmd/virt-handler/` | 25 |

### References

- SIG Control Plane charter: https://github.com/kubevirt/community/blob/main/sig-control-plane/charter.md

### Why we need it and why it was done in this way

`sig-control-plane-approvers` is currently an empty list. The SIG has no approvers and cannot merge changes to paths it owns. This is the exceptional circumstance described in the [membership policy](https://github.com/kubevirt/community/blob/main/membership_policy.md):

> In exceptional circumstances, such as when a repo is left without sufficient approvers, the project maintainers can pass a majority vote to add approvers that do not fulfill the requirements.

Since the normal approver nomination process requires "Nominated by an approver" and there are no existing SIG approvers, we are requesting a maintainer majority vote to bootstrap the list.

### Special notes for your reviewer

This PR requires maintainer votes per the exceptional-circumstances provision. Please respond with a +1 or objection.

/cc @kubevirt/maintainers

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
NONE
```