### PR TITLE
tests: consolidate 7 grace period tests into 3 functional tests

### DIFF
--- a/tests/compute/BUILD.bazel
+++ b/tests/compute/BUILD.bazel
@@ -48,6 +48,7 @@ go_library(
         "//tests/libvmops:go_default_library",
         "//tests/libwait:go_default_library",
         "//tests/testsuite:go_default_library",
+        "//tests/watcher:go_default_library",
         "//vendor/github.com/google/goexpect:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
@@ -59,6 +60,5 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
-        "//vendor/k8s.io/apimachinery/pkg/watch:go_default_library",
     ],
 )

--- a/tests/compute/vm_lifecycle.go
+++ b/tests/compute/vm_lifecycle.go
@@ -27,7 +27,6 @@ import (
 	. "github.com/onsi/gomega"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/watch"
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 
@@ -39,6 +38,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libpod"
 	"kubevirt.io/kubevirt/tests/libvmifact"
 	"kubevirt.io/kubevirt/tests/testsuite"
+	"kubevirt.io/kubevirt/tests/watcher"
 )
 
 var _ = Describe(SIG("[rfe_id:1177][crit:medium] VirtualMachine", func() {
@@ -72,51 +72,47 @@ var _ = Describe(SIG("[rfe_id:1177][crit:medium] VirtualMachine", func() {
 		Eventually(matcher.ThisVMI(vmi), 240*time.Second, 1*time.Second).Should(matcher.BeRestarted(vmi.UID))
 	})
 
-	DescribeTable("should force stop a VM with terminationGracePeriodSeconds>0", func(vmiFactory func(...libvmi.Option) *v1.VirtualMachineInstance) {
-		By("getting a VM with high TerminationGracePeriod")
-		vm := libvmi.NewVirtualMachine(vmiFactory(libvmi.WithTerminationGracePeriod(600)), libvmi.WithRunStrategy(v1.RunStrategyAlways))
-		vm, err := virtClient.VirtualMachine(testsuite.GetTestNamespace(vm)).Create(context.Background(), vm, metav1.CreateOptions{})
-		Expect(err).ToNot(HaveOccurred())
-		Eventually(matcher.ThisVM(vm)).WithTimeout(300 * time.Second).WithPolling(time.Second).Should(matcher.BeReady())
+	DescribeTable("should stop a VM, respect the grace period, and remove the VMI", decorators.WgS390x,
+		func(vmi *v1.VirtualMachineInstance, stopOpts *v1.StopOptions, expectGracePeriodRespected bool) {
+			vm := libvmi.NewVirtualMachine(vmi, libvmi.WithRunStrategy(v1.RunStrategyAlways))
+			vm, err := virtClient.VirtualMachine(testsuite.GetTestNamespace(vm)).Create(context.Background(), vm, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(matcher.ThisVM(vm)).WithTimeout(300 * time.Second).WithPolling(time.Second).Should(matcher.BeReady())
 
-		By("setting up a watch for vmi")
-		lw, err := virtClient.VirtualMachineInstance(vm.Namespace).Watch(context.Background(), metav1.ListOptions{})
-		Expect(err).ToNot(HaveOccurred())
+			vmi, err = virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
 
-		terminationGracePeriodUpdated := func(done <-chan bool, events <-chan watch.Event, updated chan<- bool) {
-			GinkgoRecover()
-			for {
-				select {
-				case <-done:
-					return
-				case e := <-events:
-					vmi, ok := e.Object.(*v1.VirtualMachineInstance)
-					Expect(ok).To(BeTrue())
-					if vmi.Name != vm.Name {
-						continue
-					}
-					if *vmi.Spec.TerminationGracePeriodSeconds == 0 {
-						updated <- true
-					}
-				}
+			ctx, cancel := context.WithCancel(context.Background())
+			DeferCleanup(cancel)
+
+			By("Stopping the VM")
+			stopTime := time.Now()
+			Expect(virtClient.VirtualMachine(vm.Namespace).Stop(context.Background(), vm.Name, stopOpts)).To(Succeed())
+
+			if expectGracePeriodRespected {
+				By("Verifying the ShuttingDown event")
+				Expect(watcher.New(vmi).SinceWatchedObjectResourceVersion().Timeout(60*time.Second).
+					WaitFor(ctx, watcher.NormalEvent, v1.ShuttingDown)).ToNot(BeNil())
 			}
-		}
-		done := make(chan bool, 1)
-		updated := make(chan bool, 1)
-		go terminationGracePeriodUpdated(done, lw.ResultChan(), updated)
 
-		By("Stopping the VM")
-		err = virtClient.VirtualMachine(vm.Namespace).Stop(context.Background(), vm.Name, &v1.StopOptions{GracePeriod: pointer.P(int64(0))})
-		Expect(err).ToNot(HaveOccurred())
+			By("Verifying the Deleted event")
+			Expect(watcher.New(vmi).SinceWatchedObjectResourceVersion().Timeout(60*time.Second).
+				WaitFor(ctx, watcher.NormalEvent, v1.Deleted)).ToNot(BeNil())
 
-		By("Ensuring the VirtualMachineInstance is removed")
-		Eventually(matcher.ThisVMIWith(vm.Namespace, vm.Name), 240*time.Second, 1*time.Second).ShouldNot(matcher.Exist())
+			if expectGracePeriodRespected {
+				Expect(time.Since(stopTime)).To(BeNumerically(">=", 5*time.Second),
+					"domain should not be killed before the grace period expires")
+			}
 
-		Expect(updated).To(Receive(), "vmi should be updated")
-		done <- true
-	},
-		Entry("with Fedora based VMI", decorators.WgS390x, libvmifact.NewFedora),
-		Entry("with unresponsive empty-disk VMI", libvmifact.NewGuestless),
+			By("Verifying the VMI is removed")
+			Eventually(matcher.ThisVMIWith(vm.Namespace, vm.Name), 120*time.Second, time.Second).ShouldNot(matcher.Exist())
+		},
+		Entry("graceful stop waits for grace period",
+			decorators.Conformance, libvmifact.NewGuestless(libvmi.WithTerminationGracePeriod(5)), &v1.StopOptions{}, true),
+		Entry("force stop bypasses grace period",
+			libvmifact.NewGuestless(libvmi.WithTerminationGracePeriod(600)), &v1.StopOptions{GracePeriod: new(int64)}, false),
+		Entry("graceful stop with ACPI-capable guest",
+			decorators.Conformance, libvmifact.NewFedora(libvmi.WithTerminationGracePeriod(30)), &v1.StopOptions{}, true),
 	)
 
 	Context("with reboot policy", func() {

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -237,28 +237,6 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			validateGenerationState(vm, 6, 6, 6, 6)
 		})
 
-		DescribeTable("[test_id:1521]should remove VirtualMachineInstance once the VM is marked for deletion", decorators.Conformance, decorators.WgS390x, func(createTemplate vmiBuilder, ensureGracefulTermination bool) {
-			template, _ := createTemplate()
-			vm := libvmops.StartVirtualMachine(createVM(virtClient, template))
-			vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			// Delete it
-			Expect(virtClient.VirtualMachine(vm.Namespace).Delete(context.Background(), vm.Name, metav1.DeleteOptions{})).To(Succeed())
-			// Wait until VMI is gone
-			Eventually(ThisVMIWith(vm.Namespace, vm.Name), 300*time.Second, 2*time.Second).ShouldNot(Exist())
-			if !ensureGracefulTermination {
-				return
-			}
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-			// Under default settings, termination is graceful (shutdown instead of destroy)
-			event := watcher.New(vmi).SinceWatchedObjectResourceVersion().Timeout(75*time.Second).WaitFor(ctx, watcher.NormalEvent, v1.ShuttingDown)
-			Expect(event).ToNot(BeNil(), "There should be a shutdown event")
-		},
-			Entry("with ContainerDisk", func() (*v1.VirtualMachineInstance, *cdiv1.DataVolume) { return libvmifact.NewAlpine(), nil }, false),
-			Entry("[storage-req]with Filesystem Disk", decorators.StorageReq, newVirtualMachineInstanceWithFileDisk, true),
-		)
-
 		It("[test_id:1522]should remove owner references on the VirtualMachineInstance if it is orphan deleted", decorators.Conformance, decorators.WgS390x, func() {
 			vm := libvmops.StartVirtualMachine(createVM(virtClient, libvmifact.NewGuestless()))
 

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -1366,62 +1366,6 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				}, 60*time.Second, 5*time.Second).Should(MatchError(k8serrors.IsNotFound, "k8serrors.IsNotFound"))
 			})
 		})
-		Context("with ACPI and some grace period seconds", decorators.WgS390x, func() {
-
-			withoutTerminationGracePeriodSeconds := func(vmi *v1.VirtualMachineInstance) {
-				vmi.Spec.TerminationGracePeriodSeconds = nil
-			}
-
-			DescribeTable("[rfe_id:273][crit:medium][vendor:cnv-qe@redhat.com][level:component]should result in vmi status succeeded", func(option libvmi.Option, gracePeriodSeconds int64) {
-				vmi := libvmifact.NewFedora(option)
-
-				By("Creating the VirtualMachineInstance")
-				vmi, err := kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi, metav1.CreateOptions{})
-				Expect(err).ToNot(HaveOccurred(), "Should create VMI")
-
-				By("Wait for the login")
-				vmi = libwait.WaitUntilVMIReady(vmi, console.LoginToFedora)
-
-				By("Deleting the VirtualMachineInstance")
-				Expect(kubevirt.Client().VirtualMachineInstance(vmi.Namespace).Delete(context.Background(), vmi.Name, metav1.DeleteOptions{})).To(Succeed(), "Should delete VMI")
-
-				By("Verifying VirtualMachineInstance's status is Succeeded")
-				Eventually(matcher.ThisVMI(vmi)).WithTimeout(time.Duration(gracePeriodSeconds) * time.Second).WithPolling(time.Second).Should(
-					matcher.BeInPhase(v1.Succeeded))
-			},
-				Entry("[test_id:1653]with set grace period seconds", decorators.Conformance, libvmi.WithTerminationGracePeriod(10), int64(10)),
-				Entry("[test_id:1654]with default grace period seconds", decorators.Conformance, withoutTerminationGracePeriodSeconds, v1.DefaultGracePeriodSeconds),
-			)
-		})
-		Context("with grace period greater than 0", func() {
-			It("[test_id:1655]should run graceful shutdown", decorators.Conformance, decorators.WgS390x, func() {
-				By("Setting a VirtualMachineInstance termination grace period to 5")
-				vmi := libvmifact.NewAlpineWithTestTooling(libvmi.WithTerminationGracePeriod(5))
-
-				By("Creating the VirtualMachineInstance")
-				vmi = libvmops.RunVMIAndExpectLaunch(vmi, startupTimeout)
-
-				// Delete the VirtualMachineInstance and wait for the confirmation of the delete
-				By("Deleting the VirtualMachineInstance")
-				Expect(kubevirt.Client().VirtualMachineInstance(vmi.Namespace).Delete(context.Background(), vmi.Name, metav1.DeleteOptions{})).To(Succeed(), "Should delete VMI gracefully")
-
-				ctx, cancel := context.WithCancel(context.Background())
-				defer cancel()
-
-				// Check if the graceful shutdown was logged
-				By("Checking that virt-handler logs VirtualMachineInstance graceful shutdown")
-				event := watcher.New(vmi).Timeout(30*time.Second).SinceWatchedObjectResourceVersion().WaitFor(ctx, watcher.NormalEvent, "ShuttingDown")
-				Expect(event).ToNot(BeNil(), "There should be a graceful shutdown")
-
-				// Verify VirtualMachineInstance is killed after grace period expires
-				// 5 seconds is grace period, doubling to prevent flakiness
-				By("Checking that the VirtualMachineInstance does not exist after grace period")
-				event = watcher.New(vmi).Timeout(10*time.Second).SinceWatchedObjectResourceVersion().WaitFor(ctx, watcher.NormalEvent, "Deleted")
-				Expect(event).ToNot(BeNil(), "There should be a graceful shutdown")
-
-				Eventually(matcher.ThisVMI(vmi)).WithTimeout(15 * time.Second).WithPolling(time.Second).Should(matcher.BeGone())
-			})
-		})
 	})
 
 	Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:component]Killed VirtualMachineInstance", Serial, decorators.WgS390x, func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

