### PR TITLE
[release-1.6] virt-handler: Avoid spam filter by sending one graceful shutdown event

### DIFF
--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -1545,6 +1545,8 @@ func (c *VirtualMachineController) processVmShutdown(vmi *v1.VirtualMachineInsta
 	return c.helperVmShutdown(vmi, domain, tryGracefully)
 }
 
+const firstGracefulShutdownAttempt = -1
+
 // Determines if a domain's grace period has expired during shutdown.
 // If the grace period has started but not expired, timeLeft represents
 // the time in seconds left until the period expires.
@@ -1575,7 +1577,7 @@ func (c *VirtualMachineController) hasGracePeriodExpired(terminationGracePeriod 
 	if startTime == 0 {
 		// If gracePeriod > 0, then the shutdown signal needs to be sent
 		// and the gracePeriod start time needs to be set.
-		timeLeft = -1
+		timeLeft = firstGracefulShutdownAttempt
 		return hasExpired, timeLeft
 	}
 
@@ -1654,12 +1656,12 @@ func (c *VirtualMachineController) shutdownVMI(vmi *v1.VirtualMachineInstance, c
 	// EventSourceObjectSpamFilter when gracefully shutting down VMIs with a
 	// large TerminationGracePeriodSeconds value set. Hitting this limit can
 	// result in the eventual VMIShutdown event being dropped.
-	if timeLeft == -1 {
+	if timeLeft == firstGracefulShutdownAttempt {
 		c.recorder.Event(vmi, k8sv1.EventTypeNormal, v1.ShuttingDown.String(), VMIGracefulShutdown)
 	}
 
 	// Make sure that we don't hot-loop in case we send the first domain notification
-	if timeLeft == -1 {
+	if timeLeft == firstGracefulShutdownAttempt {
 		timeLeft = 5
 		if vmi.Spec.TerminationGracePeriodSeconds != nil && *vmi.Spec.TerminationGracePeriodSeconds < timeLeft {
 			timeLeft = *vmi.Spec.TerminationGracePeriodSeconds

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -245,6 +245,13 @@ var _ = Describe("VirtualMachineInstance", func() {
 		controller.queue.Add(key)
 	}
 
+	updateDomain := func(domain *api.Domain) {
+		Expect(controller.domainStore.Update(domain)).To(Succeed())
+		key, err := virtcontroller.KeyFunc(domain)
+		Expect(err).ToNot(HaveOccurred())
+		controller.queue.Add(key)
+	}
+
 	sanityExecute := func() {
 		controllertesting.SanityExecute(controller, []cache.Store{
 			controller.domainStore, controller.vmiStore,
@@ -369,6 +376,29 @@ var _ = Describe("VirtualMachineInstance", func() {
 
 			sanityExecute()
 			testutils.ExpectEvent(recorder, VMIGracefulShutdown)
+		})
+
+		It("should only emit one graceful shutdown event", func() {
+			vmi := api2.NewMinimalVMI("testvmi")
+			vmi.UID = vmiTestUUID
+
+			domain := api.NewMinimalDomainWithUUID("testvmi", vmiTestUUID)
+			domain.Status.Status = api.Running
+
+			initGracePeriodHelper(600, vmi, domain)
+
+			client.EXPECT().ShutdownVirtualMachine(v1.NewVMIReferenceWithUUID(metav1.NamespaceDefault, "testvmi", vmiTestUUID)).Times(2)
+			addDomain(domain)
+
+			sanityExecute()
+			testutils.ExpectEvent(recorder, VMIGracefulShutdown)
+
+			// Set the DeletionTimestamp within the domain so this is treated as a graceful shutdown retry
+			domain.Spec.Metadata.KubeVirt.GracePeriod.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+			updateDomain(domain)
+
+			// AfterEach will assert that no additional events are seen
+			sanityExecute()
 		})
 
 		It("should attempt graceful shutdown and take the VMI grace period over the cached Domain grace", func() {


### PR DESCRIPTION
### What this PR does
#### Before this PR:
The VMIGracefulShutdown event was sent on every graceful shutdown retry, easily hitting the default EventSourceObjectSpamFilter burst limit of 25 for VMIs with a large TerminationGracePeriodSeconds. This could result in the eventual VMIShutdown event being dropped.

#### After this PR:
Only a single VMIGracefulShutdown event is sent after the initial shutdown request. Repeat attempts are still logged within virt-handler.

### References

- Cherry-pick of #15759
- Supersedes #15823 (kubevirt-bot cherry-pick with a broken unit test)
- Partially addresses #15758

### Why we need it and why it was done in this way

This is a cherry-pick of #15759 to release-1.6. The original kubevirt-bot cherry-pick #15823 had a unit test bug where `libvmi.New` was used for the mock expectation instead of `v1.NewVMIReferenceWithUUID`, causing a name mismatch due to the randomized suffix generated by `libvmi.New`.

### Special notes for your reviewer

The only change from the original #15759 is the unit test fix in the mock expectation (using `v1.NewVMIReferenceWithUUID` instead of `libvmi.New`).

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Testing: Unit test included and fixed

### Release note
```release-note
Only a single `Signaled Graceful Shutdown` event is now sent to avoid spamming the event recorder during long graceful shutdown attempts
```