### PR TITLE
tests(hostdev): migrate from AC97 sound card to ICH9

### DIFF
--- a/tests/vmi_hostdev_test.go
+++ b/tests/vmi_hostdev_test.go
@@ -67,7 +67,18 @@ var _ = Describe("[sig-compute]HostDevices", Serial, decorators.SigCompute, func
 	})
 
 	Context("with ephemeral disk", func() {
-		DescribeTable("with emulated PCI devices", func(deviceIDs []string) {
+		// Devices always present on the nodes of the clusters under test
+		// deployed using kubevirtci `cluster-up`. They are bound to
+		// the vfio-pci driver when the cluster is created by `gocli`:
+		// => https://github.com/kubevirt/kubevirtci/blob/main/cluster-provision/gocli/opts/bind-vfio/bind-vfio.go
+		hostSoundCards := []string{
+			// Intel HD Audio Controller (ich6) (aka -device intel-hda)
+			"8086:2668",
+			// Intel HD Audio Controller (ich9) (aka -device ich9-intel-hda)
+			"8086:293e",
+		}
+
+		DescribeTable("with emulated PCI devices", func(deviceIDs ...string) {
 			deviceName := "example.org/soundcard"
 
 			By("Adding the emulated sound card to the permitted host devices")
@@ -108,8 +119,8 @@ var _ = Describe("[sig-compute]HostDevices", Serial, decorators.SigCompute, func
 			Expect(err).ToNot(HaveOccurred(), failedDeleteVMI)
 			Expect(libwait.WaitForVirtualMachineToDisappearWithTimeout(vmi, 180*time.Second)).To(Succeed())
 		},
-			Entry("Should successfully passthrough an emulated PCI device", []string{"8086:2668"}),
-			Entry("Should successfully passthrough 2 emulated PCI devices", []string{"8086:2668", "8086:2415"}),
+			Entry("Should successfully passthrough an emulated PCI device", hostSoundCards[0]),
+			Entry("Should successfully passthrough 2 emulated PCI devices", hostSoundCards[0], hostSoundCards[1]),
 		)
 	})
 })


### PR DESCRIPTION
### What this PR does

Switch legacy Intel Audio AC97 sound card model to Intel Audio ICH9.

#### Before this PR:

Hostdev tests use sound card models Intel Audio AC97 (obsolete) and ICH6

#### After this PR:

Hostdev tests use sound card models Intel Audio ICH6 and ICH9 (current), the legacy model AC97 is no longer used.

### Why we need it and why it was done in this way

Clusters deployed using kubevirtci have long provided two sound cards used by hostdev tests:
- Intel 82801AA AC97 Audio (PCI ID: "8086:2415")
- Intel HD Audio Controller ICH6 (PCI ID: "8086:2668")

Because AC97 is not enabled anymore in some QEMU builds such as CentOS, kubevirtci has been recently updated to deploy another sound card model on a newer Intel HD Audio Controller ICH9 device with the aim of phasing out the legacy one.

The AC97 device is still provided by kubevirtci during this transition period for reasons of compatibility with hostdev tests.

This commit updates the hostdev tests so that they use the newer ICH9 device instead of the former AC97 device.

This will allow to remove the obsolete AC97 sound card from kubevirtci clusters while still providing two devices for the hostdev tests: ICH6 and ICH9.

### Release note
```release-note
NONE
```