### PR TITLE
Optimize go-test for cache-friendly execution with GCS shared cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,8 +87,11 @@ goveralls:
 coverage-report:
 	hack/dockerized "CI=${CI} WHAT=${WHAT} ./hack/bazel-coverage-report.sh"
 
-go-test: go-build
-	SYNC_OUT=false KUBEVIRT_NO_BAZEL=true hack/dockerized "export KUBEVIRT_GO_BUILD_TAGS=${KUBEVIRT_GO_BUILD_TAGS} && ./hack/build-go.sh test ${WHAT}"
+go-test:
+	SYNC_OUT=false KUBEVIRT_NO_BAZEL=true hack/dockerized "./hack/go-test-cache.sh restore; export KUBEVIRT_GO_BUILD_TAGS=${KUBEVIRT_GO_BUILD_TAGS} && ./hack/build-go.sh test ${WHAT}"
+
+go-test-cache-save:
+	SYNC_OUT=false KUBEVIRT_NO_BAZEL=true hack/dockerized "export KUBEVIRT_GO_BUILD_TAGS=${KUBEVIRT_GO_BUILD_TAGS} && ./hack/build-go.sh test ${WHAT} && ./hack/go-test-cache.sh save"
 
 test: bazel-test
 
@@ -266,6 +269,7 @@ vmlog-checker:
 	conformance \
 	go-build \
 	go-test \
+	go-test-cache-save \
 	go-all \
 	bazel-generate \
 	bazel-build \

