### PR TITLE
virt-controller/watch: expand linter coverage

### DIFF
--- a/hack/linter/lint-paths.txt
+++ b/hack/linter/lint-paths.txt
@@ -45,6 +45,7 @@ pkg/util/ratelimiter
 pkg/virt-controller/leaderelectionconfig
 pkg/virt-controller/watch/common
 pkg/virt-controller/watch/descheduler
+pkg/virt-controller/watch/testing
 pkg/virtctl/adm
 pkg/virtctl/clientconfig
 pkg/virtctl/configuration

--- a/hack/linter/lint-paths.txt
+++ b/hack/linter/lint-paths.txt
@@ -44,6 +44,7 @@ pkg/tpm
 pkg/util/ratelimiter
 pkg/virt-controller/leaderelectionconfig
 pkg/virt-controller/watch/common
+pkg/virt-controller/watch/descheduler
 pkg/virtctl/adm
 pkg/virtctl/clientconfig
 pkg/virtctl/configuration

--- a/pkg/virt-controller/watch/descheduler/descheduler.go
+++ b/pkg/virt-controller/watch/descheduler/descheduler.go
@@ -61,7 +61,9 @@ func MarkEvictionInProgress(virtClient kubecli.KubevirtClient, sourcePod *k8sv1.
 		return nil, err
 	}
 
-	pod, err := virtClient.CoreV1().Pods(sourcePod.Namespace).Patch(context.Background(), sourcePod.Name, types.JSONPatchType, patchBytes, v1.PatchOptions{})
+	pod, err := virtClient.CoreV1().Pods(sourcePod.Namespace).Patch(
+		context.Background(), sourcePod.Name, types.JSONPatchType, patchBytes, v1.PatchOptions{},
+	)
 	if err != nil {
 		log.Log.Object(sourcePod).Errorf("failed to add %s pod annotation: %v", EvictionInProgressAnnotation, err)
 		return nil, err
@@ -71,7 +73,6 @@ func MarkEvictionInProgress(virtClient kubecli.KubevirtClient, sourcePod *k8sv1.
 }
 
 func MarkEvictionCompleted(virtClient kubecli.KubevirtClient, sourcePod *k8sv1.Pod) (*k8sv1.Pod, error) {
-
 	if value, exists := sourcePod.GetAnnotations()[EvictionInProgressAnnotation]; exists {
 		patchSet := patch.New(
 			patch.WithTest(fmt.Sprintf("/metadata/annotations/%s", patch.EscapeJSONPointer(EvictionInProgressAnnotation)), value),
@@ -82,7 +83,9 @@ func MarkEvictionCompleted(virtClient kubecli.KubevirtClient, sourcePod *k8sv1.P
 			return nil, err
 		}
 
-		pod, err := virtClient.CoreV1().Pods(sourcePod.Namespace).Patch(context.Background(), sourcePod.Name, types.JSONPatchType, patchBytes, v1.PatchOptions{})
+		pod, err := virtClient.CoreV1().Pods(sourcePod.Namespace).Patch(
+			context.Background(), sourcePod.Name, types.JSONPatchType, patchBytes, v1.PatchOptions{},
+		)
 		if err != nil {
 			log.Log.Object(sourcePod).Errorf("failed to remove %s pod annotation : %v", EvictionInProgressAnnotation, err)
 			return nil, err

--- a/pkg/virt-controller/watch/testing/testing.go
+++ b/pkg/virt-controller/watch/testing/testing.go
@@ -16,6 +16,7 @@
  * Copyright The KubeVirt Authors.
  *
  */
+
 package testing
 
 import (
@@ -33,12 +34,20 @@ import (
 
 func MarkAsReady(vmi *v1.VirtualMachineInstance) {
 	vmi.Status.Phase = "Running"
-	controller.NewVirtualMachineInstanceConditionManager().AddPodCondition(vmi, &k8sv1.PodCondition{Type: k8sv1.PodReady, Status: k8sv1.ConditionTrue})
+	condManager := controller.NewVirtualMachineInstanceConditionManager()
+	condManager.AddPodCondition(vmi, &k8sv1.PodCondition{
+		Type:   k8sv1.PodReady,
+		Status: k8sv1.ConditionTrue,
+	})
 }
 
 func MarkAsNonReady(vmi *v1.VirtualMachineInstance) {
-	controller.NewVirtualMachineInstanceConditionManager().RemoveCondition(vmi, v1.VirtualMachineInstanceConditionType(k8sv1.PodReady))
-	controller.NewVirtualMachineInstanceConditionManager().AddPodCondition(vmi, &k8sv1.PodCondition{Type: k8sv1.PodReady, Status: k8sv1.ConditionFalse})
+	condManager := controller.NewVirtualMachineInstanceConditionManager()
+	condManager.RemoveCondition(vmi, v1.VirtualMachineInstanceConditionType(k8sv1.PodReady))
+	condManager.AddPodCondition(vmi, &k8sv1.PodCondition{
+		Type:   k8sv1.PodReady,
+		Status: k8sv1.ConditionFalse,
+	})
 }
 
 func VirtualMachineFromVMI(name string, vmi *v1.VirtualMachineInstance, started bool) *v1.VirtualMachine {
@@ -83,7 +92,7 @@ func NewRunningVirtualMachine(vmiName string, node *k8sv1.Node) *v1.VirtualMachi
 	return vmi
 }
 
-func DefaultVirtualMachineWithNames(started bool, vmName string, vmiName string) (*v1.VirtualMachine, *v1.VirtualMachineInstance) {
+func DefaultVirtualMachineWithNames(started bool, vmName, vmiName string) (*v1.VirtualMachine, *v1.VirtualMachineInstance) {
 	vmi := api.NewMinimalVMI(vmiName)
 	vmi.GenerateName = "prettyrandom"
 	vmi.Status.Phase = v1.Running


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Expand linter coverage to the `descheduler` and `testing` packages under `pkg/virt-controller/watch/`, fixing the existing violations to make them pass. Also remove an empty `BUILD.bazel` left
behind in the `dra` directory after its Go sources moved to `pkg/dra`.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

