### PR TITLE
plugin: consolidate CEL evaluators

### DIFF
--- a/pkg/plugins/cel/BUILD.bazel
+++ b/pkg/plugins/cel/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//vendor/github.com/google/cel-go/cel:go_default_library",
+        "//vendor/github.com/google/cel-go/common/types:go_default_library",
         "//vendor/github.com/google/cel-go/ext:go_default_library",
     ],
 )

--- a/pkg/plugins/cel/evaluator.go
+++ b/pkg/plugins/cel/evaluator.go
@@ -25,8 +25,8 @@ import (
 	"sync"
 
 	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/ext"
-
 	v1 "kubevirt.io/api/core/v1"
 )
 
@@ -38,9 +38,11 @@ type variable struct {
 }
 
 type config struct {
-	variables   []variable
-	containers  []string
-	nativeTypes []reflect.Type
+	variables       []variable
+	containers      []string
+	nativeTypes     []reflect.Type
+	nativeTypesJSON []reflect.Type
+	typeProvider    func(types.Provider) types.Provider
 }
 
 type Option func(*config)
@@ -63,30 +65,62 @@ func WithNativeTypes(types ...reflect.Type) Option {
 	}
 }
 
+func WithNativeTypesJSON(types ...reflect.Type) Option {
+	return func(c *config) {
+		c.nativeTypesJSON = append(c.nativeTypesJSON, types...)
+	}
+}
+
+func WithCustomTypeProvider(wrap func(types.Provider) types.Provider) Option {
+	return func(c *config) {
+		c.typeProvider = wrap
+	}
+}
+
 type Evaluator struct {
 	env   *cel.Env
 	mu    sync.RWMutex
 	cache map[string]cel.Program
 }
 
