### PR TITLE
Fix `VMNonRecoverableOSPanic` so the panic count in the alert is accurate and an int

### DIFF
--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -2000,7 +2000,7 @@ tests:
   - interval: 1m
     input_series:
       - series: 'kubevirt_vmi_guest_os_panic_total{namespace="test", name="vm-01", type="unknown", bugcheck_code="unknown"}'
-        values: '0 0 6 6 6 6 6'
+        values: '_ _ 6 6 6 6 6'
 
     alert_rule_test:
       - eval_time: 1m
@@ -2020,3 +2020,30 @@ tests:
               kubernetes_operator_component: "kubevirt"
               namespace: "test"
               name: "vm-01"
+
+  # VMNonRecoverableOSPanic - increase path: 6 -> 13 within 24h (12h interval)
+  - interval: 12h
+    input_series:
+      - series: 'kubevirt_vmi_guest_os_panic_total{namespace="test", name="vm-02", type="unknown", bugcheck_code="unknown"}'
+        values: '6 6 6 13 13 13'
+
+    alert_rule_test:
+      # Still at 6 after 24h — no increase yet
+      - eval_time: 24h
+        alertname: VMNonRecoverableOSPanic
+        exp_alerts: []
+      # Jumped to 13; increase over 24h is 7
+      - eval_time: 48h
+        alertname: VMNonRecoverableOSPanic
+        exp_alerts:
+          - exp_annotations:
+              summary: "VM vm-02 in namespace test experienced a non-recoverable guest OS panic"
+              description: "The VM has experienced 7 non-recoverable guest OS panic(s) in the last 24 hours."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/VMNonRecoverableOSPanic"
+            exp_labels:
+              severity: "critical"
+              operator_health_impact: "none"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+              namespace: "test"
+              name: "vm-02"

--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -2118,7 +2118,7 @@ tests:
   - interval: 1m
     input_series:
       - series: 'kubevirt_vmi_guest_os_panic_total{namespace="test", name="vm-01", type="unknown", bugcheck_code="unknown"}'
-        values: '0 0 6 6 6 6 6'
+        values: '_ _ 6 6 6 6 6'
 
     alert_rule_test:
       - eval_time: 1m
@@ -2165,3 +2165,31 @@ tests:
         exp_samples:
           - labels: 'pvc:kubevirt_suspected_orphaned_storage_bytes:info{namespace="ns-test", persistentvolumeclaim="orphan-disk"}'
             value: 10737418240
+
+  # VMNonRecoverableOSPanic - increase path: 6 -> 13 within 24h (12h interval)
+  - interval: 12h
+    input_series:
+      - series: 'kubevirt_vmi_guest_os_panic_total{namespace="test", name="vm-02", type="unknown", bugcheck_code="unknown"}'
+        values: '6 6 6 13 13 13'
+
+    alert_rule_test:
+      # Still at 6 after 24h — no increase yet
+      - eval_time: 24h
+        alertname: VMNonRecoverableOSPanic
+        exp_alerts: []
+      # Jumped to 13; increase over 24h is 7
+      - eval_time: 48h
+        alertname: VMNonRecoverableOSPanic
+        exp_alerts:
+          - exp_annotations:
+              summary: "VM vm-02 in namespace test experienced a non-recoverable guest OS panic"
+              description: "The VM has experienced 7 non-recoverable guest OS panic(s) in the last 24 hours."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/VMNonRecoverableOSPanic"
+            exp_labels:
+              severity: "critical"
+              operator_health_impact: "none"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+              namespace: "test"
+              name: "vm-02"
+              vm: "vm-02"

--- a/pkg/monitoring/rules/alerts/vms.go
+++ b/pkg/monitoring/rules/alerts/vms.go
@@ -251,8 +251,18 @@ var vmsAlerts = []promv1.Rule{
 	},
 	{
 		Alert: "VMNonRecoverableOSPanic",
-		Expr:  intstr.FromString(`sum by (namespace, name) (increase(kubevirt_vmi_guest_os_panic_total[24h])) > 5`),
-		For:   ptr.To(promv1.Duration("1m")),
+		Expr: intstr.FromString(`
+			floor(
+				(
+					sum by (namespace, name) (kubevirt_vmi_guest_os_panic_total)
+					unless
+					sum by (namespace, name) (kubevirt_vmi_guest_os_panic_total offset 24h)
+				)
+				or
+				sum by (namespace, name) (increase(kubevirt_vmi_guest_os_panic_total[24h]))
+			) > 5
+		`),
+		For: ptr.To(promv1.Duration("1m")),
 		Annotations: map[string]string{
 			summaryAnnotationKey:     "VM {{ $labels.name }} in namespace {{ $labels.namespace }} experienced a non-recoverable guest OS panic",
 			descriptionAnnotationKey: "The VM has experienced {{ $value }} non-recoverable guest OS panic(s) in the last 24 hours.",

--- a/pkg/monitoring/rules/alerts/vms.go
+++ b/pkg/monitoring/rules/alerts/vms.go
@@ -237,8 +237,18 @@ var vmsAlerts = []promv1.Rule{
 	},
 	{
 		Alert: "VMNonRecoverableOSPanic",
-		Expr:  intstr.FromString(withVMLabel("sum by (namespace, name) (increase(kubevirt_vmi_guest_os_panic_total[24h])) > 5")),
-		For:   ptr.To(promv1.Duration("1m")),
+		Expr: intstr.FromString(withVMLabel(`
+			floor(
+				(
+					sum by (namespace, name) (kubevirt_vmi_guest_os_panic_total)
+					unless
+					sum by (namespace, name) (kubevirt_vmi_guest_os_panic_total offset 24h)
+				)
+				or
+				sum by (namespace, name) (increase(kubevirt_vmi_guest_os_panic_total[24h]))
+			) > 5
+		`)),
+		For: ptr.To(promv1.Duration("1m")),
 		Annotations: map[string]string{
 			summaryAnnotationKey:     "VM {{ $labels.name }} in namespace {{ $labels.namespace }} experienced a non-recoverable guest OS panic",
 			descriptionAnnotationKey: "The VM has experienced {{ $value }} non-recoverable guest OS panic(s) in the last 24 hours.",


### PR DESCRIPTION
`increase()` can return fractional values and misses the first samples when a series has no prior baseline. Use the same approach as HCO ([kubevirt/hyperconverged-cluster-operator#4394](https://github.com/kubevirt/hyperconverged-cluster-operator/pull/4394)): prefer the raw counter when the series is newer than 24h, otherwise use `increase()`, and wrap with `floor()`. The critical threshold remains `> 5`.

jira-ticket: https://redhat.atlassian.net/browse/CNV-93859

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```

