### PR TITLE
pkg/virt-launcher: refactor to NewInterface builder pattern

### DIFF
--- a/pkg/virt-launcher/premigration-hook-server/network/ordinal_naming_test.go
+++ b/pkg/virt-launcher/premigration-hook-server/network/ordinal_naming_test.go
@@ -57,7 +57,7 @@ var _ = Describe("UpgradeOrdinalNamingScheme", func() {
 
 	It("should do nothing if there is only a primary interface with a tap based binding", func() {
 		vmi := libvmi.New(
-			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+			libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithMasqueradeBinding())),
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
 		)
 
@@ -76,9 +76,9 @@ var _ = Describe("UpgradeOrdinalNamingScheme", func() {
 
 	It("should do nothing if there are secondary networks with hashed naming scheme", func() {
 		vmi := libvmi.New(
-			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
-			libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetwork1Name)),
-			libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetwork2Name)),
+			libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithMasqueradeBinding())),
+			libvmi.WithInterface(libvmi.NewInterface(secondaryNetwork1Name, libvmi.WithBridgeBinding())),
+			libvmi.WithInterface(libvmi.NewInterface(secondaryNetwork2Name, libvmi.WithBridgeBinding())),
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
 			libvmi.WithNetwork(libvmi.MultusNetwork(secondaryNetwork1Name, secondaryNetwork1NADName)),
 			libvmi.WithNetwork(libvmi.MultusNetwork(secondaryNetwork2Name, secondaryNetwork2NADName)),
@@ -101,9 +101,9 @@ var _ = Describe("UpgradeOrdinalNamingScheme", func() {
 
 	It("should convert the ordinal to hashed naming scheme", func() {
 		vmi := libvmi.New(
-			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
-			libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetwork1Name)),
-			libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(secondaryNetwork2Name)),
+			libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithMasqueradeBinding())),
+			libvmi.WithInterface(libvmi.NewInterface(secondaryNetwork1Name, libvmi.WithBridgeBinding())),
+			libvmi.WithInterface(libvmi.NewInterface(secondaryNetwork2Name, libvmi.WithBridgeBinding())),
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
 			libvmi.WithNetwork(libvmi.MultusNetwork(secondaryNetwork1Name, secondaryNetwork1NADName)),
 			libvmi.WithNetwork(libvmi.MultusNetwork(secondaryNetwork2Name, secondaryNetwork2NADName)),

--- a/pkg/virt-launcher/virtwrap/converter/compute/cpu_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/cpu_test.go
@@ -314,7 +314,7 @@ var _ = Describe("CPU Domain Configurator", func() {
 			),
 			Entry("passt without explicit NUMA",
 				libvmi.New(
-					libvmi.WithInterface(libvmi.InterfaceDeviceWithPasstBinding("default")),
+					libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithPasstBinding())),
 					libvmi.WithMemoryRequest("64Mi"),
 				),
 				&api.CPUTopology{Sockets: 1, Cores: 1, Threads: 1},

--- a/pkg/virt-launcher/virtwrap/converter/compute/memory_backing_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/memory_backing_test.go
@@ -77,7 +77,7 @@ var _ = Describe("MemoryBackingConfigurator", func() {
 			},
 		),
 		Entry("passt",
-			libvmi.New(libvmi.WithInterface(libvmi.InterfaceDeviceWithPasstBinding("default"))),
+			libvmi.New(libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithPasstBinding()))),
 			memfdSupported,
 			&api.MemoryBacking{
 				Access: &api.MemoryBackingAccess{Mode: "shared"},

--- a/pkg/virt-launcher/virtwrap/converter/network/configurator_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/network/configurator_test.go
@@ -70,7 +70,7 @@ var _ = Describe("Network Domain Configurator", func() {
 		Entry(
 			"when only an SR-IOV interface is specified",
 			libvmi.New(
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithSRIOVBinding(network1Name)),
+				libvmi.WithInterface(libvmi.NewInterface(network1Name, libvmi.WithSRIOVBinding())),
 				libvmi.WithNetwork(libvmi.MultusNetwork(network1Name, nad1Name)),
 			),
 			nil,
@@ -78,7 +78,9 @@ var _ = Describe("Network Domain Configurator", func() {
 		Entry(
 			"when an interface using a non-tap binding plugin is specified",
 			libvmi.New(
-				libvmi.WithInterface(libvmi.InterfaceWithPasstBindingPlugin()),
+				libvmi.WithInterface(
+					libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithBindingPlugin(v1.PluginBinding{Name: "passt"})),
+				),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 			),
 			nil,
@@ -121,14 +123,14 @@ var _ = Describe("Network Domain Configurator", func() {
 		Entry(
 			"when a primary interface is specified",
 			libvmi.New(
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+				libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithMasqueradeBinding())),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 			),
 		),
 		Entry(
 			"when a secondary interface using bridge binding is specified",
 			libvmi.New(
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithBridgeBinding(network1Name)),
+				libvmi.WithInterface(libvmi.NewInterface(network1Name, libvmi.WithBridgeBinding())),
 				libvmi.WithNetwork(libvmi.MultusNetwork(network1Name, nad1Name)),
 			),
 		),
@@ -136,9 +138,9 @@ var _ = Describe("Network Domain Configurator", func() {
 			"when an interface using a tap based binding plugin is specified",
 			libvmi.New(
 				libvmi.WithInterface(
-					libvmi.InterfaceWithBindingPlugin(
+					libvmi.NewInterface(
 						network1Name,
-						v1.PluginBinding{Name: tapBasedBindingPluginName},
+						libvmi.WithBindingPlugin(v1.PluginBinding{Name: tapBasedBindingPluginName}),
 					),
 				),
 				libvmi.WithNetwork(libvmi.MultusNetwork(network1Name, nad1Name)),
@@ -148,8 +150,7 @@ var _ = Describe("Network Domain Configurator", func() {
 
 	DescribeTable("should configure link state",
 		func(linkState v1.InterfaceState, expectedInterface api.Interface) {
-			ifaceWithLinkState := libvmi.InterfaceDeviceWithBridgeBinding(network1Name)
-			ifaceWithLinkState.State = linkState
+			ifaceWithLinkState := libvmi.NewInterface(network1Name, libvmi.WithBridgeBinding(), libvmi.WithState(linkState))
 
 			vmi := libvmi.New(
 				libvmi.WithInterface(ifaceWithLinkState),
@@ -183,8 +184,7 @@ var _ = Describe("Network Domain Configurator", func() {
 	)
 
 	DescribeTable("multi-queue", func(model string, expectedInterface api.Interface) {
-		ifaceWithModel := libvmi.InterfaceDeviceWithBridgeBinding(network1Name)
-		ifaceWithModel.Model = model
+		ifaceWithModel := libvmi.NewInterface(network1Name, libvmi.WithBridgeBinding(), libvmi.WithModel(model))
 
 		vmi := libvmi.New(
 			libvmi.WithCPUCount(cores, threads, sockets),

--- a/pkg/virt-launcher/virtwrap/converter/network/passt_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/network/passt_test.go
@@ -53,7 +53,7 @@ var _ = Describe("Passt Network Domain Configurator", func() {
 			},
 			Entry("no corresponding network",
 				libvmi.New(
-					libvmi.WithInterface(libvmi.InterfaceDeviceWithPasstBinding("not-default")),
+					libvmi.WithInterface(libvmi.NewInterface("not-default", libvmi.WithPasstBinding())),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					libvmistatus.WithStatus(
 						libvmistatus.New(
@@ -64,13 +64,13 @@ var _ = Describe("Passt Network Domain Configurator", func() {
 			),
 			Entry("no matching status entry",
 				libvmi.New(
-					libvmi.WithInterface(libvmi.InterfaceDeviceWithPasstBinding("default")),
+					libvmi.WithInterface(libvmi.NewInterface("default", libvmi.WithPasstBinding())),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 				),
 			),
 			Entry("empty PodInterfaceName in status",
 				libvmi.New(
-					libvmi.WithInterface(libvmi.InterfaceDeviceWithPasstBinding("default")),
+					libvmi.WithInterface(libvmi.NewInterface("default", libvmi.WithPasstBinding())),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					libvmistatus.WithStatus(
 						libvmistatus.New(
@@ -195,7 +195,7 @@ var _ = Describe("Passt Network Domain Configurator", func() {
 			},
 			Entry("virtio transitional enabled",
 				libvmi.New(
-					libvmi.WithInterface(libvmi.InterfaceDeviceWithPasstBinding("default")),
+					libvmi.WithInterface(libvmi.NewInterface("default", libvmi.WithPasstBinding())),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					libvmistatus.WithStatus(
 						libvmistatus.New(
@@ -212,7 +212,7 @@ var _ = Describe("Passt Network Domain Configurator", func() {
 			Entry("isitio proxy injection enabled",
 				libvmi.New(
 					libvmi.WithAnnotation("sidecar.istio.io/inject", "true"),
-					libvmi.WithInterface(libvmi.InterfaceDeviceWithPasstBinding("default")),
+					libvmi.WithInterface(libvmi.NewInterface("default", libvmi.WithPasstBinding())),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					libvmistatus.WithStatus(
 						libvmistatus.New(
@@ -230,7 +230,7 @@ var _ = Describe("Passt Network Domain Configurator", func() {
 
 		It("should not override other interfaces", func() {
 			vmi := libvmi.New(
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithPasstBinding("default")),
+				libvmi.WithInterface(libvmi.NewInterface("default", libvmi.WithPasstBinding())),
 				libvmi.WithInterface(v1.Interface{
 					Name: multusSecondaryNetworkName,
 					InterfaceBindingMethod: v1.InterfaceBindingMethod{
@@ -270,7 +270,7 @@ var _ = Describe("Passt Network Domain Configurator", func() {
 
 		It("should set domain interface correctly when executed more than once", func() {
 			vmi := libvmi.New(
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithPasstBinding("default")),
+				libvmi.WithInterface(libvmi.NewInterface("default", libvmi.WithPasstBinding())),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 				libvmistatus.WithStatus(
 					libvmistatus.New(
@@ -300,7 +300,7 @@ var _ = Describe("Passt Network Domain Configurator", func() {
 
 		It("should set domain interface source link to the optional one if exists", func() {
 			vmi := libvmi.New(
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithPasstBinding("default")),
+				libvmi.WithInterface(libvmi.NewInterface("default", libvmi.WithPasstBinding())),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 			)
 			vmi.Status.Interfaces = []v1.VirtualMachineInstanceNetworkInterface{
@@ -439,7 +439,7 @@ func withSourceDevice(sourceDevice string) passtOption {
 type ifaceOption func(iface *v1.Interface)
 
 func newPasstInterface(options ...ifaceOption) v1.Interface {
-	newIface := libvmi.InterfaceDeviceWithPasstBinding(v1.DefaultPodNetwork().Name)
+	newIface := libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithPasstBinding())
 
 	for _, f := range options {
 		f(&newIface)


### PR DESCRIPTION
### What this PR does
#### Before this PR:
Test files in \`pkg/virt-launcher/\` use legacy interface builders (\`InterfaceDeviceWith*\`, \`InterfaceWith*\`) to construct interfaces.

#### After this PR:
All 5 test files in \`pkg/virt-launcher/\` (25 call sites) use \`NewInterface\` with option functions introduced in #18263.

### References

- Introduced the builder pattern: #18263
- First conversion PR (\`tests/network/\`): #18391
- Second conversion PR (\`pkg/network/\`): #18452
- Third conversion PR (\`tests/migration/\`): #18499

### Why we need it and why it was done in this way

Converting callers to the new builder pattern is a prerequisite for eventually deprecating the legacy functions. Splitting by directory keeps PRs reviewable and reduces merge conflict risk.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

/kind cleanup

```release-note
NONE
```