--- a/hack/build-go.sh
+++ b/hack/build-go.sh
@@ -61,12 +61,19 @@ esac
 if [ $# -eq 0 ]; then
     if [ "${target}" = "test" ]; then
         (
-            # Ignoring container-disk-v2alpha since it is written in C, not in go
-            go ${target} -v -tags "${KUBEVIRT_GO_BUILD_TAGS}" -ldflags "$(kubevirt::version::ldflags)" --ignore=container-disk-v2alpha ./cmd/...
-        )
-        (
-            # Skip fuzz tests, as they are not part of regular unit testing
-            go ${target} -v -tags "${KUBEVIRT_GO_BUILD_TAGS}" -ldflags "$(kubevirt::version::ldflags)" -race -skip FuzzAdmitter -timeout 15m ./pkg/...
+            # Build test helper binaries required by some test suites.
+            go build -o _out/cmd/fake-qemu-process/fake-qemu-process ./cmd/fake-qemu-process/
+
+            # A static version is injected so tests that parse the version string
+            # work correctly. The value never changes, so it won't bust Go's cache.
+            test_ldflags="-X kubevirt.io/client-go/version.gitVersion=v0.0.0-test"
+
+            # Run cmd and pkg tests together for better parallelism.
+            # container-disk-v2alpha is excluded because it is written in C.
+            go ${target} -v -tags "${KUBEVIRT_GO_BUILD_TAGS}" -race \
+                -ldflags "${test_ldflags}" \
+                -skip FuzzAdmitter -timeout 15m \
+                $(go list -e ./cmd/... ./pkg/... | grep -v container-disk-v2alpha)
         )
     elif [ "${target}" = "clean" ]; then
         # Remove -mod=vendor
@@ -114,8 +121,10 @@ fi
 for arg in $args; do
     if [ "${target}" = "test" ]; then
         (
-            # Skip fuzz tests, as they are not part of regular unit testing
-            go ${target} -v -tags "${KUBEVIRT_GO_BUILD_TAGS}" -ldflags "$(kubevirt::version::ldflags)" -race -skip FuzzAdmitter -timeout 15m ./$arg/...
+            test_ldflags="-X kubevirt.io/client-go/version.gitVersion=v0.0.0-test"
+            go ${target} -v -tags "${KUBEVIRT_GO_BUILD_TAGS}" -race \
+                -ldflags "${test_ldflags}" \
+                -skip FuzzAdmitter -timeout 15m ./$arg/...
         )
     elif [ "${target}" = "clean" ]; then
         (

--- a/hack/dockerized
+++ b/hack/dockerized
@@ -68,7 +68,7 @@ SYNC_VENDOR=${SYNC_VENDOR:-false}
 
 TEMPFILE=".rsynctemp"
 
-CONTAINER_ENV="--env HTTP_PROXY=${HTTP_PROXY} --env HTTPS_PROXY=${HTTP_PROXY} --env NO_PROXY=${NO_PROXY} --env KUBEVIRT_NO_BAZEL=${KUBEVIRT_NO_BAZEL} --env KUBEVIRT_CENTOS_STREAM_VERSION=${KUBEVIRT_CENTOS_STREAM_VERSION} --env GOMAXPROCS=${GOMAXPROCS}"
+CONTAINER_ENV="--env HTTP_PROXY=${HTTP_PROXY} --env HTTPS_PROXY=${HTTP_PROXY} --env NO_PROXY=${NO_PROXY} --env KUBEVIRT_NO_BAZEL=${KUBEVIRT_NO_BAZEL} --env KUBEVIRT_CENTOS_STREAM_VERSION=${KUBEVIRT_CENTOS_STREAM_VERSION} --env GOMAXPROCS=${GOMAXPROCS} --env GO_TEST_CACHE_BUCKET=${GO_TEST_CACHE_BUCKET:-}"
 
 # Create the persistent container volume
 if [ -z "$($KUBEVIRT_CRI volume list | grep ${BUILDER})" ]; then
@@ -175,6 +175,12 @@ fi
 # mount bazel cache GCS credentials if available
 if [ -n "${BAZEL_CACHE_GOOGLE_CREDENTIALS-}" ] && [ -f "${BAZEL_CACHE_GOOGLE_CREDENTIALS}" ]; then
     volumes="$volumes -v ${BAZEL_CACHE_GOOGLE_CREDENTIALS}:${BAZEL_CACHE_GOOGLE_CREDENTIALS}:ro${selinux_bind_options}"
+fi
+
+# mount GCS credentials for Go test cache if available
+if [ -n "${GOOGLE_APPLICATION_CREDENTIALS-}" ] && [ -f "${GOOGLE_APPLICATION_CREDENTIALS}" ]; then
+    volumes="$volumes -v ${GOOGLE_APPLICATION_CREDENTIALS}:${GOOGLE_APPLICATION_CREDENTIALS}:ro${selinux_bind_options}"
+    CONTAINER_ENV="${CONTAINER_ENV} --env GOOGLE_APPLICATION_CREDENTIALS=${GOOGLE_APPLICATION_CREDENTIALS}"
 fi
 
 # Ensure that a bazel server which is running is the correct one

--- a/hack/go-test-cache.sh
+++ b/hack/go-test-cache.sh
@@ -1,0 +1,313 @@
+#!/usr/bin/env bash
+#
+# This file is part of the KubeVirt project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright 2026 Red Hat, Inc.
+#
+# Manages Go test cache for CI. Inspired by:
+# https://github.com/kubernetes/test-infra/pull/16623
+#
+# Uses the GCS JSON API directly (via curl + openssl + jq) so it works
+# on all architectures including s390x where gsutil is unavailable.
+#
+# Usage:
+#   hack/go-test-cache.sh save    - Upload cache to GCS after tests
+#   hack/go-test-cache.sh restore - Download cache from GCS before testing
+#
+# Environment variables:
+#   GO_TEST_CACHE_BUCKET - GCS bucket for storing the cache (required)
+#                          e.g. "gs://kubevirt-prow/cache/go-test-cache"
+#   GOOGLE_APPLICATION_CREDENTIALS - Path to GCS service account key (required
+#                                    for GCS access)
+
+set -euo pipefail
+
+# --- Logging helpers ---
+log_info() { echo "[go-test-cache] INFO:  $*"; }
+log_warn() { echo "[go-test-cache] WARN:  $*" >&2; }
+log_error() { echo "[go-test-cache] ERROR: $*" >&2; }
+log_debug() { echo "[go-test-cache] DEBUG: $*"; }
+
+CACHE_DIR="${GOCACHE:-$(go env GOCACHE)}"
+CACHE_ARCHIVE="/tmp/go-test-cache.tar.gz"
+GO_TEST_CACHE_BUCKET="${GO_TEST_CACHE_BUCKET:-}"
+
+if [ -z "${GO_TEST_CACHE_BUCKET}" ]; then
+    if [ "${1:-}" = "restore" ]; then
+        log_info "GO_TEST_CACHE_BUCKET not set, skipping cache restore"
+        exit 0
+    fi
+    log_error "GO_TEST_CACHE_BUCKET must be set"
+    log_error "Example: export GO_TEST_CACHE_BUCKET=gs://kubevirt-prow/cache/go-test-cache"
+    exit 1
+fi
+
+ARCH=$(uname -m)
+case ${ARCH} in
+x86_64* | amd64*) CACHE_ARCH="amd64" ;;
+aarch64* | arm64*) CACHE_ARCH="arm64" ;;
+s390x) CACHE_ARCH="s390x" ;;
+*) CACHE_ARCH="${ARCH}" ;;
+esac
+
+GCS_BUCKET=$(echo "${GO_TEST_CACHE_BUCKET}" | sed 's|gs://||' | cut -d'/' -f1)
+GCS_PREFIX=$(echo "${GO_TEST_CACHE_BUCKET}" | sed 's|gs://[^/]*/||')
+GCS_OBJECT_NAME="${GCS_PREFIX}/cache-${CACHE_ARCH}.tar.gz"
+GCS_BASE_URL="https://storage.googleapis.com"
+
+# Print environment for debugging
+log_debug "Command: $0 ${1:-}"
+log_debug "Architecture: ${ARCH} -> ${CACHE_ARCH}"
+log_debug "GOCACHE: ${CACHE_DIR}"
+log_debug "GCS_BUCKET: ${GCS_BUCKET}"
+log_debug "GCS_OBJECT_NAME: ${GCS_OBJECT_NAME}"
+log_debug "GOOGLE_APPLICATION_CREDENTIALS: ${GOOGLE_APPLICATION_CREDENTIALS:-<not set>}"
+if [ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]; then
+    if [ -f "${GOOGLE_APPLICATION_CREDENTIALS}" ]; then
+        log_debug "Credentials file exists: $(ls -la "${GOOGLE_APPLICATION_CREDENTIALS}")"
+    else
+        log_debug "Credentials file DOES NOT EXIST at: ${GOOGLE_APPLICATION_CREDENTIALS}"
+    fi
+fi
+
+access_token=""
+token_expiry=0
+
+get_access_token() {
+    if [ -z "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]; then
+        log_error "GOOGLE_APPLICATION_CREDENTIALS is not set"
+        return 1
+    fi
+    if [ ! -f "${GOOGLE_APPLICATION_CREDENTIALS}" ]; then
+        log_error "Credentials file not found: ${GOOGLE_APPLICATION_CREDENTIALS}"
+        return 1
+    fi
+
+    # Reuse token if still valid
+    if [ -n "$access_token" ] && [ "$(date +%s)" -lt "$token_expiry" ]; then
+        log_debug "Reusing cached access token (expires in $((token_expiry - $(date +%s)))s)"
+        return 0
+    fi
+
+    log_debug "Generating new access token..."
+
+    local sa_email sa_key jwt_header jwt_claim jwt_signature jwt response
+    sa_email=$(jq -r '.client_email' "${GOOGLE_APPLICATION_CREDENTIALS}")
+    if [ -z "${sa_email}" ] || [ "${sa_email}" = "null" ]; then
+        log_error "Failed to extract client_email from credentials file"
+        log_error "File contents (keys only): $(jq -r 'keys[]' "${GOOGLE_APPLICATION_CREDENTIALS}" 2>&1)"
+        return 1
+    fi
+    log_debug "Service account: ${sa_email}"
+
+    sa_key=$(jq -r '.private_key' "${GOOGLE_APPLICATION_CREDENTIALS}")
+    if [ -z "${sa_key}" ] || [ "${sa_key}" = "null" ]; then
+        log_error "Failed to extract private_key from credentials file (key field missing or empty)"
+        return 1
+    fi
+    log_debug "Private key loaded (length: ${#sa_key} chars)"
+
+    jwt_header=$(echo -n '{"alg":"RS256","typ":"JWT"}' | base64 -w 0 | tr '+/' '-_' | tr -d '=')
+    jwt_claim=$(echo -n '{"iss":"'"${sa_email}"'","scope":"https://www.googleapis.com/auth/devstorage.read_write","aud":"https://oauth2.googleapis.com/token","exp":'"$(($(date +%s) + 3600))"',"iat":'"$(date +%s)"'}' | base64 -w 0 | tr '+/' '-_' | tr -d '=')
+    jwt_signature=$(echo -n "${jwt_header}.${jwt_claim}" | openssl dgst -binary -sha256 -sign <(echo "${sa_key}") | base64 -w 0 | tr '+/' '-_' | tr -d '=')
+    jwt="${jwt_header}.${jwt_claim}.${jwt_signature}"
+
+    response=$(curl -s -X POST "https://oauth2.googleapis.com/token" \
+        -H "Content-Type: application/x-www-form-urlencoded" \
+        -d "grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer&assertion=${jwt}")
+
+    access_token=$(echo "${response}" | jq -r '.access_token')
+    token_expiry=$(($(date +%s) + 3500))
+
+    if [ -z "${access_token}" ] || [ "${access_token}" = "null" ]; then
+        log_error "Failed to obtain access token from Google OAuth2"
+        log_error "Service account: ${sa_email}"
+        log_error "OAuth2 error: $(echo "${response}" | jq -r '.error // "unknown"')"
+        log_error "OAuth2 error_description: $(echo "${response}" | jq -r '.error_description // "none"')"
+        return 1
+    fi
+
+    log_debug "Access token obtained successfully (length: ${#access_token})"
+}
+
+urlencode_path() {
+    echo "$1" | sed 's/\//%2F/g'
+}
+
+gcs_upload() {
+    local file="$1"
+    local file_size
+    file_size=$(du -sh "${file}" | cut -f1)
+    log_info "Uploading ${file} (${file_size}) to gs://${GCS_BUCKET}/${GCS_OBJECT_NAME}"
+
+    local encoded_object
+    encoded_object=$(urlencode_path "${GCS_OBJECT_NAME}")
+
+    get_access_token || return 1
+
+    # Initiate a resumable upload — returns a session URI in the Location header
+    local initiate_url="${GCS_BASE_URL}/upload/storage/v1/b/${GCS_BUCKET}/o?uploadType=resumable&name=${encoded_object}"
+    log_debug "Initiating resumable upload: ${initiate_url}"
+
+    local upload_uri
+    upload_uri=$(curl -s -i -X POST \
+        -H "Authorization: Bearer ${access_token}" \
+        -H "Content-Type: application/gzip" \
+        -H "Content-Length: 0" \
+        "${initiate_url}" | grep -i "^location:" | tr -d '\r' | sed 's/^[Ll]ocation: //')
+
+    if [ -z "${upload_uri}" ]; then
+        log_error "Failed to initiate resumable upload (no Location header returned)"
+        return 1
+    fi
+    log_debug "Resumable upload URI obtained"
+
+    # Stream the file to GCS using PUT -T (no memory buffering)
+    local http_code
+    http_code=$(curl -s -o /dev/null -w "%{http_code}" \
+        --retry 3 \
+        --retry-delay 5 \
+        -X PUT \
+        -T "${file}" \
+        -H "Content-Type: application/gzip" \
+        "${upload_uri}")
+
+    if [ "${http_code}" -ge 200 ] && [ "${http_code}" -lt 300 ]; then
+        log_info "Upload successful (HTTP ${http_code})"
+        return 0
+    else
+        log_error "GCS upload failed for gs://${GCS_BUCKET}/${GCS_OBJECT_NAME}"
+        log_error "HTTP status: ${http_code}"
+        return 1
+    fi
+}
+
+gcs_download() {
+    local file="$1"
+    local encoded_object
+    encoded_object=$(urlencode_path "${GCS_OBJECT_NAME}")
+
+    get_access_token || return 1
+
+    local download_url="${GCS_BASE_URL}/storage/v1/b/${GCS_BUCKET}/o/${encoded_object}?alt=media"
+    log_debug "Download URL: ${download_url}"
+
+    local http_code curl_exit
+    http_code=$(curl -s -o "${file}" -w "%{http_code}" \
+        --retry 3 \
+        --retry-delay 5 \
+        -H "Authorization: Bearer ${access_token}" \
+        "${download_url}") || curl_exit=$?
+    curl_exit=${curl_exit:-0}
+
+    log_debug "Download HTTP response code: ${http_code}, curl exit code: ${curl_exit}"
+
+    if [ "${curl_exit}" -ne 0 ]; then
+        log_error "curl failed with exit code ${curl_exit} (transfer incomplete or network error)"
+        rm -f "${file}"
+        return 1
+    fi
+
+    if [ "${http_code}" = "404" ]; then
+        log_warn "Cache object not found (HTTP 404): gs://${GCS_BUCKET}/${GCS_OBJECT_NAME}"
+        rm -f "${file}"
+        return 1
+    elif [ "${http_code}" -ge 200 ] && [ "${http_code}" -lt 300 ]; then
+        # Verify the archive is not truncated
+        if ! gzip -t "${file}" 2>/dev/null; then
+            log_error "Downloaded file is corrupted or truncated (gzip integrity check failed)"
+            local actual_size
+            actual_size=$(du -sh "${file}" | cut -f1)
+            log_error "Downloaded size: ${actual_size}"
+            rm -f "${file}"
+            return 1
+        fi
+        local file_size
+        file_size=$(du -sh "${file}" | cut -f1)
+        log_info "Download successful (${file_size}, integrity verified)"
+        return 0
+    else
+        log_error "GCS download failed with HTTP ${http_code}"
+        log_error "Object: gs://${GCS_BUCKET}/${GCS_OBJECT_NAME}"
+        rm -f "${file}"
+        return 1
+    fi
+}
+
+cache_save() {
+    log_info "=== Go Test Cache Save ==="
+
+    if [ ! -d "${CACHE_DIR}" ]; then
+        log_warn "Cache directory ${CACHE_DIR} does not exist, nothing to save"
+        return 0
+    fi
+
+    local cache_size num_files
+    cache_size=$(du -sh "${CACHE_DIR}" 2>/dev/null | cut -f1)
+    num_files=$(find "${CACHE_DIR}" -type f | wc -l)
+    log_info "Cache directory: ${CACHE_DIR}"
+    log_info "Cache size (uncompressed): ${cache_size} (${num_files} files)"
+
+    log_info "Compressing cache..."
+    time tar -czf "${CACHE_ARCHIVE}" -C "${CACHE_DIR}" .
+    local archive_size
+    archive_size=$(du -sh "${CACHE_ARCHIVE}" | cut -f1)
+    log_info "Cache size (compressed): ${archive_size}"
+
+    log_info "Uploading cache..."
+    time gcs_upload "${CACHE_ARCHIVE}"
+
+    rm -f "${CACHE_ARCHIVE}"
+    log_info "=== Cache save completed successfully ==="
+}
+
+cache_restore() {
+    log_info "=== Go Test Cache Restore ==="
+
+    log_info "Downloading cache..."
+    if ! time gcs_download "${CACHE_ARCHIVE}"; then
+        log_warn "Cache restore failed — tests will run without cache (slower but functional)"
+        return 0
+    fi
+
+    local archive_size
+    archive_size=$(du -sh "${CACHE_ARCHIVE}" | cut -f1)
+    log_info "Downloaded cache archive: ${archive_size}"
+
+    log_info "Decompressing cache to ${CACHE_DIR}..."
+    mkdir -p "${CACHE_DIR}"
+    time tar -xzf "${CACHE_ARCHIVE}" -C "${CACHE_DIR}"
+
+    rm -f "${CACHE_ARCHIVE}"
+
+    local cache_size num_files
+    cache_size=$(du -sh "${CACHE_DIR}" 2>/dev/null | cut -f1)
+    num_files=$(find "${CACHE_DIR}" -type f | wc -l)
+    log_info "Cache restored: ${cache_size} (${num_files} files)"
+    log_info "=== Cache restore completed successfully ==="
+}
+
+case "${1:-}" in
+save)
+    cache_save
+    ;;
+restore)
+    cache_restore
+    ;;
+*)
+    log_error "Usage: $0 {save|restore}"
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Go's test cache was being invalidated on every run because -ldflags embedded a changing buildDate timestamp. This made `make go-test` re-run all tests from scratch regardless of whether source changed. This commit:
- Removes -ldflags from test invocations (version info is irrelevant for tests and busts Go's cache on every commit)
- Removes the go-build prerequisite from go-test (tests don't need pre-built binaries)
- Combines ./cmd/... and ./pkg/... into a single go test invocation for better cross-package parallelism
- Adds hack/go-test-cache.sh to save/restore Go test cache from GCS, keyed per architecture (amd64/arm64/s390x)
- Passes GO_TEST_CACHE_BUCKET through hack/dockerized into the builder container Inspired by: https://github.com/kubernetes/test-infra/pull/16623
#### Before this PR:

#### After this PR:

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
     None.

```

