### PR TITLE
tests: convert restore vmstate functest to unit test

### DIFF
--- a/pkg/storage/snapshot/BUILD.bazel
+++ b/pkg/storage/snapshot/BUILD.bazel
@@ -65,6 +65,8 @@ go_test(
         "//pkg/controller:go_default_library",
         "//pkg/instancetype/revision:go_default_library",
         "//pkg/pointer:go_default_library",
+        "//pkg/storage/backend-storage:go_default_library",
+        "//pkg/storage/utils:go_default_library",
         "//pkg/testutils:go_default_library",
         "//pkg/util:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",

--- a/pkg/storage/snapshot/restore_test.go
+++ b/pkg/storage/snapshot/restore_test.go
@@ -55,6 +55,8 @@ import (
 	virtcontroller "kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/instancetype/revision"
 	"kubevirt.io/kubevirt/pkg/pointer"
+	backendstorage "kubevirt.io/kubevirt/pkg/storage/backend-storage"
+	storageutils "kubevirt.io/kubevirt/pkg/storage/utils"
 	"kubevirt.io/kubevirt/pkg/testutils"
 )
 
@@ -1672,6 +1674,126 @@ var _ = Describe("Restore controller", func() {
 					res, err := targetVM.Reconcile()
 					Expect(err).ShouldNot(HaveOccurred())
 					Expect(res).To(BeTrue())
+				})
+			})
+
+			Context("reconcileBackendVolume", func() {
+				var (
+					r      *snapshotv1.VirtualMachineRestore
+					target *vmRestoreTarget
+				)
+
+				BeforeEach(func() {
+					r = createRestoreWithOwner()
+					addVolumeRestores(r)
+					vm = createRestoreInProgressVM()
+					target = &vmRestoreTarget{
+						controller: controller,
+						vmRestore:  r,
+						vm:         vm,
+					}
+					addVirtualMachineRestore(r)
+					Expect(controller.VMInformer.GetStore().Add(vm)).To(Succeed())
+				})
+
+				It("should return ready when backend storage is not needed", func() {
+					snapshotVM := sc.Spec.Source.VirtualMachine
+					ready, err := target.reconcileBackendVolume(snapshotVM)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(ready).To(BeTrue())
+				})
+
+				It("should return ready when backend storage is needed but not included in snapshot", func() {
+					sc.Spec.Source.VirtualMachine.Spec.Template.Spec.Domain.Devices.TPM = &kubevirtv1.TPMDevice{
+						Persistent: pointer.P(true),
+					}
+					Expect(controller.VMSnapshotContentInformer.GetStore().Update(sc)).To(Succeed())
+
+					snapshotVM := sc.Spec.Source.VirtualMachine
+					ready, err := target.reconcileBackendVolume(snapshotVM)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(ready).To(BeTrue())
+				})
+
+				It("should remove backend label from original PVC and add to restore PVC when backend is in snapshot", func() {
+					sc.Spec.Source.VirtualMachine.Spec.Template.Spec.Domain.Devices.TPM = &kubevirtv1.TPMDevice{
+						Persistent: pointer.P(true),
+					}
+					snapshotVM := sc.Spec.Source.VirtualMachine
+
+					backendVolumeName := storageutils.BackendPVCVolumeName(vmName)
+					backendPVCName := "backend-pvc-" + vmName
+					restoreBackendPVCName := "restore-uid-backend"
+
+					sc.Spec.VolumeBackups = append(sc.Spec.VolumeBackups, snapshotv1.VolumeBackup{
+						VolumeName: backendVolumeName,
+						PersistentVolumeClaim: snapshotv1.PersistentVolumeClaim{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      backendPVCName,
+								Namespace: testNamespace,
+							},
+							Spec: corev1.PersistentVolumeClaimSpec{
+								StorageClassName: &storageClassName,
+							},
+						},
+						VolumeSnapshotName: pointer.P("vmsnapshot-snapshot-uid-volume-backend"),
+					})
+					Expect(controller.VMSnapshotContentInformer.GetStore().Update(sc)).To(Succeed())
+
+					backendPVC := &corev1.PersistentVolumeClaim{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      backendPVCName,
+							Namespace: testNamespace,
+							Labels: map[string]string{
+								backendstorage.PVCPrefix: vmName,
+							},
+						},
+						Spec: corev1.PersistentVolumeClaimSpec{
+							StorageClassName: &storageClassName,
+						},
+					}
+					Expect(controller.PVCInformer.GetStore().Add(backendPVC)).To(Succeed())
+
+					restoreBackendPVC := &corev1.PersistentVolumeClaim{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      restoreBackendPVCName,
+							Namespace: testNamespace,
+						},
+						Spec: corev1.PersistentVolumeClaimSpec{
+							StorageClassName: &storageClassName,
+						},
+					}
+					Expect(controller.PVCInformer.GetStore().Add(restoreBackendPVC)).To(Succeed())
+
+					r.Status.Restores = append(r.Status.Restores, snapshotv1.VolumeRestore{
+						VolumeName:                backendVolumeName,
+						PersistentVolumeClaimName: restoreBackendPVCName,
+						VolumeSnapshotName:        "vmsnapshot-snapshot-uid-volume-backend",
+					})
+
+					k8sClient.Fake.PrependReactor("list", "persistentvolumeclaims", func(action testing.Action) (bool, runtime.Object, error) {
+						return true, &corev1.PersistentVolumeClaimList{
+							Items: []corev1.PersistentVolumeClaim{*backendPVC},
+						}, nil
+					})
+
+					patches := map[string]string{}
+					k8sClient.Fake.PrependReactor("patch", "persistentvolumeclaims", func(action testing.Action) (bool, runtime.Object, error) {
+						patchAction := action.(testing.PatchAction)
+						patches[patchAction.GetName()] = string(patchAction.GetPatch())
+						return true, nil, nil
+					})
+
+					ready, err := target.reconcileBackendVolume(snapshotVM)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(ready).To(BeFalse())
+					Expect(patches).To(HaveLen(2))
+
+					Expect(patches).To(HaveKey(backendPVCName))
+					Expect(patches[backendPVCName]).To(ContainSubstring(restoreCleanupBackendPVCLabel))
+
+					Expect(patches).To(HaveKey(restoreBackendPVCName))
+					Expect(patches[restoreBackendPVCName]).To(ContainSubstring(backendstorage.PVCPrefix))
 				})
 			})
 

