### PR TITLE
tests/virtwrap: split Grace PCIe arch test into per-arch DescribeTables

### DIFF
--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -254,6 +254,7 @@ type LibvirtDomainManager struct {
 	hypervisorDeviceAvailable bool
 	hypervisorName            string
 	allowCrossArchEmulation   bool
+	archConverter             arch.Converter
 
 	guestAgentProbePaused atomic.Bool
 	abortWg               sync.WaitGroup
@@ -1306,7 +1307,7 @@ func (l *LibvirtDomainManager) generateConverterContext(vmi *v1.VirtualMachineIn
 	// Map the VirtualMachineInstance to the Domain
 
 	c := &convertertypes.ConverterContext{
-		Architecture:              selectArchConverter(l.allowCrossArchEmulation, vmi.Spec.Architecture),
+		Architecture:              l.selectConverterArch(vmi.Spec.Architecture),
 		VirtualMachine:            vmi,
 		AllowEmulation:            allowEmulation,
 		AllowCrossArchEmulation:   l.allowCrossArchEmulation && vmi.Spec.Architecture != "" && vmi.Spec.Architecture != runtime.GOARCH,
@@ -3036,9 +3037,12 @@ func selectEFIEnvironment(hostEFI *efi.EFIEnvironment, ovmfPath string, allowCro
 	return hostEFI
 }
 
-func selectArchConverter(allowCrossArchEmulation bool, guestArch string) arch.Converter {
+func (l *LibvirtDomainManager) selectConverterArch(guestArch string) arch.Converter {
+	if l.archConverter != nil {
+		return l.archConverter
+	}
 	vmArch := runtime.GOARCH
-	if allowCrossArchEmulation && guestArch != "" && guestArch != runtime.GOARCH {
+	if l.allowCrossArchEmulation && guestArch != "" && guestArch != runtime.GOARCH {
 		vmArch = guestArch
 	}
 	return arch.NewConverter(vmArch)

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -3286,33 +3286,49 @@ var _ = Describe("Manager", func() {
 			Expect(converterContext.PCINUMAAwareTopologyEnabled).To(BeFalse())
 		})
 
-		It("should set Grace conversion flags and expected aliases from options on supported architectures", func() {
-			vmi.Spec.Domain.CPU = &v1.CPU{DedicatedCPUPlacement: true}
-			iommuFDFile, err := os.CreateTemp(GinkgoT().TempDir(), "iommufd-test")
+		assertGraceConversionSucceeded := func(c *convertertypes.ConverterContext, err error) {
+			GinkgoHelper()
 			Expect(err).ToNot(HaveOccurred())
-			DeferCleanup(iommuFDFile.Close)
-
-			options := &cmdv1.VirtualMachineOptions{
-				VirtualMachineSMBios: &cmdv1.SMBios{},
-				ClusterConfig: &cmdv1.ClusterConfig{
-					GraceIOVirtualizationEnabled: true,
-					PCINUMAAwareTopologyEnabled:  true,
-				},
-				GraceHostDeviceAliases: []string{"gpu-gpu0"},
-			}
-
-			libvirtManager := manager.(*LibvirtDomainManager)
-			libvirtManager.iommuFD = int(iommuFDFile.Fd())
-			converterContext, err := libvirtManager.generateConverterContext(vmi, true, options, false)
-
-			if arch.NewConverter(runtime.GOARCH).SupportPCIePlacement() {
+			Expect(c).ToNot(BeNil())
+			Expect(c.GraceIOVirtualizationEnabled).To(BeTrue())
+			Expect(c.GraceHostDeviceAliases).To(Equal([]string{"gpu-gpu0"}))
+		}
+		assertGraceConversionFailedForUnsupportedArch := func(c *convertertypes.ConverterContext, err error) {
+			GinkgoHelper()
+			Expect(err).To(MatchError(ContainSubstring("requires PCIe placement support")))
+			Expect(c).To(BeNil())
+		}
+		DescribeTable("should validate Grace conversion flags based on PCIe placement support",
+			func(archName string, assertFn func(*convertertypes.ConverterContext, error)) {
+				libvirtManager := manager.(*LibvirtDomainManager)
+				vmi.Spec.Architecture = archName
+				vmi.Spec.Domain.CPU = &v1.CPU{DedicatedCPUPlacement: true}
+				iommuFDFile, err := os.CreateTemp(GinkgoT().TempDir(), "iommufd-test")
 				Expect(err).ToNot(HaveOccurred())
-				Expect(converterContext.GraceIOVirtualizationEnabled).To(BeTrue())
-				Expect(converterContext.GraceHostDeviceAliases).To(Equal([]string{"gpu-gpu0"}))
-			} else {
-				Expect(err).To(MatchError(ContainSubstring("requires PCIe placement support")))
-			}
-		})
+				DeferCleanup(iommuFDFile.Close)
+				DeferCleanup(func() {
+					vmi.Spec.Architecture = ""
+					libvirtManager.archConverter = nil
+					libvirtManager.iommuFD = 0
+				})
+
+				options := &cmdv1.VirtualMachineOptions{
+					VirtualMachineSMBios: &cmdv1.SMBios{},
+					ClusterConfig: &cmdv1.ClusterConfig{
+						GraceIOVirtualizationEnabled: true,
+						PCINUMAAwareTopologyEnabled:  true,
+					},
+					GraceHostDeviceAliases: []string{"gpu-gpu0"},
+				}
+
+				libvirtManager.archConverter = arch.NewConverter(archName)
+				libvirtManager.iommuFD = int(iommuFDFile.Fd())
+				assertFn(libvirtManager.generateConverterContext(vmi, true, options, false))
+			},
+			Entry("amd64", "amd64", assertGraceConversionSucceeded),
+			Entry("arm64", "arm64", assertGraceConversionSucceeded),
+			Entry("s390x", "s390x", assertGraceConversionFailedForUnsupportedArch),
+		)
 
 		It("should reject Grace conversion when the IOMMUFD file descriptor is unavailable", func() {
 			vmi.Spec.Domain.CPU = &v1.CPU{DedicatedCPUPlacement: true}
@@ -4777,9 +4793,10 @@ var _ = Describe("Cross-architecture emulation helpers", func() {
 		Entry("re-detects EFI for cross-arch guest", true, crossArch, true),
 	)
 
-	DescribeTable("selectArchConverter",
+	DescribeTable("selectConverterArch",
 		func(allowCrossArch bool, guestArch, expectedArch string) {
-			result := selectArchConverter(allowCrossArch, guestArch)
+			l := &LibvirtDomainManager{allowCrossArchEmulation: allowCrossArch}
+			result := l.selectConverterArch(guestArch)
 			expected := arch.NewConverter(expectedArch)
 			Expect(result).To(Equal(expected))
 		},


### PR DESCRIPTION
### What this PR does
#### Before this PR:
A single `It` block tested Grace IO Virtualization flag propagation through `generateConverterContext` without considering host architecture. On s390x this caused `pull-kubevirt-unit-test-s390x` to fail with `GraceIOVirtualization requires PCIe placement support on architecture s390x` (introduced by #18474).

#### After this PR:
The single `It` block is replaced with a single `DescribeTable` with per-architecture entries:
- `amd64` and `arm64`: assert success (PCIe placement supported)
- `s390x`: asserts rejection with the expected error (no PCIe placement support)

An `archConverter arch.Converter` field is added to `LibvirtDomainManager` so tests can inject the arch converter directly into `generateConverterContext` without relying on `allowCrossArchEmulation` or `runtime.GOARCH`. A new `selectConverterArch` method returns the injected converter when set, and falls through to the existing `selectArchConverter` logic otherwise — production code is unaffected.

### References
- Partially addresses #18611

### Why we need it and why it was done in this way
The following tradeoffs were made:
- Rather than wrapping the test in an `if/else` on `runtime.GOARCH` (as proposed in #18611), using a `DescribeTable` makes the expected behaviour per architecture explicit and runs the correct assertion path on every architecture.
- The `archConverter` field is preferred over `allowCrossArchEmulation` because it directly expresses what the test needs (a specific converter), without the side-effects of cross-arch emulation mode (EFI environment selection, `AllowCrossArchEmulation` in the context, etc).

### Special notes for your reviewer
Note that the IOMMUFD temp file is required in all entries: `ValidateGraceIOVirtualizationConversion` checks `IOMMUFDEnabled` before `SupportPCIePlacement`, so a valid fd is needed to reach the architecture rejection path.

### Checklist

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
NONE
```
