### PR TITLE
virt-launcher: fix race where migration events are lost on source exit

### DIFF
--- a/pkg/virt-launcher/notify-client/client.go
+++ b/pkg/virt-launcher/notify-client/client.go
@@ -393,9 +393,6 @@ func (e *eventCaller) eventCallback(c cli.Connection, domain *api.Domain, libvir
 	eventType := watch.Modified
 
 	switch domain.Status.Reason {
-	case api.ReasonNonExistent:
-		now := metav1.Now()
-		domain.ObjectMeta.DeletionTimestamp = &now
 	case api.ReasonPausedIOError:
 		domainDisksWithErrors, err := d.GetDiskErrors(0)
 		if err != nil {
@@ -774,6 +771,19 @@ func processJobCompletedEvent(domain *api.Domain, d cli.VirDomain, jobCompletedE
 }
 
 func processLifecycleEvent(domain *api.Domain, lifecycleEvent *libvirt.DomainEventLifecycle, metadataCache *metadata.Cache, c cli.Connection, vmi *v1.VirtualMachineInstance) bool {
+	// Set DeletionTimestamp when the domain is truly gone from libvirt.
+	// Undefined is terminal for persistent domains (emitted by explicit undefine).
+	// Stopped is terminal for transient domains (e.g. migration target).
+	// Stopped(Migrated) is excluded because it only fires on the persistent source
+	// after a successful outbound migration, where Undefined follows.
+	if (lifecycleEvent.Event == libvirt.DOMAIN_EVENT_UNDEFINED) ||
+		(lifecycleEvent.Event == libvirt.DOMAIN_EVENT_STOPPED && libvirt.DomainEventStoppedDetailType(lifecycleEvent.Detail) != libvirt.DOMAIN_EVENT_STOPPED_MIGRATED) {
+		if domain.Status.Reason == api.ReasonNonExistent {
+			now := metav1.Now()
+			domain.ObjectMeta.DeletionTimestamp = &now
+		}
+		return false
+	}
 	if lifecycleEvent.Event == libvirt.DOMAIN_EVENT_DEFINED &&
 		libvirt.DomainEventDefinedDetailType(lifecycleEvent.Detail) == libvirt.DOMAIN_EVENT_DEFINED_ADDED {
 		return true

--- a/pkg/virt-launcher/notify-client/notify_test.go
+++ b/pkg/virt-launcher/notify-client/notify_test.go
@@ -243,6 +243,45 @@ var _ = Describe("Notify", func() {
 				Expect(timedOut).To(BeFalse())
 			})
 
+		It("should not set DeletionTimestamp for stopped/migrated event when domain is already gone", func() {
+			ctrl := gomock.NewController(GinkgoT())
+			mockLib := testing.NewLibvirt(ctrl)
+			mockLib.ConnectionEXPECT().LookupDomainByName(gomock.Any()).Return(nil, libvirt.Error{Code: libvirt.ERR_NO_DOMAIN}).AnyTimes()
+
+			domain := util.NewDomainFromName("test", "1234")
+			e.eventCallback(mockLib.VirtConnection, domain, libvirtEvent{Event: &libvirt.DomainEventLifecycle{
+				Event:  libvirt.DOMAIN_EVENT_STOPPED,
+				Detail: int(libvirt.DOMAIN_EVENT_STOPPED_MIGRATED),
+			}}, client, deleteNotificationSent, nil, nil, nil, nil, metadataCache(), false)
+
+			Expect(domain.Status.Reason).To(Equal(api.ReasonNonExistent))
+			Expect(domain.ObjectMeta.DeletionTimestamp).To(BeNil())
+			Consistently(deleteNotificationSent, 200*time.Millisecond).ShouldNot(Receive())
+		})
+
+		It("should not set DeletionTimestamp for Job Completed event when domain is already gone", func() {
+			ctrl := gomock.NewController(GinkgoT())
+			mockLib := testing.NewLibvirt(ctrl)
+			mockLib.ConnectionEXPECT().LookupDomainByName(gomock.Any()).Return(nil, libvirt.Error{Code: libvirt.ERR_NO_DOMAIN}).AnyTimes()
+
+			mc := metadataCache()
+			mc.Migration.Store(api.MigrationMetadata{UID: "test-migration-uid"})
+
+			domain := util.NewDomainFromName("test", "1234")
+			e.eventCallback(mockLib.VirtConnection, domain, libvirtEvent{
+				JobCompletedEvent: &libvirt.DomainEventJobCompleted{
+					Info: libvirt.DomainJobInfo{
+						Type:      libvirt.DOMAIN_JOB_COMPLETED,
+						Operation: libvirt.DOMAIN_JOB_OPERATION_MIGRATION_OUT,
+					},
+				},
+			}, client, deleteNotificationSent, nil, nil, nil, nil, mc, false)
+
+			Expect(domain.Status.Reason).To(Equal(api.ReasonNonExistent))
+			Expect(domain.ObjectMeta.DeletionTimestamp).To(BeNil())
+			Consistently(deleteNotificationSent, 200*time.Millisecond).ShouldNot(Receive())
+		})
+
 		It("should update Interface status",
 			func() {
 				domain := api.NewMinimalDomain("test")


### PR DESCRIPTION
During live migration, the source virt-launcher processes libvirt events (stopped/migrated, Job Completed, undefined) through a serial event loop. When eventCallback calls LookupDomainByName for a stopped/migrated event and the domain was already undefined by virt-handler, it gets NotFound and sets ReasonNonExistent + DeletionTimestamp. This triggers firstDelete, causing the launcher to exit before the Job Completed event is processed, losing migration statistics.
Move DeletionTimestamp out of the generic ReasonNonExistent switch in eventCallback and into processLifecycleEvent, gated on DOMAIN_EVENT_UNDEFINED. Since undefined is always the last libvirt event in the migration sequence, all preceding events (including Job Completed) have a chance to be processed before the exit path is triggered.
The main exit path is still the QEMU PID detection in virt-launcher-monitor, that also serves as a fallback for a missing event.


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
fixes race condition on migration completion, as a side effect fixing the migration stats logging

### References

- Fixes #18629 

<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:
just logging without changing the logic - that would make it very specific to logging event, fully processing the event queue seems to be a more correct fix, especially considering #17974 intends to do more than just print.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [X] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [X] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [X] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [X] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [X] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [X] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [X] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

