### PR TITLE
Add VirtualMachinePool metrics

### DIFF
--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -98,6 +98,9 @@
 | kubevirt_vmi_vcpu_seconds_total | Metric | Counter | Total amount of time spent in each state by each vcpu (cpu_time excluding hypervisor time). Where `id` is the vcpu identifier and `state` can be one of the following: [`OFFLINE`, `RUNNING`, `BLOCKED`]. |
 | kubevirt_vmi_vcpu_wait_seconds_total | Metric | Counter | Amount of time spent by each vcpu while waiting on I/O. |
 | kubevirt_vmi_vnic_info | Metric | Gauge | Details of VirtualMachineInstance (VMI) vNIC interfaces, such as vNIC name, binding type, network name, and binding name for each vNIC of a running instance. |
+| kubevirt_vmpool_auto_healing_operations_total | Metric | Counter | Total number of successful auto healing operations performed by the VMPool. |
+| kubevirt_vmpool_vms_started_total | Metric | Counter | Total number of VMs started per pool. |
+| kubevirt_vmpool_vms_stopped_total | Metric | Counter | Total number of VMs stopped per pool. |
 | kubevirt_vmsnapshot_succeeded_timestamp_seconds | Metric | Gauge | Returns the timestamp of successful virtual machine snapshot. |
 | kubevirt_vnc_active_connections | Metric | Gauge | Amount of active VNC connections, broken down by namespace and vmi name. |
 | kubevirt_workqueue_adds_total | Metric | Counter | Total number of adds handled by workqueue |

--- a/pkg/monitoring/metrics/virt-controller/BUILD.bazel
+++ b/pkg/monitoring/metrics/virt-controller/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "migration_metrics.go",
         "migrationstats_collector.go",
         "perfscale_metrics.go",
+        "pool.go",
         "vmistats_collector.go",
         "vmsnapshot.go",
         "vmstats_collector.go",

--- a/pkg/monitoring/metrics/virt-controller/metrics.go
+++ b/pkg/monitoring/metrics/virt-controller/metrics.go
@@ -69,6 +69,7 @@ var (
 		migrationMetrics,
 		perfscaleMetrics,
 		vmSnapshotMetrics,
+		vmPoolMetrics,
 	}
 
 	indexers       *Indexers

--- a/pkg/monitoring/metrics/virt-controller/pool.go
+++ b/pkg/monitoring/metrics/virt-controller/pool.go
@@ -1,0 +1,68 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package virtcontroller
+
+import (
+	"github.com/rhobs/operator-observability-toolkit/pkg/operatormetrics"
+)
+
+var (
+	vmPoolMetrics = []operatormetrics.Metric{
+		vmPoolVMsStartedTotal,
+		vmPoolVMsStoppedTotal,
+		vmPoolAutoHealingOperationsTotal,
+	}
+
+	vmPoolVMsStartedTotal = operatormetrics.NewCounterVec(
+		operatormetrics.MetricOpts{
+			Name: "kubevirt_vmpool_vms_started_total",
+			Help: "Total number of VMs started per pool.",
+		},
+		[]string{"pool_name", "namespace"},
+	)
+
+	vmPoolVMsStoppedTotal = operatormetrics.NewCounterVec(
+		operatormetrics.MetricOpts{
+			Name: "kubevirt_vmpool_vms_stopped_total",
+			Help: "Total number of VMs stopped per pool.",
+		},
+		[]string{"pool_name", "namespace"},
+	)
+
+	vmPoolAutoHealingOperationsTotal = operatormetrics.NewCounterVec(
+		operatormetrics.MetricOpts{
+			Name: "kubevirt_vmpool_auto_healing_operations_total",
+			Help: "Total number of successful auto healing operations performed by the VMPool.",
+		},
+		[]string{"pool_name", "namespace"},
+	)
+)
+
+func RecordVMPoolVMStarted(poolName, namespace string) {
+	vmPoolVMsStartedTotal.WithLabelValues(poolName, namespace).Inc()
+}
+
+func RecordVMPoolVMStopped(poolName, namespace string) {
+	vmPoolVMsStoppedTotal.WithLabelValues(poolName, namespace).Inc()
+}
+
+func RecordVMPoolAutoHealingOperation(poolName, namespace string) {
+	vmPoolAutoHealingOperationsTotal.WithLabelValues(poolName, namespace).Inc()
+}

