### PR TITLE
hw_utils: skip memoryless NUMA cells in vCPU-to-cell mapping

### DIFF
--- a/pkg/util/hardware/hw_utils.go
+++ b/pkg/util/hardware/hw_utils.go
@@ -265,6 +265,11 @@ func LookupDevicesNumaNodesWithWarnings(pciAddresses []string, domainSpec *api.D
 	// vcpu -> vnuma mapping
 	vCPUToCellMap := make(map[uint32]uint32)
 	for _, cell := range domainSpec.CPU.NUMA.Cells {
+		// Memoryless NUMA cells (e.g. Grace GI nodes) have no CPUs — skip
+		// them here rather than treating the empty string as a parse error.
+		if cell.CPUs == "" {
+			continue
+		}
 		vcpusInCell, err := ParseCPUSetLine(cell.CPUs, MAX_CPU_LIMIT)
 		if err != nil {
 			warnings = append(warnings, DeviceNUMANodeLookupWarning{

--- a/pkg/util/hardware/hw_utils.go
+++ b/pkg/util/hardware/hw_utils.go
@@ -265,6 +265,10 @@ func LookupDevicesNumaNodesWithWarnings(pciAddresses []string, domainSpec *api.D
 	// vcpu -> vnuma mapping
 	vCPUToCellMap := make(map[uint32]uint32)
 	for _, cell := range domainSpec.CPU.NUMA.Cells {
+		// Memoryless cells (e.g. Grace GI nodes) carry no CPUs; skip rather than treating "" as a parse error.
+		if cell.CPUs == "" {
+			continue
+		}
 		vcpusInCell, err := ParseCPUSetLine(cell.CPUs, MAX_CPU_LIMIT)
 		if err != nil {
 			warnings = append(warnings, DeviceNUMANodeLookupWarning{

--- a/pkg/util/hardware/hw_utils_test.go
+++ b/pkg/util/hardware/hw_utils_test.go
@@ -497,6 +497,34 @@ var _ = Describe("Hardware utils test", func() {
 			Expect(devicesNumaNodes).To(Equal(map[string]uint32{testPCIAddress: 0}))
 		})
 
+		It("should silently skip memoryless NUMA cells with no CPUs", func() {
+			domainSpec := &api.DomainSpec{
+				CPU: api.CPU{
+					NUMA: &api.NUMA{
+						Cells: []api.NUMACell{
+							{ID: "0", CPUs: "0-7"},
+							{ID: "1", CPUs: ""},
+							{ID: "2", CPUs: ""},
+						},
+					},
+				},
+				CPUTune: &api.CPUTune{
+					VCPUPin: []api.CPUTuneVCPUPin{
+						{VCPU: 0, CPUSet: "0"},
+					},
+				},
+				NUMATune: &api.NUMATune{
+					MemNodes: []api.MemNode{
+						{CellID: 0, Mode: "strict", NodeSet: "0"},
+					},
+				},
+			}
+
+			devicesNumaNodes, warnings := LookupDevicesNumaNodesWithWarnings([]string{testPCIAddress}, domainSpec)
+			Expect(devicesNumaNodes).To(Equal(map[string]uint32{testPCIAddress: 0}))
+			Expect(warnings).To(BeEmpty())
+		})
+
 		It("should keep unambiguous NUMATune memnode mappings when another host node is ambiguous", func() {
 			domainSpec := &api.DomainSpec{
 				CPU: api.CPU{

--- a/pkg/util/hardware/hw_utils_test.go
+++ b/pkg/util/hardware/hw_utils_test.go
@@ -497,6 +497,38 @@ var _ = Describe("Hardware utils test", func() {
 			Expect(devicesNumaNodes).To(Equal(map[string]uint32{testPCIAddress: 0}))
 		})
 
+		It("should silently skip memoryless NUMA cells with no CPUs", func() {
+			// Grace GI (GPU Instance) NUMA nodes have memory=0 and no CPUs.
+			// They must be skipped without emitting a warning.
+			domainSpec := &api.DomainSpec{
+				CPU: api.CPU{
+					NUMA: &api.NUMA{
+						Cells: []api.NUMACell{
+							{ID: "0", CPUs: "0-7"},
+							{ID: "1", CPUs: ""},
+							{ID: "2", CPUs: ""},
+						},
+					},
+				},
+				CPUTune: &api.CPUTune{
+					VCPUPin: []api.CPUTuneVCPUPin{
+						{VCPU: 0, CPUSet: "0"},
+					},
+				},
+				NUMATune: &api.NUMATune{
+					MemNodes: []api.MemNode{
+						{CellID: 0, Mode: "strict", NodeSet: "0"},
+					},
+				},
+			}
+
+			devicesNumaNodes, warnings := LookupDevicesNumaNodesWithWarnings([]string{testPCIAddress}, domainSpec)
+			Expect(devicesNumaNodes).To(Equal(map[string]uint32{testPCIAddress: 0}))
+			for _, w := range warnings {
+				Expect(w.String()).NotTo(ContainSubstring("invalid CPU set"))
+			}
+		})
+
 		It("should keep unambiguous NUMATune memnode mappings when another host node is ambiguous", func() {
 			domainSpec := &api.DomainSpec{
 				CPU: api.CPU{


### PR DESCRIPTION
### What this PR does
#### Before this PR:

VMIs using Grace GPU passthrough with `guestMappingPassthrough` emit a
spurious warning every polling interval (~10s) for each memoryless GI
NUMA cell:

```
PCI NUMA-aware placement: ignoring guest NUMA cell "1" with invalid CPU set "": strconv.Atoi: parsing "": invalid syntax
```

Grace GI (GPU Instance) NUMA nodes are memoryless — their domain XML
`<cell>` entries have no `cpus` attribute, resulting in an empty string
that `ParseCPUSetLine` cannot parse.

#### After this PR:

Memoryless cells (empty `CPUs` field) are silently skipped before
`ParseCPUSetLine` is called. The warning is only emitted for cells that
have a non-empty but genuinely malformed CPU set.

### References

- Observed during Grace Blackwell (GB200) GPU passthrough validation
  with `GraceIOVirtualization` + `guestMappingPassthrough`

### Why we need it and why it was done in this way

Memoryless NUMA cells are valid by design on Grace hardware — they
represent GI nodes that hold GPU memory but no CPUs. The
`vCPUToCellMap` built in `LookupDevicesNumaNodesWithWarnings` is only
relevant for the CPU-pinning placement path; GI nodes are handled
earlier via the NUMATune memnode path and don't need to appear in this
map at all.

The fix is a single guard before the parse call rather than a change to
`ParseCPUSetLine` itself, since an empty CPU set is only valid for
memoryless cells — it would still be an error for a cell that is
expected to have CPUs.

### Special notes for your reviewer

The warning is harmless functionally — GPU placement via `acpi nodeset`
is correct regardless. This is purely a log-noise fix.

### Checklist

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
NONE
```