### PR TITLE
tests: assert Grace IO virtualization rejection on unsupported architectures

### DIFF
--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -3258,7 +3258,7 @@ var _ = Describe("Manager", func() {
 			Expect(converterContext.PCINUMAAwareTopologyEnabled).To(BeFalse())
 		})
 
-		It("should set Grace conversion flags and expected aliases from options", func() {
+		It("should set Grace conversion flags and expected aliases from options on supported architectures", func() {
 			vmi.Spec.Domain.CPU = &v1.CPU{DedicatedCPUPlacement: true}
 			iommuFDFile, err := os.CreateTemp(GinkgoT().TempDir(), "iommufd-test")
 			Expect(err).ToNot(HaveOccurred())
@@ -3277,9 +3277,13 @@ var _ = Describe("Manager", func() {
 			libvirtManager.iommuFD = int(iommuFDFile.Fd())
 			converterContext, err := libvirtManager.generateConverterContext(vmi, true, options, false)
 
-			Expect(err).ToNot(HaveOccurred())
-			Expect(converterContext.GraceIOVirtualizationEnabled).To(BeTrue())
-			Expect(converterContext.GraceHostDeviceAliases).To(Equal([]string{"gpu-gpu0"}))
+			if arch.NewConverter(runtime.GOARCH).SupportPCIePlacement() {
+				Expect(err).ToNot(HaveOccurred())
+				Expect(converterContext.GraceIOVirtualizationEnabled).To(BeTrue())
+				Expect(converterContext.GraceHostDeviceAliases).To(Equal([]string{"gpu-gpu0"}))
+			} else {
+				Expect(err).To(MatchError(ContainSubstring("requires PCIe placement support")))
+			}
 		})
 
 		It("should reject Grace conversion when the IOMMUFD file descriptor is unavailable", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
The `should set Grace conversion flags and expected aliases from options` unit test in `pkg/virt-launcher/virtwrap` fails on s390x because it exercises GraceIOVirtualization, which requires PCIe placement a capability s390x does not support. The test only asserted the success path, so it broke on architectures where `SupportPCIePlacement()` returns false.

#### After this PR:
The test branches on `arch.NewConverter(runtime.GOARCH).SupportPCIePlacement()` and asserts the expected behavior for both supported and unsupported architectures, fixing the `pull-kubevirt-unit-test-s390x` CI lane.


### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The production code in `converter/grace.go` already rejects GraceIOVirtualization on architectures where `SupportPCIePlacement()` returns false. The test was only asserting the success path, which made it fail on s390x. By branching on the same capability check, the test now validates the success path on supported architectures (amd64, arm64) and the expected rejection on unsupported ones (s390x).

The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
`generateConverterContext` internally uses `arch.NewConverter(runtime.GOARCH)` to select the architecture converter, so the test is implicitly coupled to the host architecture. A broader refactor to inject the architecture into `generateConverterContext` would decouple this, but that is out of scope for this fix.


<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
     None.

```

