### PR TITLE
tests: explicitly set storage-class and access-mode in [test_id:11657]

### DIFF
--- a/tests/virtctl/imageupload.go
+++ b/tests/virtctl/imageupload.go
@@ -225,10 +225,17 @@ var _ = Describe(SIG("[sig-storage]ImageUpload", decorators.SigStorage, func() {
 		})
 
 		DescribeTable("[test_id:11657]Should succeed", func(resource string, uploadDV bool) {
+			sc, exists := libstorage.GetRWOFileSystemStorageClass()
+			if !exists {
+				Fail("Fail test when RWO filesystem storage class is not present")
+			}
+
 			By("Upload archive content")
 			err := runImageUploadCmd(
 				resource, targetName,
 				"--archive-path", archivePath,
+				"--storage-class", sc,
+				"--access-mode", "ReadWriteOnce",
 				"--force-bind",
 			)
 			Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
 - The test expect a default storage class is defined when running `test_id:11657`. which causes failures on clusters without defined storage class.
 - The test is not consistent to other tests in the file that do define a storage class
   - [test_id:4621]
   - [test_id:11655]
   - [test_id:10671/10672]
   - [test_id:11656]
   - [test_id:11658]

#### After this PR:
 - The test explicitly specify the storage class and access mode, similar to what other tests in the same file do (e.g., test_id:11655)

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:
 - CDI could be enhanced to also consider the virt default storage class for archive content type, since archives are fundamentally a CDI/virtualization concept, but this drifts from the nature of the test.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