--- a/pkg/virt-controller/watch/pool/BUILD.bazel
+++ b/pkg/virt-controller/watch/pool/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//pkg/apimachinery/patch:go_default_library",
         "//pkg/controller:go_default_library",
+        "//pkg/monitoring/metrics/virt-controller:go_default_library",
         "//pkg/pointer:go_default_library",
         "//pkg/util/trace:go_default_library",
         "//pkg/virt-controller/watch/common:go_default_library",

--- a/pkg/virt-controller/watch/pool/pool.go
+++ b/pkg/virt-controller/watch/pool/pool.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
+	virtcontroller "kubevirt.io/kubevirt/pkg/monitoring/metrics/virt-controller"
 	"kubevirt.io/kubevirt/pkg/pointer"
 
 	virtv1 "kubevirt.io/api/core/v1"
@@ -217,6 +218,20 @@ func (c *Controller) addVMIHandler(obj interface{}) {
 }
 
 func (c *Controller) updateVMIHandler(old, cur interface{}) {
+	oldVMI := old.(*virtv1.VirtualMachineInstance)
+	curVMI := cur.(*virtv1.VirtualMachineInstance)
+	if oldVMI.ResourceVersion == curVMI.ResourceVersion {
+		return
+	}
+
+	if pool := c.getVMPoolFromVMI(curVMI); pool != "" {
+		if oldVMI.Status.Phase != virtv1.Running && curVMI.Status.Phase == virtv1.Running {
+			virtcontroller.RecordVMPoolVMStarted(pool, curVMI.Namespace)
+		} else if oldVMI.Status.Phase == virtv1.Running && curVMI.Status.Phase != virtv1.Running {
+			virtcontroller.RecordVMPoolVMStopped(pool, curVMI.Namespace)
+		}
+	}
+
 	c.addVMIHandler(cur)
 }
 
@@ -1981,7 +1996,16 @@ func isAutohealingEnabled(pool *poolv1.VirtualMachinePool) bool {
 func (c *Controller) autoHealFailingVMs(pool *poolv1.VirtualMachinePool, vms []*virtv1.VirtualMachine) error {
 	vmsToCleanup := filterFailingVMsToStart(vms, pool.Spec.Autohealing)
 
-	return c.scaleIn(pool, vmsToCleanup, len(vmsToCleanup))
+	if len(vmsToCleanup) == 0 {
+		return nil
+	}
+
+	if err := c.scaleIn(pool, vmsToCleanup, len(vmsToCleanup)); err != nil {
+		return err
+	}
+
+	virtcontroller.RecordVMPoolAutoHealingOperation(pool.Name, pool.Namespace)
+	return nil
 }
 
 func filterFailingVMsToStart(vms []*virtv1.VirtualMachine, autohealing *poolv1.VirtualMachinePoolAutohealingStrategy) []*virtv1.VirtualMachine {
@@ -2104,4 +2128,18 @@ func preserveVMIdentityFields(originalVM, updatedVM *virtv1.VirtualMachine) {
 			updatedSpec.Domain.Firmware.Serial = originalSpec.Domain.Firmware.Serial
 		}
 	}
+}
+
+func (c *Controller) getVMPoolFromVMI(vmi *virtv1.VirtualMachineInstance) string {
+	vmRef := metav1.GetControllerOf(vmi)
+	if vmRef != nil {
+		if vm := c.resolveVMIControllerRef(vmi.Namespace, vmRef); vm != nil {
+			if poolRef := metav1.GetControllerOf(vm); poolRef != nil {
+				if pool := c.resolveControllerRef(vm.Namespace, poolRef); pool != nil {
+					return pool.Name
+				}
+			}
+		}
+	}
+	return ""
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
There are no metrics collected that are specific to the VMPool objects.

#### After this PR:
Added

- A metric to measure the number of VM starts within a pool.
- A metric to measure the number of VM stops within a pool.
- A metric to measure the autohealing operations performed.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add VirtualMachinePool metrics
```