-func NewEvaluator(opts ...Option) (*Evaluator, error) {
+var (
+	baseEnvOnce sync.Once
+	baseEnv     *cel.Env
+	baseEnvErr  error
+)
+
+func getBaseEnv() (*cel.Env, error) {
+	baseEnvOnce.Do(func() {
+		baseEnv, baseEnvErr = cel.NewEnv(
+			ext.Strings(),
+			ext.Math(),
+			ext.Lists(),
+			cel.Variable("vmi", cel.ObjectType("v1.VirtualMachineInstance")),
+			cel.CrossTypeNumericComparisons(true),
+			cel.EagerlyValidateDeclarations(true),
+		)
+	})
+	return baseEnv, baseEnvErr
+}
+
+func NewBaseEvaluator(opts ...Option) (*cel.Env, error) {
 	cfg := &config{}
 	for _, o := range opts {
 		o(cfg)
 	}
 
-	nativeTypes := []any{reflect.TypeFor[*v1.VirtualMachineInstance]()}
-	for _, t := range cfg.nativeTypes {
-		nativeTypes = append(nativeTypes, t)
+	base, err := getBaseEnv()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create base CEL environment: %w", err)
 	}
 
-	envOpts := []cel.EnvOption{
-		ext.NativeTypes(append(nativeTypes, ext.ParseStructTag("json"))...),
-		ext.Strings(),
-		ext.Math(),
-		ext.Lists(),
-		cel.Variable("vmi", cel.ObjectType("v1.VirtualMachineInstance")),
-		cel.CrossTypeNumericComparisons(true),
+	var envOpts []cel.EnvOption
+	for _, t := range cfg.nativeTypes {
+		envOpts = append(envOpts, ext.NativeTypes(t))
+	}
+
+	for _, t := range cfg.nativeTypesJSON {
+		envOpts = append(envOpts, ext.NativeTypes(t, ext.ParseStructTag("json")))
 	}
 
 	for _, container := range cfg.containers {
@@ -97,7 +131,24 @@ func NewEvaluator(opts ...Option) (*Evaluator, error) {
 		envOpts = append(envOpts, cel.Variable(v.name, v.typ))
 	}
 
-	env, err := cel.NewEnv(envOpts...)
+	env, err := base.Extend(envOpts...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create CEL environment: %w", err)
+	}
+
+	if cfg.typeProvider != nil {
+		env, err = env.Extend(cel.CustomTypeProvider(cfg.typeProvider(env.CELTypeProvider())))
+		if err != nil {
+			return nil, fmt.Errorf("failed to extend CEL environment with custom type provider: %w", err)
+		}
+	}
+
+	return env, err
+}
+
+func NewEvaluator(opts ...Option) (*Evaluator, error) {
+	envOpts := append([]Option{WithNativeTypesJSON(reflect.TypeOf(&v1.VirtualMachineInstance{}))}, opts...)
+	env, err := NewBaseEvaluator(envOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create CEL environment: %w", err)
 	}

--- a/pkg/plugins/cel/evaluator_test.go
+++ b/pkg/plugins/cel/evaluator_test.go
@@ -20,6 +20,8 @@
 package cel_test
 
 import (
+	"reflect"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -65,6 +67,13 @@ var _ = Describe("CEL Evaluator", func() {
 				},
 			},
 		}
+	})
+
+	Context("NewBaseEvaluator", func() {
+		It("should create base evaluator", func() {
+			_, err := cel.NewBaseEvaluator()
+			Expect(err).ToNot(HaveOccurred())
+		})
 	})
 
 	Context("VMI field access", func() {
@@ -126,6 +135,21 @@ var _ = Describe("CEL Evaluator", func() {
 		It("should accept valid expressions", func() {
 			err := evaluator.CompileCondition(`vmi.spec.domain.cpu.cores > 0`)
 			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should reject go struct parsing when default tag parser is JSON", func() {
+			err := evaluator.CompileCondition(`vmi.Spec.Domain.CPU.Cores > 0`)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should accept go struct parsing when default tag parser is not JSON", func() {
+			eval, err := cel.NewBaseEvaluator(
+				cel.WithNativeTypes(reflect.TypeOf(&v1.VirtualMachineInstance{})),
+			)
+			Expect(err).ToNot(HaveOccurred())
+
+			_, issue := eval.Compile(`vmi.Spec.Domain.CPU.Cores > 0`)
+			Expect(issue.Err()).ToNot(HaveOccurred())
 		})
 	})
 

--- a/pkg/virt-launcher/virtwrap/plugins/cel/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/plugins/cel/BUILD.bazel
@@ -11,12 +11,12 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/plugins/cel",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/plugins/cel:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//vendor/github.com/google/cel-go/cel:go_default_library",
         "//vendor/github.com/google/cel-go/common/types:go_default_library",
         "//vendor/github.com/google/cel-go/common/types/ref:go_default_library",
         "//vendor/github.com/google/cel-go/common/types/traits:go_default_library",
-        "//vendor/github.com/google/cel-go/ext:go_default_library",
         "//vendor/libvirt.org/go/libvirtxml:go_default_library",
     ],
 )

--- a/pkg/virt-launcher/virtwrap/plugins/cel/evaluator.go
+++ b/pkg/virt-launcher/virtwrap/plugins/cel/evaluator.go
@@ -25,12 +25,14 @@ import (
 	"sync"
 
 	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
 	"github.com/google/cel-go/common/types/ref"
-	"github.com/google/cel-go/ext"
 
 	v1 "kubevirt.io/api/core/v1"
 
 	"libvirt.org/go/libvirtxml"
+
+	celutil "kubevirt.io/kubevirt/pkg/plugins/cel"
 )
 
 const costLimit = 10_000_000
@@ -56,26 +58,15 @@ func GetEvaluator() *Evaluator {
 }
 
 func NewEvaluator() (*Evaluator, error) {
-	base, err := cel.NewEnv(
-		ext.NativeTypes(
-			reflect.TypeOf(&libvirtxml.Domain{}),
-			reflect.TypeOf(&v1.VirtualMachineInstance{}),
-		),
-		cel.Container("libvirtxml"),
+	env, err := celutil.NewBaseEvaluator(
+		celutil.WithNativeTypes(reflect.TypeOf(&libvirtxml.Domain{}),
+			reflect.TypeOf(&v1.VirtualMachineInstance{})),
+		celutil.WithContainer("libvirtxml"),
+		celutil.WithCustomTypeProvider(func(wrap types.Provider) types.Provider { return &sparseProvider{delegate: wrap} }),
+		celutil.WithVariable("domainSpec", cel.ObjectType("libvirtxml.Domain")),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("creating base CEL environment: %w", err)
-	}
-
-	wrapper := &sparseProvider{delegate: base.CELTypeProvider()}
-
-	env, err := base.Extend(
-		cel.CustomTypeProvider(wrapper),
-		cel.Variable("vmi", cel.ObjectType("v1.VirtualMachineInstance")),
-		cel.Variable("domainSpec", cel.ObjectType("libvirtxml.Domain")),
-	)
-	if err != nil {
-		return nil, fmt.Errorf("extending CEL environment: %w", err)
 	}
 
 	return &Evaluator{env: env}, nil

--- a/pkg/virt-launcher/virtwrap/plugins/cel/evaluator_test.go
+++ b/pkg/virt-launcher/virtwrap/plugins/cel/evaluator_test.go
@@ -142,6 +142,24 @@ var _ = Describe("CEL Evaluator", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("mutation must return a Domain object"))
 		})
+
+		It("should be able to use lists extension to create new domain elements", func() {
+			domain.IOThreads = uint(4)
+
+			// expression should create new DomainIOThreadIDs and populate elements for each IOThread
+			expr := `Domain{IOThreadIDs: DomainIOThreadIDs{IOThreads: .lists.range(int(domainSpec.IOThreads))
+				.map(i, DomainIOThread{ID: uint(i+1), PoolMin: uint(1), PoolMax: uint(1)})}}`
+
+			result, err := evaluator.EvaluateMutation(expr, vmi, domain)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.IOThreadIDs).NotTo(BeNil())
+			Expect(result.IOThreadIDs.IOThreads).NotTo(BeEmpty())
+			Expect(result.IOThreadIDs.IOThreads).To(HaveLen(int(domain.IOThreads)))
+			for _, t := range result.IOThreadIDs.IOThreads {
+				Expect(int(*t.PoolMax)).To(Equal(1))
+				Expect(int(*t.PoolMin)).To(Equal(1))
+			}
+		})
 	})
 
 	Context("deep merge", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
PR addresses conversation of implementing a common base evaluator from the plugin VEP implementation https://github.com/kubevirt/kubevirt/pull/18001#discussion_r3435472385

Currently, we use two separate evaluators for compiling and validating CEL conditions for either node or domain spec hooks. Because they share a lot of the same setup, we can consolidate the common steps into a base evaluator which we can then cache so it only needs to setup once, then the specific evaluators can use and extend the base with their specific criteria.


### References
- Fixes: https://redhat.atlassian.net/browse/CNV-31845
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
plugin: consolidate CEL evaluators
```

