### PR TITLE
migration: nova-style max downtime stepping (PoC)

### DIFF
--- a/pkg/util/migrations/migrations.go
+++ b/pkg/util/migrations/migrations.go
@@ -174,6 +174,7 @@ func ToVMIMConfigurationOptions(cfg *v1.MigrationConfiguration) *v1.VMIMConfigur
 		BandwidthPerMigration:             cfg.BandwidthPerMigration,
 		CompletionTimeoutPerGiB:           cfg.CompletionTimeoutPerGiB,
 		MaxDowntimeMs:                     cfg.MaxDowntimeMs,
+		MaxDowntimeSteps:                  cfg.MaxDowntimeSteps,
 		ProgressTimeout:                   cfg.ProgressTimeout,
 		UtilityVolumesTimeout:             cfg.UtilityVolumesTimeout,
 		UnsafeMigrationOverride:           cfg.UnsafeMigrationOverride,

--- a/pkg/virt-handler/cmd-client/client.go
+++ b/pkg/virt-handler/cmd-client/client.go
@@ -83,6 +83,7 @@ type MigrationOptions struct {
 	ProgressTimeout          int64
 	CompletionTimeoutPerGiB  int64
 	MaxDowntimeMs            uint64
+	MaxDowntimeSteps         uint32
 	UnsafeMigration          bool
 	AllowAutoConverge        bool
 	AllowPostCopy            bool

--- a/pkg/virt-handler/migration-source.go
+++ b/pkg/virt-handler/migration-source.go
@@ -25,6 +25,7 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"strconv"
 	"time"
 
 	k8sv1 "k8s.io/api/core/v1"
@@ -544,6 +545,11 @@ func (c *MigrationSourceController) migrateVMI(vmi *v1.VirtualMachineInstance, d
 		AllowWorkloadDisruption: *migrationConfiguration.AllowWorkloadDisruption,
 	}
 
+	if migrationConfiguration.MaxDowntimeSteps != nil {
+		options.MaxDowntimeSteps = *migrationConfiguration.MaxDowntimeSteps
+	}
+	applyMigrationDowntimeAnnotationOverrides(vmi, options)
+
 	if c.clusterConfig.MigrationStallDetectionEnabled() {
 		applyExperimentalMigrationDefaults(migrationConfiguration)
 		stallDetector := migrationConfiguration.ExperimentalMigrationOptions.StallDetector
@@ -743,4 +749,30 @@ func configureParallelMigrationThreads(options *cmdclient.MigrationOptions, vm *
 	}
 
 	options.ParallelMigrationThreads = pointer.P(parallelMultifdMigrationThreads)
+}
+
+// applyMigrationDowntimeAnnotationOverrides overrides the migration max
+// downtime options with per VMI annotation values, when present. This exists
+// for experimentation (PoC): it allows tuning the switchover downtime of a
+// single VMI without touching the cluster wide MigrationConfiguration.
+func applyMigrationDowntimeAnnotationOverrides(vmi *v1.VirtualMachineInstance, options *cmdclient.MigrationOptions) {
+	parse := func(annotation string) (uint64, bool) {
+		raw, exists := vmi.Annotations[annotation]
+		if !exists {
+			return 0, false
+		}
+		value, err := strconv.ParseUint(raw, 10, 32)
+		if err != nil {
+			log.Log.Object(vmi).Reason(err).Warningf("ignoring invalid %s annotation value %q", annotation, raw)
+			return 0, false
+		}
+		return value, true
+	}
+
+	if value, exists := parse(v1.MigrationMaxDowntimeMsAnnotation); exists {
+		options.MaxDowntimeMs = value
+	}
+	if value, exists := parse(v1.MigrationMaxDowntimeStepsAnnotation); exists {
+		options.MaxDowntimeSteps = uint32(value)
+	}
 }

--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -98,6 +98,80 @@ type migrationMonitor struct {
 	progressWatermark  uint64
 	remainingData      uint64
 	progressTimeout    int64
+
+	// downtimeSteps is the remaining schedule of migration max downtime
+	// values to apply while the migration is running. See
+	// calculateMigrationDowntimeSteps. Empty when stepping is not enabled
+	// (options.MaxDowntimeSteps unset or 0).
+	downtimeSteps []migrationDowntimeStep
+	// downtimeSteppingActive tracks whether the max downtime is driven by the
+	// stepping schedule, so other initial max downtime handling (e.g. the
+	// stall detector's) does not override it.
+	downtimeSteppingActive bool
+}
+
+// migrationDowntimeStep is a migration max downtime value to apply once the
+// migration has been running for AfterElapsedSeconds.
+type migrationDowntimeStep struct {
+	AfterElapsedSeconds int64
+	DowntimeMS          uint64
+}
+
+// migrationDowntimeStepDelaySecondsPerGiB is the time to wait between
+// migration downtime step increases, per GiB of migration data. Mirrors
+// OpenStack Nova's live_migration_downtime_delay default.
+const migrationDowntimeStepDelaySecondsPerGiB = int64(75)
+
+// calculateMigrationDowntimeSteps builds a linear schedule of migration max
+// downtime values from downtime/steps up to downtime, mirroring OpenStack
+// Nova's downtime stepping algorithm: idle guests converge within the first,
+// smallest step (minimizing the switchover pause), while busy guests get
+// progressively larger downtime allowances so the migration can complete.
+// Returns nil when stepping is not requested (steps == 0) or no downtime is
+// configured.
+func calculateMigrationDowntimeSteps(downtimeMS uint64, steps int64, dataGiB int64) []migrationDowntimeStep {
+	if downtimeMS == 0 || steps < 1 {
+		return nil
+	}
+	if steps == 1 {
+		return []migrationDowntimeStep{{AfterElapsedSeconds: 0, DowntimeMS: downtimeMS}}
+	}
+	if dataGiB < 1 {
+		dataGiB = 1
+	}
+	delay := migrationDowntimeStepDelaySecondsPerGiB * dataGiB
+
+	base := downtimeMS / uint64(steps)
+	if base == 0 {
+		base = 1
+	}
+	offset := (downtimeMS - base) / uint64(steps)
+
+	schedule := make([]migrationDowntimeStep, 0, steps+1)
+	for i := int64(0); i <= steps; i++ {
+		schedule = append(schedule, migrationDowntimeStep{
+			AfterElapsedSeconds: delay * i,
+			DowntimeMS:          base + offset*uint64(i),
+		})
+	}
+	// make sure the last step is the exact requested downtime
+	schedule[len(schedule)-1].DowntimeMS = downtimeMS
+	return schedule
+}
+
+// processDowntimeSteps applies any due migration max downtime step to the
+// in-flight migration.
+func (m *migrationMonitor) processDowntimeSteps(dom cli.VirDomain, elapsedSeconds int64) {
+	logger := log.Log.Object(m.vmi)
+	for len(m.downtimeSteps) > 0 && m.downtimeSteps[0].AfterElapsedSeconds <= elapsedSeconds {
+		step := m.downtimeSteps[0]
+		if err := dom.MigrateSetMaxDowntime(step.DowntimeMS, 0); err != nil {
+			logger.Reason(err).Warningf("failed setting migration max downtime to %dms, will retry", step.DowntimeMS)
+			return
+		}
+		logger.Infof("set migration max downtime to %dms (%d steps left)", step.DowntimeMS, len(m.downtimeSteps)-1)
+		m.downtimeSteps = m.downtimeSteps[1:]
+	}
 }
 
 var libvirtCompressionMethods = map[v1.MigrationCompression]string{
@@ -439,6 +513,10 @@ func (l *LibvirtDomainManager) setMigrationAbortStatus(abortStatus v1.MigrationA
 
 func newMigrationMonitor(vmi *v1.VirtualMachineInstance, l *LibvirtDomainManager, options *cmdclient.MigrationOptions, migrationDone <-chan struct{}) *migrationMonitor {
 	stallDetectorEnabled := options.StallDetectorOptions != nil
+	downtimeSteps := calculateMigrationDowntimeSteps(
+		options.MaxDowntimeMs,
+		int64(options.MaxDowntimeSteps),
+		getVMIMigrationDataSize(vmi, l.ephemeralDiskDir))
 	monitor := &migrationMonitor{
 		l:                        l,
 		vmi:                      vmi,
@@ -449,6 +527,8 @@ func newMigrationMonitor(vmi *v1.VirtualMachineInstance, l *LibvirtDomainManager
 		progressTimeout:          options.ProgressTimeout,
 		acceptableCompletionTime: options.CompletionTimeoutPerGiB * getVMIMigrationDataSize(vmi, l.ephemeralDiskDir),
 		stallDetectionEnabled:    stallDetectorEnabled,
+		downtimeSteps:            downtimeSteps,
+		downtimeSteppingActive:   len(downtimeSteps) > 0,
 		logger:                   log.Log.Object(vmi),
 	}
 
@@ -681,14 +761,20 @@ func (m *migrationMonitor) handleStallDetection(dom cli.VirDomain, stats *libvir
 	sd := m.stallDetector
 
 	if !sd.initialMaxDowntimeSet {
-		initialMaxDowntime := m.options.MaxDowntimeMs
-		if initialMaxDowntime > migrationutils.QEMUDefaultTargetDowntimeMS {
-			initialMaxDowntime = migrationutils.QEMUDefaultTargetDowntimeMS
-		}
-		if err := dom.MigrateSetMaxDowntime(initialMaxDowntime, 0); err != nil {
-			logger.Reason(err).Warning("failed to set initial max downtime")
-		} else {
+		if m.downtimeSteppingActive {
+			// the downtime stepping schedule owns the max downtime value;
+			// don't override its (smaller) first step
 			sd.initialMaxDowntimeSet = true
+		} else {
+			initialMaxDowntime := m.options.MaxDowntimeMs
+			if initialMaxDowntime > migrationutils.QEMUDefaultTargetDowntimeMS {
+				initialMaxDowntime = migrationutils.QEMUDefaultTargetDowntimeMS
+			}
+			if err := dom.MigrateSetMaxDowntime(initialMaxDowntime, 0); err != nil {
+				logger.Reason(err).Warning("failed to set initial max downtime")
+			} else {
+				sd.initialMaxDowntimeSet = true
+			}
 		}
 	}
 
@@ -918,6 +1004,8 @@ func (m *migrationMonitor) startMonitor(ready chan<- error) {
 			loopLogger.Reason(err).Info("failed to get domain job info")
 			jobStats = nil
 		}
+
+		m.processDowntimeSteps(dom, (time.Now().UTC().UnixNano()-m.start)/int64(time.Second))
 
 		m.processInflightMigration(dom, jobStats, isIterationBoundary, loopLogger)
 
@@ -1327,6 +1415,21 @@ func (l *LibvirtDomainManager) migrateHelper(vmi *v1.VirtualMachineInstance, opt
 		return fmt.Errorf("failed to retrive domain state")
 	}
 	migrateFlags := generateMigrationFlags(vmi.IsBlockMigration(), migratePaused, options)
+
+	// Apply the first migration max downtime step before the migration starts
+	// so it takes effect even for migrations that converge faster than the
+	// migration monitor's first tick. Best effort: the migration monitor
+	// (re)applies the downtime schedule while the migration is running.
+	if schedule := calculateMigrationDowntimeSteps(
+		options.MaxDowntimeMs,
+		int64(options.MaxDowntimeSteps),
+		getVMIMigrationDataSize(vmi, l.ephemeralDiskDir)); len(schedule) > 0 {
+		if err := dom.MigrateSetMaxDowntime(schedule[0].DowntimeMS, 0); err != nil {
+			log.Log.Object(vmi).Reason(err).Warningf("failed setting initial migration max downtime to %dms", schedule[0].DowntimeMS)
+		} else {
+			log.Log.Object(vmi).Infof("set initial migration max downtime to %dms", schedule[0].DowntimeMS)
+		}
+	}
 
 	// anything that modifies the domain needs to be performed with the domainModifyLock held
 	// The domain params and unHotplug need to be performed in a critical section together.

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -1427,6 +1427,16 @@ var CRDsValidation map[string]string = map[string]string{
                   maximum: 2000000
                   minimum: 1
                   type: integer
+                maxDowntimeSteps:
+                  description: |-
+                    MaxDowntimeSteps is the number of incremental steps used to reach the
+                    MaxDowntimeMs value: the migration starts with a max downtime of
+                    MaxDowntimeMs/MaxDowntimeSteps milliseconds and increases it linearly up
+                    to MaxDowntimeMs, waiting 75 seconds per GiB of VM memory between
+                    increases. When unset or 0, no stepping is performed. Inspired by
+                    OpenStack Nova's live_migration_downtime_steps.
+                  format: int32
+                  type: integer
                 network:
                   description: |-
                     Network is the name of the CNI network to use for live migrations. By default, migrations go
@@ -15655,6 +15665,16 @@ var CRDsValidation map[string]string = map[string]string{
                   maximum: 2000000
                   minimum: 1
                   type: integer
+                maxDowntimeSteps:
+                  description: |-
+                    MaxDowntimeSteps is the number of incremental steps used to reach the
+                    MaxDowntimeMs value: the migration starts with a max downtime of
+                    MaxDowntimeMs/MaxDowntimeSteps milliseconds and increases it linearly up
+                    to MaxDowntimeMs, waiting 75 seconds per GiB of VM memory between
+                    increases. When unset or 0, no stepping is performed. Inspired by
+                    OpenStack Nova's live_migration_downtime_steps.
+                  format: int32
+                  type: integer
                 network:
                   description: |-
                     Network is the name of the CNI network to use for live migrations. By default, migrations go
@@ -16342,6 +16362,16 @@ var CRDsValidation map[string]string = map[string]string{
                   format: int64
                   maximum: 2000000
                   minimum: 1
+                  type: integer
+                maxDowntimeSteps:
+                  description: |-
+                    MaxDowntimeSteps is the number of incremental steps used to reach the
+                    MaxDowntimeMs value: the migration starts with a max downtime of
+                    MaxDowntimeMs/MaxDowntimeSteps milliseconds and increases it linearly up
+                    to MaxDowntimeMs, waiting 75 seconds per GiB of VM memory between
+                    increases. When unset or 0, no stepping is performed. Inspired by
+                    OpenStack Nova's live_migration_downtime_steps.
+                  format: int32
                   type: integer
                 network:
                   description: |-

--- a/staging/src/kubevirt.io/api/core/v1/deepcopy_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/deepcopy_generated.go
@@ -3525,6 +3525,11 @@ func (in *MigrationConfiguration) DeepCopyInto(out *MigrationConfiguration) {
 		*out = new(uint64)
 		**out = **in
 	}
+	if in.MaxDowntimeSteps != nil {
+		in, out := &in.MaxDowntimeSteps, &out.MaxDowntimeSteps
+		*out = new(uint32)
+		**out = **in
+	}
 	if in.ProgressTimeout != nil {
 		in, out := &in.ProgressTimeout, &out.ProgressTimeout
 		*out = new(int64)
@@ -5455,6 +5460,11 @@ func (in *VMIMConfigurationOptions) DeepCopyInto(out *VMIMConfigurationOptions) 
 	if in.MaxDowntimeMs != nil {
 		in, out := &in.MaxDowntimeMs, &out.MaxDowntimeMs
 		*out = new(uint64)
+		**out = **in
+	}
+	if in.MaxDowntimeSteps != nil {
+		in, out := &in.MaxDowntimeSteps, &out.MaxDowntimeSteps
+		*out = new(uint32)
 		**out = **in
 	}
 	if in.ProgressTimeout != nil {

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -1322,6 +1322,20 @@ const (
 	// Migration will stay in Pending state while utility volumes exist, and will fail if they are not removed before timeout
 	MigrationUtilityVolumesTimeoutSecondsAnnotation string = "kubevirt.io/migrationUtilityVolumesTimeoutSeconds"
 
+	// MigrationMaxDowntimeMsAnnotation overrides, for this VMI, the maximum
+	// tolerable downtime (in milliseconds) during the live migration
+	// switchover. It overrides the cluster wide
+	// MigrationConfiguration.MaxDowntimeMs value.
+	// This exists for experimentation (PoC).
+	MigrationMaxDowntimeMsAnnotation string = "kubevirt.io/migrationMaxDowntimeMs"
+
+	// MigrationMaxDowntimeStepsAnnotation overrides, for this VMI, the number
+	// of incremental steps used to reach the migration max downtime value. It
+	// overrides the cluster wide MigrationConfiguration.MaxDowntimeSteps
+	// value.
+	// This exists for experimentation (PoC).
+	MigrationMaxDowntimeStepsAnnotation string = "kubevirt.io/migrationMaxDowntimeSteps"
+
 	// CustomLibvirtLogFiltersAnnotation can be used to customized libvirt log filters. Example value could be
 	// "3:remote 4:event 3:util.json 3:util.object 3:util.dbus 3:util.netlink 3:node_device 3:rpc 3:access 1:*".
 	// For more info: https://libvirt.org/kbase/debuglogs.html
@@ -3506,6 +3520,13 @@ type VMIMConfigurationOptions struct {
 	//+kubebuilder:validation:Minimum=1
 	//+kubebuilder:validation:Maximum=2000000
 	MaxDowntimeMs *uint64 `json:"maxDowntimeMs,omitempty"`
+	// MaxDowntimeSteps is the number of incremental steps used to reach the
+	// MaxDowntimeMs value: the migration starts with a max downtime of
+	// MaxDowntimeMs/MaxDowntimeSteps milliseconds and increases it linearly up
+	// to MaxDowntimeMs, waiting 75 seconds per GiB of VM memory between
+	// increases. When unset or 0, no stepping is performed. Inspired by
+	// OpenStack Nova's live_migration_downtime_steps.
+	MaxDowntimeSteps *uint32 `json:"maxDowntimeSteps,omitempty"`
 	// ProgressTimeout is the maximum number of seconds a live migration is allowed to make no progress.
 	// Hitting this timeout means a migration transferred 0 data for that many seconds. The migration is
 	// then considered stuck and therefore cancelled. Defaults to 150
@@ -3571,6 +3592,13 @@ type MigrationConfiguration struct {
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:Maximum=2000000
 	MaxDowntimeMs *uint64 `json:"maxDowntimeMs,omitempty"`
+	// MaxDowntimeSteps is the number of incremental steps used to reach the
+	// MaxDowntimeMs value: the migration starts with a max downtime of
+	// MaxDowntimeMs/MaxDowntimeSteps milliseconds and increases it linearly up
+	// to MaxDowntimeMs, waiting 75 seconds per GiB of VM memory between
+	// increases. When unset or 0, no stepping is performed. Inspired by
+	// OpenStack Nova's live_migration_downtime_steps.
+	MaxDowntimeSteps *uint32 `json:"maxDowntimeSteps,omitempty"`
 	// ProgressTimeout is the maximum number of seconds a live migration is allowed to make no progress.
 	// Hitting this timeout means a migration transferred 0 data for that many seconds. The migration is
 	// then considered stuck and therefore cancelled. Defaults to 150


### PR DESCRIPTION
### What this PR does

#### Before this PR:

The migration max downtime (`MigrationConfiguration.maxDowntimeMs`) is applied to QEMU once, at migration start, capped at QEMU's 300ms default (and only when stall detection is enabled). The full downtime budget is granted upfront: idle guests get paused longer than they need, and there is no way to tune the value for a single VMI.

#### After this PR:

A new `MigrationConfiguration.maxDowntimeSteps` field (plus per-VMI annotation overrides `kubevirt.io/migrationMaxDowntimeMs` / `kubevirt.io/migrationMaxDowntimeSteps`, PoC convenience) applies `maxDowntimeMs` with OpenStack Nova-style linear stepping through `virDomainMigrateSetMaxDowntime`:

- the migration starts with a limit of `maxDowntimeMs / maxDowntimeSteps` (applied right before `MigrateToURI3`, so it governs even migrations that converge before the monitor's first tick)
- the migration monitor raises the limit linearly up to `maxDowntimeMs`, waiting 75 s per GiB of migration data between increases (Nova's `live_migration_downtime_delay` default)
- idle guests converge within the first, smallest step (near-minimal pause); busy guests still receive the full budget eventually, so convergence guarantees are unchanged
- with stepping unset, behavior is exactly as today (the VEP 248 stall-detector initial application is skipped only while stepping owns the value)

Measured on a kind cluster (fedora guest, 1GiB, idle, `maxDowntimeMs=50` + `maxDowntimeSteps=5` -> first step 10ms), `virsh domjobinfo --completed`:

| | guest pause (Total downtime) |
|---|---|
| QEMU default 300ms budget | 220-230 ms |
| this PR, 10ms first step | ~90 ms (consistently; residual is device-state save/load on that rig) |

End-to-end ICMP blackout during live migration dropped from ~300 ms to ~100 ms in combination with constant-time network switchover (measured separately).

### References

Replicates OpenStack Nova's `live_migration_downtime` / `live_migration_downtime_steps` / `live_migration_downtime_delay` mechanism on top of the existing `maxDowntimeMs` (VEP 248).

### Why we need it and why it was done in this way

The following tradeoffs were made:

- stepping is opt-in (`maxDowntimeSteps` unset = today's behavior) to avoid changing VEP 248 semantics
- the generated deepcopy/CRD validation updates are hand-written in the API commit for this PoC instead of regenerated
- per-VMI annotations are a PoC convenience for experimentation; MigrationPolicy is likely the proper user surface and can replace them

The following alternatives were considered:

- adding a separate `downtime` field: rejected, duplicates `maxDowntimeMs`
- relying only on the stall detector's initial `min(maxDowntimeMs, 300)`: does not reduce the pause below QEMU's default for idle guests, and grants the full budget immediately

### Special notes for your reviewer

Draft/PoC to support an ongoing discussion about reducing live-migration downtime for KubeVirt VMs (together with an OVN-Kubernetes multichassis port-binding PoC on the network side). Unit tests for the stepping schedule and e2e coverage will follow if the approach is agreed on.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note

```release-note
Add MigrationConfiguration.maxDowntimeSteps: apply the migration max downtime with Nova-style linear stepping so idle guests migrate with the smallest possible pause.
```
