### PR TITLE
virt-operator: add configurable kubelet root directory

### DIFF
--- a/pkg/virt-operator/resource/generate/components/daemonsets.go
+++ b/pkg/virt-operator/resource/generate/components/daemonsets.go
@@ -2,6 +2,7 @@ package components
 
 import (
 	"fmt"
+	"path"
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -22,7 +23,6 @@ import (
 
 const (
 	VirtHandlerName                = "virt-handler"
-	kubeletPodsPath                = util.KubeletRoot + "/pods"
 	runtimesPath                   = "/var/run/kubevirt-libvirt-runtimes"
 	PrHelperName                   = "pr-helper"
 	prVolumeName                   = "pr-helper-socket-vol"
@@ -315,6 +315,13 @@ func NewHandlerDaemonSet(config *operatorutil.KubeVirtDeploymentConfig, productN
 
 	bidi := corev1.MountPropagationBidirectional
 	hostToContainer := corev1.MountPropagationHostToContainer
+	// The host kubelet root directory is configurable to support distributions
+	// with a non-standard kubelet root (e.g. k0s, RKE2). It is always mounted
+	// at util.KubeletRoot inside the container so that in-container lookups
+	// (e.g. cpu_manager_state) keep resolving to the same path regardless of
+	// where the kubelet root lives on the host.
+	kubeletRootDir := config.GetKubeletRootDir()
+	kubeletPodsPath := path.Join(kubeletRootDir, "pods")
 	// NOTE: the 'kubelet-pods' volume mount exists because that path holds unix socket files.
 	// Socket files fail when their path is longer than 108 characters,
 	//   so that shortened volume path is to allow domain socket connections.
@@ -324,7 +331,7 @@ func NewHandlerDaemonSet(config *operatorutil.KubeVirtDeploymentConfig, productN
 		{"virt-share-dir", util.VirtShareDir, util.VirtShareDir, &bidi},
 		{"virt-private-dir", util.VirtPrivateDir, util.VirtPrivateDir, nil},
 		{"kubelet-pods", kubeletPodsPath, "/pods", nil},
-		{"kubelet", util.KubeletRoot, util.KubeletRoot, &hostToContainer},
+		{"kubelet", kubeletRootDir, util.KubeletRoot, &hostToContainer},
 		{"node-labeller", nodeLabellerVolumePath, nodeLabellerVolumePath, nil},
 	}
 

--- a/pkg/virt-operator/resource/generate/components/daemonsets_test.go
+++ b/pkg/virt-operator/resource/generate/components/daemonsets_test.go
@@ -4,7 +4,10 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+
+	v1 "kubevirt.io/api/core/v1"
 
 	operatorutil "kubevirt.io/kubevirt/pkg/virt-operator/util"
 )
@@ -30,5 +33,74 @@ var _ = Describe("Handler DaemonSet", func() {
 		Expect(kubeletMount).NotTo(BeNil(), "kubelet volume mount should exist")
 		Expect(kubeletMount.MountPropagation).NotTo(BeNil())
 		Expect(*kubeletMount.MountPropagation).To(Equal(corev1.MountPropagationHostToContainer))
+	})
+
+	hostPathFor := func(ds *appsv1.DaemonSet, name string) string {
+		for i := range ds.Spec.Template.Spec.Volumes {
+			vol := ds.Spec.Template.Spec.Volumes[i]
+			if vol.Name == name {
+				Expect(vol.HostPath).NotTo(BeNil(), "volume %q should be a hostPath volume", name)
+				return vol.HostPath.Path
+			}
+		}
+		Fail("volume " + name + " not found")
+		return ""
+	}
+
+	mountPathFor := func(ds *appsv1.DaemonSet, name string) string {
+		container := ds.Spec.Template.Spec.Containers[0]
+		for i := range container.VolumeMounts {
+			if container.VolumeMounts[i].Name == name {
+				return container.VolumeMounts[i].MountPath
+			}
+		}
+		Fail("volume mount " + name + " not found")
+		return ""
+	}
+
+	It("should use the default kubelet root for host paths when unset", func() {
+		ds := NewHandlerDaemonSet(config, "", "", "")
+
+		Expect(hostPathFor(ds, "kubelet")).To(Equal("/var/lib/kubelet"))
+		Expect(hostPathFor(ds, "kubelet-pods")).To(Equal("/var/lib/kubelet/pods"))
+	})
+
+	It("should thread a custom kubelet root into the host paths", func() {
+		config.KubeletRootDir = "/var/lib/k0s/kubelet"
+		ds := NewHandlerDaemonSet(config, "", "", "")
+
+		Expect(hostPathFor(ds, "kubelet")).To(Equal("/var/lib/k0s/kubelet"))
+		Expect(hostPathFor(ds, "kubelet-pods")).To(Equal("/var/lib/k0s/kubelet/pods"))
+	})
+
+	It("should keep the in-container kubelet mount target stable regardless of the host root", func() {
+		config.KubeletRootDir = "/var/lib/k0s/kubelet"
+		ds := NewHandlerDaemonSet(config, "", "", "")
+
+		// The in-container mount targets must stay constant so that in-container
+		// lookups (e.g. cpu_manager_state under /var/lib/kubelet) keep working.
+		Expect(mountPathFor(ds, "kubelet")).To(Equal("/var/lib/kubelet"))
+		Expect(mountPathFor(ds, "kubelet-pods")).To(Equal("/pods"))
+	})
+
+	It("should clean a trailing slash from the kubelet pods host path", func() {
+		config.KubeletRootDir = "/var/lib/k0s/kubelet/"
+		ds := NewHandlerDaemonSet(config, "", "", "")
+
+		Expect(hostPathFor(ds, "kubelet-pods")).To(Equal("/var/lib/k0s/kubelet/pods"))
+	})
+
+	It("should thread KUBELET_ROOT_DIR through config into the DaemonSet host paths", func() {
+		const customRoot = "/var/lib/rancher/rke2/agent/kubelet"
+		envVarManager := &operatorutil.EnvVarManagerMock{}
+		Expect(envVarManager.Setenv(operatorutil.KubeletRootDirEnvName, customRoot)).To(Succeed())
+
+		parsedConfig := operatorutil.GetTargetConfigFromKVWithEnvVarManager(&v1.KubeVirt{}, envVarManager)
+		ds := NewHandlerDaemonSet(parsedConfig, "", "", "")
+
+		Expect(hostPathFor(ds, "kubelet")).To(Equal(customRoot))
+		Expect(hostPathFor(ds, "kubelet-pods")).To(Equal(customRoot + "/pods"))
+		Expect(mountPathFor(ds, "kubelet")).To(Equal("/var/lib/kubelet"))
+		Expect(mountPathFor(ds, "kubelet-pods")).To(Equal("/pods"))
 	})
 })

--- a/pkg/virt-operator/util/config.go
+++ b/pkg/virt-operator/util/config.go
@@ -38,6 +38,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
 
+	virtutil "kubevirt.io/kubevirt/pkg/util"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 )
@@ -60,6 +61,10 @@ const (
 	VirtTemplateApiserverImageEnvName         = "VIRT_TEMPLATE_APISERVER_IMAGE"
 	VirtTemplateControllerImageEnvName        = "VIRT_TEMPLATE_CONTROLLER_IMAGE"
 	RunbookURLTemplate                        = "RUNBOOK_URL_TEMPLATE"
+
+	// KubeletRootDirEnvName is the operator env var used to override the host
+	// kubelet root directory for distributions with a non-default kubelet root.
+	KubeletRootDirEnvName = "KUBELET_ROOT_DIR"
 
 	KubeVirtVersionEnvName = "KUBEVIRT_VERSION"
 	// Deprecated, use TargetDeploymentConfig instead
@@ -160,6 +165,11 @@ type KubeVirtDeploymentConfig struct {
 	// matches the image tag, if tags are used, either by the manifest, or by the KubeVirt CR
 	// used on the KubeVirt CR status and on annotations, and for determining up-/downgrade paths
 	KubeVirtVersion string `json:"kubeVirtVersion,omitempty" optional:"true"`
+
+	// KubeletRootDir is the host directory where the kubelet stores its state.
+	// It defaults to /var/lib/kubelet and can be overridden for distributions
+	// that use a non-standard kubelet root (e.g. k0s, RKE2, some managed offerings).
+	KubeletRootDir string `json:"kubeletRootDir,omitempty" optional:"true"`
 
 	// the images names of every image we use
 	ComponentImages
@@ -349,8 +359,9 @@ func getConfig(providedRegistry, providedTag, namespace string, additionalProper
 	GsImage := envVarManager.Getenv(GsImageEnvName)
 	PrHelperImage := envVarManager.Getenv(PrHelperImageEnvName)
 	SidecarShimImage := envVarManager.Getenv(SidecarShimImageEnvName)
+	kubeletRootDir := envVarManager.Getenv(KubeletRootDirEnvName)
 
-	return newDeploymentConfigWithTag(registry, imagePrefix, tag, namespace, operatorImage, apiImage, controllerImage, handlerImage, launcherImage, exportProxyImage, exportServerImage, synchronizationControllerImage, virtTemplateApiserverImage, virtTemplateControllerImage, GsImage, PrHelperImage, SidecarShimImage, additionalProperties, passthroughEnv)
+	return newDeploymentConfigWithTag(registry, imagePrefix, tag, namespace, operatorImage, apiImage, controllerImage, handlerImage, launcherImage, exportProxyImage, exportServerImage, synchronizationControllerImage, virtTemplateApiserverImage, virtTemplateControllerImage, GsImage, PrHelperImage, SidecarShimImage, kubeletRootDir, additionalProperties, passthroughEnv)
 }
 
 func VerifyEnv() error {
@@ -384,11 +395,12 @@ func GetPassthroughEnvWithEnvVarManager(envVarManager EnvVarManager) map[string]
 	return passthroughEnv
 }
 
-func newDeploymentConfigWithTag(registry, imagePrefix, tag, namespace, operatorImage, apiImage, controllerImage, handlerImage, launcherImage, exportProxyImage, exportServerImage, synchronizationControllerImage, virtTemplateApiserverImage, virtTemplateControllerImage, gsImage, prHelperImage, sidecarShimImage string, kvSpec, passthroughEnv map[string]string) *KubeVirtDeploymentConfig {
+func newDeploymentConfigWithTag(registry, imagePrefix, tag, namespace, operatorImage, apiImage, controllerImage, handlerImage, launcherImage, exportProxyImage, exportServerImage, synchronizationControllerImage, virtTemplateApiserverImage, virtTemplateControllerImage, gsImage, prHelperImage, sidecarShimImage, kubeletRootDir string, kvSpec, passthroughEnv map[string]string) *KubeVirtDeploymentConfig {
 	c := &KubeVirtDeploymentConfig{
 		Registry:        registry,
 		ImagePrefix:     imagePrefix,
 		KubeVirtVersion: tag,
+		KubeletRootDir:  kubeletRootDir,
 		ComponentImages: ComponentImages{
 			VirtOperatorImage:                  operatorImage,
 			VirtApiImage:                       apiImage,
@@ -490,6 +502,15 @@ func (c *KubeVirtDeploymentConfig) GetSidecarShimVersion() string {
 
 func (c *KubeVirtDeploymentConfig) GetKubeVirtVersion() string {
 	return c.KubeVirtVersion
+}
+
+// GetKubeletRootDir returns the configured host kubelet root directory,
+// falling back to the default /var/lib/kubelet when unset.
+func (c *KubeVirtDeploymentConfig) GetKubeletRootDir() string {
+	if c.KubeletRootDir == "" {
+		return virtutil.KubeletRoot
+	}
+	return c.KubeletRootDir
 }
 
 func (c *KubeVirtDeploymentConfig) GetImageRegistry() string {

--- a/pkg/virt-operator/util/config_test.go
+++ b/pkg/virt-operator/util/config_test.go
@@ -182,6 +182,46 @@ var _ = Describe("Operator Config", func() {
 
 	})
 
+	Describe("GetKubeletRootDir()", func() {
+		It("should default to /var/lib/kubelet when unset", func() {
+			config := &KubeVirtDeploymentConfig{}
+			Expect(config.GetKubeletRootDir()).To(Equal("/var/lib/kubelet"))
+		})
+
+		It("should return the configured value when set", func() {
+			config := &KubeVirtDeploymentConfig{KubeletRootDir: "/var/lib/k0s/kubelet"}
+			Expect(config.GetKubeletRootDir()).To(Equal("/var/lib/k0s/kubelet"))
+		})
+
+		It("should default when the config is read without the env var", func() {
+			parsedConfig := GetTargetConfigFromKVWithEnvVarManager(&v1.KubeVirt{}, envVarManager)
+			Expect(parsedConfig.KubeletRootDir).To(BeEmpty())
+			Expect(parsedConfig.GetKubeletRootDir()).To(Equal("/var/lib/kubelet"))
+		})
+
+		It("should be sourced from the KUBELET_ROOT_DIR env var", func() {
+			const customRoot = "/var/lib/rancher/rke2/agent/kubelet"
+			Expect(envVarManager.Setenv(KubeletRootDirEnvName, customRoot)).To(Succeed())
+			defer func() { _ = envVarManager.Unsetenv(KubeletRootDirEnvName) }()
+
+			parsedConfig := GetTargetConfigFromKVWithEnvVarManager(&v1.KubeVirt{}, envVarManager)
+			Expect(parsedConfig.KubeletRootDir).To(Equal(customRoot))
+			Expect(parsedConfig.GetKubeletRootDir()).To(Equal(customRoot))
+		})
+
+		It("should result in different install strategy IDs for different kubelet roots", func() {
+			cfgDefault := &KubeVirtDeploymentConfig{}
+			cfgDefault.generateInstallStrategyID()
+
+			cfgCustom := &KubeVirtDeploymentConfig{KubeletRootDir: "/var/lib/k0s/kubelet"}
+			cfgCustom.generateInstallStrategyID()
+
+			Expect(cfgDefault.ID).ToNot(BeEmpty())
+			Expect(cfgCustom.ID).ToNot(BeEmpty())
+			Expect(cfgCustom.ID).ToNot(Equal(cfgDefault.ID))
+		})
+	})
+
 	Context("Product Names and Versions", func() {
 		DescribeTable("label validation", func(testVector string, expectedResult bool) {
 			Expect(IsValidLabel(testVector)).To(Equal(expectedResult))


### PR DESCRIPTION
Add an optional KubeletRootDir (default `/var/lib/kubelet`), sourced from the `KUBELET_ROOT_DIR` operator env var, and thread it into the virt-handler DaemonSet host paths so KubeVirt works on distributions with a non-standard kubelet root (k0s, RKE2). Backward compatible adds unit tests for config defaulting and DaemonSet rendering.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:

KubeVirt hard-codes the kubelet root directory to `/var/lib/kubelet`. On distributions that use a non-standard kubelet root (e.g. k0s, RKE2, some managed offerings), the virt-handler DaemonSet mounts the wrong host paths, so kubelet-dependent lookups such as `cpu_manager_state` and device-plugin sockets are not discovered. Working around it requires patching the generated DaemonSet or creating symlinks.

#### After this PR:

`KubeVirtDeploymentConfig` gains an optional `KubeletRootDir` (default `/var/lib/kubelet`), sourced from the `KUBELET_ROOT_DIR` operator env var. It is threaded into the virt-handler DaemonSet so the `kubelet` and `kubelet-pods` volumes use the configured host path, while the in-container mount target stays at `/var/lib/kubelet`. As a result, existing in-container path lookups (`cpu_manager_state`, device-plugins, pod-resources, seccomp) resolve to the configured host root with no virt-handler code changes. Behavior is unchanged when the value is left at its default.

### References

Fixes #18563

<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
Several widely used Kubernetes distributions do not use `/var/lib/kubelet` as the kubelet root, which makes KubeVirt unusable on them without manual manifest surgery. A first-class, backward-compatible configuration option keeps KubeVirt portable across distributions.

The following tradeoffs were made:
- The host kubelet root is made configurable, but the **in-container mount target is kept fixed at `/var/lib/kubelet`**. This lets every existing in-container `/var/lib/kubelet` reference (cpu_manager_state, device-plugins, pod-resources, seccomp) keep working unchanged, avoiding invasive plumbing through virt-handler for this first step.
- The value is sourced from the `KUBELET_ROOT_DIR` operator env var (feeding `KubeVirtDeploymentConfig`) rather than the `KubeVirt` CR. This keeps the change small and self-contained in virt-operator.

The following alternatives were considered:
- Exposing the setting through `KubeVirtConfiguration` in the `KubeVirt` CR (API type + CRD regeneration). This is the more discoverable admin-facing knob and is planned as a follow-up PR.
- Explicitly threading `--kubelet-root` into the virt-handler container args and making heartbeat/device-manager/gpuinfo/seccomp use a configurable path directly, instead of relying on the mount remap.
- Manual DaemonSet patching or symlinking the kubelet directory (operationally fragile).

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added an optional kubeletRootDir setting to support clusters with a non-default kubelet root directory.
```

