### PR TITLE
[DNM]Revert "Use actual migration priority when re-queuing"

### DIFF
--- a/pkg/util/migrations/migrations.go
+++ b/pkg/util/migrations/migrations.go
@@ -21,6 +21,7 @@ const (
 	QueuePriorityUserTriggered     int    = 50
 	QueuePrioritySystemMaintenance int    = 20
 	QueuePriorityDefault           int    = 0
+	QueuePriorityPending           int    = -100
 )
 
 func ListUnfinishedMigrations(indexer cache.Indexer) []*v1.VirtualMachineInstanceMigration {

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/migration-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/migration-create-admitter.go
@@ -110,6 +110,16 @@ func (admitter *MigrationCreateAdmitter) Admit(ctx context.Context, ar *admissio
 	}
 
 	if migration.Spec.Priority != nil {
+		if !admitter.clusterConfig.MigrationPriorityQueueEnabled() {
+			return webhookutils.ToAdmissionResponse([]metav1.StatusCause{
+				{
+					Type:    metav1.CauseTypeForbidden,
+					Message: "MigrationPriorityQueue feature gate is not enabled in kubevirt resource",
+					Field:   "spec.migrationPriority",
+				},
+			})
+		}
+
 		if !hasRequestOriginatedFromVirtController(ar.Request.UserInfo.Username, admitter.kubeVirtServiceAccounts) {
 			return webhookutils.ToAdmissionResponse([]metav1.StatusCause{
 				{

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/migration-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/migration-create-admitter_test.go
@@ -22,6 +22,7 @@ package admitters_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -285,25 +286,56 @@ var _ = Describe("Validating MigrationCreate Admitter", func() {
 	})
 
 	Context("handling priority field", func() {
-		DescribeTable("should", func(user string, matcher types.GomegaMatcher) {
-			vmi := libvmi.New(libvmi.WithNamespace(k8sv1.NamespaceDefault))
-			vmi.Status.Phase = v1.Running
-			virtClient := kubevirtfake.NewSimpleClientset(vmi)
-			migration := createMigration(vmi.Namespace, testMigrationName, vmi.Name)
-			migration.Spec.Priority = pointer.P(v1.MigrationPriority("system-critical"))
-			ar, err := newAdmissionReviewForVMIMCreation(migration)
-			ar.Request.UserInfo.Username = user
-			Expect(err).ToNot(HaveOccurred())
-			admitter := admitters.NewMigrationCreateAdmitter(virtClient, config, webhooks.KubeVirtServiceAccounts("kubevirt"))
-			resp := admitter.Admit(context.Background(), ar)
-			Expect(resp.Allowed).To(matcher)
-			if matcher == BeFalse() {
-				Expect(resp.Result.Message).To(ContainSubstring("Migration priority queue, only virt-controller is allowed to set priority field"))
-			}
-		},
-			Entry("reject the external requests", "system:serviceaccount:external-user", BeFalse()),
-			Entry("allow the virt-controller requests", "system:serviceaccount:kubevirt:kubevirt-controller", BeTrue()),
-		)
+		When("MigrationPriorityQueue feature gate is disabled", func() {
+			BeforeEach(func() {
+				kvConfig := kv.DeepCopy()
+				kvConfig.Spec.Configuration.DeveloperConfiguration.DisabledFeatureGates = []string{featuregate.MigrationPriorityQueue}
+				testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kvConfig)
+			})
+
+			DescribeTable("should reject the", func(user string) {
+				vmi := libvmi.New(libvmi.WithNamespace(k8sv1.NamespaceDefault))
+				vmi.Status.Phase = v1.Running
+				virtClient := kubevirtfake.NewSimpleClientset(vmi)
+				migration := createMigration(vmi.Namespace, testMigrationName, vmi.Name)
+				migration.Spec.Priority = pointer.P(v1.MigrationPriority("system-critical"))
+				ar, err := newAdmissionReviewForVMIMCreation(migration)
+				ar.Request.UserInfo.Username = user
+				Expect(err).ToNot(HaveOccurred())
+				admitter := admitters.NewMigrationCreateAdmitter(virtClient, config, webhooks.KubeVirtServiceAccounts("kubevirt"))
+				resp := admitter.Admit(context.Background(), ar)
+				Expect(resp.Allowed).To(BeFalse())
+				Expect(resp.Result.Message).To(ContainSubstring("MigrationPriorityQueue feature gate is not enabled in kubevirt resource"))
+			},
+				Entry("virt-controller requests", "system:serviceaccount:kubevirt:kubevirt-controller"),
+				Entry("external requests", "system:serviceaccount:external-user"),
+			)
+		})
+		When("MigrationPriorityQueue feature gate is enabled", func() {
+			BeforeEach(func() {
+				enableFeatureGate(featuregate.MigrationPriorityQueue)
+			})
+
+			DescribeTable("should", func(user string, matcher types.GomegaMatcher) {
+				vmi := libvmi.New(libvmi.WithNamespace(k8sv1.NamespaceDefault))
+				vmi.Status.Phase = v1.Running
+				virtClient := kubevirtfake.NewSimpleClientset(vmi)
+				migration := createMigration(vmi.Namespace, testMigrationName, vmi.Name)
+				migration.Spec.Priority = pointer.P(v1.MigrationPriority("system-critical"))
+				ar, err := newAdmissionReviewForVMIMCreation(migration)
+				ar.Request.UserInfo.Username = user
+				Expect(err).ToNot(HaveOccurred())
+				admitter := admitters.NewMigrationCreateAdmitter(virtClient, config, webhooks.KubeVirtServiceAccounts("kubevirt"))
+				resp := admitter.Admit(context.Background(), ar)
+				Expect(resp.Allowed).To(matcher)
+				if matcher == BeFalse() {
+					Expect(resp.Result.Message).To(ContainSubstring("Migration priority queue, only virt-controller is allowed to set priority field"))
+				}
+			},
+				Entry("reject the external requests", "system:serviceaccount:external-user", BeFalse()),
+				Entry("allow the virt-controller requests", fmt.Sprintf("system:serviceaccount:kubevirt:kubevirt-controller"), BeTrue()),
+			)
+		})
 	})
 })
 

--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -193,6 +193,10 @@ func (config *ClusterConfig) IncrementalBackupEnabled() bool {
 	return config.isFeatureGateEnabled(featuregate.IncrementalBackupGate)
 }
 
+func (config *ClusterConfig) MigrationPriorityQueueEnabled() bool {
+	return config.isFeatureGateEnabled(featuregate.MigrationPriorityQueue)
+}
+
 func (config *ClusterConfig) PodSecondaryInterfaceNamingUpgradeEnabled() bool {
 	return config.isFeatureGateEnabled(featuregate.PodSecondaryInterfaceNamingUpgrade)
 }

--- a/pkg/virt-config/featuregate/active.go
+++ b/pkg/virt-config/featuregate/active.go
@@ -149,6 +149,15 @@ const (
 	// PasstBinding enables the use of passt core network binding
 	PasstBinding = "PasstBinding"
 
+	// MigrationPriorityQueue enables controllers to assign priorities to migrations,
+	// ensuring system-initiated migrations (e.g., node drains, upgrades) take precedence
+	// over user-initiated ones (e.g., hot plug operations).
+	// Owner: sig-compute / @fossedihelm
+	// Alpha: v1.7.0
+	// Beta: v1.8.0
+	//
+	MigrationPriorityQueue = "MigrationPriorityQueue"
+
 	// Owner: @harshitgupta1337
 	// Alpha: v1.8.0
 	// This feature is disabled by default. When enabled, it allows using
@@ -325,6 +334,7 @@ func init() {
 	RegisterFeatureGate(FeatureGate{Name: ConfigurableHypervisor, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: PasstBinding, State: Beta})
 	RegisterFeatureGate(FeatureGate{Name: IncrementalBackupGate, State: Alpha})
+	RegisterFeatureGate(FeatureGate{Name: MigrationPriorityQueue, State: Beta})
 	RegisterFeatureGate(FeatureGate{Name: PodSecondaryInterfaceNamingUpgrade, State: Beta})
 	RegisterFeatureGate(FeatureGate{Name: ExternalNetResourceInjection, State: Beta})
 	RegisterFeatureGate(FeatureGate{Name: RebootPolicy, State: Beta})

--- a/pkg/virt-config/featuregate/inactive.go
+++ b/pkg/virt-config/featuregate/inactive.go
@@ -178,15 +178,6 @@ const (
 	//
 	// SecureExecution introduces secure execution of VMs on IBM Z architecture
 	SecureExecution = "SecureExecution"
-
-	// MigrationPriorityQueue enables controllers to assign priorities to migrations,
-	// ensuring system-initiated migrations (e.g., node drains, upgrades) take precedence
-	// over user-initiated ones (e.g., hot plug operations).
-	// Owner: sig-compute / @fossedihelm
-	// Alpha: v1.7.0
-	// Beta: v1.8.0
-	// GA: v1.9.0
-	MigrationPriorityQueue = "MigrationPriorityQueue"
 )
 
 func init() {
@@ -230,5 +221,4 @@ func init() {
 	RegisterFeatureGate(FeatureGate{Name: HotplugVolumesGate, State: Deprecated, Message: "HotplugVolumes has been deprecated since v1.9.0 and has been replaced by DeclarativeHotplugVolumes"})
 	RegisterFeatureGate(FeatureGate{Name: VideoConfig, State: GA})
 	RegisterFeatureGate(FeatureGate{Name: SecureExecution, State: GA})
-	RegisterFeatureGate(FeatureGate{Name: MigrationPriorityQueue, State: GA})
 }

--- a/pkg/virt-controller/watch/drain/evacuation/BUILD.bazel
+++ b/pkg/virt-controller/watch/drain/evacuation/BUILD.bazel
@@ -35,6 +35,7 @@ go_test(
         "//pkg/controller/testing:go_default_library",
         "//pkg/pointer:go_default_library",
         "//pkg/testutils:go_default_library",
+        "//pkg/virt-config/featuregate:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/api:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",

--- a/pkg/virt-controller/watch/drain/evacuation/evacuation.go
+++ b/pkg/virt-controller/watch/drain/evacuation/evacuation.go
@@ -3,6 +3,7 @@ package evacuation
 import (
 	"context"
 	"fmt"
+	"math"
 	"sync"
 	"time"
 
@@ -333,7 +334,7 @@ func getMarkedForEvictionVMIs(vmis []*virtv1.VirtualMachineInstance) []*virtv1.V
 	return evictionCandidates
 }
 
-func GenerateNewMigration(vmi *virtv1.VirtualMachineInstance, key string) *virtv1.VirtualMachineInstanceMigration {
+func GenerateNewMigration(vmi *virtv1.VirtualMachineInstance, key string, config *virtconfig.ClusterConfig) *virtv1.VirtualMachineInstanceMigration {
 
 	annotations := map[string]string{
 		virtv1.EvacuationMigrationAnnotation: key,
@@ -347,9 +348,11 @@ func GenerateNewMigration(vmi *virtv1.VirtualMachineInstance, key string) *virtv
 			VMIName: vmi.Name,
 		},
 	}
-	mig.Spec.Priority = pointer.P(virtv1.PrioritySystemCritical)
-	if value, exists := vmi.GetAnnotations()[virtv1.EvictionSourceAnnotation]; exists && value == "descheduler" {
-		mig.Spec.Priority = pointer.P(virtv1.PrioritySystemMaintenance)
+	if config.MigrationPriorityQueueEnabled() {
+		mig.Spec.Priority = pointer.P(virtv1.PrioritySystemCritical)
+		if value, exists := vmi.GetAnnotations()[virtv1.EvictionSourceAnnotation]; exists && value == "descheduler" {
+			mig.Spec.Priority = pointer.P(virtv1.PrioritySystemMaintenance)
+		}
 	}
 
 	return mig
@@ -374,6 +377,45 @@ func (c *EvacuationController) sync(node *k8sv1.Node, vmisOnNode []*virtv1.Virtu
 	}
 
 	selectedCandidates := migrationCandidates
+	if !c.clusterConfig.MigrationPriorityQueueEnabled() {
+		runningMigrations := migrationutils.FilterRunningMigrations(activeMigrations)
+		activeMigrationsFromThisSourceNode := c.numOfVMIMForThisSourceNode(vmisOnNode, runningMigrations)
+		maxParallelMigrationsPerOutboundNode :=
+			int(*c.clusterConfig.GetMigrationConfiguration().ParallelOutboundMigrationsPerNode)
+		maxParallelMigrations := int(*c.clusterConfig.GetMigrationConfiguration().ParallelMigrationsPerCluster)
+		freeSpotsPerCluster := maxParallelMigrations - len(runningMigrations)
+		freeSpotsPerThisSourceNode := maxParallelMigrationsPerOutboundNode - activeMigrationsFromThisSourceNode
+		freeSpots := int(math.Min(float64(freeSpotsPerCluster), float64(freeSpotsPerThisSourceNode)))
+		if freeSpots <= 0 {
+			c.Queue.AddAfter(node.Name, 5*time.Second)
+			return nil
+		}
+
+		diff := int(math.Min(float64(freeSpots), float64(len(migrationCandidates))))
+		remaining := freeSpots - diff
+		remainingForNonMigrateableDiff := int(math.Min(float64(remaining), float64(len(nonMigrateable))))
+
+		if remainingForNonMigrateableDiff > 0 {
+			// for all non-migrating VMIs which would get e spot emit a warning
+			for _, vmi := range nonMigrateable[0:remainingForNonMigrateableDiff] {
+				c.recorder.Eventf(vmi, k8sv1.EventTypeNormal, FailedCreateVirtualMachineInstanceMigrationReason, "VirtualMachineInstance is not migrateable")
+			}
+
+		}
+
+		if diff == 0 {
+			if remainingForNonMigrateableDiff > 0 {
+				// Let's ensure that some warnings will stay in the event log and periodically update
+				// In theory the warnings could disappear after one hour if nothing else updates
+				c.Queue.AddAfter(node.Name, 1*time.Minute)
+			}
+			// nothing to do
+			return nil
+		}
+
+		// TODO: should the order be randomized?
+		selectedCandidates = migrationCandidates[0:diff]
+	}
 
 	actualSpots := len(selectedCandidates)
 	log.DefaultLogger().Infof("node: %v, migrations: %v, candidates: %v, selected: %v", node.Name, len(activeMigrations), len(migrationCandidates), len(selectedCandidates))
@@ -387,7 +429,7 @@ func (c *EvacuationController) sync(node *k8sv1.Node, vmisOnNode []*virtv1.Virtu
 	for _, vmi := range selectedCandidates {
 		go func(vmi *virtv1.VirtualMachineInstance) {
 			defer wg.Done()
-			createdMigration, err := c.clientset.VirtualMachineInstanceMigration(vmi.Namespace).Create(context.Background(), GenerateNewMigration(vmi, node.Name), v1.CreateOptions{})
+			createdMigration, err := c.clientset.VirtualMachineInstanceMigration(vmi.Namespace).Create(context.Background(), GenerateNewMigration(vmi, node.Name, c.clusterConfig), v1.CreateOptions{})
 			if err != nil {
 				c.migrationExpectations.CreationObserved(node.Name)
 				c.recorder.Eventf(vmi, k8sv1.EventTypeWarning, FailedCreateVirtualMachineInstanceMigrationReason, "Error creating a Migration: %v", err)

--- a/pkg/virt-controller/watch/drain/evacuation/evacuation_test.go
+++ b/pkg/virt-controller/watch/drain/evacuation/evacuation_test.go
@@ -28,6 +28,7 @@ import (
 	controllertesting "kubevirt.io/kubevirt/pkg/controller/testing"
 	"kubevirt.io/kubevirt/pkg/pointer"
 	"kubevirt.io/kubevirt/pkg/testutils"
+	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 )
 
 var _ = Describe("Evacuation", func() {
@@ -100,18 +101,25 @@ var _ = Describe("Evacuation", func() {
 	}
 
 	Context("migration object creation", func() {
-		DescribeTable("should have expected values, annotations and priority", func(annotations map[string]string, matcher types.GomegaMatcher) {
+		DescribeTable("should have expected values, annotations and priority", func(devConfig *v1.DeveloperConfiguration, annotations map[string]string, matcher types.GomegaMatcher) {
+			config, _, _ := testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{
+				DeveloperConfiguration: devConfig,
+			})
 			vmi := newVirtualMachine("my-vmi", "somenode")
 			vmi.Annotations = annotations
-			migration := GenerateNewMigration(vmi, "somenode")
+			migration := GenerateNewMigration(vmi, "somenode", config)
 			Expect(migration.Spec.VMIName).To(Equal("my-vmi"))
 			Expect(migration.Annotations[v1.EvacuationMigrationAnnotation]).To(Equal("somenode"))
 			Expect(migration.Spec.Priority).To(matcher)
 		},
-			Entry("default priority is system-critical",
-				nil,
+			Entry("with MigrationPriorityQueue feature gate disabled",
+				&v1.DeveloperConfiguration{DisabledFeatureGates: []string{featuregate.MigrationPriorityQueue}},
+				nil, BeNil()),
+			Entry("with MigrationPriorityQueue feature gate enabled",
+				nil, nil,
 				gstruct.PointTo(BeEquivalentTo("system-critical"))),
-			Entry("with descheduler annotation, priority is system-maintenance",
+			Entry("with MigrationPriorityQueue feature gate enabled, and descheduler annotation",
+				nil,
 				map[string]string{v1.EvictionSourceAnnotation: "descheduler"},
 				gstruct.PointTo(BeEquivalentTo("system-maintenance"))),
 		)
@@ -191,7 +199,12 @@ var _ = Describe("Evacuation", func() {
 			)
 		})
 
-		It("should evict VMIs even if 5 migrations are in progress", func() {
+		It("should not evict VMIs if 5 migrations are in progress", func() {
+			updateKV(func(kv *v1.KubeVirt) {
+				kv.Spec.Configuration.DeveloperConfiguration = &v1.DeveloperConfiguration{
+					DisabledFeatureGates: []string{featuregate.MigrationPriorityQueue},
+				}
+			})
 			node := newNode("testnode")
 			node.Spec.Taints = append(node.Spec.Taints, *newTaint())
 			addNode(node)
@@ -210,6 +223,42 @@ var _ = Describe("Evacuation", func() {
 			controller.migrationIndexer.Add(newMigration("mig4", vmi.Name, v1.MigrationRunning))
 			controller.migrationIndexer.Add(newMigration("mig5", vmi.Name, v1.MigrationRunning))
 
+			sanityExecute()
+
+		})
+
+		It("should start another migration if one completes and we have a free spot", func() {
+			updateKV(func(kv *v1.KubeVirt) {
+				kv.Spec.Configuration.DeveloperConfiguration = &v1.DeveloperConfiguration{
+					DisabledFeatureGates: []string{featuregate.MigrationPriorityQueue},
+				}
+			})
+			node := newNode("testnode")
+			node.Spec.Taints = append(node.Spec.Taints, *newTaint())
+			addNode(node)
+			enqueue(node)
+
+			vmi1 := newVirtualMachineMarkedForEviction("testvmi1", node.Name)
+			migration1 := newMigration("mig1", vmi1.Name, v1.MigrationRunning)
+			controller.vmiIndexer.Add(vmi1)
+			controller.migrationIndexer.Add(migration1)
+
+			vmi2 := newVirtualMachineMarkedForEviction("testvmi2", node.Name)
+			migration2 := newMigration("mig2", vmi1.Name, v1.MigrationRunning)
+			controller.vmiIndexer.Add(vmi2)
+			controller.migrationIndexer.Add(migration2)
+
+			vmi3 := newVirtualMachineMarkedForEviction("testvmi3", node.Name)
+			controller.vmiIndexer.Add(vmi3)
+
+			enqueue(node)
+			sanityExecute()
+			Expect(recorder.Events).To(BeEmpty())
+
+			migration2.Status.Phase = v1.MigrationSucceeded
+			controller.migrationIndexer.Update(migration2)
+
+			enqueue(node)
 			sanityExecute()
 			testutils.ExpectEvent(recorder, SuccessfulCreateVirtualMachineInstanceMigrationReason)
 			expectMigrationCreation()
@@ -260,7 +309,29 @@ var _ = Describe("Evacuation", func() {
 			testutils.ExpectEvent(recorder, FailedCreateVirtualMachineInstanceMigrationReason)
 		})
 
-		It("Should do nothing when active migrations exceed the configured concurrent maximum", func() {
+		It("Should not evict VMI if max migrations are in progress", func() {
+			node := newNode("foo")
+			addNode(node)
+			enqueue(node)
+			vmi := newVirtualMachine("testvm", node.Name)
+			vmi.Spec.EvictionStrategy = newEvictionStrategyLiveMigrate()
+			vmi.Status.Conditions = []v1.VirtualMachineInstanceCondition{
+				{
+					Type:   v1.VirtualMachineInstanceIsMigratable,
+					Status: k8sv1.ConditionFalse,
+				},
+			}
+			vmi.Status.EvacuationNodeName = node.Name
+			controller.vmiIndexer.Add(vmi)
+			controller.migrationIndexer.Add(newMigration("mig1", vmi.Name, v1.MigrationRunning))
+			controller.migrationIndexer.Add(newMigration("mig2", vmi.Name, v1.MigrationRunning))
+			controller.migrationIndexer.Add(newMigration("mig3", vmi.Name, v1.MigrationRunning))
+			controller.migrationIndexer.Add(newMigration("mig4", vmi.Name, v1.MigrationRunning))
+			controller.migrationIndexer.Add(newMigration("mig5", vmi.Name, v1.MigrationRunning))
+			sanityExecute()
+		})
+
+		It("Shound do nothing when active migrations exceed the configured concurrent maximum", func() {
 			const maxParallelMigrationsPerCluster uint32 = 2
 			const maxParallelMigrationsPerSourceNode uint32 = 1
 			const activeMigrations = 10
@@ -384,6 +455,50 @@ var _ = Describe("Evacuation", func() {
 			controller.vmiIndexer.Add(vmi)
 
 			sanityExecute()
+		})
+
+		It("Should create new evictions up to the configured maximum migrations per outbound node", func() {
+			updateKV(func(kv *v1.KubeVirt) {
+				kv.Spec.Configuration.DeveloperConfiguration = &v1.DeveloperConfiguration{
+					DisabledFeatureGates: []string{featuregate.MigrationPriorityQueue},
+				}
+			})
+			var maxParallelMigrationsPerCluster uint32 = 10
+			var maxParallelMigrationsPerOutboundNode uint32 = 5
+			var activeMigrationsFromThisSourceNode = 4
+			var migrationCandidatesFromThisSourceNode = 4
+
+			updateKV(func(kv *v1.KubeVirt) {
+				kv.Spec.Configuration.MigrationConfiguration = &v1.MigrationConfiguration{
+					ParallelMigrationsPerCluster:      &maxParallelMigrationsPerCluster,
+					ParallelOutboundMigrationsPerNode: &maxParallelMigrationsPerOutboundNode,
+				}
+			})
+
+			nodeName := "node01"
+			node := newNode(nodeName)
+			addNode(node)
+			enqueue(node)
+
+			By(fmt.Sprintf("Creating %d active migrations from source node %s", activeMigrationsFromThisSourceNode, nodeName))
+			for i := 1; i <= activeMigrationsFromThisSourceNode; i++ {
+				vmiName := fmt.Sprintf("testvmi%d", i)
+				controller.vmiIndexer.Add(newVirtualMachineMarkedForEviction(vmiName, nodeName))
+				controller.migrationIndexer.Add(newMigration(fmt.Sprintf("mig%d", i), vmiName, v1.MigrationRunning))
+			}
+
+			By(fmt.Sprintf("Creating %d migration candidates from source node %s", migrationCandidatesFromThisSourceNode, nodeName))
+			for i := 1; i <= migrationCandidatesFromThisSourceNode; i++ {
+				vmiName := fmt.Sprintf("testvmi%d", i+activeMigrationsFromThisSourceNode)
+				controller.vmiIndexer.Add(newVirtualMachineMarkedForEviction(vmiName, nodeName))
+			}
+
+			By(fmt.Sprintf("Expect only one new migration from node %s although cluster capacity allows more candidates", nodeName))
+
+			sanityExecute()
+
+			testutils.ExpectEvent(recorder, SuccessfulCreateVirtualMachineInstanceMigrationReason)
+			expectMigrationCreation()
 		})
 
 		It("should treat pending migrations as non-running migrations", func() {

--- a/pkg/virt-controller/watch/drain/evacuation/evacuation_test.go
+++ b/pkg/virt-controller/watch/drain/evacuation/evacuation_test.go
@@ -163,6 +163,11 @@ var _ = Describe("Evacuation", func() {
 		})
 
 		It("should ignore VMIs which are not migratable", func() {
+			updateKV(func(kv *v1.KubeVirt) {
+				kv.Spec.Configuration.DeveloperConfiguration = &v1.DeveloperConfiguration{
+					DisabledFeatureGates: []string{featuregate.MigrationPriorityQueue},
+				}
+			})
 			node := newNode("testnode")
 			addNode(newNode("anothernode"))
 			node.Spec.Taints = append(node.Spec.Taints, *newTaint())
@@ -180,10 +185,10 @@ var _ = Describe("Evacuation", func() {
 			controller.vmiIndexer.Add(vmi1)
 
 			sanityExecute()
-
-			migrationList, err := virtClient.VirtualMachineInstanceMigration(k8sv1.NamespaceDefault).List(context.TODO(), metav1.ListOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			Expect(migrationList.Items).To(BeEmpty())
+			testutils.ExpectEvents(recorder,
+				FailedCreateVirtualMachineInstanceMigrationReason,
+				FailedCreateVirtualMachineInstanceMigrationReason,
+			)
 		})
 
 		It("should evict VMIs even if 5 migrations are in progress", func() {
@@ -224,6 +229,35 @@ var _ = Describe("Evacuation", func() {
 			sanityExecute()
 			testutils.ExpectEvent(recorder, SuccessfulCreateVirtualMachineInstanceMigrationReason)
 			expectMigrationCreation()
+		})
+
+		It("Should record a warning on a not migratable VMI", func() {
+			updateKV(func(kv *v1.KubeVirt) {
+				kv.Spec.Configuration.DeveloperConfiguration = &v1.DeveloperConfiguration{
+					DisabledFeatureGates: []string{featuregate.MigrationPriorityQueue},
+				}
+			})
+			node := newNode("foo")
+			addNode(node)
+			enqueue(node)
+			vmi := newVirtualMachine("testvm", node.Name)
+			vmi.Spec.EvictionStrategy = newEvictionStrategyLiveMigrate()
+			vmi.Status.Conditions = []v1.VirtualMachineInstanceCondition{
+				{
+					Type:   v1.VirtualMachineInstanceIsMigratable,
+					Status: k8sv1.ConditionFalse,
+				},
+			}
+			vmi.Status.Conditions = []v1.VirtualMachineInstanceCondition{
+				{
+					Type:   v1.VirtualMachineInstanceIsMigratable,
+					Status: k8sv1.ConditionFalse,
+				},
+			}
+			vmi.Status.EvacuationNodeName = vmi.Status.NodeName
+			controller.vmiIndexer.Add(vmi)
+			sanityExecute()
+			testutils.ExpectEvent(recorder, FailedCreateVirtualMachineInstanceMigrationReason)
 		})
 
 		It("Should do nothing when active migrations exceed the configured concurrent maximum", func() {

--- a/pkg/virt-controller/watch/migration/BUILD.bazel
+++ b/pkg/virt-controller/watch/migration/BUILD.bazel
@@ -60,6 +60,7 @@ go_test(
         "//pkg/testutils:go_default_library",
         "//pkg/util/migrations:go_default_library",
         "//pkg/virt-config:go_default_library",
+        "//pkg/virt-config/featuregate:go_default_library",
         "//pkg/virt-controller/services:go_default_library",
         "//staging/src/kubevirt.io/api/backup/v1alpha1:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
@@ -89,5 +90,6 @@ go_test(
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/client-go/tools/record:go_default_library",
         "//vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
+        "//vendor/sigs.k8s.io/controller-runtime/pkg/controller/priorityqueue:go_default_library",
     ],
 )

--- a/pkg/virt-controller/watch/migration/migration.go
+++ b/pkg/virt-controller/watch/migration/migration.go
@@ -439,10 +439,12 @@ func (c *Controller) execute(key string) error {
 		if err != nil {
 			return err
 		}
-		// re-enqueue of highest priority pending migration since now there is a free spot
-		err = c.reEnqueueHighestPriorityPendingMigrations()
-		if err != nil {
-			return err
+		if c.clusterConfig.MigrationPriorityQueueEnabled() {
+			// re-enqueue of highest priority pending migration since now there is a free spot
+			err = c.reEnqueueHighestPriorityPendingMigrations()
+			if err != nil {
+				return err
+			}
 		}
 	}
 
@@ -1369,9 +1371,13 @@ func (c *Controller) handleTargetPodCreation(key string, migration *virtv1.Virtu
 	if len(runningMigrations) >= int(*c.clusterConfig.GetMigrationConfiguration().ParallelMigrationsPerCluster) {
 		log.Log.Object(migration).Infof("Waiting to schedule target pod for vmi [%s/%s] migration because total running parallel migration count [%d] is currently at the global cluster limit.", vmi.Namespace, vmi.Name, len(runningMigrations))
 		// The controller is busy with active migrations, mark ourselves as low priority to give more cycles to those
-		priority := migrationsutil.PriorityFromMigration(migration)
-		delay := getRequeueDelayForPriority(*priority)
-		c.Queue.AddWithOpts(priorityqueue.AddOpts{Priority: priority, After: delay}, key)
+		if c.clusterConfig.MigrationPriorityQueueEnabled() {
+			priority := migrationsutil.PriorityFromMigration(migration)
+			delay := getRequeueDelayForPriority(*priority)
+			c.Queue.AddWithOpts(priorityqueue.AddOpts{Priority: priority, After: delay}, key)
+		} else {
+			c.Queue.AddWithOpts(priorityqueue.AddOpts{Priority: pointer.P(migrationsutil.QueuePriorityPending), After: 5 * time.Second}, key)
+		}
 
 		return nil
 	}
@@ -1382,9 +1388,13 @@ func (c *Controller) handleTargetPodCreation(key string, migration *virtv1.Virtu
 		// XXX: Make this configurable, think about inbound migration limit, bandwidth per migration, and so on.
 		log.Log.Object(migration).Infof("Waiting to schedule target pod for vmi [%s/%s] migration because total running parallel outbound migrations on target node [%d] has hit outbound migrations per node limit.", vmi.Namespace, vmi.Name, outboundMigrations)
 		// The controller is busy with active migrations, mark ourselves as low priority to give more cycles to those
-		priority := migrationsutil.PriorityFromMigration(migration)
-		delay := getRequeueDelayForPriority(*priority)
-		c.Queue.AddWithOpts(priorityqueue.AddOpts{Priority: priority, After: delay}, key)
+		if c.clusterConfig.MigrationPriorityQueueEnabled() {
+			priority := migrationsutil.PriorityFromMigration(migration)
+			delay := getRequeueDelayForPriority(*priority)
+			c.Queue.AddWithOpts(priorityqueue.AddOpts{Priority: priority, After: delay}, key)
+		} else {
+			c.Queue.AddWithOpts(priorityqueue.AddOpts{Priority: pointer.P(migrationsutil.QueuePriorityPending), After: 5 * time.Second}, key)
+		}
 		return nil
 	}
 
@@ -1603,9 +1613,13 @@ func (c *Controller) handleVMBackup(migration *virtv1.VirtualMachineInstanceMigr
 		return true, err
 	}
 
-	priority := migrationsutil.PriorityFromMigration(migration)
-	delay := getRequeueDelayForPriority(*priority)
-	c.Queue.AddWithOpts(priorityqueue.AddOpts{Priority: priority, After: delay}, migrationKey)
+	if c.clusterConfig.MigrationPriorityQueueEnabled() {
+		priority := migrationsutil.PriorityFromMigration(migration)
+		delay := getRequeueDelayForPriority(*priority)
+		c.Queue.AddWithOpts(priorityqueue.AddOpts{Priority: priority, After: delay}, migrationKey)
+	} else {
+		c.Queue.AddWithOpts(priorityqueue.AddOpts{Priority: pointer.P(migrationsutil.QueuePriorityPending), After: 5 * time.Second}, migrationKey)
+	}
 
 	return true, nil
 }
@@ -2009,7 +2023,13 @@ func (c *Controller) enqueueMigration(obj interface{}) {
 	if migration.Status.Phase == virtv1.MigrationRunning {
 		c.Queue.AddWithOpts(priorityqueue.AddOpts{Priority: pointer.P(migrationsutil.QueuePriorityRunning)}, key)
 	} else {
-		c.Queue.AddWithOpts(priorityqueue.AddOpts{Priority: migrationsutil.PriorityFromMigration(migration)}, key)
+		if c.clusterConfig.MigrationPriorityQueueEnabled() {
+			c.Queue.AddWithOpts(priorityqueue.AddOpts{Priority: migrationsutil.PriorityFromMigration(migration)}, key)
+		} else {
+			// If the key is already in the queue at active priority or higher, it will keep that priority.
+			// If the key is already in the queue at pending priority, it will be bumped to 0 (still below all active ones).
+			c.Queue.Add(key)
+		}
 	}
 }
 

--- a/pkg/virt-controller/watch/migration/migration.go
+++ b/pkg/virt-controller/watch/migration/migration.go
@@ -1349,11 +1349,11 @@ func (c *Controller) handleTargetPodCreation(key string, migration *virtv1.Virtu
 
 	// Don't start new migrations if we wait for cache updates on migration target pods
 	if c.podExpectations.AllPendingCreations() > 0 {
-		c.Queue.AddWithOpts(priorityqueue.AddOpts{Priority: migrationsutil.PriorityFromMigration(migration), After: 1 * time.Second}, key)
+		c.Queue.AddWithOpts(priorityqueue.AddOpts{Priority: pointer.P(migrationsutil.QueuePriorityRunning), After: 1 * time.Second}, key)
 		return nil
 	} else if controller.VMIActivePodsCount(vmi, c.podIndexer) > 1 {
 		log.Log.Object(migration).Infof("Waiting to schedule target pod for migration because there are already multiple pods running for vmi %s/%s", vmi.Namespace, vmi.Name)
-		c.Queue.AddWithOpts(priorityqueue.AddOpts{Priority: migrationsutil.PriorityFromMigration(migration), After: 1 * time.Second}, key)
+		c.Queue.AddWithOpts(priorityqueue.AddOpts{Priority: pointer.P(migrationsutil.QueuePriorityRunning), After: 1 * time.Second}, key)
 		return nil
 
 	}

--- a/pkg/virt-controller/watch/migration/migration_test.go
+++ b/pkg/virt-controller/watch/migration/migration_test.go
@@ -2904,7 +2904,9 @@ var _ = Describe("Migration watcher", func() {
 			Expect(shutdown).To(BeFalse())
 		})
 
-		It("should get items in order based on priority", func() {
+		// TODO: This test is flaky due to https://github.com/kubernetes-sigs/controller-runtime/issues/3363
+		//  Promote this back to stable once a fix is merged
+		PIt("should get items in order based on priority", func() {
 
 			const (
 				runningMigNamePrefix       = "testmigration%d"

--- a/pkg/virt-controller/watch/migration/migration_test.go
+++ b/pkg/virt-controller/watch/migration/migration_test.go
@@ -2946,7 +2946,7 @@ var _ = Describe("Migration watcher", func() {
 
 			Eventually(func() int {
 				return controller.Queue.Len()
-			}, 2*time.Second, 20*time.Millisecond).Should(Equal(25))
+			}, 20*time.Millisecond, 2*time.Second).Should(Equal(25))
 			runningMigrationsFromQueue := make([]string, 0, 5)
 			for range 5 {
 				item, priority, shutdown := controller.Queue.GetWithPriority()

--- a/pkg/virt-controller/watch/migration/migration_test.go
+++ b/pkg/virt-controller/watch/migration/migration_test.go
@@ -26,6 +26,9 @@ import (
 	"strings"
 	"time"
 
+	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/controller/priorityqueue"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
@@ -54,7 +57,6 @@ import (
 	kubevirtfake "kubevirt.io/client-go/kubevirt/fake"
 	fakenetworkclient "kubevirt.io/client-go/networkattachmentdefinitionclient/fake"
 	kvtesting "kubevirt.io/client-go/testing"
-	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
 	virtcontroller "kubevirt.io/kubevirt/pkg/controller"
 	controllertesting "kubevirt.io/kubevirt/pkg/controller/testing"
@@ -63,6 +65,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/testutils"
 	migrationsutil "kubevirt.io/kubevirt/pkg/util/migrations"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
+	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"
 )
 
@@ -2850,37 +2853,30 @@ var _ = Describe("Migration watcher", func() {
 	})
 
 	Context("Priority queue", func() {
-		It("new items should have a priority strictly lower than active and higher than default", func() {
-			controller.Queue.Add("default/testmigrationpending")
-			item, priority, shutdown := controller.Queue.GetWithPriority()
-			Expect(item).To(Equal("default/testmigrationpending"))
-			Expect(priority).To(BeNumerically("<", migrationsutil.QueuePriorityRunning))
-			Expect(priority).To(BeNumerically(">=", migrationsutil.QueuePriorityDefault))
-			Expect(shutdown).To(BeFalse())
-		})
-
-		It("should properly re-enqueue pending migrations with the defined priority when no new migration can start", func() {
+		It("should properly re-enqueue pending migrations as low priority when no new migration can start", func() {
+			setConfig(&v1.KubeVirtConfiguration{
+				DeveloperConfiguration: &v1.DeveloperConfiguration{
+					DisabledFeatureGates: []string{featuregate.MigrationPriorityQueue},
+				},
+			})
 			By("Creating 1 pending migration. It will be picked up by the call to Execute()")
 			vmi := newVirtualMachine("testvmipending", v1.Running)
 			migration := newMigration("testmigrationpending", vmi.Name, v1.MigrationPending)
-			migration.Spec.Priority = pointer.P(v1.PrioritySystemCritical)
 			addMigration(migration)
 			addVirtualMachineInstance(vmi)
 			addPod(newSourcePodForVirtualMachine(vmi))
 
-			const migrationNamePrefix = "testmigration%d"
-			By("Creating 5 running system maintenance migrations")
+			By("Creating 5 running migrations")
 			for i := range 5 {
 				vmi := newVirtualMachine(fmt.Sprintf("testvmi%d", i), v1.Running)
-				migration := newMigration(fmt.Sprintf(migrationNamePrefix, i), vmi.Name, v1.MigrationRunning)
-				migration.Spec.Priority = pointer.P(v1.PrioritySystemMaintenance)
+				migration := newMigration(fmt.Sprintf("testmigration%d", i), vmi.Name, v1.MigrationRunning)
 				pod := newTargetPodForVirtualMachine(vmi, migration, k8sv1.PodRunning)
 				addMigration(migration)
 				addVirtualMachineInstance(vmi)
 				addPod(pod)
 			}
 
-			By("Executing the controller and expecting the pending migration to have the defined priority")
+			By("Executing the controller and expecting the pending migration to have a low priority")
 			controller.Execute()
 			runningMigrationsFromQueue := make([]string, 0, 5)
 			for range 5 {
@@ -2891,64 +2887,57 @@ var _ = Describe("Migration watcher", func() {
 			}
 			Expect(runningMigrationsFromQueue).To(
 				ConsistOf(
-					fmt.Sprintf("default/"+migrationNamePrefix, 0),
-					fmt.Sprintf("default/"+migrationNamePrefix, 1),
-					fmt.Sprintf("default/"+migrationNamePrefix, 2),
-					fmt.Sprintf("default/"+migrationNamePrefix, 3),
-					fmt.Sprintf("default/"+migrationNamePrefix, 4),
+					"default/testmigration0",
+					"default/testmigration1",
+					"default/testmigration2",
+					"default/testmigration3",
+					"default/testmigration4",
 				),
 			)
 			item, priority, shutdown := controller.Queue.GetWithPriority()
 			Expect(item).To(Equal("default/testmigrationpending"))
-			Expect(priority).To(Equal(migrationsutil.QueuePrioritySystemCritical))
+			Expect(priority).To(Equal(migrationsutil.QueuePriorityPending))
 			Expect(shutdown).To(BeFalse())
 		})
 
-		// TODO: This test is flaky due to https://github.com/kubernetes-sigs/controller-runtime/issues/3363
-		//  Promote this back to stable once a fix is merged
-		PIt("should get items in order based on priority", func() {
+		It("existing items should keep low priority after regular Add", func() {
+			controller.Queue.AddWithOpts(priorityqueue.AddOpts{
+				Priority: pointer.P(migrationsutil.QueuePriorityPending),
+			}, "default/testmigrationpending")
 
-			const (
-				runningMigNamePrefix       = "testmigration%d"
-				userTriggeredMigNamePrefix = "test-user-migration-%d"
-				criticalMigNamePrefix      = "test-crit-migration-%d"
-				defaultMigNamePrefix       = "test-noprio-migration-%d"
-				maintenanceMigNamePrefix   = "test-maint-migration-%d"
-			)
+			// Simulating what we do with informer handler
+			controller.Queue.Add("default/testmigrationpending")
+			item, priority, shutdown := controller.Queue.GetWithPriority()
+			Expect(item).To(Equal("default/testmigrationpending"))
+			Expect(priority).To(BeNumerically("<", migrationsutil.QueuePriorityRunning))
+			Expect(shutdown).To(BeFalse())
+		})
 
-			By("Creating 5 running system critical migrations")
+		It("new items should have a priority strictly lower than active and higher than pending", func() {
+			controller.Queue.Add("default/testmigrationpending")
+			item, priority, shutdown := controller.Queue.GetWithPriority()
+			Expect(item).To(Equal("default/testmigrationpending"))
+			Expect(priority).To(BeNumerically("<", migrationsutil.QueuePriorityRunning))
+			Expect(priority).To(BeNumerically(">", migrationsutil.QueuePriorityPending))
+			Expect(shutdown).To(BeFalse())
+		})
+
+		It("should get items in order based on priority", func() {
 			for i := range 5 {
-				vmi := newVirtualMachine(fmt.Sprintf("testvmi%d", i), v1.Running)
-				migration := newMigration(fmt.Sprintf(runningMigNamePrefix, i), vmi.Name, v1.MigrationRunning)
-				migration.Spec.Priority = pointer.P(v1.PrioritySystemCritical)
-				controller.enqueueMigration(migration)
+				controller.Queue.AddWithOpts(priorityqueue.AddOpts{
+					Priority: pointer.P(migrationsutil.QueuePriorityPending),
+				}, fmt.Sprintf("default/pending%d", i))
 			}
-
-			By("Creating 5 critical, 5 maintenance, 5 user triggered and 5 non-defined priority migrations")
 			for i := range 5 {
-				vmi := newVirtualMachine(fmt.Sprintf("testvmi-user-%d", i), v1.Running)
-				migration := newMigration(fmt.Sprintf(userTriggeredMigNamePrefix, i), vmi.Name, v1.MigrationPending)
-				migration.Spec.Priority = pointer.P(v1.PriorityUserTriggered)
-				controller.enqueueMigration(migration)
-
-				vmi = newVirtualMachine(fmt.Sprintf("testvmi-crit-%d", i), v1.Running)
-				migration = newMigration(fmt.Sprintf(criticalMigNamePrefix, i), vmi.Name, v1.MigrationPending)
-				migration.Spec.Priority = pointer.P(v1.PrioritySystemCritical)
-				controller.enqueueMigration(migration)
-
-				vmi = newVirtualMachine(fmt.Sprintf("testvmi-noprio-%d", i), v1.Running)
-				migration = newMigration(fmt.Sprintf(defaultMigNamePrefix, i), vmi.Name, v1.MigrationPending)
-				controller.enqueueMigration(migration)
-
-				vmi = newVirtualMachine(fmt.Sprintf("testvmi-maint-%d", i), v1.Running)
-				migration = newMigration(fmt.Sprintf(maintenanceMigNamePrefix, i), vmi.Name, v1.MigrationPending)
-				migration.Spec.Priority = pointer.P(v1.PrioritySystemMaintenance)
-				controller.enqueueMigration(migration)
+				controller.Queue.AddWithOpts(priorityqueue.AddOpts{
+					Priority: pointer.P(migrationsutil.QueuePriorityRunning),
+				}, fmt.Sprintf("default/active%d", i))
 			}
+			// Add should not change active3's priority
+			controller.Queue.Add("default/active3")
+			// Add should bump pending3 higher than pending but lower than active
+			controller.Queue.Add("default/pending3")
 
-			Eventually(func() int {
-				return controller.Queue.Len()
-			}, 20*time.Millisecond, 2*time.Second).Should(Equal(25))
 			runningMigrationsFromQueue := make([]string, 0, 5)
 			for range 5 {
 				item, priority, shutdown := controller.Queue.GetWithPriority()
@@ -2958,81 +2947,220 @@ var _ = Describe("Migration watcher", func() {
 			}
 			Expect(runningMigrationsFromQueue).To(
 				ConsistOf(
-					fmt.Sprintf("default/"+runningMigNamePrefix, 0),
-					fmt.Sprintf("default/"+runningMigNamePrefix, 1),
-					fmt.Sprintf("default/"+runningMigNamePrefix, 2),
-					fmt.Sprintf("default/"+runningMigNamePrefix, 3),
-					fmt.Sprintf("default/"+runningMigNamePrefix, 4),
+					"default/active0",
+					"default/active1",
+					"default/active2",
+					"default/active3",
+					"default/active4",
 				),
 			)
 
-			criticalMigrationsFromQueue := make([]string, 0, 5)
-			for range 5 {
+			item, priority, shutdown := controller.Queue.GetWithPriority()
+			Expect(item).To(BeEquivalentTo("default/pending3"))
+			Expect(priority).To(BeNumerically("<", migrationsutil.QueuePriorityRunning))
+			Expect(priority).To(BeNumerically(">", migrationsutil.QueuePriorityPending))
+			Expect(shutdown).To(BeFalse())
+			runningMigrationsFromQueue = make([]string, 0, 4)
+			for range 4 {
 				item, priority, shutdown := controller.Queue.GetWithPriority()
-				criticalMigrationsFromQueue = append(criticalMigrationsFromQueue, item)
+				runningMigrationsFromQueue = append(runningMigrationsFromQueue, item)
+				Expect(priority).To(Equal(migrationsutil.QueuePriorityPending))
+				Expect(shutdown).To(BeFalse())
+			}
+			Expect(runningMigrationsFromQueue).To(
+				ConsistOf(
+					"default/pending0",
+					"default/pending1",
+					"default/pending2",
+					"default/pending4",
+				),
+			)
+		})
+
+		Context("with MigrationPriorityQueue feature gate enabled", func() {
+			BeforeEach(func() {
+				setConfig(&v1.KubeVirtConfiguration{
+					DeveloperConfiguration: &v1.DeveloperConfiguration{
+						FeatureGates: []string{featuregate.MigrationPriorityQueue},
+					},
+				})
+			})
+
+			It("should properly re-enqueue pending migrations with the defined priority when no new migration can start", func() {
+				By("Creating 1 pending migration. It will be picked up by the call to Execute()")
+				vmi := newVirtualMachine("testvmipending", v1.Running)
+				migration := newMigration("testmigrationpending", vmi.Name, v1.MigrationPending)
+				migration.Spec.Priority = pointer.P(v1.PrioritySystemCritical)
+				addMigration(migration)
+				addVirtualMachineInstance(vmi)
+				addPod(newSourcePodForVirtualMachine(vmi))
+
+				const migrationNamePrefix = "testmigration%d"
+				By("Creating 5 running system maintenance migrations")
+				for i := range 5 {
+					vmi := newVirtualMachine(fmt.Sprintf("testvmi%d", i), v1.Running)
+					migration := newMigration(fmt.Sprintf(migrationNamePrefix, i), vmi.Name, v1.MigrationRunning)
+					migration.Spec.Priority = pointer.P(v1.PrioritySystemMaintenance)
+					pod := newTargetPodForVirtualMachine(vmi, migration, k8sv1.PodRunning)
+					addMigration(migration)
+					addVirtualMachineInstance(vmi)
+					addPod(pod)
+				}
+
+				By("Executing the controller and expecting the pending migration to have the defined priority")
+				controller.Execute()
+				runningMigrationsFromQueue := make([]string, 0, 5)
+				for range 5 {
+					item, priority, shutdown := controller.Queue.GetWithPriority()
+					runningMigrationsFromQueue = append(runningMigrationsFromQueue, item)
+					Expect(priority).To(Equal(0))
+					Expect(shutdown).To(BeFalse())
+				}
+				Expect(runningMigrationsFromQueue).To(
+					ConsistOf(
+						fmt.Sprintf("default/"+migrationNamePrefix, 0),
+						fmt.Sprintf("default/"+migrationNamePrefix, 1),
+						fmt.Sprintf("default/"+migrationNamePrefix, 2),
+						fmt.Sprintf("default/"+migrationNamePrefix, 3),
+						fmt.Sprintf("default/"+migrationNamePrefix, 4),
+					),
+				)
+				item, priority, shutdown := controller.Queue.GetWithPriority()
+				Expect(item).To(Equal("default/testmigrationpending"))
 				Expect(priority).To(Equal(migrationsutil.QueuePrioritySystemCritical))
 				Expect(shutdown).To(BeFalse())
-			}
-			Expect(criticalMigrationsFromQueue).To(
-				ConsistOf(
-					fmt.Sprintf("default/"+criticalMigNamePrefix, 0),
-					fmt.Sprintf("default/"+criticalMigNamePrefix, 1),
-					fmt.Sprintf("default/"+criticalMigNamePrefix, 2),
-					fmt.Sprintf("default/"+criticalMigNamePrefix, 3),
-					fmt.Sprintf("default/"+criticalMigNamePrefix, 4),
-				),
-			)
+			})
 
-			userMigrationsFromQueue := make([]string, 0, 5)
-			for range 5 {
-				item, priority, shutdown := controller.Queue.GetWithPriority()
-				userMigrationsFromQueue = append(userMigrationsFromQueue, item)
-				Expect(priority).To(Equal(migrationsutil.QueuePriorityUserTriggered))
-				Expect(shutdown).To(BeFalse())
-			}
-			Expect(userMigrationsFromQueue).To(
-				ConsistOf(
-					fmt.Sprintf("default/"+userTriggeredMigNamePrefix, 0),
-					fmt.Sprintf("default/"+userTriggeredMigNamePrefix, 1),
-					fmt.Sprintf("default/"+userTriggeredMigNamePrefix, 2),
-					fmt.Sprintf("default/"+userTriggeredMigNamePrefix, 3),
-					fmt.Sprintf("default/"+userTriggeredMigNamePrefix, 4),
-				),
-			)
+			// TODO: This test is flaky due to https://github.com/kubernetes-sigs/controller-runtime/issues/3363
+			//  Promote this back to stable once a fix is merged
+			PIt("should get items in order based on priority", func() {
 
-			maintenanceMigrationsFromQueue := make([]string, 0, 5)
-			for range 5 {
-				item, priority, shutdown := controller.Queue.GetWithPriority()
-				maintenanceMigrationsFromQueue = append(maintenanceMigrationsFromQueue, item)
-				Expect(priority).To(Equal(migrationsutil.QueuePrioritySystemMaintenance))
-				Expect(shutdown).To(BeFalse())
-			}
-			Expect(maintenanceMigrationsFromQueue).To(
-				ConsistOf(
-					fmt.Sprintf("default/"+maintenanceMigNamePrefix, 0),
-					fmt.Sprintf("default/"+maintenanceMigNamePrefix, 1),
-					fmt.Sprintf("default/"+maintenanceMigNamePrefix, 2),
-					fmt.Sprintf("default/"+maintenanceMigNamePrefix, 3),
-					fmt.Sprintf("default/"+maintenanceMigNamePrefix, 4),
-				),
-			)
+				const (
+					runningMigNamePrefix       = "testmigration%d"
+					userTriggeredMigNamePrefix = "test-user-migration-%d"
+					criticalMigNamePrefix      = "test-crit-migration-%d"
+					defaultMigNamePrefix       = "test-noprio-migration-%d"
+					maintenanceMigNamePrefix   = "test-maint-migration-%d"
+				)
 
-			defaultMigrationsFromQueue := make([]string, 0, 5)
-			for range 5 {
-				item, priority, shutdown := controller.Queue.GetWithPriority()
-				defaultMigrationsFromQueue = append(defaultMigrationsFromQueue, item)
-				Expect(priority).To(Equal(migrationsutil.QueuePriorityDefault))
-				Expect(shutdown).To(BeFalse())
-			}
-			Expect(defaultMigrationsFromQueue).To(
-				ConsistOf(
-					fmt.Sprintf("default/"+defaultMigNamePrefix, 0),
-					fmt.Sprintf("default/"+defaultMigNamePrefix, 1),
-					fmt.Sprintf("default/"+defaultMigNamePrefix, 2),
-					fmt.Sprintf("default/"+defaultMigNamePrefix, 3),
-					fmt.Sprintf("default/"+defaultMigNamePrefix, 4),
-				),
-			)
+				By("Creating 5 running system critical migrations")
+				for i := range 5 {
+					vmi := newVirtualMachine(fmt.Sprintf("testvmi%d", i), v1.Running)
+					migration := newMigration(fmt.Sprintf(runningMigNamePrefix, i), vmi.Name, v1.MigrationRunning)
+					migration.Spec.Priority = pointer.P(v1.PrioritySystemCritical)
+					controller.enqueueMigration(migration)
+				}
+
+				By("Creating 5 critical, 5 maintenance, 5 user triggered and 5 non-defined priority migrations")
+				for i := range 5 {
+					vmi := newVirtualMachine(fmt.Sprintf("testvmi-user-%d", i), v1.Running)
+					migration := newMigration(fmt.Sprintf(userTriggeredMigNamePrefix, i), vmi.Name, v1.MigrationPending)
+					migration.Spec.Priority = pointer.P(v1.PriorityUserTriggered)
+					controller.enqueueMigration(migration)
+
+					vmi = newVirtualMachine(fmt.Sprintf("testvmi-crit-%d", i), v1.Running)
+					migration = newMigration(fmt.Sprintf(criticalMigNamePrefix, i), vmi.Name, v1.MigrationPending)
+					migration.Spec.Priority = pointer.P(v1.PrioritySystemCritical)
+					controller.enqueueMigration(migration)
+
+					vmi = newVirtualMachine(fmt.Sprintf("testvmi-noprio-%d", i), v1.Running)
+					migration = newMigration(fmt.Sprintf(defaultMigNamePrefix, i), vmi.Name, v1.MigrationPending)
+					controller.enqueueMigration(migration)
+
+					vmi = newVirtualMachine(fmt.Sprintf("testvmi-maint-%d", i), v1.Running)
+					migration = newMigration(fmt.Sprintf(maintenanceMigNamePrefix, i), vmi.Name, v1.MigrationPending)
+					migration.Spec.Priority = pointer.P(v1.PrioritySystemMaintenance)
+					controller.enqueueMigration(migration)
+				}
+
+				Eventually(func() int {
+					return controller.Queue.Len()
+				}, 20*time.Millisecond, 2*time.Second).Should(Equal(25))
+				runningMigrationsFromQueue := make([]string, 0, 5)
+				for range 5 {
+					item, priority, shutdown := controller.Queue.GetWithPriority()
+					runningMigrationsFromQueue = append(runningMigrationsFromQueue, item)
+					Expect(priority).To(Equal(migrationsutil.QueuePriorityRunning))
+					Expect(shutdown).To(BeFalse())
+				}
+				Expect(runningMigrationsFromQueue).To(
+					ConsistOf(
+						fmt.Sprintf("default/"+runningMigNamePrefix, 0),
+						fmt.Sprintf("default/"+runningMigNamePrefix, 1),
+						fmt.Sprintf("default/"+runningMigNamePrefix, 2),
+						fmt.Sprintf("default/"+runningMigNamePrefix, 3),
+						fmt.Sprintf("default/"+runningMigNamePrefix, 4),
+					),
+				)
+
+				criticalMigrationsFromQueue := make([]string, 0, 5)
+				for range 5 {
+					item, priority, shutdown := controller.Queue.GetWithPriority()
+					criticalMigrationsFromQueue = append(criticalMigrationsFromQueue, item)
+					Expect(priority).To(Equal(migrationsutil.QueuePrioritySystemCritical))
+					Expect(shutdown).To(BeFalse())
+				}
+				Expect(criticalMigrationsFromQueue).To(
+					ConsistOf(
+						fmt.Sprintf("default/"+criticalMigNamePrefix, 0),
+						fmt.Sprintf("default/"+criticalMigNamePrefix, 1),
+						fmt.Sprintf("default/"+criticalMigNamePrefix, 2),
+						fmt.Sprintf("default/"+criticalMigNamePrefix, 3),
+						fmt.Sprintf("default/"+criticalMigNamePrefix, 4),
+					),
+				)
+
+				userMigrationsFromQueue := make([]string, 0, 5)
+				for range 5 {
+					item, priority, shutdown := controller.Queue.GetWithPriority()
+					userMigrationsFromQueue = append(userMigrationsFromQueue, item)
+					Expect(priority).To(Equal(migrationsutil.QueuePriorityUserTriggered))
+					Expect(shutdown).To(BeFalse())
+				}
+				Expect(userMigrationsFromQueue).To(
+					ConsistOf(
+						fmt.Sprintf("default/"+userTriggeredMigNamePrefix, 0),
+						fmt.Sprintf("default/"+userTriggeredMigNamePrefix, 1),
+						fmt.Sprintf("default/"+userTriggeredMigNamePrefix, 2),
+						fmt.Sprintf("default/"+userTriggeredMigNamePrefix, 3),
+						fmt.Sprintf("default/"+userTriggeredMigNamePrefix, 4),
+					),
+				)
+
+				maintenanceMigrationsFromQueue := make([]string, 0, 5)
+				for range 5 {
+					item, priority, shutdown := controller.Queue.GetWithPriority()
+					maintenanceMigrationsFromQueue = append(maintenanceMigrationsFromQueue, item)
+					Expect(priority).To(Equal(migrationsutil.QueuePrioritySystemMaintenance))
+					Expect(shutdown).To(BeFalse())
+				}
+				Expect(maintenanceMigrationsFromQueue).To(
+					ConsistOf(
+						fmt.Sprintf("default/"+maintenanceMigNamePrefix, 0),
+						fmt.Sprintf("default/"+maintenanceMigNamePrefix, 1),
+						fmt.Sprintf("default/"+maintenanceMigNamePrefix, 2),
+						fmt.Sprintf("default/"+maintenanceMigNamePrefix, 3),
+						fmt.Sprintf("default/"+maintenanceMigNamePrefix, 4),
+					),
+				)
+
+				defaultMigrationsFromQueue := make([]string, 0, 5)
+				for range 5 {
+					item, priority, shutdown := controller.Queue.GetWithPriority()
+					defaultMigrationsFromQueue = append(defaultMigrationsFromQueue, item)
+					Expect(priority).To(Equal(migrationsutil.QueuePriorityDefault))
+					Expect(shutdown).To(BeFalse())
+				}
+				Expect(defaultMigrationsFromQueue).To(
+					ConsistOf(
+						fmt.Sprintf("default/"+defaultMigNamePrefix, 0),
+						fmt.Sprintf("default/"+defaultMigNamePrefix, 1),
+						fmt.Sprintf("default/"+defaultMigNamePrefix, 2),
+						fmt.Sprintf("default/"+defaultMigNamePrefix, 3),
+						fmt.Sprintf("default/"+defaultMigNamePrefix, 4),
+					),
+				)
+			})
 		})
 	})
 

--- a/pkg/virt-controller/watch/migration/migration_test.go
+++ b/pkg/virt-controller/watch/migration/migration_test.go
@@ -2904,45 +2904,6 @@ var _ = Describe("Migration watcher", func() {
 			Expect(shutdown).To(BeFalse())
 		})
 
-		It("should re-enqueue with migration priority when pending pod creations exist", func() {
-			vmi := newVirtualMachine("testvmipending", v1.Running)
-			migration := newMigration("testmigrationpending", vmi.Name, v1.MigrationPending)
-			migration.Spec.Priority = pointer.P(v1.PriorityUserTriggered)
-			addMigration(migration)
-			addVirtualMachineInstance(vmi)
-			addPod(newSourcePodForVirtualMachine(vmi))
-
-			By("Setting up pending pod creation expectations so AllPendingCreations() > 0")
-			controller.podExpectations.ExpectCreations("some-other-key", 1)
-
-			controller.Execute()
-
-			item, priority, shutdown := controller.Queue.GetWithPriority()
-			Expect(item).To(Equal("default/testmigrationpending"))
-			Expect(priority).To(Equal(migrationsutil.QueuePriorityUserTriggered))
-			Expect(shutdown).To(BeFalse())
-		})
-
-		It("should re-enqueue with migration priority when multiple active pods exist for VMI", func() {
-			vmi := newVirtualMachine("testvmipending", v1.Running)
-			migration := newMigration("testmigrationpending", vmi.Name, v1.MigrationPending)
-			migration.Spec.Priority = pointer.P(v1.PrioritySystemMaintenance)
-
-			pod1 := newTargetPodForVirtualMachine(vmi, migration, k8sv1.PodPending)
-			pod1.Labels[v1.MigrationJobLabel] = "some-other-job"
-			addPod(pod1)
-			addMigration(migration)
-			addVirtualMachineInstance(vmi)
-			addPod(newSourcePodForVirtualMachine(vmi))
-
-			controller.Execute()
-
-			item, priority, shutdown := controller.Queue.GetWithPriority()
-			Expect(item).To(Equal("default/testmigrationpending"))
-			Expect(priority).To(Equal(migrationsutil.QueuePrioritySystemMaintenance))
-			Expect(shutdown).To(BeFalse())
-		})
-
 		It("should get items in order based on priority", func() {
 
 			const (

--- a/pkg/virt-controller/watch/workload-updater/BUILD.bazel
+++ b/pkg/virt-controller/watch/workload-updater/BUILD.bazel
@@ -46,6 +46,7 @@ go_test(
         "//pkg/pointer:go_default_library",
         "//pkg/testutils:go_default_library",
         "//pkg/virt-config:go_default_library",
+        "//pkg/virt-config/featuregate:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubevirt/fake:go_default_library",

--- a/pkg/virt-controller/watch/workload-updater/workload-updater.go
+++ b/pkg/virt-controller/watch/workload-updater/workload-updater.go
@@ -579,12 +579,14 @@ func (c *WorkloadUpdateController) sync(kv *virtv1.KubeVirt) error {
 					VMIName: vmi.Name,
 				},
 			}
-			// default is upgrade
-			priority := v1.PrioritySystemCritical
-			if isHotplugInProgress(vmi) || isVolumesUpdateInProgress(vmi) {
-				priority = v1.PriorityUserTriggered
+			if c.clusterConfig.MigrationPriorityQueueEnabled() {
+				// default is upgrade
+				priority := v1.PrioritySystemCritical
+				if isHotplugInProgress(vmi) || isVolumesUpdateInProgress(vmi) {
+					priority = v1.PriorityUserTriggered
+				}
+				wuMigration.Spec.Priority = &priority
 			}
-			wuMigration.Spec.Priority = &priority
 			createdMigration, err := c.clientset.VirtualMachineInstanceMigration(vmi.Namespace).Create(context.Background(), wuMigration, metav1.CreateOptions{})
 			if err != nil {
 				log.Log.Object(vmi).Reason(err).Errorf("Failed to migrate vmi as part of workload update")

--- a/pkg/virt-controller/watch/workload-updater/workload-updater_test.go
+++ b/pkg/virt-controller/watch/workload-updater/workload-updater_test.go
@@ -35,6 +35,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/pointer"
 	"kubevirt.io/kubevirt/pkg/testutils"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
+	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 )
 
 var _ = Describe("Workload Updater", func() {
@@ -691,36 +692,47 @@ var _ = Describe("Workload Updater", func() {
 		)
 	})
 
-	DescribeTable("should set correct priority to the migration object", func(condition *v1.VirtualMachineInstanceCondition, expectedPriority string) {
-		vmi := newVirtualMachineInstance("testvm", true, "madeup")
-		if condition != nil {
-			virtcontroller.NewVirtualMachineInstanceConditionManager().UpdateCondition(vmi, condition)
-		}
-		pod := newLauncherPodForVMI(vmi)
-		kv := newKubeVirt(1)
-		kv.Spec.WorkloadUpdateStrategy.WorkloadUpdateMethods = []v1.WorkloadUpdateMethod{v1.WorkloadUpdateMethodLiveMigrate, v1.WorkloadUpdateMethodEvict}
+	Context("when MigrationPriorityQueue feature gate is enabled", func() {
+		BeforeEach(func() {
+			config, _, _ := testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{
+				DeveloperConfiguration: &v1.DeveloperConfiguration{
+					FeatureGates: []string{featuregate.MigrationPriorityQueue},
+				},
+			})
+			controller.clusterConfig = config
+		})
 
-		addKubeVirt(kv)
-		controller.vmiStore.Add(vmi)
-		controller.podIndexer.Add(pod)
-		waitForNumberOfInstancesOnVMIInformerCache(controller, 1)
-		sanityExecute()
-		testutils.ExpectEvent(recorder, SuccessfulCreateVirtualMachineInstanceMigrationReason)
-		migrations, err := fakeVirtClient.KubevirtV1().VirtualMachineInstanceMigrations(k8sv1.NamespaceDefault).List(context.Background(), metav1.ListOptions{})
-		Expect(err).ToNot(HaveOccurred())
-		Expect(migrations.Items).To(HaveLen(1))
-		Expect(migrations.Items[0].Spec.Priority).To(gstruct.PointTo(BeEquivalentTo(expectedPriority)))
-	},
-		Entry("system-critical in case of upgrade", nil, "system-critical"),
-		Entry("user-triggered in case of hotplug", &v1.VirtualMachineInstanceCondition{
-			Type:   v1.VirtualMachineInstanceMemoryChange,
-			Status: k8sv1.ConditionTrue,
-		}, "user-triggered"),
-		Entry("user-triggered in case of volume update", &v1.VirtualMachineInstanceCondition{
-			Type:   v1.VirtualMachineInstanceVolumesChange,
-			Status: k8sv1.ConditionTrue,
-		}, "user-triggered"),
-	)
+		DescribeTable("should set correct priority to the migration object", func(condition *v1.VirtualMachineInstanceCondition, expectedPriority string) {
+			vmi := newVirtualMachineInstance("testvm", true, "madeup")
+			if condition != nil {
+				virtcontroller.NewVirtualMachineInstanceConditionManager().UpdateCondition(vmi, condition)
+			}
+			pod := newLauncherPodForVMI(vmi)
+			kv := newKubeVirt(1)
+			kv.Spec.WorkloadUpdateStrategy.WorkloadUpdateMethods = []v1.WorkloadUpdateMethod{v1.WorkloadUpdateMethodLiveMigrate, v1.WorkloadUpdateMethodEvict}
+
+			addKubeVirt(kv)
+			controller.vmiStore.Add(vmi)
+			controller.podIndexer.Add(pod)
+			waitForNumberOfInstancesOnVMIInformerCache(controller, 1)
+			sanityExecute()
+			testutils.ExpectEvent(recorder, SuccessfulCreateVirtualMachineInstanceMigrationReason)
+			migrations, err := fakeVirtClient.KubevirtV1().VirtualMachineInstanceMigrations(k8sv1.NamespaceDefault).List(context.Background(), metav1.ListOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(migrations.Items).To(HaveLen(1))
+			Expect(migrations.Items[0].Spec.Priority).To(gstruct.PointTo(BeEquivalentTo(expectedPriority)))
+		},
+			Entry("system-critical in case of upgrade", nil, "system-critical"),
+			Entry("user-triggered in case of hotplug", &v1.VirtualMachineInstanceCondition{
+				Type:   v1.VirtualMachineInstanceMemoryChange,
+				Status: k8sv1.ConditionTrue,
+			}, "user-triggered"),
+			Entry("user-triggered in case of volume update", &v1.VirtualMachineInstanceCondition{
+				Type:   v1.VirtualMachineInstanceVolumesChange,
+				Status: k8sv1.ConditionTrue,
+			}, "user-triggered"),
+		)
+	})
 
 	AfterEach(func() {
 		Expect(recorder.Events).To(BeEmpty())

--- a/tests/migration/priority.go
+++ b/tests/migration/priority.go
@@ -38,6 +38,7 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
 	"kubevirt.io/kubevirt/pkg/pointer"
+	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/flags"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
@@ -61,6 +62,12 @@ var _ = Describe(SIG("Live Migrations with priority", decorators.RequiresTwoSche
 		cfg.MigrationConfiguration = &v1.MigrationConfiguration{
 			ParallelMigrationsPerCluster: pointer.P(uint32(1)),
 		}
+		if cfg.DeveloperConfiguration == nil {
+			cfg.DeveloperConfiguration = &v1.DeveloperConfiguration{
+				FeatureGates: []string{},
+			}
+		}
+		cfg.DeveloperConfiguration.FeatureGates = append(cfg.DeveloperConfiguration.FeatureGates, featuregate.MigrationPriorityQueue)
 		cfg.DeveloperConfiguration.LogVerbosity = &v1.LogVerbosity{
 			VirtController: 9,
 		}

--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -1046,8 +1046,8 @@ var _ = Describe("[sig-operator]Operator", Serial, decorators.SigOperator, func(
 			By("Deleting KubeVirt object")
 			deleteAllKvAndWait(false, originalKv.Name)
 		},
-			Entry("[QUARANTINE]from previous y release by patching KubeVirt CR", decorators.Quarantine, fromY, false),
-			Entry("[QUARANTINE]from previous y release by updating virt-operator", decorators.Quarantine, fromY, true),
+			Entry("from previous y release by patching KubeVirt CR", fromY, false),
+			Entry("from previous y release by updating virt-operator", fromY, true),
 			Entry("from previous z release by patching KubeVirt CR", fromZ, false),
 			Entry("from previous z release by updating virt-operator", fromZ, true),
 		)


### PR DESCRIPTION
This reverts commit 886c3ce.<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:

#### After this PR:

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

