### PR TITLE
Quarantine flaky guest OS panic metric test

### DIFF
--- a/tests/monitoring/vm_monitoring.go
+++ b/tests/monitoring/vm_monitoring.go
@@ -623,7 +623,7 @@ var _ = Describe("[sig-monitoring]VM Monitoring", decorators.SigMonitoring, func
 	})
 
 	Context("VM guest panic metrics", decorators.RequiresAMD64, func() {
-		It("should increment kubevirt_vmi_guest_os_panic_total when a guest OS panics", func() {
+		It("[QUARANTINE] should increment kubevirt_vmi_guest_os_panic_total when a guest OS panics", decorators.Quarantine, func() {
 			virtClient := kubevirt.Client()
 
 			By("creating a Fedora VMI with ISA panic device")


### PR DESCRIPTION
The VM Monitoring guest panic metric test is failing and needs investigation.
Issue opened: https://github.com/kubevirt/kubevirt/issues/18654

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```

