### PR TITLE
tests: rename sig-operator CI lane to sig-control-plane

### DIFF
--- a/.github/ISSUE_TEMPLATE/flaky_test_report.md
+++ b/.github/ISSUE_TEMPLATE/flaky_test_report.md
@@ -17,7 +17,7 @@ Flaky test detected: {test_name} [1]
 
 <!-- sig assignment
      all tests contain a sig identifier, please assign the corresponding SIG to the issue, i.e.
-     for a test name containing [sig-compute] or [sig-operator]
+     for a test name containing [sig-compute] or [sig-control-plane]
 -->
 /sig compute
 

--- a/automation/test.sh
+++ b/automation/test.sh
@@ -146,8 +146,8 @@ case "$TARGET" in
   *sig-compute*)
     export KUBEVIRT_PROVIDER=${TARGET/-sig-compute/}
     ;;
-  *sig-operator*)
-    export KUBEVIRT_PROVIDER=${TARGET/-sig-operator*/}
+  *sig-control-plane*)
+    export KUBEVIRT_PROVIDER=${TARGET/-sig-control-plane*/}
     export KUBEVIRT_WITH_CNAO=true
     export KUBEVIRT_NUM_SECONDARY_NICS=1
     ;;
@@ -580,13 +580,13 @@ if [[ -z ${KUBEVIRT_E2E_FOCUS} && -z ${KUBEVIRT_E2E_SKIP} && -z ${label_filter} 
     label_filter='(sig-compute && !(GPU,VGPU,sig-compute-migrations,sig-storage,DRA-GPU) && !(SEV, SEVES, secure-execution))'
   elif [[ $TARGET =~ sig-monitoring ]]; then
     label_filter='(sig-monitoring)'
-  elif [[ $TARGET =~ sig-operator ]]; then
-    if [[ $TARGET =~ sig-operator-upgrade ]]; then
+  elif [[ $TARGET =~ sig-control-plane ]]; then
+    if [[ $TARGET =~ sig-control-plane-upgrade ]]; then
       label_filter='(Upgrade)'
-    elif [[ $TARGET =~ sig-operator-configuration ]]; then
-      label_filter='(sig-operator && !(Upgrade))'
+    elif [[ $TARGET =~ sig-control-plane-configuration ]]; then
+      label_filter='(sig-control-plane && !(Upgrade))'
     else
-      label_filter='(sig-operator)'
+      label_filter='(sig-control-plane)'
     fi
   elif [[ $TARGET =~ sriov.* ]]; then
     label_filter='(SRIOV)'

--- a/hack/check-unassigned-tests.sh
+++ b/hack/check-unassigned-tests.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 
 main() {
-    skip="SRIOV|GPU|\\[sig-operator\\]|\\[sig-network\\]|\\[sig-storage\\]|\\[sig-compute\\]|\\[sig-compute-migrations\\]|\\[sig-performance\\]|\\[sig-compute-realtime\\]|\\[sig-monitoring\\]"
+    skip="SRIOV|GPU|\\[sig-control-plane\\]|\\[sig-network\\]|\\[sig-storage\\]|\\[sig-compute\\]|\\[sig-compute-migrations\\]|\\[sig-performance\\]|\\[sig-compute-realtime\\]|\\[sig-monitoring\\]"
     result=$(FUNC_TEST_ARGS="--dry-run --no-color -skip=${skip}" make functest)
     total_tests=$(echo "${result}" | sed -n "s/.*Ran \([0-9]\+\) of .* Specs in .* seconds.*/\1/p")
     if [ "${total_tests}" != "0" ]; then
         echo "Found ${total_tests} tests not assigned to any SIG, please check: ${result}"
         exit 1
     fi
-    labels="!(SRIOV,GPU,sig-operator,sig-network,sig-storage,sig-compute,sig-compute-migrations,sig-performance,sig-compute-realtime,sig-monitoring)"
+    labels="!(SRIOV,GPU,sig-control-plane,sig-network,sig-storage,sig-compute,sig-compute-migrations,sig-performance,sig-compute-realtime,sig-monitoring)"
     result=$(FUNC_TEST_ARGS="--dry-run --no-color --label-filter=${labels}" make functest)
     total_tests=$(echo "${result}" | sed -n "s/.*Ran \([0-9]\+\) of .* Specs in .* seconds.*/\1/p")
     if [ "${total_tests}" != "0" ]; then

--- a/tests/canary_upgrade_test.go
+++ b/tests/canary_upgrade_test.go
@@ -46,7 +46,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libkubevirt"
 )
 
-var _ = Describe("[sig-operator]virt-handler canary upgrade", Serial, decorators.SigOperator, func() {
+var _ = Describe("[sig-control-plane]virt-handler canary upgrade", Serial, decorators.SigControlPlane, func() {
 
 	var originalKV *v1.KubeVirt
 	var virtCli kubecli.KubevirtClient

--- a/tests/decorators/decorators.go
+++ b/tests/decorators/decorators.go
@@ -10,7 +10,7 @@ var (
 	/* SIGs */
 
 	SigCompute             = Label("sig-compute")
-	SigOperator            = Label("sig-operator")
+	SigControlPlane        = Label("sig-control-plane")
 	SigNetwork             = Label("sig-network")
 	SigStorage             = Label("sig-storage")
 	SigComputeInstancetype = Label("sig-compute-instancetype")

--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -131,7 +131,7 @@ const (
 	secondaryNetworkName          = "secondarynet"
 )
 
-var _ = Describe("[sig-operator]Operator", Serial, decorators.SigOperator, func() {
+var _ = Describe("[sig-control-plane]Operator", Serial, decorators.SigControlPlane, func() {
 
 	var originalKv *v1.KubeVirt
 	var originalOperatorVersion string


### PR DESCRIPTION
### What this PR does
#### Before this PR:
The CI test lane covering operator/upgrade tests is labeled `sig-operator`,
reflecting the old informal SIG grouping name.

#### After this PR:
The CI test lane is relabeled `sig-control-plane`, matching the SIG's
current formal name. This includes the Ginkgo label decorator, test
`Describe` strings, `automation/test.sh` pattern matching, the
unassigned-tests check script, and the flaky test issue template.

### References

- Fixes #18572

### Why we need it and why it was done in this way
SIG Control Plane has been established as the successor to the informal
sig-operator grouping. Keeping the CI lane named `sig-operator` no longer
reflects the SIG that owns these tests and components, which causes
confusion since the SIG is already referenced under its new name in
OWNERS files, GitHub labels, and community docs.

The following tradeoffs were made:
None — this is a mechanical, like-for-like rename with no behavior change.

The following alternatives were considered:
Keeping the old `sig-operator` name and aliasing it to `sig-control-plane`
was considered, but this would cause ongoing confusion since the SIG is
already referenced under the new name elsewhere.

### Special notes for your reviewer
This PR is part of a coordinated rename across kubevirt/kubevirt,
kubevirt/project-infra, and kubevirt/ci-health. It depends on the
corresponding job-generation rename landing in kubevirt/project-infra
(kubevirt/project-infra#5319) first, since job names are generated there.
Opening as a draft until that lands to avoid breaking CI job matching.

Related: kubevirt/ci-health#169

This is a pure rename with no logic changes, so no new tests were added.

### Checklist
- [x] Design: not required, this is a simple rename with no architectural impact
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [ ] Refactor: not applicable
- [ ] Upgrade: not applicable, no upgrade-path impact
- [ ] Testing: not applicable, this is a pure rename with no behavior change
- [x] Documentation: not required, no user-facing API change
- [ ] Community: not required for this internal CI change

### Release note
```release-note
NONE
```
