### PR TITLE
fix: gate migration source ownership transfer on domainMigrated

### DIFF
--- a/pkg/virt-handler/migration-source.go
+++ b/pkg/virt-handler/migration-source.go
@@ -217,69 +217,79 @@ func (c *MigrationSourceController) setMigrationProgressStatus(vmi *v1.VirtualMa
 	vmi.Status.MigrationState.Mode = migrationMetadata.Mode
 }
 
+// failPostMigration marks the VMI as failed after a completed domain migration
+// when ownership cannot be transferred. MigrationState mutations are skipped
+// (with a warning) if MigrationState is unexpectedly nil.
+func (c *MigrationSourceController) failPostMigration(vmi *v1.VirtualMachineInstance) {
+	vmi.Status.Phase = v1.Failed
+	if vmi.Status.MigrationState == nil {
+		c.logger.Object(vmi).Warning("cannot update MigrationState on failed post-migration: MigrationState is nil")
+		return
+	}
+	vmi.Status.MigrationState.Completed = true
+	vmi.Status.MigrationState.Failed = true
+	if vmi.Status.MigrationState.EndTimestamp == nil {
+		vmi.Status.MigrationState.EndTimestamp = pointer.P(metav1.NewTime(time.Now()))
+	}
+}
+
 func (c *MigrationSourceController) updateStatus(vmi *v1.VirtualMachineInstance, domain *api.Domain) error {
 	c.setMigrationProgressStatus(vmi, domain)
 
-	// handle migrations differently than normal status updates.
+	// Once the domain has migrated off this node, finalize the source-side handoff:
 	//
-	// When a successful migration is detected, we must transfer ownership of the VMI
-	// from the source node (this node) to the target node (node the domain was migrated to).
+	//  1. Require MigrationState.TargetNode (known target).
+	//  2. Wait up to 60s from EndTimestamp for TargetState.DomainDetected and
+	//     DomainReadyTimestamp (hasTargetDetectedReadyDomain requeues while waiting).
+	//  3. If the target is unknown or never reports readiness, mark the VMI Failed
+	//     so the cluster VMI controller can tear down pods.
+	//  4. For decentralized migrations, set Phase=Succeeded when the target has
+	//     confirmed readiness and MigrationState.Completed is set.
 	//
-	// Transfer ownership by...
-	// 1. Marking vmi.Status.MigrationState as completed
-	// 2. Update the vmi.Status.NodeName to reflect the target node's name
-	// 3. Update the VMI's NodeNameLabel annotation to reflect the target node's name
-	// 4. Clear the LauncherContainerImageVersion which virt-controller will detect
-	//    and accurately based on the version used on the target pod
-	//
-	// After a migration, the VMI's phase is no longer owned by this node. Only the
-	// MigrationState status field is eligible to be mutated.
-	migrationHost := ""
-	if vmi.Status.MigrationState != nil {
-		migrationHost = vmi.Status.MigrationState.TargetNode
-	}
-
-	targetNodeDetectedDomain, timeLeft := c.hasTargetDetectedReadyDomain(vmi)
-	// If we can't detect where the migration went to, then we have no
-	// way of transferring ownership. The only option here is to move the
-	// vmi to failed.  The cluster vmi controller will then tear down the
-	// resulting pods.
-	if migrationHost == "" {
-		// migrated to unknown host.
-		vmi.Status.Phase = v1.Failed
-		vmi.Status.MigrationState.Completed = true
-		vmi.Status.MigrationState.Failed = true
-		if vmi.Status.MigrationState.EndTimestamp == nil {
-			vmi.Status.MigrationState.EndTimestamp = pointer.P(metav1.NewTime(time.Now()))
+	// NodeName/label transfer is done by the target controller's
+	// ackMigrationCompletion, not here. After migration the source normally must
+	// not mutate Phase; steps 3 and 4 are the only exceptions.
+	if domainMigrated(domain) {
+		migrationHost := ""
+		if vmi.Status.MigrationState != nil {
+			migrationHost = vmi.Status.MigrationState.TargetNode
 		}
 
-		c.logger.Object(vmi).Warning("the vmi migrated to an unknown host")
-		c.recorder.Event(vmi, k8sv1.EventTypeWarning, v1.Migrated.String(), fmt.Sprintf("The VirtualMachineInstance migrated to unknown host."))
-	} else if !targetNodeDetectedDomain {
-		if timeLeft <= 0 {
-			vmi.Status.Phase = v1.Failed
+		targetNodeDetectedDomain, timeLeft := c.hasTargetDetectedReadyDomain(vmi)
+		if migrationHost == "" {
+			// No TargetNode → cannot hand off; fail so the cluster controller cleans up.
+			c.failPostMigration(vmi)
+			c.logger.Object(vmi).Warning("the vmi migrated to an unknown host")
+			c.recorder.Event(vmi, k8sv1.EventTypeWarning, v1.Migrated.String(), fmt.Sprintf("The VirtualMachineInstance migrated to unknown host."))
+		} else if !targetNodeDetectedDomain {
+			if timeLeft <= 0 {
+				// Target never ACK'd the domain within the grace window.
+				c.failPostMigration(vmi)
+				c.logger.Object(vmi).Warning("the domain was never observed on the target after the migration completed within the timeout period")
+				c.recorder.Event(vmi, k8sv1.EventTypeWarning, v1.Migrated.String(), fmt.Sprintf("The VirtualMachineInstance's domain was never observed on the target after the migration completed within the timeout period."))
+			}
+			// else: still waiting for target ACK (requeued by hasTargetDetectedReadyDomain).
+		}
+
+		// Decentralized migrations have no shared VMI controller to advance phase;
+		// the source marks Succeeded once the target has the domain and migration completed.
+		if targetNodeDetectedDomain && vmi.IsDecentralizedMigration() && vmi.Status.MigrationState != nil && vmi.Status.MigrationState.Completed {
+			c.logger.Object(vmi).V(2).Infof("decentralized migration completed successfully, marking VMI as succeeded")
+			vmi.Status.Phase = v1.Succeeded
+		}
+	}
+
+	// Keep MigrationState aligned when a decentralized source VMI is already Failed
+	// (e.g. via failPostMigration above).
+	if vmi.Status.Phase == v1.Failed && vmi.IsDecentralizedMigration() {
+		if vmi.Status.MigrationState == nil {
+			c.logger.Object(vmi).Warning("cannot update MigrationState on failed decentralized migration: MigrationState is nil")
+		} else {
 			vmi.Status.MigrationState.Completed = true
 			vmi.Status.MigrationState.Failed = true
-			if vmi.Status.MigrationState.EndTimestamp == nil {
-				vmi.Status.MigrationState.EndTimestamp = pointer.P(metav1.NewTime(time.Now()))
-			}
-
-			c.logger.Object(vmi).Warning("the domain was never observed on the taget after the migration completed within the timeout period")
-			c.recorder.Event(vmi, k8sv1.EventTypeWarning, v1.Migrated.String(), fmt.Sprintf("The VirtualMachineInstance's domain was never observed on the target after the migration completed within the timeout period."))
 		}
-	}
-
-	if vmi.Status.Phase == v1.Failed && vmi.IsDecentralizedMigration() {
-		vmi.Status.MigrationState.Completed = true
-		vmi.Status.MigrationState.Failed = true
 		c.logger.Object(vmi).Warning("the decentralized migration failed due to the source VMI being failed")
 		c.recorder.Event(vmi, k8sv1.EventTypeWarning, v1.Migrated.String(), fmt.Sprintf("The VirtualMachineInstance's decentralized migration failed due to the source VMI being failed."))
-	}
-
-	if targetNodeDetectedDomain && vmi.IsDecentralizedMigration() && vmi.Status.MigrationState != nil && vmi.Status.MigrationState.Completed {
-		c.logger.Object(vmi).V(2).Infof("decentralized migration completed successfully, marking VMI as succeeded")
-		// this is a decentralized migration, and the migration completed successfully, we need to mark the VMI as succeeded
-		vmi.Status.Phase = v1.Succeeded
 	}
 
 	return nil

--- a/pkg/virt-handler/migration-source_test.go
+++ b/pkg/virt-handler/migration-source_test.go
@@ -393,6 +393,142 @@ var _ = Describe("VirtualMachineInstance migration target", func() {
 		})
 	})
 
+	Context("failPostMigration", func() {
+		DescribeTable("should mark the VMI as failed",
+			func(migrationState *v1.VirtualMachineInstanceMigrationState, expectMigrationStateUpdated bool) {
+				vmi := libvmi.New(libvmistatus.WithStatus(libvmistatus.New(
+					libvmistatus.WithPhase(v1.Running),
+				)))
+				vmi.Status.MigrationState = migrationState
+
+				Expect(func() { controller.failPostMigration(vmi) }).ToNot(Panic())
+				Expect(vmi.Status.Phase).To(Equal(v1.Failed))
+
+				if !expectMigrationStateUpdated {
+					Expect(vmi.Status.MigrationState).To(BeNil())
+					return
+				}
+
+				Expect(vmi.Status.MigrationState).ToNot(BeNil())
+				Expect(vmi.Status.MigrationState.Completed).To(BeTrue())
+				Expect(vmi.Status.MigrationState.Failed).To(BeTrue())
+				Expect(vmi.Status.MigrationState.EndTimestamp).ToNot(BeNil())
+			},
+			Entry("when MigrationState is nil", nil, false),
+			Entry("when MigrationState is present", &v1.VirtualMachineInstanceMigrationState{}, true),
+		)
+
+		It("should preserve an existing EndTimestamp", func() {
+			existingEnd := metav1.NewTime(time.Now().Add(-time.Minute))
+			vmi := libvmi.New(libvmistatus.WithStatus(libvmistatus.New(
+				libvmistatus.WithPhase(v1.Running),
+				libvmistatus.WithMigrationState(v1.VirtualMachineInstanceMigrationState{
+					EndTimestamp: &existingEnd,
+				}),
+			)))
+
+			controller.failPostMigration(vmi)
+
+			Expect(vmi.Status.MigrationState.EndTimestamp).To(Equal(&existingEnd))
+			Expect(vmi.Status.MigrationState.Completed).To(BeTrue())
+			Expect(vmi.Status.MigrationState.Failed).To(BeTrue())
+		})
+	})
+
+	Context("updateStatus after domain migration", func() {
+		migratedDomain := func() *api.Domain {
+			d := api.NewMinimalDomain("testvmi")
+			d.Status.Status = api.Shutoff
+			d.Status.Reason = api.ReasonMigrated
+			return d
+		}
+
+		It("should not finalize handoff while the domain is still running", func() {
+			vmi := libvmi.New(libvmistatus.WithStatus(libvmistatus.New(
+				libvmistatus.WithPhase(v1.Running),
+				libvmistatus.WithMigrationState(v1.VirtualMachineInstanceMigrationState{
+					SourceNode: host,
+				}),
+			)))
+			originalStatus := vmi.Status.DeepCopy()
+
+			runningDomain := api.NewMinimalDomain("testvmi")
+			runningDomain.Status.Status = api.Running
+
+			Expect(controller.updateStatus(vmi, runningDomain)).To(Succeed())
+			Expect(vmi.Status).To(Equal(*originalStatus))
+		})
+
+		It("should not panic and should fail the VMI when MigrationState is nil", func() {
+			vmi := libvmi.New(libvmistatus.WithStatus(libvmistatus.New(
+				libvmistatus.WithPhase(v1.Running),
+			)))
+
+			Expect(func() {
+				Expect(controller.updateStatus(vmi, migratedDomain())).To(Succeed())
+			}).ToNot(Panic())
+
+			Expect(vmi.Status.Phase).To(Equal(v1.Failed))
+			Expect(vmi.Status.MigrationState).To(BeNil())
+			testutils.ExpectEvent(recorder, v1.Migrated.String())
+		})
+
+		It("should fail the VMI when TargetNode is empty", func() {
+			vmi := libvmi.New(libvmistatus.WithStatus(libvmistatus.New(
+				libvmistatus.WithPhase(v1.Running),
+				libvmistatus.WithMigrationState(v1.VirtualMachineInstanceMigrationState{}),
+			)))
+
+			Expect(controller.updateStatus(vmi, migratedDomain())).To(Succeed())
+
+			Expect(vmi.Status.Phase).To(Equal(v1.Failed))
+			Expect(vmi.Status.MigrationState.Completed).To(BeTrue())
+			Expect(vmi.Status.MigrationState.Failed).To(BeTrue())
+			Expect(vmi.Status.MigrationState.EndTimestamp).ToNot(BeNil())
+			testutils.ExpectEvent(recorder, v1.Migrated.String())
+		})
+
+		It("should fail the VMI when the target never detects the domain within the timeout", func() {
+			oldEnd := metav1.NewTime(time.Now().Add(-2 * time.Minute))
+			vmi := libvmi.New(libvmistatus.WithStatus(libvmistatus.New(
+				libvmistatus.WithPhase(v1.Running),
+				libvmistatus.WithMigrationState(v1.VirtualMachineInstanceMigrationState{
+					TargetNode:   "othernode",
+					EndTimestamp: &oldEnd,
+				}),
+			)))
+
+			Expect(controller.updateStatus(vmi, migratedDomain())).To(Succeed())
+
+			Expect(vmi.Status.Phase).To(Equal(v1.Failed))
+			Expect(vmi.Status.MigrationState.Completed).To(BeTrue())
+			Expect(vmi.Status.MigrationState.Failed).To(BeTrue())
+			Expect(vmi.Status.MigrationState.EndTimestamp).To(Equal(&oldEnd))
+			testutils.ExpectEvent(recorder, v1.Migrated.String())
+		})
+
+		It("should not fail the VMI when the target has detected the domain", func() {
+			now := metav1.Now()
+			vmi := libvmi.New(libvmistatus.WithStatus(libvmistatus.New(
+				libvmistatus.WithPhase(v1.Running),
+				libvmistatus.WithMigrationState(v1.VirtualMachineInstanceMigrationState{
+					TargetNode:   "othernode",
+					EndTimestamp: &now,
+					TargetState: &v1.VirtualMachineInstanceMigrationTargetState{
+						DomainDetected:       true,
+						DomainReadyTimestamp: &now,
+					},
+				}),
+			)))
+
+			Expect(controller.updateStatus(vmi, migratedDomain())).To(Succeed())
+
+			Expect(vmi.Status.Phase).To(Equal(v1.Running))
+			Expect(vmi.Status.MigrationState.Failed).To(BeFalse())
+			Expect(vmi.Status.MigrationState.Completed).To(BeFalse())
+		})
+	})
+
 	Context("handleMigrationAbort", func() {
 		DescribeTable("should abort the migration with an abort request", func(vmi *v1.VirtualMachineInstance, domain *api.Domain) {
 			client.EXPECT().CancelVirtualMachineMigration(vmi)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Restore the pre-split VMI controller guard so the unknown-host failure path only runs after the domain has actually migrated off the source node, instead of racing when SourceNode is set before TargetNode.

#### Before this PR:
There is a race where SourceNode can be set before TargetNode, this would cause a migration failure where everything is fine, just the status update was wrong.

#### After this PR:
The race is no longer a problem, we restored the domainMigrated guard.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: Fixed race condition where target node and source fields were racing which could cause a migration failed.
```

