### PR TITLE
storage/admitters: parse VMRestore patches as JSON

### DIFF
--- a/pkg/storage/admitters/BUILD.bazel
+++ b/pkg/storage/admitters/BUILD.bazel
@@ -66,6 +66,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/storage/admitters",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/apimachinery/patch:go_default_library",
         "//pkg/storage/backend-storage:go_default_library",
         "//pkg/storage/cbt:go_default_library",
         "//pkg/util/hardware:go_default_library",

--- a/pkg/storage/admitters/vmrestore.go
+++ b/pkg/storage/admitters/vmrestore.go
@@ -37,6 +37,7 @@ import (
 	snapshotv1 "kubevirt.io/api/snapshot/v1beta1"
 	"kubevirt.io/client-go/kubecli"
 
+	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
 	backendstorage "kubevirt.io/kubevirt/pkg/storage/backend-storage"
 	webhookutils "kubevirt.io/kubevirt/pkg/util/webhooks"
 )
@@ -234,36 +235,39 @@ func (admitter *VMRestoreAdmitter) validateTargetVM(ctx context.Context, field *
 }
 
 func (admitter *VMRestoreAdmitter) validatePatches(patches []string, field *k8sfield.Path) (causes []metav1.StatusCause) {
-	// Validate patches are either on labels/annotations or on elements under "/spec/" path only
-	for _, patch := range patches {
-		for _, patchKeyValue := range strings.Split(strings.Trim(patch, "{}"), ",") {
-			// For example, if the original patch is {"op": "replace", "path": "/metadata/name", "value": "someValue"}
-			// now we're iterating on [`"op": "replace"`, `"path": "/metadata/name"`, `"value": "someValue"`]
-			keyValSlice := strings.Split(patchKeyValue, ":")
-			if len(keyValSlice) != 2 {
-				causes = append(causes, metav1.StatusCause{
-					Type:    metav1.CauseTypeFieldValueInvalid,
-					Message: fmt.Sprintf(`patch format is not valid - one ":" expected in a single key-value json patch: %s`, patchKeyValue),
-					Field:   field.String(),
-				})
-				continue
-			}
+	// Validate patches are either on labels/annotations or on elements under "/spec/" path only.
+	// Every entry is expected to be a single JSON patch operation, for example
+	// {"op": "replace", "path": "/metadata/name", "value": "someValue"}
+	for _, rawPatch := range patches {
+		var patchOp patch.PatchOperation
+		if err := json.Unmarshal([]byte(rawPatch), &patchOp); err != nil {
+			causes = append(causes, metav1.StatusCause{
+				Type:    metav1.CauseTypeFieldValueInvalid,
+				Message: fmt.Sprintf("patch is not a valid JSON patch operation: %s", rawPatch),
+				Field:   field.String(),
+			})
+			continue
+		}
 
-			key := strings.TrimSpace(keyValSlice[0])
-			value := strings.TrimSpace(keyValSlice[1])
+		if patchOp.Path == "" {
+			causes = append(causes, metav1.StatusCause{
+				Type:    metav1.CauseTypeFieldValueInvalid,
+				Message: fmt.Sprintf(`patch does not contain a "path": %s`, rawPatch),
+				Field:   field.String(),
+			})
+			continue
+		}
 
-			if key == `"path"` {
-				if strings.HasPrefix(value, `"/metadata/labels/`) || strings.HasPrefix(value, `"/metadata/annotations/`) {
-					continue
-				}
-				if !strings.HasPrefix(value, `"/spec/`) {
-					causes = append(causes, metav1.StatusCause{
-						Type:    metav1.CauseTypeFieldValueInvalid,
-						Message: fmt.Sprintf("patching is valid only for elements under /spec/ only: %s", patchKeyValue),
-						Field:   field.String(),
-					})
-				}
-			}
+		if strings.HasPrefix(patchOp.Path, "/metadata/labels/") || strings.HasPrefix(patchOp.Path, "/metadata/annotations/") {
+			continue
+		}
+
+		if !strings.HasPrefix(patchOp.Path, "/spec/") {
+			causes = append(causes, metav1.StatusCause{
+				Type:    metav1.CauseTypeFieldValueInvalid,
+				Message: fmt.Sprintf("patching is valid only for elements under /spec/ only: %s", rawPatch),
+				Field:   field.String(),
+			})
 		}
 	}
 

--- a/pkg/storage/admitters/vmrestore_test.go
+++ b/pkg/storage/admitters/vmrestore_test.go
@@ -630,9 +630,9 @@ var _ = Describe("Validating VirtualMachineRestore Admitter", func() {
 				})
 
 				DescribeTable("should reject patching elements not under /spec/:", func(patchSet *patch.PatchSet) {
-					patchBytes, err := patchSet.GeneratePayload()
+					patches, err := patchSet.ToSlice()
 					Expect(err).To(Not(HaveOccurred()))
-					restore.Spec.Patches = []string{string(patchBytes)}
+					restore.Spec.Patches = patches
 
 					ar := createRestoreAdmissionReview(restore)
 					resp := createTestVMRestoreAdmitter(stubVMRestoreConfigChecker{snapshotEnabled: true}, vm, snapshot).Admit(context.Background(), ar)
@@ -649,31 +649,45 @@ var _ = Describe("Validating VirtualMachineRestore Admitter", func() {
 				)
 
 				DescribeTable("should allow patching elements under /spec/:", func(patchSet *patch.PatchSet) {
-					patchBytes, err := patchSet.GeneratePayload()
+					patches, err := patchSet.ToSlice()
 					Expect(err).To(Not(HaveOccurred()))
-					restore.Spec.Patches = []string{string(patchBytes)}
+					restore.Spec.Patches = patches
 
 					ar := createRestoreAdmissionReview(restore)
 					resp := createTestVMRestoreAdmitter(stubVMRestoreConfigChecker{snapshotEnabled: true}, vm, snapshot).Admit(context.Background(), ar)
 					Expect(resp.Allowed).To(BeTrue())
 				},
 					Entry("patch to replace MAC", patch.New(patch.WithReplace("/spec/template/spec/domain/devices/interfaces/0/macAddress", "some-value"))),
+					Entry("patch to replace MAC with a colon separated address",
+						patch.New(patch.WithReplace("/spec/template/spec/domain/devices/interfaces/0/macAddress", "be:ad:00:00:be:04"))),
+					Entry("patch to replace a value containing a comma",
+						patch.New(patch.WithReplace("/spec/template/spec/domain/firmware/serial", "some,value"))),
+					Entry("patch to replace a value that is an object",
+						patch.New(patch.WithReplace("/spec/template/spec/nodeSelector", map[string]string{"key": "value"}))),
+					Entry("patch to replace a value that is an array",
+						patch.New(patch.WithReplace("/spec/template/spec/tolerations", []string{"a", "b"}))),
 					Entry("patch to add running", patch.New(patch.WithAdd("/spec/running", "some-value"))),
 					Entry("patch to remove instancetype", patch.New(patch.WithRemove("/spec/instancetype"))),
 					Entry("patch to replace a label", patch.New(patch.WithReplace("/metadata/labels/key", "some-value"))),
 					Entry("patch to remove an annotation", patch.New(patch.WithRemove("/metadata/annotations/key"))),
+					Entry("patch to replace an annotation with a colon separated value",
+						patch.New(patch.WithReplace("/metadata/annotations/key", "some:value"))),
 				)
 
-				It("should reject an invalid patch", func() {
-					const invalidPatch = `{"op": "remove", "path": "/spec/running" : "illegal-field"}`
-					restore.Spec.Patches = []string{invalidPatch}
+				DescribeTable("should reject a malformed patch:", func(malformedPatch string) {
+					restore.Spec.Patches = []string{malformedPatch}
 
 					ar := createRestoreAdmissionReview(restore)
 					resp := createTestVMRestoreAdmitter(stubVMRestoreConfigChecker{snapshotEnabled: true}, vm, snapshot).Admit(context.Background(), ar)
 					Expect(resp.Allowed).To(BeFalse())
 					Expect(resp.Result.Details.Causes).To(HaveLen(1))
 					Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.patches"))
-				})
+				},
+					Entry("patch that is not valid JSON", `{"op": "remove", "path": "/spec/running" : "illegal-field"}`),
+					Entry("patch without a path", `{"op": "replace", "value": "some-value"}`),
+					Entry("patch that is a list of operations instead of a single operation",
+						`[{"op": "replace", "path": "/spec/running", "value": "some-value"}]`),
+				)
 			})
 
 		})


### PR DESCRIPTION
### What this PR does

The `VirtualMachineRestore` admitter validates `spec.patches` without parsing them as JSON. It splits each entry on `,`, then splits every fragment on `:`, and requires exactly two parts. Any patch whose value legitimately contains a `:` or a `,`, or whose value is an object or an array, is rejected.

#### Before this PR:

A restore that replaces a MAC address is rejected:

```yaml
patches:
  - '{"op": "replace", "path": "/spec/template/spec/domain/devices/interfaces/0/macAddress", "value": "be:ad:00:00:be:04"}'
```

```
patch format is not valid - one ":" expected in a single key-value json patch:  "value": "be:ad:00:00:be:04"
```

This is the patch the clone controller generates for `VirtualMachineClone.spec.newMacAddresses`, so cloning with a colon separated MAC fails at admission. The same applies to any string value containing `,` or `:` and to object or array values.

The hand written parser also only applied the `/spec/` restriction when a fragment parsed into exactly the key `"path"`. An entry with no `path` key produced no cause and was accepted.

#### After this PR:

Each entry is unmarshalled into `patch.PatchOperation` and the decoded `Path` is validated. Valid JSON patch operations under `/spec/`, `/metadata/labels/` and `/metadata/annotations/` are accepted regardless of their value. Entries that are not a single valid JSON patch operation, or that carry no path, are rejected with a clear message.

### References

- Fixes #18617

### Why we need it and why it was done in this way

Restoring a snapshot into a different VM, and cloning a VM, both rely on patching the MAC address of the target so it does not collide with the source. Colon separated MAC addresses are the common notation, so this path is broken for the ordinary case.

The following tradeoffs were made:

- Entries that are a JSON *array* of operations are now rejected. They were accepted before, but they never worked: the restore controller's `patchVM` joins the entries into an array itself, so an array entry produces a nested array and fails to decode later on. Rejecting at admission turns a confusing controller error into a clear one.
- Entries with no `path` are now rejected. `path` is required by RFC 6902, and accepting them meant silently skipping the `/spec/` restriction.

The following alternatives were considered:

- Keeping the string parser and special casing quoted values. That re-implements a JSON parser and stays fragile.

### Special notes for your reviewer

The existing unit tests fed `PatchSet.GeneratePayload()` into `spec.patches`, which produces a JSON array rather than the single operation per entry that `patchVM` expects, so they were not exercising the real input shape. They now use `PatchSet.ToSlice()`.

Two existing tests hid the bug by coincidence:

- the unit test entry `"patch to replace MAC"` used the value `"some-value"`
- the e2e test `"clone with changed MAC address"` uses `BE-AD-00-00-BE-04`, the dash separated notation

The added unit tests cover values containing `:` and `,`, object and array values, an entry with no path, and an entry that is a list of operations. All seven added cases fail on `main` and pass with this change.

### Checklist

- [x] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note

```release-note
Fixed the VirtualMachineRestore admitter rejecting valid patches whose value contains ":" or "," , such as replacing an interface MAC address, or whose value is an object or an array.
```
