### PR TITLE
virt-operator: retry monitoring SA lookup during install strategy dump

### DIFF
--- a/pkg/virt-operator/resource/generate/install/BUILD.bazel
+++ b/pkg/virt-operator/resource/generate/install/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/install",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/apimachinery/wait:go_default_library",
         "//pkg/monitoring/rules:go_default_library",
         "//pkg/virt-operator/resource/generate/components:go_default_library",
         "//pkg/virt-operator/resource/generate/components/validatingadmissionpolicies:go_default_library",
@@ -33,6 +34,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/util/wait:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/typed/core/v1:go_default_library",
         "//vendor/k8s.io/kube-aggregator/pkg/apis/apiregistration/v1:go_default_library",
@@ -63,6 +65,7 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/fake:go_default_library",
+        "//vendor/k8s.io/client-go/testing:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/sigs.k8s.io/yaml:go_default_library",
     ],

--- a/pkg/virt-operator/resource/generate/install/strategy.go
+++ b/pkg/virt-operator/resource/generate/install/strategy.go
@@ -29,6 +29,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"time"
 
 	routev1 "github.com/openshift/api/route/v1"
 	secv1 "github.com/openshift/api/security/v1"
@@ -44,6 +45,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	k8coresv1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	apiregv1 "k8s.io/kube-aggregator/pkg/apis/apiregistration/v1"
@@ -53,6 +55,7 @@ import (
 	instancetypev1beta1 "kubevirt.io/api/instancetype/v1beta1"
 	"kubevirt.io/client-go/log"
 
+	virtwait "kubevirt.io/kubevirt/pkg/apimachinery/wait"
 	"kubevirt.io/kubevirt/pkg/monitoring/rules"
 	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/components"
 	vap "kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/components/validatingadmissionpolicies"
@@ -385,13 +388,38 @@ func getConfigFromEnvWithEnvVarManager(envVarManager operatorutil.EnvVarManager)
 	return nil, fmt.Errorf("no config provided")
 }
 
