### PR TITLE
tests: convert cert rotation e2e tests to unit tests

### DIFF
--- a/pkg/virt-operator/webhooks/kubevirt-update-admitter_test.go
+++ b/pkg/virt-operator/webhooks/kubevirt-update-admitter_test.go
@@ -24,6 +24,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -267,6 +268,64 @@ var _ = Describe("Validating KubeVirtUpdate Admitter", func() {
 				},
 			},
 		}, 0),
+	)
+
+	DescribeTable("validateCertificates", func(certConfig *v1.KubeVirtSelfSignConfiguration, expectedCauses int) {
+		causes := validateCertificates(certConfig)
+		Expect(causes).To(HaveLen(expectedCauses))
+	},
+		Entry("nil config accepted", nil, 0),
+		Entry("valid cert rotation parameters accepted", &v1.KubeVirtSelfSignConfiguration{
+			CA: &v1.CertConfig{
+				Duration:    &metav1.Duration{Duration: 24 * time.Hour},
+				RenewBefore: &metav1.Duration{Duration: 16 * time.Hour},
+			},
+			Server: &v1.CertConfig{
+				Duration:    &metav1.Duration{Duration: 12 * time.Hour},
+				RenewBefore: &metav1.Duration{Duration: 10 * time.Hour},
+			},
+		}, 0),
+		Entry("combining deprecated and new cert rotation parameters rejected", &v1.KubeVirtSelfSignConfiguration{
+			CA: &v1.CertConfig{
+				Duration:    &metav1.Duration{Duration: 24 * time.Hour},
+				RenewBefore: &metav1.Duration{Duration: 16 * time.Hour},
+			},
+			Server: &v1.CertConfig{
+				Duration:    &metav1.Duration{Duration: 12 * time.Hour},
+				RenewBefore: &metav1.Duration{Duration: 10 * time.Hour},
+			},
+			CAOverlapInterval: &metav1.Duration{Duration: 8 * time.Hour},
+		}, 1),
+		Entry("CA expires before rotation rejected", &v1.KubeVirtSelfSignConfiguration{
+			CA: &v1.CertConfig{
+				Duration:    &metav1.Duration{Duration: 14 * time.Hour},
+				RenewBefore: &metav1.Duration{Duration: 16 * time.Hour},
+			},
+			Server: &v1.CertConfig{
+				Duration:    &metav1.Duration{Duration: 12 * time.Hour},
+				RenewBefore: &metav1.Duration{Duration: 10 * time.Hour},
+			},
+		}, 1),
+		Entry("Cert expires before rotation rejected", &v1.KubeVirtSelfSignConfiguration{
+			CA: &v1.CertConfig{
+				Duration:    &metav1.Duration{Duration: 24 * time.Hour},
+				RenewBefore: &metav1.Duration{Duration: 16 * time.Hour},
+			},
+			Server: &v1.CertConfig{
+				Duration:    &metav1.Duration{Duration: 8 * time.Hour},
+				RenewBefore: &metav1.Duration{Duration: 10 * time.Hour},
+			},
+		}, 1),
+		Entry("Cert rotates after CA expires rejected", &v1.KubeVirtSelfSignConfiguration{
+			CA: &v1.CertConfig{
+				Duration:    &metav1.Duration{Duration: 24 * time.Hour},
+				RenewBefore: &metav1.Duration{Duration: 16 * time.Hour},
+			},
+			Server: &v1.CertConfig{
+				Duration:    &metav1.Duration{Duration: 48 * time.Hour},
+				RenewBefore: &metav1.Duration{Duration: 36 * time.Hour},
+			},
+		}, 1),
 	)
 
 	Context("with TLSConfiguration", func() {

--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -1867,31 +1867,6 @@ var _ = Describe("[sig-operator]Operator", Serial, decorators.SigOperator, func(
 			patches := patch.New(patch.WithReplace("/spec/certificateRotateStrategy", certRotationStrategy))
 			patchKV(kv.Name, patches)
 		})
-
-		It("[test_id:6258]should reject combining deprecated and new cert rotation parameters", func() {
-			kv := copyOriginalKv(originalKv)
-			certConfig.CAOverlapInterval = &metav1.Duration{Duration: 8 * time.Hour}
-			Expect(patchKvCertConfig(kv.Name, certConfig)).ToNot(Succeed())
-		})
-
-		It("[test_id:6259]should reject CA expires before rotation", func() {
-			kv := copyOriginalKv(originalKv)
-			certConfig.CA.Duration = &metav1.Duration{Duration: 14 * time.Hour}
-			Expect(patchKvCertConfig(kv.Name, certConfig)).ToNot(Succeed())
-		})
-
-		It("[test_id:6260]should reject Cert expires before rotation", func() {
-			kv := copyOriginalKv(originalKv)
-			certConfig.Server.Duration = &metav1.Duration{Duration: 8 * time.Hour}
-			Expect(patchKvCertConfig(kv.Name, certConfig)).ToNot(Succeed())
-		})
-
-		It("[test_id:6261]should reject Cert rotates after CA expires", func() {
-			kv := copyOriginalKv(originalKv)
-			certConfig.Server.Duration = &metav1.Duration{Duration: 48 * time.Hour}
-			certConfig.Server.RenewBefore = &metav1.Duration{Duration: 36 * time.Hour}
-			Expect(patchKvCertConfig(kv.Name, certConfig)).ToNot(Succeed())
-		})
 	})
 
 	Context("with ContainerPathVolumes feature gate toggled", func() {
@@ -2897,18 +2872,6 @@ func patchKVComponentConfig(kvName string, toChange, origField *v1.ComponentConf
 
 	_, err = kubevirt.Client().KubeVirt(flags.KubeVirtInstallNamespace).Patch(context.Background(), kvName, types.JSONPatchType, data, metav1.PatchOptions{})
 
-	return err
-}
-
-func patchKvCertConfig(name string, certConfig *v1.KubeVirtSelfSignConfiguration) error {
-	certRotationStrategy := v1.KubeVirtCertificateRotateStrategy{
-		SelfSigned: certConfig,
-	}
-
-	data, err := patch.New(patch.WithReplace("/spec/certificateRotateStrategy", certRotationStrategy)).GeneratePayload()
-	Expect(err).ToNot(HaveOccurred())
-
-	_, err = kubevirt.Client().KubeVirt(flags.KubeVirtInstallNamespace).Patch(context.Background(), name, types.JSONPatchType, data, metav1.PatchOptions{})
 	return err
 }
 


### PR DESCRIPTION
### What this PR does
#### Before this PR:
`validateCertificates` (pkg/virt-operator/webhooks/kubevirt-update-admitter.go)
had zero unit test coverage. It's a pure function — takes a
`*v1.KubeVirtSelfSignConfiguration`, returns `[]metav1.StatusCause`, no
cluster or client dependency — but the only coverage came from four e2e
tests (test_id:6258-6261) that each spin up a KubeVirt CR patch just to
hit one rejection branch:
- combining deprecated (`caOverlapInterval`) and current (`ca`/`server`)
  rotation parameters
- CA `renewBefore` exceeding `duration`
- Cert `renewBefore` exceeding `duration`
- Cert `duration` exceeding CA `duration`

#### After this PR:
- `validateCertificates` has direct unit coverage via a `DescribeTable`
  in `kubevirt-update-admitter_test.go`, with entries for a nil config,
  a valid config, and the four rejection scenarios above.
- The four corresponding e2e `It` blocks are removed from
  `tests/operator/operator.go`.
- `patchKvCertConfig`, which becomes dead code once its only callers
  are gone, is removed.

### References
- Partially addresses #18548

### Why we need it and why it was done in this way
e2e tests that exercise pure webhook validation logic add CI time and
resource cost without giving coverage a unit test can't already
provide. Moving this logic to a `DescribeTable` unit test keeps the
same scenario coverage at a fraction of the cost, in line with the
goal of #18548.

The following tradeoffs were made:

The following alternatives were considered:

### Special notes for your reviewer
This PR only touches unit/e2e test files — no production code changes.

### Checklist
- [ ] Design: A VEP was considered and is not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: Write code that humans can understand and keep it simple
- [ ] Refactor: Left the code cleaner than found (removed now-dead `patchKvCertConfig`)
- [ ] Upgrade: N/A — test-only change, no upgrade flow impact
- [ ] Testing: New unit tests added for previously-uncovered `validateCertificates`; no new e2e test needed since this is an e2e-to-unit conversion
- [ ] Documentation: Not required — no user-facing/API change
- [ ] Community: Announcement to kubevirt-dev not needed for a test-only change
- [ ] AI Contributions: Disclosed via `Assisted-by: Claude <noreply@anthropic.com>` commit trailer, per the KubeVirt AI Contribution Policy

### Release note
\`\`\`release-note
NONE
\`\`\`