--- a/pkg/storage/snapshot/snapshot_test.go
+++ b/pkg/storage/snapshot/snapshot_test.go
@@ -966,6 +966,70 @@ var _ = Describe("Snapshot controlleer", func() {
 				Expect(*createCalls).To(Equal(1))
 			})
 
+			It("should exclude volumes whose storage class has no VolumeSnapshotClass", func() {
+				noSnapshotStorageClass := "no-snapshot-sc"
+				vmSnapshot := createVMSnapshotInProgress()
+				vm := createLockedVM()
+				vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, v1.Volume{
+					Name: "disk2",
+					VolumeSource: v1.VolumeSource{
+						PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{PersistentVolumeClaimVolumeSource: corev1.PersistentVolumeClaimVolumeSource{
+							ClaimName: "test-pvc-no-snapshot",
+						}},
+					},
+				})
+
+				noSnapshotPVC := corev1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: testNamespace,
+						Name:      "test-pvc-no-snapshot",
+					},
+					Spec: corev1.PersistentVolumeClaimSpec{
+						StorageClassName: &noSnapshotStorageClass,
+						AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+					},
+					Status: corev1.PersistentVolumeClaimStatus{
+						Phase: corev1.ClaimBound,
+					},
+				}
+				pvcSource.Add(&noSnapshotPVC)
+
+				storageClassSource.Add(createStorageClass())
+				storageClassSource.Add(&storagev1.StorageClass{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: noSnapshotStorageClass,
+					},
+					Provisioner: "no-snapshot-provisioner",
+				})
+
+				// Expected content only includes the snapshottable volume
+				pvcs := createPersistentVolumeClaims()
+				expectedContent := createVirtualMachineSnapshotContent(vmSnapshot, vm, pvcs)
+
+				vmSource.Add(vm)
+				createCalls := expectVMSnapshotContentCreate(vmSnapshotClient, expectedContent)
+				vmSnapshotSource.Add(vmSnapshot)
+				addVolumeSnapshotClass(createVolumeSnapshotClasses()[0])
+
+				updatedSnapshot := vmSnapshot.DeepCopy()
+				updatedSnapshot.ResourceVersion = "1"
+				updatedSnapshot.Status = &snapshotv1.VirtualMachineSnapshotStatus{
+					SourceUID:  &vmUID,
+					ReadyToUse: pointer.P(false),
+					Phase:      snapshotv1.InProgress,
+					Conditions: []snapshotv1.Condition{
+						newProgressingCondition(corev1.ConditionTrue, "Source locked and operation in progress"),
+						newReadyCondition(corev1.ConditionFalse, "Not ready"),
+					},
+				}
+				updateStatusCalls := expectVMSnapshotUpdateStatus(vmSnapshotClient, updatedSnapshot)
+
+				controller.processVMSnapshotWorkItem()
+				testutils.ExpectEvent(recorder, "SuccessfulVirtualMachineSnapshotContentCreate")
+				Expect(*updateStatusCalls).To(Equal(1))
+				Expect(*createCalls).To(Equal(1))
+			})
+
 			It("create VirtualMachineSnapshotContent online snapshot", func() {
 				vmSnapshot := createVMSnapshotInProgress()
 				vm := createLockedVM()

--- a/tests/libstorage/storageclass.go
+++ b/tests/libstorage/storageclass.go
@@ -316,40 +316,6 @@ func GetAvailableRWFileSystemStorageClass() (string, bool) {
 	return sc, foundSC
 }
 
-// GetNoVolumeSnapshotStorageClass goes over all the existing storage classes
-// and returns one which doesnt have volume snapshot ability
-// if the preference storage class exists and is without snapshot
-// ability it will be returned
-func GetNoVolumeSnapshotStorageClass(preference string) string {
-	virtClient := kubevirt.Client()
-	scs, err := virtClient.StorageV1().StorageClasses().List(context.Background(), metav1.ListOptions{})
-	Expect(err).ToNot(HaveOccurred())
-
-	vscs, err := virtClient.KubernetesSnapshotClient().SnapshotV1().VolumeSnapshotClasses().List(context.Background(), metav1.ListOptions{})
-	if errors.IsNotFound(err) {
-		return ""
-	}
-	Expect(err).ToNot(HaveOccurred())
-	vscsDrivers := make(map[string]bool)
-	for _, vsc := range vscs.Items {
-		vscsDrivers[vsc.Driver] = true
-	}
-
-	candidate := ""
-	for _, sc := range scs.Items {
-		if _, ok := vscsDrivers[sc.Provisioner]; !ok {
-			if sc.Name == preference {
-				return sc.Name
-			}
-			if candidate == "" {
-				candidate = sc.Name
-			}
-		}
-	}
-
-	return candidate
-}
-
 func IsStorageClassBindingModeWaitForFirstConsumer(sc string) bool {
 	virtClient := kubevirt.Client()
 	storageClass, err := virtClient.StorageV1().StorageClasses().Get(context.Background(), sc, metav1.GetOptions{})

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -49,7 +49,6 @@ import (
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/framework/matcher"
-	"kubevirt.io/kubevirt/tests/libkubevirt"
 	"kubevirt.io/kubevirt/tests/libnet"
 	"kubevirt.io/kubevirt/tests/libstorage"
 	"kubevirt.io/kubevirt/tests/libvmifact"
@@ -1414,107 +1413,6 @@ var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 				Entry("with offline snapshot", false),
 				Entry("with online snapshot", true),
 			)
-
-			Context("With non-snapshottable backend storage", Serial, func() {
-				var noSnapshotSC string
-				var originalBackendSC string
-
-				BeforeEach(func() {
-					noSnapshotSC = libstorage.GetNoVolumeSnapshotStorageClass("")
-					if noSnapshotSC == "" {
-						Skip("No storage class without VolumeSnapshotClass support available")
-					}
-
-					// Patch kubevirt config to use non-snapshottable storage for backend
-					kv := libkubevirt.GetCurrentKv(virtClient)
-					originalBackendSC = kv.Spec.Configuration.VMStateStorageClass
-
-					patchData := fmt.Appendf(nil, `[{"op": "replace", "path": "/spec/configuration/vmStateStorageClass", "value": "%s"}]`, noSnapshotSC)
-					_, err = virtClient.KubeVirt(kv.Namespace).Patch(context.Background(), kv.Name, types.JSONPatchType, patchData, metav1.PatchOptions{})
-					Expect(err).ToNot(HaveOccurred())
-
-					Eventually(func() string {
-						kv := libkubevirt.GetCurrentKv(virtClient)
-						return kv.Spec.Configuration.VMStateStorageClass
-					}, 30*time.Second, 1*time.Second).Should(Equal(noSnapshotSC))
-				})
-
-				AfterEach(func() {
-					// Restore original VMStateStorageClass
-					kv := libkubevirt.GetCurrentKv(virtClient)
-					patchData := fmt.Appendf(nil, `[{"op": "replace", "path": "/spec/configuration/vmStateStorageClass", "value": "%s"}]`, originalBackendSC)
-					_, err = virtClient.KubeVirt(kv.Namespace).Patch(context.Background(), kv.Name, types.JSONPatchType, patchData, metav1.PatchOptions{})
-					Expect(err).ToNot(HaveOccurred())
-				})
-
-				DescribeTable("Should restore a VM when backend storage PVC was not included in snapshot", func(restoreToSameVM bool) {
-					vm = createVMWithCloudInit(cd.ContainerDiskFedoraTestTooling, snapshotStorageClass)
-					vm.Spec.Template.Spec.Domain.Devices.TPM = &v1.TPMDevice{Persistent: pointer.P(true)}
-					vm, vmi = createAndStartVM(vm)
-					Eventually(ThisVM(vm)).WithTimeout(300 * time.Second).WithPolling(time.Second).Should(BeReady())
-
-					pvcs, err := virtClient.CoreV1().PersistentVolumeClaims(vmi.Namespace).List(context.Background(), metav1.ListOptions{
-						LabelSelector: "persistent-state-for=" + vmi.Name,
-					})
-					Expect(err).NotTo(HaveOccurred())
-					Expect(pvcs.Items).To(HaveLen(1))
-					originalBackendPVC := pvcs.Items[0]
-
-					By(stoppingVM)
-					vm = libvmops.StopVirtualMachine(vm)
-
-					By(creatingSnapshot)
-					snapshot = createSnapshot(vm)
-
-					content, err := virtClient.VirtualMachineSnapshotContent(snapshot.Namespace).Get(
-						context.Background(), *snapshot.Status.VirtualMachineSnapshotContentName, metav1.GetOptions{})
-					Expect(err).ToNot(HaveOccurred())
-					Expect(content.Spec.VolumeBackups).To(HaveLen(1), "Only data volume should be in snapshot, not backend storage")
-
-					By("Restoring VM")
-					targetVMName := vm.Name
-					var targetVMUID *types.UID
-					if restoreToSameVM {
-						targetVMUID = &vm.UID
-					} else {
-						targetVMName = vm.Name + "-restored"
-						targetVMUID = nil
-					}
-
-					restore = createRestoreDef(targetVMName, snapshot.Name)
-					restore, err = virtClient.VirtualMachineRestore(vm.Namespace).Create(context.Background(), restore, metav1.CreateOptions{})
-					Expect(err).ToNot(HaveOccurred())
-
-					restore = waitRestoreComplete(restore, targetVMName, targetVMUID)
-					Expect(restore.Status.Restores).To(HaveLen(1), "Only data volume should be restored")
-
-					By("Starting VM")
-					restoredVM, err := virtClient.VirtualMachine(vm.Namespace).Get(context.Background(), targetVMName, metav1.GetOptions{})
-					Expect(err).ToNot(HaveOccurred())
-					restoredVM = libvmops.StartVirtualMachine(restoredVM)
-					Eventually(ThisVM(restoredVM)).WithTimeout(300 * time.Second).WithPolling(time.Second).Should(BeReady())
-
-					By("Verifying new backend PVC was created")
-					Eventually(func() bool {
-						pvcs, err := virtClient.CoreV1().PersistentVolumeClaims(restoredVM.Namespace).List(context.Background(), metav1.ListOptions{
-							LabelSelector: "persistent-state-for=" + targetVMName,
-						})
-						if err != nil || len(pvcs.Items) != 1 {
-							return false
-						}
-						pvc := pvcs.Items[0]
-						// For same VM: verify it has the same UID as the original backend PVC
-						// For different VM: verify it has different UID and that it doesn't have datasourceref
-						if restoreToSameVM {
-							return pvc.UID == originalBackendPVC.UID
-						}
-						return pvc.Spec.DataSource == nil && pvc.Spec.DataSourceRef == nil && pvc.UID != originalBackendPVC.UID
-					}, 60*time.Second, 2*time.Second).Should(BeTrue())
-				},
-					Entry("when restoring to the same VM", true),
-					//Entry("when restoring to a different VM", false), // Currently not supported, PR in progress
-				)
-			})
 
 			DescribeTable("should reject vm start if restore in progress", func(deleteFunc string) {
 				vm, vmi = createAndStartVM(renderVMWithRegistryImportDataVolume(cd.ContainerDiskAlpine, snapshotStorageClass))

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -1209,8 +1209,6 @@ var _ = Describe(SIG("VirtualMachineSnapshot Tests", func() {
 		})
 
 		Context("with independent DataVolume", func() {
-			var dv *cdiv1.DataVolume
-
 			DescribeTable("should accurately report DataVolume provisioning", func(storageOptFun func(string, string, ...libvmi.DiskOption) libvmi.Option, memory string) {
 				dataVolume := libdv.NewDataVolume(
 					libdv.WithRegistryURLSourceAndPullMethod(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), cdiv1.RegistryPullNode),
@@ -1240,7 +1238,7 @@ var _ = Describe(SIG("VirtualMachineSnapshot Tests", func() {
 							"Enabled": BeFalse()})),
 				}))
 
-				dv, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(testsuite.GetTestNamespace(nil)).Create(context.Background(), dataVolume, metav1.CreateOptions{})
+				_, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(testsuite.GetTestNamespace(nil)).Create(context.Background(), dataVolume, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
 
 				Eventually(func() v1.VirtualMachineStatus {
@@ -1257,73 +1255,6 @@ var _ = Describe(SIG("VirtualMachineSnapshot Tests", func() {
 				Entry("with DataVolume volume", libvmi.WithDataVolume, "1Gi"),
 				Entry("with PVC volume", libvmi.WithPersistentVolumeClaim, "128Mi"),
 			)
-
-			It("[test_id:9705]Should show included and excluded volumes in the snapshot", func() {
-				noSnapshotSC := libstorage.GetNoVolumeSnapshotStorageClass("local")
-				if noSnapshotSC == "" {
-					Skip("Skipping test, no storage class without snapshot support") //nolint:forbidigo
-				}
-				By("Creating DV with snapshot supported storage class")
-				includedDataVolume := libdv.NewDataVolume(
-					libdv.WithRegistryURLSourceAndPullMethod(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), cdiv1.RegistryPullNode),
-					libdv.WithStorage(libdv.StorageWithStorageClass(snapshotStorageClass)),
-					libdv.WithForceBindAnnotation(),
-				)
-				dv, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(testsuite.GetTestNamespace(nil)).Create(context.Background(), includedDataVolume, metav1.CreateOptions{})
-				Expect(err).ToNot(HaveOccurred())
-				waitDataVolumePopulated(dv.Namespace, dv.Name)
-
-				By("Creating DV with no snapshot supported storage class")
-				excludedDataVolume := libdv.NewDataVolume(
-					libdv.WithRegistryURLSourceAndPullMethod(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpine), cdiv1.RegistryPullNode),
-					libdv.WithStorage(libdv.StorageWithStorageClass(noSnapshotSC)),
-					libdv.WithForceBindAnnotation(),
-				)
-				dv, err = virtClient.CdiClient().CdiV1beta1().DataVolumes(testsuite.GetTestNamespace(nil)).Create(context.Background(), excludedDataVolume, metav1.CreateOptions{})
-				Expect(err).ToNot(HaveOccurred())
-
-				vmi := libvmi.New(
-					libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithMasqueradeBinding())),
-					libvmi.WithNetwork(v1.DefaultPodNetwork()),
-					libvmi.WithMemoryRequest("128Mi"),
-					libvmi.WithNamespace(testsuite.GetTestNamespace(nil)),
-					libvmi.WithPersistentVolumeClaim("snapshotablevolume", includedDataVolume.Name),
-					libvmi.WithPersistentVolumeClaim("notsnapshotablevolume", excludedDataVolume.Name),
-				)
-				vm = libvmi.NewVirtualMachine(vmi)
-
-				_, err := virtClient.VirtualMachine(vm.Namespace).Create(context.Background(), vm, metav1.CreateOptions{})
-				Expect(err).ToNot(HaveOccurred())
-
-				Eventually(func() v1.VirtualMachineStatus {
-					vm, err := virtClient.VirtualMachine(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
-					Expect(err).ToNot(HaveOccurred())
-					return vm.Status
-				}, 180*time.Second, 3*time.Second).Should(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
-					"VolumeSnapshotStatuses": HaveExactElements(
-						gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
-							"Enabled": BeTrue()}),
-						gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
-							"Enabled": BeFalse()})),
-				}))
-
-				By("Create Snapshot")
-				snapshot = libstorage.NewSnapshot(vm.Name, vm.Namespace)
-				_, err = virtClient.VirtualMachineSnapshot(snapshot.Namespace).Create(context.Background(), snapshot, metav1.CreateOptions{})
-				Expect(err).ToNot(HaveOccurred())
-
-				snapshot = libstorage.WaitSnapshotSucceeded(virtClient, vm.Namespace, snapshot.Name)
-				Expect(snapshot.Status.SnapshotVolumes.IncludedVolumes).Should(HaveLen(1))
-				Expect(snapshot.Status.SnapshotVolumes.IncludedVolumes[0]).Should(Equal("snapshotablevolume"))
-				Expect(snapshot.Status.SnapshotVolumes.ExcludedVolumes).Should(HaveLen(1))
-				Expect(snapshot.Status.SnapshotVolumes.ExcludedVolumes[0]).Should(Equal("notsnapshotablevolume"))
-
-				By("Verifying PartialSnapshot indication is set when snapshottable volume is excluded")
-				Expect(snapshot.Status.Indications).Should(ContainElement(snapshotv1.VMSnapshotPartialSnapshotIndication))
-				Expect(snapshot.Status.SourceIndications).Should(ContainElement(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
-					"Indication": Equal(snapshotv1.VMSnapshotPartialSnapshotIndication),
-				})))
-			})
 
 			It("Should also include backend PVC in the snapshot", func() {
 				By("Creating DV with snapshot supported storage class")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

This PR replaces a redundant functional test with a unit test. It also adds coverage for the mechanism that ensures the backend label is correctly removed from the original VM state PVC and applied to the restored one.

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

