### PR TITLE
fix(virt-operator): use kind-based dispatch in getKVMapFromSpec for JSON serialization

### DIFF
--- a/pkg/virt-operator/util/config.go
+++ b/pkg/virt-operator/util/config.go
@@ -245,16 +245,19 @@ func getKVMapFromSpec(spec v1.KubeVirtSpec) map[string]string {
 			// these are handled in the root deployment config already
 			continue
 		}
-		if name == "ImagePullSecrets" {
-			value, err := json.Marshal(v.Field(i).Interface())
+		field := v.Field(i)
+		var value string
+		switch field.Type().Kind() {
+		case reflect.String:
+			value = field.String()
+		default:
+			bytes, err := json.Marshal(field.Interface())
 			if err != nil {
-				fmt.Printf("Cannot encode ImagePullsecrets to JSON %v", err)
-			} else {
-				kvMap[name] = string(value)
+				fmt.Printf("Cannot encode %s to JSON %v", name, err)
+				continue
 			}
-			continue
+			value = string(bytes)
 		}
-		value := v.Field(i).String()
 		kvMap[name] = value
 	}
 	return kvMap

--- a/pkg/virt-operator/util/config_test.go
+++ b/pkg/virt-operator/util/config_test.go
@@ -19,6 +19,7 @@
 package util
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"strings"
@@ -28,6 +29,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 
 	k8sv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/rand"
 )
 
@@ -359,6 +361,67 @@ var _ = Describe("Operator Config", func() {
 			Entry(fmt.Sprintf("provided via old %s env variable - expected to pass", OldOperatorImageEnvName), OldOperatorImageEnvName, true),
 			Entry("not provided at all - expected to fail", "", false),
 		)
+	})
+
+	Describe("getKVMapFromSpec", func() {
+		It("should serialize string fields as plain strings", func() {
+			spec := v1.KubeVirtSpec{
+				ImagePullPolicy: k8sv1.PullAlways,
+			}
+			result := getKVMapFromSpec(spec)
+			Expect(result).To(HaveKeyWithValue("ImagePullPolicy", "Always"))
+		})
+
+		It("should serialize struct fields as JSON", func() {
+			spec := v1.KubeVirtSpec{
+				CertificateRotationStrategy: v1.KubeVirtCertificateRotateStrategy{
+					SelfSigned: &v1.KubeVirtSelfSignConfiguration{
+						CARotateInterval:   &metav1.Duration{Duration: 1},
+						CAOverlapInterval:  &metav1.Duration{Duration: 1},
+						CertRotateInterval: &metav1.Duration{Duration: 1},
+					},
+				},
+			}
+			result := getKVMapFromSpec(spec)
+			value, ok := result["CertificateRotationStrategy"]
+			Expect(ok).To(BeTrue())
+			Expect(json.Valid([]byte(value))).To(BeTrue(),
+				fmt.Sprintf("expected valid JSON, got: %s", value))
+		})
+
+		It("should serialize pointer-to-struct fields as JSON", func() {
+			spec := v1.KubeVirtSpec{
+				Infra: &v1.ComponentConfig{
+					NodePlacement: &v1.NodePlacement{
+						NodeSelector: map[string]string{"node-role.kubernetes.io/compute": "true"},
+					},
+				},
+			}
+			result := getKVMapFromSpec(spec)
+			value, ok := result["Infra"]
+			Expect(ok).To(BeTrue())
+			Expect(json.Valid([]byte(value))).To(BeTrue(),
+				fmt.Sprintf("expected valid JSON, got: %s", value))
+			Expect(value).To(ContainSubstring("node-role.kubernetes.io/compute"))
+		})
+
+		It("should serialize nil pointer fields as null", func() {
+			spec := v1.KubeVirtSpec{}
+			result := getKVMapFromSpec(spec)
+			value, ok := result["Infra"]
+			Expect(ok).To(BeTrue())
+			Expect(value).To(Equal("null"))
+		})
+
+		It("should skip ImageTag and ImageRegistry", func() {
+			spec := v1.KubeVirtSpec{
+				ImageTag:      "v1.0.0",
+				ImageRegistry: "quay.io/kubevirt",
+			}
+			result := getKVMapFromSpec(spec)
+			Expect(result).ToNot(HaveKey("ImageTag"))
+			Expect(result).ToNot(HaveKey("ImageRegistry"))
+		})
 	})
 
 	Context("kubevirt version", func() {


### PR DESCRIPTION
…SON serialization

Replace name-based field special-casing with kind-based dispatch in getKVMapFromSpec. Previously, all non-string Spec fields (structs, pointers, slices) produced Go reflect type strings like '<v1.KubeVirtCertificateRotateStrategy Value>' instead of proper JSON in status.observedDeploymentConfig / status.targetDeploymentConfig.

Use reflect.String for .String() serialization and json.Marshal for all other kinds. This eliminates the ImagePullSecrets name-based special case since slices are naturally handled by json.Marshal.

Upgrade note: struct/pointer field values in AdditionalProperties will change format on upgrade, causing a one-time deployment ID change and single extra reconciliation cycle — no different from any other config-affecting change between versions.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
getKVMapFromSpec in pkg/virt-operator/util/config.go serializes KubeVirtSpec fields into AdditionalProperties (a map[string]string), which is then stored in status.observedDeploymentConfig and status.targetDeploymentConfig. For struct/pointer/slice fields, it calls reflect.Value.String(), producing Go reflect type strings like <v1.KubeVirtCertificateRotateStrategy Value> or <*v1.ComponentConfig Value> instead of proper JSON.

#### After this PR:
Uses kind-based dispatch: reflect.String fields use .String(), all other kinds use json.Marshal. This ensures struct, pointer, and slice fields are serialized as valid JSON. The ImagePullSecrets name-based special case is removed since slices are naturally handled by json.Marshal.

### References

Fixes #18602
  
### Why we need it and why it was done in this way
The current status.observedDeploymentConfig and status.targetDeploymentConfig contain unreadable Go type descriptors for structured Spec fields, making them unusable for debugging or automation. The kind-based approach is more maintainable than enumerating field names — it automatically handles new types added to KubeVirtSpec without code changes.

The following tradeoffs were made:
- One-time extra reconciliation cycle on upgrade as deployment IDs change due to corrected serialization format. This is no different from any other config-affecting change between versions and has no risk of infinite reconciliation loop.

The following alternatives were considered:
- Continue with name-based special cases for every struct field — rejected as fragile and verbose.
- Remove struct/pointer fields from AdditionalProperties entirely — rejected as it would change the deployment ID computation and break existing consumers that expect these fields.

Links to places where the discussion took place: https://github.com/kubevirt/kubevirt/issues/18602

### Special notes for your reviewer
Unit tests added for getKVMapFromSpec covering string fields, struct fields, pointer-to-struct fields, nil pointer fields, and ImageTag/ImageRegistry exclusion.


<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix KubeVirt CR status.observedDeploymentConfig and status.targetDeploymentConfig containing Go reflect type strings instead of JSON for struct-typed Spec fields
```