### PR TITLE
tests/storage: refactor to NewInterface builder pattern

### DIFF
--- a/tests/storage/configuration.go
+++ b/tests/storage/configuration.go
@@ -67,7 +67,7 @@ var _ = Describe("[sig-storage] Storage configuration", decorators.SigStorage, d
 			libstorage.EventuallyDV(dataVolume, 240, Or(HaveSucceeded(), WaitForFirstConsumer()))
 
 			vmi := libvmi.New(
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+				libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithMasqueradeBinding())),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 				libvmi.WithPersistentVolumeClaim("disk0", dataVolume.Name),
 				libvmi.WithMemoryRequest("128Mi"),

--- a/tests/storage/datavolume.go
+++ b/tests/storage/datavolume.go
@@ -391,7 +391,7 @@ var _ = Describe(SIG("DataVolume Integration", func() {
 				By("requiring a VM with 2 DataVolumes")
 				vmi := libvmi.New(
 					libvmi.WithMemoryRequest("128Mi"),
-					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+					libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithMasqueradeBinding())),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					libvmi.WithDataVolume(dataVolume1.Name, dataVolume1.Name),
 					libvmi.WithDataVolume(dataVolume2.Name, dataVolume2.Name),

--- a/tests/storage/events.go
+++ b/tests/storage/events.go
@@ -74,7 +74,7 @@ var _ = Describe(SIG("K8s IO events", Serial, func() {
 	It("[test_id:6225]Should catch the IO error event", func() {
 		By("Creating VMI with faulty disk")
 		vmi := libvmi.New(
-			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+			libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithMasqueradeBinding())),
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
 			libvmi.WithPersistentVolumeClaim("disk0", pvc.Name),
 			libvmi.WithMemoryRequest("128Mi"),

--- a/tests/storage/hotplug.go
+++ b/tests/storage/hotplug.go
@@ -1199,7 +1199,7 @@ var _ = Describe(SIG("Hotplug", func() {
 
 			containerDiskVMIFunc := func() *v1.VirtualMachineInstance {
 				return libvmifact.NewAlpineWithTestTooling(
-					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+					libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithMasqueradeBinding())),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 				)
 			}
@@ -1219,7 +1219,7 @@ var _ = Describe(SIG("Hotplug", func() {
 					libvmi.WithDataVolume("disk0", dataVolume.Name),
 					libvmi.WithMemoryRequest("128Mi"),
 					libvmi.WithCloudInitNoCloud(libvmifact.WithDummyCloudForFastBoot()),
-					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+					libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithMasqueradeBinding())),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					// Stir things up, /dev/urandom access will be needed
 					libvmi.WithRng(),

--- a/tests/storage/migration.go
+++ b/tests/storage/migration.go
@@ -172,7 +172,7 @@ var _ = Describe(SIG("Volumes update with migration", decorators.RequiresTwoSche
 		createVMWithDV := func(dv *cdiv1.DataVolume, volName string) *virtv1.VirtualMachine {
 			vmi := libvmi.New(
 				libvmi.WithNamespace(ns),
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+				libvmi.WithInterface(libvmi.NewInterface(virtv1.DefaultPodNetwork().Name, libvmi.WithMasqueradeBinding())),
 				libvmi.WithNetwork(virtv1.DefaultPodNetwork()),
 				libvmi.WithMemoryRequest("128Mi"),
 				libvmi.WithDataVolume(volName, dv.Name),
@@ -283,7 +283,7 @@ var _ = Describe(SIG("Volumes update with migration", decorators.RequiresTwoSche
 				dv := createDV()
 				vmi := libvmi.New(
 					libvmi.WithNamespace(ns),
-					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+					libvmi.WithInterface(libvmi.NewInterface(virtv1.DefaultPodNetwork().Name, libvmi.WithMasqueradeBinding())),
 					libvmi.WithNetwork(virtv1.DefaultPodNetwork()),
 					libvmi.WithMemoryRequest("128Mi"),
 					libvmi.WithDataVolume(volName, dv.Name),
@@ -397,7 +397,7 @@ var _ = Describe(SIG("Volumes update with migration", decorators.RequiresTwoSche
 			Expect(err).ToNot(HaveOccurred())
 			vmi := libvmi.New(
 				libvmi.WithNamespace(ns),
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+				libvmi.WithInterface(libvmi.NewInterface(virtv1.DefaultPodNetwork().Name, libvmi.WithMasqueradeBinding())),
 				libvmi.WithNetwork(virtv1.DefaultPodNetwork()),
 				libvmi.WithMemoryRequest("256Mi"),
 				libvmi.WithDataVolume(volName, srcDV.Name),
@@ -619,7 +619,7 @@ var _ = Describe(SIG("Volumes update with migration", decorators.RequiresTwoSche
 			libstorage.CreateBlankFSDataVolume(destPVC, ns, size, nil)
 			vmi := libvmifact.NewAlpine(
 				libvmi.WithNamespace(ns),
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+				libvmi.WithInterface(libvmi.NewInterface(virtv1.DefaultPodNetwork().Name, libvmi.WithMasqueradeBinding())),
 				libvmi.WithNetwork(virtv1.DefaultPodNetwork()),
 				libvmi.WithMemoryRequest("128Mi"),
 				libvmi.WithDataVolume(volName, srcPVC),
@@ -717,7 +717,7 @@ var _ = Describe(SIG("Volumes update with migration", decorators.RequiresTwoSche
 			destDV := createBlankDV(virtClient, ns, size)
 			vmi := libvmi.New(
 				libvmi.WithNamespace(ns),
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+				libvmi.WithInterface(libvmi.NewInterface(virtv1.DefaultPodNetwork().Name, libvmi.WithMasqueradeBinding())),
 				libvmi.WithNetwork(virtv1.DefaultPodNetwork()),
 				libvmi.WithMemoryRequest("128Mi"),
 				libvmi.WithDataVolume(volName, dv1.Name),
@@ -856,7 +856,7 @@ var _ = Describe(SIG("Volumes update with migration", decorators.RequiresTwoSche
 			createAndStartVM := func(dv *cdiv1.DataVolume) *virtv1.VirtualMachine {
 				vmi := libvmi.New(
 					libvmi.WithNamespace(ns),
-					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+					libvmi.WithInterface(libvmi.NewInterface(virtv1.DefaultPodNetwork().Name, libvmi.WithMasqueradeBinding())),
 					libvmi.WithNetwork(virtv1.DefaultPodNetwork()),
 					libvmi.WithMemoryRequest("128Mi"),
 					libvmi.WithDataVolume(volName, dv.Name),
@@ -974,7 +974,7 @@ var _ = Describe(SIG("Volumes update with migration", decorators.RequiresTwoSche
 			dv := createBlankDV(virtClient, ns, "1Gi")
 			vmi := libvmifact.NewAlpine(
 				libvmi.WithNamespace(ns),
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+				libvmi.WithInterface(libvmi.NewInterface(virtv1.DefaultPodNetwork().Name, libvmi.WithMasqueradeBinding())),
 				libvmi.WithNetwork(virtv1.DefaultPodNetwork()),
 			)
 			vm := libvmi.NewVirtualMachine(vmi,
@@ -1111,7 +1111,7 @@ var _ = Describe(SIG("Volumes update with migration", decorators.RequiresTwoSche
 				dv := createBlankDV(virtClient, ns, "2G")
 				vmi := libvmifact.NewAlpineWithTestTooling(
 					libvmi.WithNamespace(ns),
-					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+					libvmi.WithInterface(libvmi.NewInterface(virtv1.DefaultPodNetwork().Name, libvmi.WithMasqueradeBinding())),
 					libvmi.WithNetwork(virtv1.DefaultPodNetwork()),
 				)
 				vm := libvmi.NewVirtualMachine(vmi,
@@ -1164,7 +1164,7 @@ var _ = Describe(SIG("Volumes update with migration", decorators.RequiresTwoSche
 				)
 				vmi := libvmi.New(
 					libvmi.WithNamespace(ns),
-					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+					libvmi.WithInterface(libvmi.NewInterface(virtv1.DefaultPodNetwork().Name, libvmi.WithMasqueradeBinding())),
 					libvmi.WithNetwork(virtv1.DefaultPodNetwork()),
 					// CPU manager clashes with hotplugging close to boot time, overriding the allowed hotplug volume
 					// For testing purposes, we're okay with using guaranteed QoS, which ensures CPU set gets set on boot

--- a/tests/storage/objectgraph_test.go
+++ b/tests/storage/objectgraph_test.go
@@ -78,7 +78,7 @@ var _ = Describe("[sig-storage]ObjectGraph", decorators.SigStorage, func() {
 			By("Creating a VM with dependencies")
 			vm = libvmi.NewVirtualMachine(
 				libvmi.New(
-					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+					libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithMasqueradeBinding())),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					libvmi.WithPersistentVolumeClaim("disk0", pvc.Name),
 					libvmi.WithAccessCredentialUserPassword(secret.Name),
@@ -271,7 +271,7 @@ var _ = Describe("[sig-storage]ObjectGraph", decorators.SigStorage, func() {
 			By("Creating and starting a VMI")
 			vmi = libvmi.New(
 				libvmi.WithMemoryRequest("128Mi"),
-				libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+				libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithMasqueradeBinding())),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 			)
 			var err error
@@ -312,7 +312,7 @@ var _ = Describe("[sig-storage]ObjectGraph", decorators.SigStorage, func() {
 			By("Creating a VM with instance type")
 			vm = libvmi.NewVirtualMachine(
 				libvmi.New(
-					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+					libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithMasqueradeBinding())),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 				),
 			)

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -283,7 +283,7 @@ var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 		BeforeEach(func() {
 			vm = libvmi.NewVirtualMachine(
 				libvmifact.NewAlpine(
-					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+					libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithMasqueradeBinding())),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 				))
 			vm.Labels = map[string]string{
@@ -1356,7 +1356,7 @@ var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 					libvmi.NewVirtualMachine(
 						libvmifact.NewAlpineWithTestTooling(
 							libvmi.WithNamespace(testsuite.GetTestNamespace(nil)),
-							libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+							libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithMasqueradeBinding())),
 							libvmi.WithNetwork(v1.DefaultPodNetwork()),
 							libvmi.WithDataVolume("blank", dv.Name),
 						),

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -1218,7 +1218,7 @@ var _ = Describe(SIG("VirtualMachineSnapshot Tests", func() {
 				)
 
 				vmi := libvmi.New(
-					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+					libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithMasqueradeBinding())),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					libvmi.WithMemoryRequest(memory),
 					libvmi.WithNamespace(testsuite.GetTestNamespace(nil)),
@@ -1283,7 +1283,7 @@ var _ = Describe(SIG("VirtualMachineSnapshot Tests", func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				vmi := libvmi.New(
-					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+					libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithMasqueradeBinding())),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					libvmi.WithMemoryRequest("128Mi"),
 					libvmi.WithNamespace(testsuite.GetTestNamespace(nil)),
@@ -1338,7 +1338,7 @@ var _ = Describe(SIG("VirtualMachineSnapshot Tests", func() {
 
 				By("Creating a VMI with persistent TPM")
 				vmi := libvmi.New(
-					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+					libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithMasqueradeBinding())),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					libvmi.WithMemoryRequest("128Mi"),
 					libvmi.WithNamespace(testsuite.GetTestNamespace(nil)),

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -548,7 +548,7 @@ var _ = Describe(SIG("Storage", func() {
 					DescribeTable("Should create a disk image and start", func(driver v1.DiskBus) {
 						By(startingVMInstance)
 						vmi = libvmi.New(
-							libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+							libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithMasqueradeBinding())),
 							libvmi.WithNetwork(v1.DefaultPodNetwork()),
 							libvmi.WithMemoryRequest("128Mi"),
 							libvmi.WithHostDisk("host-disk", diskPath, v1.HostDiskExistsOrCreate),
@@ -579,7 +579,7 @@ var _ = Describe(SIG("Storage", func() {
 					It("[test_id:3107]should start with multiple hostdisks in the same directory", func() {
 						By(startingVMInstance)
 						vmi = libvmi.New(
-							libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+							libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithMasqueradeBinding())),
 							libvmi.WithNetwork(v1.DefaultPodNetwork()),
 							libvmi.WithMemoryRequest("128Mi"),
 							libvmi.WithHostDisk("host-disk", diskPath, v1.HostDiskExistsOrCreate),
@@ -634,7 +634,7 @@ var _ = Describe(SIG("Storage", func() {
 					It("[test_id:2306]Should use existing disk image and start", func() {
 						By(startingVMInstance)
 						vmi = libvmi.New(
-							libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+							libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithMasqueradeBinding())),
 							libvmi.WithNetwork(v1.DefaultPodNetwork()),
 							libvmi.WithMemoryRequest("128Mi"),
 							libvmi.WithHostDisk("host-disk", diskPath, v1.HostDiskExists),
@@ -660,7 +660,7 @@ var _ = Describe(SIG("Storage", func() {
 					It("[test_id:847]Should fail with a capacity option", func() {
 						By(startingVMInstance)
 						vmi = libvmi.New(
-							libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+							libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithMasqueradeBinding())),
 							libvmi.WithNetwork(v1.DefaultPodNetwork()),
 							libvmi.WithMemoryRequest("128Mi"),
 							libvmi.WithHostDisk("host-disk", diskPath, v1.HostDiskExists),
@@ -683,7 +683,7 @@ var _ = Describe(SIG("Storage", func() {
 					It("[test_id:852]Should fail to start VMI", func() {
 						By(startingVMInstance)
 						vmi = libvmi.New(
-							libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+							libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithMasqueradeBinding())),
 							libvmi.WithNetwork(v1.DefaultPodNetwork()),
 							libvmi.WithMemoryRequest("128Mi"),
 							libvmi.WithHostDisk("host-disk", "/data/unknown.img", "unknown"),
@@ -727,7 +727,7 @@ var _ = Describe(SIG("Storage", func() {
 							libvmi.WithPersistentVolumeClaim("disk0", fmt.Sprintf("disk-%s", pvc)),
 							libvmi.WithMemoryRequest("256Mi"),
 							libvmi.WithNetwork(v1.DefaultPodNetwork()),
-							libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+							libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithMasqueradeBinding())),
 							libvmi.WithNodeSelectorFor(node))
 						vmi = libvmops.RunVMIAndExpectLaunch(vmi, flags.StartupTimeoutSecondsMedium())
 
@@ -813,7 +813,7 @@ var _ = Describe(SIG("Storage", func() {
 
 					By(startingVMInstance)
 					vmi = libvmi.New(
-						libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+						libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithMasqueradeBinding())),
 						libvmi.WithNetwork(v1.DefaultPodNetwork()),
 						libvmi.WithMemoryRequest("128Mi"),
 						libvmi.WithHostDisk("host-disk", diskPath, v1.HostDiskExistsOrCreate),
@@ -840,7 +840,7 @@ var _ = Describe(SIG("Storage", func() {
 
 					By(startingVMInstance)
 					vmi = libvmi.New(
-						libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+						libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithMasqueradeBinding())),
 						libvmi.WithNetwork(v1.DefaultPodNetwork()),
 						libvmi.WithMemoryRequest("128Mi"),
 						libvmi.WithHostDisk("host-disk", diskPath, v1.HostDiskExistsOrCreate),
@@ -1065,14 +1065,14 @@ var _ = Describe(SIG("Storage", func() {
 					},
 				}
 				vmi1 = libvmi.New(
-					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+					libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithMasqueradeBinding())),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					libvmi.WithDataVolume("disk0", dv.Name),
 					libvmi.WithMemoryRequest("1Gi"),
 					libvmi.WithLabel(labelKey, ""),
 				)
 				vmi2 = libvmi.New(
-					libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+					libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithMasqueradeBinding())),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					libvmi.WithDataVolume("disk0", dv.Name),
 					libvmi.WithMemoryRequest("1Gi"),


### PR DESCRIPTION
### What this PR does
#### Before this PR:
Test files in \`tests/storage/\` use legacy interface builders (\`InterfaceDeviceWithMasqueradeBinding\`) to construct interfaces.

#### After this PR:
All 9 test files in \`tests/storage/\` (32 call sites) use \`NewInterface\` with option functions introduced in #18263.

### References

- Introduced the builder pattern: #18263
- First conversion PR (\`tests/network/\`): #18391
- Second conversion PR (\`pkg/network/\`): #18452
- Third conversion PR (\`tests/migration/\`): #18499
- Fourth conversion PR (\`pkg/virt-launcher/\`): #18596

### Why we need it and why it was done in this way

Converting callers to the new builder pattern is a prerequisite for eventually deprecating the legacy functions. Splitting by directory keeps PRs reviewable and reduces merge conflict risk.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

/kind cleanup

```release-note
NONE
```