### PR TITLE
tests: guard DV creation behind CSI storage availability in monitoring tests

### DIFF
--- a/tests/libmonitoring/prometheus.go
+++ b/tests/libmonitoring/prometheus.go
@@ -44,6 +44,9 @@ const (
 	defaultAlertWaitTimeout         = 5 * time.Minute
 	defaultMetricsPort              = 8443
 	prometheusPortForwardTargetPort = 9090
+	prometheusPortForwardTimeout    = 90 * time.Second
+	prometheusRequestTimeout        = 30 * time.Second
+	prometheusHTTPTimeout           = 10 * time.Second
 )
 
 var (
@@ -221,7 +224,9 @@ func DoPrometheusHTTPRequest(cli kubecli.KubevirtClient, endpoint string) []byte
 	var result []byte
 	if checks.IsOpenShift() {
 		promURL := getPrometheusURLForOpenShift()
-		result = doHTTPRequest(promURL, endpoint, token)
+		var err error
+		result, err = doHTTPRequest(promURL, endpoint, token)
+		Expect(err).ShouldNot(HaveOccurred())
 	} else {
 		Eventually(func() error {
 			_, cmd, cmdErr := clientcmd.CreateCommandWithNS(monitoringNs, "kubectl",
@@ -240,9 +245,10 @@ func DoPrometheusHTTPRequest(cli kubecli.KubevirtClient, endpoint string) []byte
 			sourcePort := WaitForPortForwardCmd(stdout)
 
 			promURL := fmt.Sprintf("http://localhost:%d", sourcePort)
-			result = doHTTPRequest(promURL, endpoint, token)
-			return nil
-		}, 10*time.Second, time.Second).ShouldNot(HaveOccurred())
+			var err error
+			result, err = doHTTPRequest(promURL, endpoint, token)
+			return err
+		}, prometheusPortForwardTimeout, time.Second).ShouldNot(HaveOccurred())
 	}
 	return result
 }
@@ -260,38 +266,56 @@ func getPrometheusURLForOpenShift() string {
 	return fmt.Sprintf("https://%s", route.Spec.Host)
 }
 
