### PR TITLE
[release-1.7] (manual) virt-launcher, notify-client: always process libvirt events

### DIFF
--- a/pkg/virt-launcher/notify-client/client.go
+++ b/pkg/virt-launcher/notify-client/client.go
@@ -321,13 +321,12 @@ func (e *eventCaller) eventCallback(c cli.Connection, domain *api.Domain, libvir
 		e.updateStatus(&domain.Status)
 	}
 
+	eventType := watch.Modified
+
 	switch domain.Status.Reason {
 	case api.ReasonNonExistent:
 		now := metav1.Now()
 		domain.ObjectMeta.DeletionTimestamp = &now
-		watchEvent := watch.Event{Type: watch.Modified, Object: domain}
-		client.SendDomainEvent(watchEvent)
-		updateEvents(watchEvent, domain, events)
 	case api.ReasonPausedIOError:
 		domainDisksWithErrors, err := d.GetDiskErrors(0)
 		if err != nil {
@@ -348,44 +347,44 @@ func (e *eventCaller) eventCallback(c cli.Connection, domain *api.Domain, libvir
 			if err != nil {
 				log.Log.Reason(err).Error(fmt.Sprintf("Could not send k8s event"))
 			}
-			event := watch.Event{Type: watch.Modified, Object: domain}
-			client.SendDomainEvent(event)
-			updateEvents(event, domain, events)
-		}
-	default:
-		if libvirtEvent.Event != nil {
-			processLifecycleEvent(client, domain, libvirtEvent.Event, metadataCache, events, c, vmi)
-		}
-		if interfaceStatus != nil {
-			domain.Status.Interfaces = interfaceStatus
-		}
-		if osInfo != nil {
-			domain.Status.OSInfo = *osInfo
-		}
-
-		if fsFreezeStatus != nil {
-			domain.Status.FSFreezeStatus = *fsFreezeStatus
-		}
-
-		err := client.SendDomainEvent(watch.Event{Type: watch.Modified, Object: domain})
-		if err != nil {
-			log.Log.Reason(err).Error("Could not send domain notify event.")
 		}
 	}
+
+	if libvirtEvent.Event != nil {
+		if shouldAdd := processLifecycleEvent(client, domain, libvirtEvent.Event, metadataCache, events, c, vmi); shouldAdd {
+			eventType = watch.Added
+		}
+	}
+
+	if interfaceStatus != nil {
+		domain.Status.Interfaces = interfaceStatus
+	}
+	if osInfo != nil {
+		domain.Status.OSInfo = *osInfo
+	}
+
+	if fsFreezeStatus != nil {
+		domain.Status.FSFreezeStatus = *fsFreezeStatus
+	}
+
+	event := watch.Event{Type: eventType, Object: domain}
+
+	if err := client.SendDomainEvent(event); err != nil {
+		log.Log.Reason(err).Error("Could not send domain notify event.")
+	}
+	updateEvents(event, domain, events)
 }
 