This PR consolidates 7 overlapping shutdown/grace-period test entries into a single DescribeTable with 3 entries:

1. Graceful stop (5s grace period, Guestless): verifies ShuttingDown event, Deleted event, grace period timing, and VMI removal.
2. Force stop (600s grace period, GracePeriod=0): verifies Deleted event and VMI removal.
3. Graceful stop with ACPI-capable guest (30s grace period, Fedora): exercises the guest-agent/ACPI shutdown path through libvirt's DOMAIN_SHUTDOWN_DEFAULT.

#### Removed tests

* [test_id:1655] bare-VMI graceful shutdown - flaky due to tight 10-30s event timeouts around a 5s grace period (see #18504 for details)
* [test_id:1521] VM deletion cascade - 2 entries (ContainerDisk, FileDisk)
* "should force stop a VM with terminationGracePeriodSeconds>0" - 2 entries (Fedora, Guestless)
* [test_id:1653] VMI delete with set grace period (Fedora)
* [test_id:1654] VMI delete with default grace period (Fedora)


#### Why no coverage is lost

- There is no need to run these scenarios with multiple disk types - the shutdown and grace period logic in virt-handler is independent of the disk backend, so Guestless is sufficient.

- The Fedora entry exercises the ACPI/guest-agent shutdown path (libvirt uses `DOMAIN_SHUTDOWN_DEFAULT` which prefers guest-agent when available, falling back to ACPI).

- VM deletion cascading to VMI removal is already verified by [test_id:837](https://github.com/kubevirt/kubevirt/blob/2e601ce4ec0b53f632bd0b08bd4badf26503be29/tests/storage/datavolume.go#L620) ("deleting VM should automatically delete DataVolumes and VMI owned by VM").

- Stopping a VM triggers VMI deletion through the same virt-handler shutdown path, so the consolidated test implicitly covers the bare-VMI deletion scenario from test_id:1655.

- Event timeouts are increased from 10-30s to 60s to eliminate the flakiness.


### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