-func doHTTPRequest(promURL, endpoint, token string) []byte {
-	var result []byte
+func doHTTPRequest(promURL, endpoint, token string) ([]byte, error) {
 	client := &http.Client{
 		Transport: &http.Transport{
 			TLSClientConfig:   &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
-			ForceAttemptHTTP2: true,
+			DisableKeepAlives: true,
 		},
 	}
-	Eventually(func() error {
+
+	var lastErr error
+	deadline := time.Now().Add(prometheusRequestTimeout)
+	for time.Now().Before(deadline) {
+		ctx, cancel := context.WithTimeout(context.Background(), prometheusHTTPTimeout)
+
 		req, err := http.NewRequestWithContext(
-			context.Background(),
+			ctx,
 			"GET",
-			fmt.Sprintf("%s/api/v1/%s", promURL, endpoint),
+			fmt.Sprintf("%s/api/v1/%s", promURL, strings.TrimLeft(endpoint, "/")),
 			http.NoBody,
 		)
 		if err != nil {
-			return err
+			cancel()
+			return nil, fmt.Errorf("creating request: %w", err)
 		}
 		req.Header.Add("Authorization", "Bearer "+token)
+
 		resp, err := client.Do(req)
 		if err != nil {
-			return err
+			cancel()
+			lastErr = err
+			time.Sleep(time.Second)
+			continue
 		}
-		defer resp.Body.Close()
-		if resp.StatusCode != http.StatusOK {
-			return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
-		}
-		result, err = io.ReadAll(resp.Body)
-		return err
-	}, 10*time.Second, 1*time.Second).Should(Not(HaveOccurred()))
 
-	return result
+		result, readErr := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		cancel()
+
+		if resp.StatusCode != http.StatusOK {
+			lastErr = fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+			time.Sleep(time.Second)
+			continue
+		}
+		if readErr != nil {
+			lastErr = readErr
+			time.Sleep(time.Second)
+			continue
+		}
+		return result, nil
+	}
+	return nil, fmt.Errorf("timed out after %s: %w", prometheusRequestTimeout, lastErr)
 }
 
 func getAuthorizationToken(cli kubecli.KubevirtClient, monitoringNs string) string {

--- a/tests/libstorage/datavolume.go
+++ b/tests/libstorage/datavolume.go
@@ -71,7 +71,7 @@ func AddDataVolume(vm *v1.VirtualMachine, diskName string, dataVolume *v1beta1.D
 }
 
 func CreateBlankFSDataVolume(name, namespace, size string, labels map[string]string) *v1beta1.DataVolume {
-	sc, _ := GetCSIStorageClass()
+	sc, hasCSI := GetCSIStorageClass()
 	dv := libdv.NewDataVolume(
 		libdv.WithNamespace(namespace),
 		libdv.WithName(name),
@@ -82,6 +82,9 @@ func CreateBlankFSDataVolume(name, namespace, size string, labels map[string]str
 			libdv.StorageWithFilesystemVolumeMode(),
 		),
 	)
+	if !hasCSI {
+		dv.Spec.Storage.StorageClassName = nil
+	}
 	if labels != nil && dv.Labels == nil {
 		dv.Labels = map[string]string{}
 	}
@@ -93,7 +96,7 @@ func CreateBlankFSDataVolume(name, namespace, size string, labels map[string]str
 }
 
 func CreateBlankBlockDataVolume(name, namespace, size string) *v1beta1.DataVolume {
-	sc, _ := GetRWOBlockStorageClass()
+	sc, hasBlock := GetRWOBlockStorageClass()
 	dv := libdv.NewDataVolume(
 		libdv.WithNamespace(namespace),
 		libdv.WithName(name),
@@ -104,6 +107,9 @@ func CreateBlankBlockDataVolume(name, namespace, size string) *v1beta1.DataVolum
 			libdv.StorageWithBlockVolumeMode(),
 		),
 	)
+	if !hasBlock {
+		dv.Spec.Storage.StorageClassName = nil
+	}
 
 	return createDataVolume(dv, namespace)
 }

--- a/tests/monitoring/metrics.go
+++ b/tests/monitoring/metrics.go
@@ -52,6 +52,7 @@ var _ = Describe("[sig-monitoring]Metrics", decorators.SigMonitoring, func() {
 	var virtClient kubecli.KubevirtClient
 	var metrics *libmonitoring.QueryRequestResult
 	var vm *v1.VirtualMachine
+	var hasCSIStorage bool
 
 	BeforeEach(func() {
 		virtClient = kubevirt.Client()
@@ -111,7 +112,7 @@ var _ = Describe("[sig-monitoring]Metrics", decorators.SigMonitoring, func() {
 		}
 
 		BeforeAll(func() {
-			vm = setupSharedVM(virtClient)
+			vm, hasCSIStorage = setupSharedVM(virtClient)
 			metrics = fetchPrometheusKubevirtMetrics(virtClient)
 			Expect(metrics.Data.Result).ToNot(BeEmpty(), "No metrics found")
 		})
@@ -122,6 +123,9 @@ var _ = Describe("[sig-monitoring]Metrics", decorators.SigMonitoring, func() {
 
 			for _, metric := range operatormetrics.ListMetrics() {
 				if excludedMetrics[metric.GetOpts().Name] {
+					continue
+				}
+				if !hasCSIStorage && metric.GetOpts().Name == "kubevirt_vm_disk_allocated_size_bytes" {
 					continue
 				}
 
@@ -152,6 +156,9 @@ var _ = Describe("[sig-monitoring]Metrics", decorators.SigMonitoring, func() {
 		})
 
 		It("should contain disk metrics", func() {
+			if !hasCSIStorage {
+				Skip("no CSI storage class configured")
+			}
 			By("Verifying kubevirt_vm_disk_allocated_size_bytes metric")
 			metric := operatormetrics.NewGauge(operatormetrics.MetricOpts{
 				Name: "kubevirt_vm_disk_allocated_size_bytes",
@@ -287,19 +294,24 @@ func fetchPrometheusMetrics(virtClient kubecli.KubevirtClient, query string) *li
 	return metrics
 }
 
-func setupSharedVM(virtClient kubecli.KubevirtClient) *v1.VirtualMachine {
-	vmDiskPVC := "test-vm-pvc"
-	dv := libstorage.CreateBlankFSDataVolume(vmDiskPVC, testsuite.GetTestNamespace(nil), "512Mi", nil)
+func setupSharedVM(virtClient kubecli.KubevirtClient) (*v1.VirtualMachine, bool) {
+	_, hasCSI := libstorage.GetCSIStorageClass()
 	iface := *v1.DefaultMasqueradeNetworkInterface()
 
-	vmi := libvmifact.NewFedora(
+	opts := []libvmi.Option{
 		libvmi.WithNamespace(testsuite.GetTestNamespace(nil)),
 		libvmi.WithMemoryLimit(libvmifact.FedoraMemory),
-		libvmi.WithDataVolume("testdisk", dv.Name),
 		libvmi.WithInterface(iface),
 		libvmi.WithNetwork(v1.DefaultPodNetwork()),
 		libvmi.WithLabel("vm.kubevirt.io/test", "test-vm-labels"),
-	)
+	}
+
+	if hasCSI {
+		dv := libstorage.CreateBlankFSDataVolume("test-vm-pvc", testsuite.GetTestNamespace(nil), "512Mi", nil)
+		opts = append(opts, libvmi.WithDataVolume("testdisk", dv.Name))
+	}
+
+	vmi := libvmifact.NewFedora(opts...)
 
 	vm := createRunningVM(virtClient, vmi, v1.RunStrategyAlways, true)
 
@@ -319,7 +331,7 @@ func setupSharedVM(virtClient kubecli.KubevirtClient) *v1.VirtualMachine {
 		virtClient, "kubevirt_vmi_filesystem_capacity_bytes", fsLabels, 0, ">", 0,
 	)
 
-	return vm
+	return vm, hasCSI
 }
 
 func gomegaContainsMetricMatcher(metric operatormetrics.Metric, labels map[string]string) types.GomegaMatcher {


### PR DESCRIPTION
### What this PR does
#### Before this PR:

The sig-monitoring lane fails when the `[BeforeAll]` in `tests/monitoring/metrics.go` tries to create a DataVolume-backed PVC (`test-vm-pvc`). `CreateBlankFSDataVolume` passes an empty-string `StorageClassName` (`&""`) to CDI when no CSI StorageClass is configured, which CDI rejects with `ErrClaimNotValid` ("PVC spec is missing accessMode and no storageClass to choose profile"). This is because the sig-monitoring lane does not set `KUBEVIRT_STORAGE` in `automation/test.sh`, so `tests/default-config.json` (which has no `storageClassCSI` field) is used.

#### After this PR:

- `setupSharedVM` checks for CSI storage availability and only creates the DataVolume when a CSI StorageClass is configured
- The `should contain disk metrics` test is skipped when no CSI storage is available
- The `should contain virt components metrics` test excludes `kubevirt_vm_disk_allocated_size_bytes` when no CSI storage is available
- `CreateBlankFSDataVolume` and `CreateBlankBlockDataVolume` clear `StorageClassName` when the config returns an empty string, so CDI falls back to the default StorageClass rather than receiving an invalid empty-string pointer

### References

- Build failure: [pull-kubevirt-e2e-k8s-1.34-sig-monitoring #2082768863916724224](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/18544/pull-kubevirt-e2e-k8s-1.34-sig-monitoring/2082768863916724224)
- Partially addresses the storage gap in the sig-monitoring lane (sig-storage sets `KUBEVIRT_STORAGE="rook-ceph-default"` but sig-monitoring does not)

### Why we need it and why it was done in this way
The following tradeoffs were made:

The monitoring lane's purpose is to validate Prometheus metrics, not storage functionality. Rather than adding rook-ceph to the sig-monitoring lane (which would add ~5 min setup time and require bare-metal nodes), the test is made self-sufficient by only creating a DataVolume when storage is available. Disk metric coverage is preserved in sig-storage lanes where storage actually exists.

The following alternatives were considered:

- **Adding `KUBEVIRT_STORAGE="rook-ceph-default"` to sig-monitoring**: rejected due to added setup time, bare-metal node requirement, and scope mismatch
- **Only fixing the empty-string SC bug**: insufficient alone since the sig-monitoring cluster has no default StorageClass either

### Special notes for your reviewer

This PR is based on top of #18544 (HTTP/2 transport fix). The empty-string `StorageClassName` bug (`&""` vs `nil`) in `CreateBlankFSDataVolume` and `CreateBlankBlockDataVolume` affects all callers, not just the monitoring test.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Testing: Fix is validated by running the sig-monitoring lane

```release-note
NONE
```

🤖 Assisted by Claude