-func processLifecycleEvent(client *Notifier, domain *api.Domain, lifecycleEvent *libvirt.DomainEventLifecycle, metadataCache *metadata.Cache, events chan watch.Event, c cli.Connection, vmi *v1.VirtualMachineInstance) {
+func processLifecycleEvent(client *Notifier, domain *api.Domain, lifecycleEvent *libvirt.DomainEventLifecycle, metadataCache *metadata.Cache, events chan watch.Event, c cli.Connection, vmi *v1.VirtualMachineInstance) bool {
 	if lifecycleEvent.Event == libvirt.DOMAIN_EVENT_DEFINED &&
 		libvirt.DomainEventDefinedDetailType(lifecycleEvent.Detail) == libvirt.DOMAIN_EVENT_DEFINED_ADDED {
-		event := watch.Event{Type: watch.Added, Object: domain}
-		client.SendDomainEvent(event)
-		updateEvents(event, domain, events)
-	} else if lifecycleEvent.Event == libvirt.DOMAIN_EVENT_STARTED &&
+		return true
+	}
+	if lifecycleEvent.Event == libvirt.DOMAIN_EVENT_STARTED &&
 		libvirt.DomainEventStartedDetailType(lifecycleEvent.Detail) == libvirt.DOMAIN_EVENT_STARTED_MIGRATED {
-		event := watch.Event{Type: watch.Added, Object: domain}
-		client.SendDomainEvent(event)
-		updateEvents(event, domain, events)
-	} else if (lifecycleEvent.Event == libvirt.DOMAIN_EVENT_RESUMED && libvirt.DomainEventResumedDetailType(lifecycleEvent.Detail) == libvirt.DOMAIN_EVENT_RESUMED_MIGRATED) ||
+		return true
+	}
+	if (lifecycleEvent.Event == libvirt.DOMAIN_EVENT_RESUMED && libvirt.DomainEventResumedDetailType(lifecycleEvent.Detail) == libvirt.DOMAIN_EVENT_RESUMED_MIGRATED) ||
 		(lifecycleEvent.Event == libvirt.DOMAIN_EVENT_SUSPENDED && libvirt.DomainEventSuspendedDetailType(lifecycleEvent.Detail) == libvirt.DOMAIN_EVENT_SUSPENDED_PAUSED) {
 		// This is a libvirt event that only the target can see, and it means that the migration has completed
 		// we just set the EndTimestamp here so that the source can finalize the migration.
@@ -400,6 +399,7 @@ func processLifecycleEvent(client *Notifier, domain *api.Domain, lifecycleEvent 
 		monitor := virtwrap.NewTargetMigrationMonitor(c, events, vmi, domain, metadataCache, notifier)
 		monitor.StartMonitor()
 	}
+	return false
 }
 
 var updateEvents = updateEventsClosure()

--- a/pkg/virt-launcher/notify-client/client.go
+++ b/pkg/virt-launcher/notify-client/client.go
@@ -354,29 +354,7 @@ func (e *eventCaller) eventCallback(c cli.Connection, domain *api.Domain, libvir
 		}
 	default:
 		if libvirtEvent.Event != nil {
-			if libvirtEvent.Event.Event == libvirt.DOMAIN_EVENT_DEFINED && libvirt.DomainEventDefinedDetailType(libvirtEvent.Event.Detail) == libvirt.DOMAIN_EVENT_DEFINED_ADDED {
-				event := watch.Event{Type: watch.Added, Object: domain}
-				client.SendDomainEvent(event)
-				updateEvents(event, domain, events)
-			} else if libvirtEvent.Event.Event == libvirt.DOMAIN_EVENT_STARTED && libvirt.DomainEventStartedDetailType(libvirtEvent.Event.Detail) == libvirt.DOMAIN_EVENT_STARTED_MIGRATED {
-				event := watch.Event{Type: watch.Added, Object: domain}
-				client.SendDomainEvent(event)
-				updateEvents(event, domain, events)
-			} else if (libvirtEvent.Event.Event == libvirt.DOMAIN_EVENT_RESUMED && libvirt.DomainEventResumedDetailType(libvirtEvent.Event.Detail) == libvirt.DOMAIN_EVENT_RESUMED_MIGRATED) ||
-				(libvirtEvent.Event.Event == libvirt.DOMAIN_EVENT_SUSPENDED && libvirt.DomainEventSuspendedDetailType(libvirtEvent.Event.Detail) == libvirt.DOMAIN_EVENT_SUSPENDED_PAUSED) {
-				// This is a libvirt event that only the target can see, and it means that the migration has completed
-				// we just set the EndTimestamp here so that the source can finalize the migration.
-				// Usually this is performed by the source launcher/handler. However, in case of upgrade, this is not
-				// guaranteed as the cluster will have an updated virt-handler together with outdated launchers, this
-				// makes sure that migrations actually finish in those cases.
-				notifier := eventNotifier{
-					client: client,
-					domain: domain,
-					events: events,
-				}
-				monitor := virtwrap.NewTargetMigrationMonitor(c, events, vmi, domain, metadataCache, notifier)
-				monitor.StartMonitor()
-			}
+			processLifecycleEvent(client, domain, libvirtEvent.Event, metadataCache, events, c, vmi)
 		}
 		if interfaceStatus != nil {
 			domain.Status.Interfaces = interfaceStatus
@@ -393,6 +371,34 @@ func (e *eventCaller) eventCallback(c cli.Connection, domain *api.Domain, libvir
 		if err != nil {
 			log.Log.Reason(err).Error("Could not send domain notify event.")
 		}
+	}
+}
+
+func processLifecycleEvent(client *Notifier, domain *api.Domain, lifecycleEvent *libvirt.DomainEventLifecycle, metadataCache *metadata.Cache, events chan watch.Event, c cli.Connection, vmi *v1.VirtualMachineInstance) {
+	if lifecycleEvent.Event == libvirt.DOMAIN_EVENT_DEFINED &&
+		libvirt.DomainEventDefinedDetailType(lifecycleEvent.Detail) == libvirt.DOMAIN_EVENT_DEFINED_ADDED {
+		event := watch.Event{Type: watch.Added, Object: domain}
+		client.SendDomainEvent(event)
+		updateEvents(event, domain, events)
+	} else if lifecycleEvent.Event == libvirt.DOMAIN_EVENT_STARTED &&
+		libvirt.DomainEventStartedDetailType(lifecycleEvent.Detail) == libvirt.DOMAIN_EVENT_STARTED_MIGRATED {
+		event := watch.Event{Type: watch.Added, Object: domain}
+		client.SendDomainEvent(event)
+		updateEvents(event, domain, events)
+	} else if (lifecycleEvent.Event == libvirt.DOMAIN_EVENT_RESUMED && libvirt.DomainEventResumedDetailType(lifecycleEvent.Detail) == libvirt.DOMAIN_EVENT_RESUMED_MIGRATED) ||
+		(lifecycleEvent.Event == libvirt.DOMAIN_EVENT_SUSPENDED && libvirt.DomainEventSuspendedDetailType(lifecycleEvent.Detail) == libvirt.DOMAIN_EVENT_SUSPENDED_PAUSED) {
+		// This is a libvirt event that only the target can see, and it means that the migration has completed
+		// we just set the EndTimestamp here so that the source can finalize the migration.
+		// Usually this is performed by the source launcher/handler. However, in case of upgrade, this is not
+		// guaranteed as the cluster will have an updated virt-handler together with outdated launchers, this
+		// makes sure that migrations actually finish in those cases.
+		notifier := eventNotifier{
+			client: client,
+			domain: domain,
+			events: events,
+		}
+		monitor := virtwrap.NewTargetMigrationMonitor(c, events, vmi, domain, metadataCache, notifier)
+		monitor.StartMonitor()
 	}
 }
 

