### PR TITLE
synchronization-controller: redial when the peer sync address changes

### DIFF
--- a/pkg/synchronization-controller/synchronization-controller.go
+++ b/pkg/synchronization-controller/synchronization-controller.go
@@ -616,23 +616,28 @@ func (s *SynchronizationController) getOutboundConnectionByMigrationID(vmi *virt
 	}
 	log.Log.Object(vmi).V(4).Infof("found migration ID %s", migrationID)
 	obj, ok := connectionMap.Load(migrationID)
-	if !ok {
-		grpcClientConnection, err := s.createOutboundConnection(syncAddress)
-		if err != nil {
-			return nil, err
+	if ok {
+		outboundSyncConnection, ok := obj.(*SynchronizationConnection)
+		if !ok {
+			return nil, fmt.Errorf("found unknown object in outbound connection cache %#v", obj)
 		}
-		conn := &SynchronizationConnection{
-			migrationID:          migrationID,
-			grpcClientConnection: grpcClientConnection,
+		currentAddress := outboundSyncConnection.grpcClientConnection.Target()
+		if currentAddress == syncAddress {
+			return outboundSyncConnection, nil
 		}
-		connectionMap.Store(migrationID, conn)
-		return conn, nil
+		log.Log.Object(vmi).V(2).Infof("synchronization address for migration %s changed from %s to %s, reconnecting", migrationID, currentAddress, syncAddress)
+		_ = s.closeConnectionForMigrationID(connectionMap, migrationID)
 	}
-	outboundSyncConnection, ok := obj.(*SynchronizationConnection)
-	if !ok {
-		return nil, fmt.Errorf("found unknown object in outbound connection cache %#v", outboundSyncConnection)
+	grpcClientConnection, err := s.createOutboundConnection(syncAddress)
+	if err != nil {
+		return nil, err
 	}
-	return outboundSyncConnection, nil
+	conn := &SynchronizationConnection{
+		migrationID:          migrationID,
+		grpcClientConnection: grpcClientConnection,
+	}
+	connectionMap.Store(migrationID, conn)
+	return conn, nil
 }
 
 func (s *SynchronizationController) handleSourceState(vmi *virtv1.VirtualMachineInstance, migration *virtv1.VirtualMachineInstanceMigration) error {

--- a/pkg/synchronization-controller/synchronization-controller_test.go
+++ b/pkg/synchronization-controller/synchronization-controller_test.go
@@ -1624,6 +1624,46 @@ var _ = Describe("VMI status synchronization controller", func() {
 		Expect(loaded).To(BeFalse())
 	})
 
+	Context("getOutboundConnectionByMigrationID", func() {
+		const (
+			addrA = "10.0.0.1:9185"
+			addrB = "10.0.0.2:9185"
+		)
+		var vmi *virtv1.VirtualMachineInstance
+
+		BeforeEach(func() {
+			vmi = clientgoapi.NewMinimalVMI("testvmi")
+		})
+
+		AfterEach(func() {
+			controller.closeConnectionForMigrationID(controller.syncOutboundConnectionMap, testMigrationID)
+		})
+
+		It("should reuse the cached connection when the address is unchanged", func() {
+			first, err := controller.getOutboundConnectionByMigrationID(vmi, testMigrationID, addrA, controller.syncOutboundConnectionMap)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(first.grpcClientConnection.Target()).To(Equal(addrA))
+
+			second, err := controller.getOutboundConnectionByMigrationID(vmi, testMigrationID, addrA, controller.syncOutboundConnectionMap)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(second).To(BeIdenticalTo(first))
+		})
+
+		It("should redial and replace the cached connection when the peer address changed", func() {
+			first, err := controller.getOutboundConnectionByMigrationID(vmi, testMigrationID, addrA, controller.syncOutboundConnectionMap)
+			Expect(err).ToNot(HaveOccurred())
+
+			second, err := controller.getOutboundConnectionByMigrationID(vmi, testMigrationID, addrB, controller.syncOutboundConnectionMap)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(second).ToNot(BeIdenticalTo(first))
+			Expect(second.grpcClientConnection.Target()).To(Equal(addrB))
+
+			stored, loaded := controller.syncOutboundConnectionMap.Load(testMigrationID)
+			Expect(loaded).To(BeTrue())
+			Expect(stored).To(BeIdenticalTo(second))
+		})
+	})
+
 	Context("resource handler functions", func() {
 		var (
 			sourceMigration, targetMigration *virtv1.VirtualMachineInstanceMigration


### PR DESCRIPTION
### What this PR does
#### Before this PR:

A decentralized migration could hang forever in `WaitingForSync`/`Synchronizing`. The sync-controller caches one gRPC connection per migration and, on a cache hit, reused it without checking the peer's address. When the peer pod is rescheduled to a new IP, the old connection keeps dialing the dead IP, and gRPC never re-resolves a literal IP.

#### After this PR:

On a cache hit, `getOutboundConnectionByMigrationID` compares the dialed target (`ClientConn.Target()`) with the current sync address, and redials when they differ. Same-address restarts still recover through gRPC's transport reconnect.

### References

- Fixes #17317

### Why we need it and why it was done in this way
The following tradeoffs were made:

- If the code starts working with FQDN, this fix will not be needed

The following alternatives were considered:

- Adding timeout for marking migration as failed: https://github.com/kubevirt/kubevirt/pull/17318

### Special notes for your reviewer

Functional tests reproducing is complicated,it requires a decentralized stand.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note

```release-note
Fixed decentralized live migrations stuck in WaitingForSync/Synchronizing after the peer virt-synchronization-controller pod was rescheduled to a new IP.
```

