### PR TITLE
virt-handler: reset device plugin channels on Start

### DIFF
--- a/pkg/virt-handler/device-manager/mediated_device.go
+++ b/pkg/virt-handler/device-manager/mediated_device.go
@@ -59,6 +59,8 @@ type MediatedDevicePlugin struct {
 func (dpi *MediatedDevicePlugin) Start(stop <-chan struct{}) (err error) {
 	logger := log.DefaultLogger()
 	dpi.stop = stop
+	dpi.done = make(chan struct{})
+	dpi.deregistered = make(chan struct{})
 
 	err = dpi.cleanup()
 	if err != nil {

--- a/pkg/virt-handler/device-manager/pci_device.go
+++ b/pkg/virt-handler/device-manager/pci_device.go
@@ -62,6 +62,8 @@ type PCIDevicePlugin struct {
 func (dpi *PCIDevicePlugin) Start(stop <-chan struct{}) (err error) {
 	logger := log.DefaultLogger()
 	dpi.stop = stop
+	dpi.done = make(chan struct{})
+	dpi.deregistered = make(chan struct{})
 
 	err = dpi.cleanup()
 	if err != nil {

--- a/pkg/virt-handler/device-manager/socket_device.go
+++ b/pkg/virt-handler/device-manager/socket_device.go
@@ -73,6 +73,8 @@ type SocketDevicePlugin struct {
 func (dpi *SocketDevicePlugin) Start(stop <-chan struct{}) (err error) {
 	logger := log.DefaultLogger()
 	dpi.stop = stop
+	dpi.done = make(chan struct{})
+	dpi.deregistered = make(chan struct{})
 
 	err = dpi.cleanup()
 	if err != nil {

--- a/pkg/virt-handler/device-manager/usb_device.go
+++ b/pkg/virt-handler/device-manager/usb_device.go
@@ -92,6 +92,8 @@ func newPluginDevices(resourceName string, index int, usbdevs []*USBDevice) *Plu
 
 func (plugin *USBDevicePlugin) Start(stop <-chan struct{}) error {
 	plugin.stop = stop
+	plugin.done = make(chan struct{})
+	plugin.deregistered = make(chan struct{})
 
 	err := plugin.cleanup()
 	if err != nil {


### PR DESCRIPTION
Device plugins built on `DevicePluginBase` create `done` and `deregistered` once in their constructors, so a plugin the controller stops and starts on the same object — every kubelet restart on a node with host devices — reuses closed channels and panics at the unguarded `close(dpi.deregistered)` in `ListAndWatch`. `GenericDevicePlugin` already re-creates both in `Start`; this does the same for the rest.

No unit test — the channel setup in `Start` isn't separable from the socket and registration work; happy to add one if you'd like.

### Release note

```release-note
Fixed a virt-handler panic when a device plugin is restarted, which on nodes with host devices happened on every kubelet restart.
```