--- a/pkg/virt-launcher/notify-client/notify_test.go
+++ b/pkg/virt-launcher/notify-client/notify_test.go
@@ -342,6 +342,87 @@ var _ = Describe("Notify", func() {
 			Expect(event).To(Equal(fmt.Sprintf("%s %s %s involvedObject{kind=VirtualMachineInstance,apiVersion=kubevirt.io/v1}", eventType, eventReason, eventMessage)))
 		})
 
+		It("should consolidate I/O error status and Agent updates into a single watch event", func() {
+			faultDisk := []libvirt.DomainDiskError{
+				{
+					Disk:  "vda",
+					Error: libvirt.DOMAIN_DISK_ERROR_NO_SPACE,
+				},
+			}
+			domain := api.NewMinimalDomain("test")
+			domain.Status.Reason = api.ReasonPausedIOError
+			x, err := xml.Marshal(domain.Spec)
+			Expect(err).ToNot(HaveOccurred())
+
+			ctrl := gomock.NewController(GinkgoT())
+			mockLibvirt := testing.NewLibvirt(ctrl)
+			mockLibvirt.ConnectionEXPECT().LookupDomainByName(gomock.Any()).Return(mockLibvirt.VirtDomain, nil).AnyTimes()
+			mockLibvirt.DomainEXPECT().GetState().Return(libvirt.DOMAIN_PAUSED, int(libvirt.DOMAIN_PAUSED_IOERROR), nil)
+			mockLibvirt.DomainEXPECT().Free()
+			mockLibvirt.DomainEXPECT().GetXMLDesc(gomock.Eq(libvirt.DomainXMLFlags(0))).Return(string(x), nil)
+			mockLibvirt.DomainEXPECT().GetDiskErrors(uint32(0)).Return(faultDisk, nil)
+
+			vmi := api2.NewMinimalVMI("test-vmi")
+			vmi.UID = "1234"
+			vmiStore.Add(vmi)
+
+			metadataCache := metadata.NewCache()
+			interfaceStatus := []api.InterfaceStatus{{Ip: "10.0.0.1", InterfaceName: "eth0"}}
+			osInfo := &api.GuestOSInfo{Name: "test-os"}
+			fsFreezeStatus := &api.FSFreeze{Status: "frozen"}
+			e.eventCallback(mockLibvirt.VirtConnection, domain, libvirtEvent{}, client, deleteNotificationSent, interfaceStatus, osInfo, vmi, fsFreezeStatus, metadataCache)
+
+			var event watch.Event
+			Eventually(eventChan, 2*time.Second).Should(Receive(&event))
+			Expect(event.Type).To(Equal(watch.Modified))
+
+			newDomain, ok := event.Object.(*api.Domain)
+			Expect(ok).To(BeTrue())
+			Expect(newDomain.Status.Reason).To(Equal(api.ReasonPausedIOError))
+			Expect(newDomain.Status.Interfaces).To(HaveLen(1))
+			Expect(newDomain.Status.Interfaces[0].Ip).To(Equal("10.0.0.1"))
+			Expect(newDomain.Status.OSInfo.Name).To(Equal("test-os"))
+			Expect(newDomain.Status.FSFreezeStatus.Status).To(Equal("frozen"))
+		})
+
+		It("should process lifecycle events even if the domain is paused due to an I/O error", func() {
+			faultDisk := []libvirt.DomainDiskError{
+				{
+					Disk:  "vda",
+					Error: libvirt.DOMAIN_DISK_ERROR_UNSPEC,
+				},
+			}
+			domain := api.NewMinimalDomain("test")
+			domain.Status.Reason = api.ReasonPausedIOError
+			x, err := xml.Marshal(domain.Spec)
+			Expect(err).ToNot(HaveOccurred())
+
+			ctrl := gomock.NewController(GinkgoT())
+			mockLibvirt := testing.NewLibvirt(ctrl)
+			mockLibvirt.ConnectionEXPECT().LookupDomainByName(gomock.Any()).Return(mockLibvirt.VirtDomain, nil).AnyTimes()
+			mockLibvirt.DomainEXPECT().GetState().Return(libvirt.DOMAIN_PAUSED, int(libvirt.DOMAIN_PAUSED_IOERROR), nil)
+			mockLibvirt.DomainEXPECT().Free()
+			mockLibvirt.DomainEXPECT().GetXMLDesc(gomock.Eq(libvirt.DomainXMLFlags(0))).Return(string(x), nil)
+			mockLibvirt.DomainEXPECT().GetDiskErrors(uint32(0)).Return(faultDisk, nil)
+
+			vmi := api2.NewMinimalVMI("test-vmi")
+			vmi.UID = "1234"
+			vmiStore.Add(vmi)
+
+			metadataCache := metadata.NewCache()
+			lifecycleEvent := libvirtEvent{
+				Event: &libvirt.DomainEventLifecycle{
+					Event:  libvirt.DOMAIN_EVENT_DEFINED,
+					Detail: int(libvirt.DOMAIN_EVENT_DEFINED_ADDED),
+				},
+			}
+			e.eventCallback(mockLibvirt.VirtConnection, domain, lifecycleEvent, client, deleteNotificationSent, nil, nil, vmi, nil, metadataCache)
+
+			var event watch.Event
+			Eventually(eventChan, 2*time.Second).Should(Receive(&event))
+			Expect(event.Type).To(Equal(watch.Added))
+		})
+
 	})
 
 	Describe("Version mismatch", func() {


### PR DESCRIPTION
Backport of upstream 9f14a3450109 (PR #16778) to release-1.7.

Previously if the domain became paused due to an I/O error the switch case in eventCallback would not hit the default case and would therefore skip processing of incoming libvirt events until the domain was unpaused. Lifecycle events (migration started/finished on the target) and agent-sourced status (interfaces, OS info, fsFreeze) were dropped, and domain state updates only propagated at all if GetDiskErrors happened to return a faulty disk.

Adapted for release-1.7: the 1.7 tree predates the JobCompletedEvent field and the processJobCompletedEvent/processLifecycleEvent helper refactor, so the lifecycle handling is extracted here in the same shape as the upstream fix, without the backup-job path.

(cherry picked from commit 9f14a3450109e6abbce6c14a4475190e7ed8e014)

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix: domain job completion events would not be processed if the domain was paused due to an I/O error.
```

