### PR TITLE
vmi-ctrl: extract listPodsOwnedByVMI helper

### DIFF
--- a/pkg/virt-controller/watch/vmi/lifecycle.go
+++ b/pkg/virt-controller/watch/vmi/lifecycle.go
@@ -992,13 +992,13 @@ func checkForContainerImageError(pod *k8sv1.Pod) common.SyncError {
 }
 
 func (c *Controller) deleteAllMatchingPods(vmi *virtv1.VirtualMachineInstance) error {
-	pods, err := c.listPodsFromNamespace(vmi.Namespace)
+	pods, err := c.listPodsOwnedByVMI(vmi)
 	if err != nil {
 		return err
 	}
 	vmiKey := controller.VirtualMachineInstanceKey(vmi)
 	for _, pod := range pods {
-		if pod.DeletionTimestamp != nil && !isPodFinal(pod) || !v1.IsControlledBy(pod, vmi) {
+		if pod.DeletionTimestamp != nil && !isPodFinal(pod) {
 			continue
 		}
 		if err = c.deletePod(vmiKey, pod, v1.DeleteOptions{}); err != nil {

--- a/pkg/virt-controller/watch/vmi/lifecycle.go
+++ b/pkg/virt-controller/watch/vmi/lifecycle.go
@@ -457,12 +457,12 @@ func (c *Controller) updateStatus(vmi *virtv1.VirtualMachineInstance, pod *k8sv1
 			}
 		}
 	case vmi.IsFinal():
-		allDeleted, err := c.allPodsDeleted(vmi)
+		podsOwnedByVMI, err := c.listPodsOwnedByVMI(vmi)
 		if err != nil {
 			return err
 		}
 
-		if allDeleted {
+		if len(podsOwnedByVMI) == 0 {
 			log.Log.V(3).Object(vmi).Infof("all pods have been deleted, removing finalizer")
 			controller.RemoveFinalizer(vmiCopy, virtv1.DeprecatedVirtualMachineInstanceFinalizer)
 			controller.RemoveFinalizer(vmiCopy, virtv1.VirtualMachineInstanceFinalizer)
@@ -1027,38 +1027,34 @@ func (c *Controller) listPodsFromNamespace(namespace string) ([]*k8sv1.Pod, erro
 	return pods, nil
 }
 
-func (c *Controller) setActivePods(vmi *virtv1.VirtualMachineInstance) (*virtv1.VirtualMachineInstance, error) {
+func (c *Controller) listPodsOwnedByVMI(vmi *virtv1.VirtualMachineInstance) ([]*k8sv1.Pod, error) {
 	pods, err := c.listPodsFromNamespace(vmi.Namespace)
 	if err != nil {
 		return nil, err
 	}
-	activePods := make(map[types.UID]string)
-	count := 0
+	var ownedPods []*k8sv1.Pod
 	for _, pod := range pods {
-		if !v1.IsControlledBy(pod, vmi) {
-			continue
+		if v1.IsControlledBy(pod, vmi) {
+			ownedPods = append(ownedPods, pod)
 		}
-		count++
-		activePods[pod.UID] = pod.Spec.NodeName
 	}
-	if count == 0 && vmi.Status.ActivePods == nil {
+	return ownedPods, nil
+}
+
+func (c *Controller) setActivePods(vmi *virtv1.VirtualMachineInstance) (*virtv1.VirtualMachineInstance, error) {
+	pods, err := c.listPodsOwnedByVMI(vmi)
+	if err != nil {
+		return nil, err
+	}
+	if len(pods) == 0 && vmi.Status.ActivePods == nil {
 		return vmi, nil
+	}
+	activePods := make(map[types.UID]string)
+	for _, pod := range pods {
+		activePods[pod.UID] = pod.Spec.NodeName
 	}
 	vmi.Status.ActivePods = activePods
 	return vmi, nil
-}
-
-func (c *Controller) allPodsDeleted(vmi *virtv1.VirtualMachineInstance) (bool, error) {
-	pods, err := c.listPodsFromNamespace(vmi.Namespace)
-	if err != nil {
-		return false, err
-	}
-	for _, pod := range pods {
-		if v1.IsControlledBy(pod, vmi) {
-			return false, nil
-		}
-	}
-	return true, nil
 }
 
 func (c *Controller) deletePod(vmiKey string, pod *k8sv1.Pod, options v1.DeleteOptions) error {

--- a/pkg/virt-controller/watch/vmi/volume-hotplug.go
+++ b/pkg/virt-controller/watch/vmi/volume-hotplug.go
@@ -364,7 +364,7 @@ func (c *Controller) deleteAllAttachmentPods(vmi *v1.VirtualMachineInstance) err
 func (c *Controller) deleteOrphanedAttachmentPods(vmi *v1.VirtualMachineInstance) error {
 	podsOwnedByVMI, err := c.listPodsOwnedByVMI(vmi)
 	if err != nil {
-		return fmt.Errorf("failed to list controlled pods: %v", err)
+		return fmt.Errorf("failed to list pods owned by VMI %s/%s: %w", vmi.Namespace, vmi.Name, err)
 	}
 
 	for _, pod := range podsOwnedByVMI {

--- a/pkg/virt-controller/watch/vmi/volume-hotplug.go
+++ b/pkg/virt-controller/watch/vmi/volume-hotplug.go
@@ -362,16 +362,12 @@ func (c *Controller) deleteAllAttachmentPods(vmi *v1.VirtualMachineInstance) err
 }
 
 func (c *Controller) deleteOrphanedAttachmentPods(vmi *v1.VirtualMachineInstance) error {
-	pods, err := c.listPodsFromNamespace(vmi.Namespace)
+	podsOwnedByVMI, err := c.listPodsOwnedByVMI(vmi)
 	if err != nil {
-		return fmt.Errorf("failed to list pods from namespace %s: %v", vmi.Namespace, err)
+		return fmt.Errorf("failed to list controlled pods: %v", err)
 	}
 
-	for _, pod := range pods {
-		if !metav1.IsControlledBy(pod, vmi) {
-			continue
-		}
-
+	for _, pod := range podsOwnedByVMI {
 		if !controller.PodIsDown(pod) {
 			continue
 		}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
The VMI controller has four callers that list pods from a namespace and then immediately filter by ownership. This duplicated pattern makes each caller longer than it needs to be and scatters the same `IsControlledBy` check across multiple functions. This PR extracts a `listPodsOwnedByVMI` helper that combines the listing and ownership filter, and converts each caller to use it.
`allPodsDeleted` is inlined at its single call site since it becomes a trivial `len() == 0` check.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

