### PR TITLE
virt-operator: wait for DaemonSet rollout before updating controllers

### DIFF
--- a/pkg/virt-operator/resource/apply/apps.go
+++ b/pkg/virt-operator/resource/apply/apps.go
@@ -292,14 +292,17 @@ func (r *Reconciler) processCanaryUpgrade(cachedDaemonSet, newDS *appsv1.DaemonS
 				return false, nil, waiting
 			}
 		}
-		// rollout has completed and all virt-handlers are ready revert
-		// maxUnavailable to default value
-		setMaxUnavailable(newDS, daemonSetDefaultMaxUnavailable)
-		newDS, err = r.patchDaemonSet(cachedDaemonSet, newDS)
-		if err != nil {
-			return false, err, failed
+		if !daemonHasDefaultRolloutStrategy(cachedDaemonSet) {
+			setMaxUnavailable(newDS, daemonSetDefaultMaxUnavailable)
+			newDS, err = r.patchDaemonSet(cachedDaemonSet, newDS)
+			if err != nil {
+				return false, err, failed
+			}
+			SetGeneration(&r.kv.Status.Generations, newDS)
+			log.V(2).Infof("daemonSet %v reverted maxUnavailable to default", newDS.GetName())
+			return false, nil, waiting
 		}
-		SetGeneration(&r.kv.Status.Generations, newDS)
+		SetGeneration(&r.kv.Status.Generations, cachedDaemonSet)
 		log.V(2).Infof("daemonSet %v is ready", newDS.GetName())
 		return true, nil, successful
 	default:
@@ -360,13 +363,10 @@ func unattachCertificateSecret(spec *corev1.PodSpec, secretName string) {
 func getMaxUnavailable(daemonSet *appsv1.DaemonSet) int {
 	update := daemonSet.Spec.UpdateStrategy.RollingUpdate
 
-	if update == nil {
-		return 0
+	if update == nil || update.MaxUnavailable == nil {
+		return daemonSetDefaultMaxUnavailable.IntValue()
 	}
-	if update.MaxUnavailable != nil {
-		return update.MaxUnavailable.IntValue()
-	}
-	return daemonSetDefaultMaxUnavailable.IntValue()
+	return update.MaxUnavailable.IntValue()
 }
 
 func (r *Reconciler) syncDaemonSet(daemonSet *appsv1.DaemonSet) (bool, error) {

--- a/pkg/virt-operator/resource/apply/apps_test.go
+++ b/pkg/virt-operator/resource/apply/apps_test.go
@@ -742,7 +742,7 @@ var _ = Describe("Apply Apps", func() {
 						Expect(rollingUpdate.MaxUnavailable).ToNot(BeNil())
 						Expect(rollingUpdate.MaxUnavailable.IntValue()).To(Equal(1))
 					},
-					successful, true, false, true, false,
+					successful, true, false, false, false,
 				),
 
 				Entry("should unattach secret before complete rollout",

--- a/pkg/virt-operator/resource/apply/update.go
+++ b/pkg/virt-operator/resource/apply/update.go
@@ -20,6 +20,11 @@ func (r *Reconciler) updateKubeVirtSystem(controllerDeploymentsRolledOver bool) 
 		}
 	}
 
+	// wait for daemonsets to fully stabilize before updating controllers
+	if !haveDaemonSetsRolledOver(r.targetStrategy, r.kv, r.stores) {
+		return false, nil
+	}
+
 	// create/update Controller Deployments
 	for _, deployment := range r.targetStrategy.ControllerDeployments() {
 		deployment, err := r.syncDeployment(deployment)

--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -658,7 +658,7 @@ var _ = Describe("[sig-operator]Operator", Serial, decorators.SigOperator, func(
 			if !libstorage.HasCDI() {
 				Fail("Fail update test when CDI is not present")
 			}
-
+			// [Focus-for-flakes]
 			if updateOperator && flags.OperatorManifestPath == "" {
 				Fail("operator manifest path must be configured for update tests")
 			}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
During an upgrade, the operator syncs virt-handler DaemonSet and virt-controller Deployment in the same reconcile pass. The canary upgrade flow (introduced in PR#16759) patches the DaemonSet multiple times across reconcile cycles. Between canary stages, syncDaemonSet can briefly report done=true while the DaemonSet spec is not yet stable. During this window, the operator proceeds to sync virt-controller. The new virt-controller creates workload-update migrations while virt-handler is still being rolled out.

On k8s 1.36, the StaleControllerConsistencyDaemonSet feature changes DaemonSet rollout timing, making virt-handler restarts overlap with in-flight migrations. When virt-handler is killed mid-migration, the migration proxy is destroyed. The source QEMU stays alive because MigrateToURI3() cannot complete its handshake, leaving an orphaned Running pod that blocks both new migrations and VMI finalization.

Fix this with two changes:

1. In processCanaryUpgrade, only return done=true when the DaemonSet spec is fully stable (maxUnavailable already at default). If it needs reverting, return done=false so the next reconcile confirms stability before proceeding.

2. In updateKubeVirtSystem, add an explicit haveDaemonSetsRolledOver check between DaemonSet sync and controller sync. This ensures virt-handler pods are fully ready before virt-controller is updated.

Also fix getMaxUnavailable to treat nil RollingUpdate as the default value, avoiding unnecessary patches when no explicit strategy is set.

### References
- Fixes https://github.com/kubevirt/kubevirt/issues/18670
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