+var (
+	monitorRetryInterval = 5 * time.Second
+	monitorRetryTimeout  = 1 * time.Minute
+)
+
+func getMonitorNamespaceWithRetry(clientset k8coresv1.CoreV1Interface, potentialMonitorNamespaces []string, monitorServiceAccount string) (string, error) {
+	var namespace string
+	err := virtwait.PollImmediately(monitorRetryInterval, monitorRetryTimeout, func(_ context.Context) (bool, error) {
+		ns, err := getMonitorNamespace(clientset, potentialMonitorNamespaces, monitorServiceAccount)
+		if err != nil {
+			return false, err
+		}
+		if ns != "" {
+			namespace = ns
+			return true, nil
+		}
+		log.Log.Infof("monitoring ServiceAccount %s not found yet, retrying", monitorServiceAccount)
+		return false, nil
+	})
+	if err != nil && !wait.Interrupted(err) {
+		return "", err
+	}
+	return namespace, nil
+}
+
 func DumpInstallStrategyToConfigMap(clientset kubernetes.Interface, operatorNamespace string) error {
 	config, err := GetConfigFromEnv()
 	if err != nil {
 		return err
 	}
 
-	monitorNamespace, err := getMonitorNamespace(clientset.CoreV1(), config.GetPotentialMonitorNamespaces(), config.GetMonitorServiceAccountName())
+	monitorNamespace, err := getMonitorNamespaceWithRetry(clientset.CoreV1(), config.GetPotentialMonitorNamespaces(), config.GetMonitorServiceAccountName())
 	if err != nil {
 		return err
 	}

--- a/pkg/virt-operator/resource/generate/install/strategy_test.go
+++ b/pkg/virt-operator/resource/generate/install/strategy_test.go
@@ -21,10 +21,13 @@ package install
 
 import (
 	"strings"
+	"sync/atomic"
+	"time"
 
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -106,6 +109,66 @@ var _ = Describe("Install Strategy", func() {
 				newNS("monitoring"),
 			),
 		)
+
+		Context("with retry", func() {
+			It("should return immediately when the SA exists", func() {
+				client := fake.NewSimpleClientset(
+					newNS("openshift-monitoring"),
+					newSA("openshift-monitoring", "prometheus-k8s"),
+				)
+				ns, err := getMonitorNamespaceWithRetry(client.CoreV1(), config.GetPotentialMonitorNamespaces(), config.GetMonitorServiceAccountName())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ns).To(Equal("openshift-monitoring"))
+			})
+
+			It("should find the SA after retrying", func() {
+				origInterval := monitorRetryInterval
+				origTimeout := monitorRetryTimeout
+				defer func() {
+					monitorRetryInterval = origInterval
+					monitorRetryTimeout = origTimeout
+				}()
+				monitorRetryInterval = 10 * time.Millisecond
+				monitorRetryTimeout = 5 * time.Second
+
+				client := fake.NewSimpleClientset(
+					newNS("openshift-monitoring"),
+				)
+
+				var calls atomic.Int32
+				client.PrependReactor("get", "serviceaccounts", func(action k8stesting.Action) (bool, runtime.Object, error) {
+					if calls.Add(1) >= 3 {
+						client.Tracker().Add(newSA("openshift-monitoring", "prometheus-k8s"))
+					}
+					return false, nil, nil
+				})
+
+				ns, err := getMonitorNamespaceWithRetry(client.CoreV1(), config.GetPotentialMonitorNamespaces(), config.GetMonitorServiceAccountName())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ns).To(Equal("openshift-monitoring"))
+				Expect(calls.Load()).To(BeNumerically(">=", int32(3)))
+			})
+
+			It("should return empty after timeout when SA never appears", func() {
+				origInterval := monitorRetryInterval
+				origTimeout := monitorRetryTimeout
+				defer func() {
+					monitorRetryInterval = origInterval
+					monitorRetryTimeout = origTimeout
+				}()
+				monitorRetryInterval = 10 * time.Millisecond
+				monitorRetryTimeout = 50 * time.Millisecond
+
+				client := fake.NewSimpleClientset(
+					newNS("openshift-monitoring"),
+					newNS("monitoring"),
+				)
+
+				ns, err := getMonitorNamespaceWithRetry(client.CoreV1(), config.GetPotentialMonitorNamespaces(), config.GetMonitorServiceAccountName())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(ns).To(BeEmpty())
+			})
+		})
 	})
 
 	Context("should generate", func() {


### PR DESCRIPTION
### What this PR does
#### Before this PR:
The install-strategy Job does a one-shot lookup of the monitoring ServiceAccount (`prometheus-k8s`) when generating the install strategy ConfigMap. If the SA doesn't exist at that instant — common during upgrades when the monitoring stack is also reconciling, or during early cluster bootstrap — the ConfigMap is created without `ServiceMonitor` and `PrometheusRule` resources. Since the operator never re-evaluates this decision, metrics scraping is permanently broken until manual intervention.

#### After this PR:
The monitoring SA lookup retries with polling (every 5s, up to 1 minute) before giving up. If the SA appears during that window, monitoring resources are included as expected. If it's still absent after the timeout, the Job proceeds without them (same as current behavior for genuinely unmonitored clusters).

### References
- Partially addresses #16593

### Why we need it and why it was done in this way
The install strategy ConfigMap is effectively immutable after creation for a given deployment ID. There is no mechanism for the operator to detect that monitoring resources are missing and trigger regeneration. The simplest fix is to give the SA time to appear during the dump Job, which handles the most common scenario (race during upgrade or bootstrap).

The following alternatives were considered:
- Moving monitoring resource generation out of the install strategy and into the reconciler's runtime logic. This would be more robust but is a larger refactor and risks duplicating validation/generation code.
- Having the operator delete and regenerate the ConfigMap when it detects `ServiceMonitorEnabled` but no ServiceMonitor in the strategy. This adds complexity to the reconciler and could cause unnecessary churn.

### Special notes for your reviewer
The retry uses the in-tree `pkg/apimachinery/wait.PollImmediately` wrapper, consistent with other wait patterns in the codebase. The retry interval/timeout are package-level vars to allow test overrides.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Testing: New unit tests cover SA found immediately, SA found after retry, and timeout with no SA
- [x] AI Contributions: The PR abides by the KubeVirt AI Contribution Policy.

### Release note
```release-note
Fixed a race condition where ServiceMonitor and PrometheusRule resources could be permanently omitted from the install strategy during KubeVirt upgrade or early bootstrap, breaking VM metrics scraping.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installation strategy generation by retrying monitoring namespace discovery when the monitoring service account is not immediately available.
  * Added timeout handling to prevent indefinite waiting when the service account cannot be found.

* **Tests**
  * Added coverage for immediate discovery, delayed availability, and timeout scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->