### PR TITLE
workload-updater: fix potential deadlock in abortChangeVMIs goroutines

### DIFF
--- a/pkg/virt-controller/watch/workload-updater/workload-updater.go
+++ b/pkg/virt-controller/watch/workload-updater/workload-updater.go
@@ -641,6 +641,7 @@ func (c *WorkloadUpdateController) sync(kv *virtv1.KubeVirt) error {
 					log.Log.Object(vmi).Reason(err).Errorf("Failed to delete the migration due to a migration abortion")
 					c.recorder.Eventf(vmi, k8sv1.EventTypeNormal, FailedChangeAbortionReason, "Failed to abort change for vmi: %s: %v", vmi.Name, err)
 					errChan <- err
+					break
 				} else if err == nil {
 					log.Log.Infof("Delete migration %s due to an update change abortion", mig.Name)
 					c.recorder.Eventf(vmi, k8sv1.EventTypeNormal, SuccessfulChangeAbortionReason, "Aborted change for vmi: %s", vmi.Name)

--- a/pkg/virt-controller/watch/workload-updater/workload-updater_test.go
+++ b/pkg/virt-controller/watch/workload-updater/workload-updater_test.go
@@ -633,6 +633,30 @@ var _ = Describe("Workload Updater", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
+		It("should not deadlock when multiple migrations fail to delete for the same VMI", func() {
+			vmi := createVM(withAnnotation, withoutMemoryChangeCondition)
+			createMig(vmi.Name, v1.MigrationRunning)
+
+			mig2 := newMigration("test2", vmi.Name, v1.MigrationRunning)
+			mig2.Annotations = map[string]string{v1.WorkloadUpdateMigrationAnnotation: ""}
+			controller.migrationIndexer.Add(mig2)
+			_, err := fakeVirtClient.KubevirtV1().VirtualMachineInstanceMigrations(mig2.Namespace).Create(context.Background(), mig2, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			fakeVirtClient.Fake.PrependReactor("delete", "virtualmachineinstancemigrations", func(action k8stesting.Action) (handled bool, ret runtime.Object, err error) {
+				return true, nil, fmt.Errorf("some error")
+			})
+
+			done := make(chan struct{})
+			go func() {
+				defer GinkgoRecover()
+				sanityExecute()
+				close(done)
+			}()
+			Eventually(done, 5*time.Second).Should(BeClosed())
+			testutils.ExpectEvent(recorder, FailedChangeAbortionReason)
+		})
+
 		It("shouldn't cancel the migration if the migration object is still in running phase but the domain is ready on the target", func() {
 			vmi := libvmi.New(
 				libvmi.WithName("testvm"),


### PR DESCRIPTION
### What this PR does
#### Before this PR:
Each `abortChangeVMIs` goroutine loops over `migList` and sends an error to `errChan` for every failed migration deletion. Since `errChan` is sized with one slot per goroutine, a VMI with two or more migrations that both fail to delete blocks on the second send, preventing `wg.Done()` from being called and causing `wg.Wait()` to deadlock.

#### After this PR:
The goroutine breaks out of the `migList` loop after the first error, sending at most one error per goroutine. The remaining migrations are retried on the next sync.

### References
- Partially addresses #16979

### Why we need it and why it was done in this way
The data race portion of #16979 (Bug #1) was already fixed by commit a2013e17e6. This PR fixes the remaining deadlock (Bug #2) with a minimal change — breaking after the first error keeps the fix contained and matches the existing error-handling pattern where `errChan` is drained for a single error at the end of `sync()`.

The following alternatives were considered:
- Increasing the `errChan` buffer to account for multiple errors per goroutine, but this would require knowing the maximum number of migrations per VMI upfront and the single-error drain at the end of `sync()` would still discard all but the first error.

### Special notes for your reviewer
The deadlock requires a VMI with 2+ pending workload-update migrations where both deletions fail — an unlikely but possible scenario.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Testing: New unit test verifies the fix by asserting `sync()` completes within 5 seconds with two failing migration deletions
- [x] AI Contributions: The PR abides by the KubeVirt AI Contribution Policy.

### Release note
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling when automatically stopping workload-update migrations encounters a deletion error.
  - Prevented the controller from continuing to process additional migrations after a failure, avoiding potential hangs.
  - Ensured the failure is reported through the appropriate event.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->