### PR TITLE
tests: deploy rook-ceph storage in sig-monitoring lane

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -166,6 +166,7 @@ case "$TARGET" in
   *sig-monitoring*)
     export KUBEVIRT_PROVIDER=${TARGET/-sig-monitoring/}
     export KUBEVIRT_DEPLOY_PROMETHEUS=true
+    export KUBEVIRT_STORAGE="rook-ceph-default"
     ;;
   *wg-s390x*)
     export KUBEVIRT_PROVIDER=${TARGET/-wg-s390x}

--- a/tests/libmonitoring/prometheus.go
+++ b/tests/libmonitoring/prometheus.go
@@ -44,6 +44,9 @@ const (
 	defaultAlertWaitTimeout         = 5 * time.Minute
 	defaultMetricsPort              = 8443
 	prometheusPortForwardTargetPort = 9090
+	prometheusPortForwardTimeout    = 90 * time.Second
+	prometheusRequestTimeout        = 30 * time.Second
+	prometheusHTTPTimeout           = 10 * time.Second
 )
 
 var (
@@ -221,7 +224,9 @@ func DoPrometheusHTTPRequest(cli kubecli.KubevirtClient, endpoint string) []byte
 	var result []byte
 	if checks.IsOpenShift() {
 		promURL := getPrometheusURLForOpenShift()
-		result = doHTTPRequest(promURL, endpoint, token)
+		var err error
+		result, err = doHTTPRequest(promURL, endpoint, token)
+		Expect(err).ShouldNot(HaveOccurred())
 	} else {
 		Eventually(func() error {
 			_, cmd, cmdErr := clientcmd.CreateCommandWithNS(monitoringNs, "kubectl",
@@ -240,9 +245,10 @@ func DoPrometheusHTTPRequest(cli kubecli.KubevirtClient, endpoint string) []byte
 			sourcePort := WaitForPortForwardCmd(stdout)
 
 			promURL := fmt.Sprintf("http://localhost:%d", sourcePort)
-			result = doHTTPRequest(promURL, endpoint, token)
-			return nil
-		}, 10*time.Second, time.Second).ShouldNot(HaveOccurred())
+			var err error
+			result, err = doHTTPRequest(promURL, endpoint, token)
+			return err
+		}, prometheusPortForwardTimeout, time.Second).ShouldNot(HaveOccurred())
 	}
 	return result
 }
@@ -260,38 +266,56 @@ func getPrometheusURLForOpenShift() string {
 	return fmt.Sprintf("https://%s", route.Spec.Host)
 }
 
-func doHTTPRequest(promURL, endpoint, token string) []byte {
-	var result []byte
+func doHTTPRequest(promURL, endpoint, token string) ([]byte, error) {
 	client := &http.Client{
 		Transport: &http.Transport{
 			TLSClientConfig:   &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
-			ForceAttemptHTTP2: true,
+			DisableKeepAlives: true,
 		},
 	}
-	Eventually(func() error {
+
+	var lastErr error
+	deadline := time.Now().Add(prometheusRequestTimeout)
+	for time.Now().Before(deadline) {
+		ctx, cancel := context.WithTimeout(context.Background(), prometheusHTTPTimeout)
+
 		req, err := http.NewRequestWithContext(
-			context.Background(),
+			ctx,
 			"GET",
-			fmt.Sprintf("%s/api/v1/%s", promURL, endpoint),
+			fmt.Sprintf("%s/api/v1/%s", promURL, strings.TrimLeft(endpoint, "/")),
 			http.NoBody,
 		)
 		if err != nil {
-			return err
+			cancel()
+			return nil, fmt.Errorf("creating request: %w", err)
 		}
 		req.Header.Add("Authorization", "Bearer "+token)
+
 		resp, err := client.Do(req)
 		if err != nil {
-			return err
+			cancel()
+			lastErr = err
+			time.Sleep(time.Second)
+			continue
 		}
-		defer resp.Body.Close()
-		if resp.StatusCode != http.StatusOK {
-			return fmt.Errorf("unexpected status code: %d", resp.StatusCode)
-		}
-		result, err = io.ReadAll(resp.Body)
-		return err
-	}, 10*time.Second, 1*time.Second).Should(Not(HaveOccurred()))
 
-	return result
+		result, readErr := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		cancel()
+
+		if resp.StatusCode != http.StatusOK {
+			lastErr = fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+			time.Sleep(time.Second)
+			continue
+		}
+		if readErr != nil {
+			lastErr = readErr
+			time.Sleep(time.Second)
+			continue
+		}
+		return result, nil
+	}
+	return nil, fmt.Errorf("timed out after %s: %w", prometheusRequestTimeout, lastErr)
 }
 
 func getAuthorizationToken(cli kubecli.KubevirtClient, monitoringNs string) string {


### PR DESCRIPTION
### What this PR does
#### Before this PR:

The sig-monitoring lane fails when the `[BeforeAll]` in `tests/monitoring/metrics.go` tries to create a DataVolume-backed PVC (`test-vm-pvc`). The lane does not set `KUBEVIRT_STORAGE`, so no CSI storage provider is deployed and `tests/default-config.json` (which has no `storageClassCSI` field) is used. `CreateBlankFSDataVolume` ends up setting `StorageClassName` to a pointer-to-empty-string, which CDI rejects with `ErrClaimNotValid`.

#### After this PR:

Adds `KUBEVIRT_STORAGE="rook-ceph-default"` to the sig-monitoring case in `automation/test.sh`, matching what sig-storage already does. This deploys rook-ceph into the test cluster and resolves the test config to `tests/default-ceph-config.json` which provides a valid `storageClassCSI: "rook-ceph-block"`.

### References

- Build failure: [pull-kubevirt-e2e-k8s-1.34-sig-monitoring #2082768863916724224](https://prow.ci.kubevirt.io/view/gs/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/18544/pull-kubevirt-e2e-k8s-1.34-sig-monitoring/2082768863916724224)
- Alternative approach to #18667 (which guards the test instead of adding storage)

### Why we need it and why it was done in this way
The following tradeoffs were made:

This is the simplest possible fix — one line in `test.sh`. It makes the sig-monitoring environment match sig-storage so the DataVolume-backed VM can be created successfully.

The following alternatives were considered:

- **Guarding DV creation behind CSI storage availability** (#18667): more surgical but moves disk metric coverage out of the monitoring lane
- **Fixing the empty-string SC bug only**: insufficient since the cluster still has no default StorageClass

**Known tradeoffs of this approach:**
- Adds ~5 min of rook-ceph setup time to every sig-monitoring run
- The Prow job in project-infra may need `nodeSelector: type: bare-metal-external` if rook-ceph requires local block devices — this PR does NOT change the Prow job config (separate repo)

### Special notes for your reviewer

This PR is based on top of #18544 (HTTP/2 transport fix). Compare with the alternative approach in #18667 which avoids the storage setup overhead.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple

```release-note
NONE
```

🤖 Assisted by Claude