### PR TITLE
virt-handler: Survive recreation of a socket device's directory

### DIFF
--- a/pkg/virt-handler/device-manager/socket_device.go
+++ b/pkg/virt-handler/device-manager/socket_device.go
@@ -68,11 +68,15 @@ type SocketDevicePlugin struct {
 	p             PermissionManager
 	healthChecks  bool
 	hostRootMount string
+	// healthy is the last health reported to ListAndWatch; only the health check goroutine touches it.
+	healthy bool
 }
 
 func (dpi *SocketDevicePlugin) Start(stop <-chan struct{}) (err error) {
 	logger := log.DefaultLogger()
 	dpi.stop = stop
+	dpi.done = make(chan struct{})
+	dpi.deregistered = make(chan struct{})
 
 	err = dpi.cleanup()
 	if err != nil {
@@ -163,6 +167,14 @@ func (dpi *SocketDevicePlugin) setSocketDirectoryPermissions() error {
 	return nil
 }
 
+// applyPermissions hands the socket and its directory over to the non-root user consumers run as.
+func (dpi *SocketDevicePlugin) applyPermissions() error {
+	if err := dpi.setSocketDirectoryPermissions(); err != nil {
+		return err
+	}
+	return dpi.setSocketPermissions()
+}
+
 func NewSocketDevicePlugin(socketName, socketDir, socket string, maxDevices int, executor selinux.Executor, p PermissionManager, useHostRootMount bool) (*SocketDevicePlugin, error) {
 	socketRoot := "/"
 	if useHostRootMount {
@@ -185,6 +197,9 @@ func NewSocketDevicePlugin(socketName, socketDir, socket string, maxDevices int,
 		executor:     executor,
 		p:            p,
 		healthChecks: true,
+		// Must match the initial Healthy state of devs, or the first unhealthy report is deduplicated away.
+		// Both survive a plugin restart, so healthCheck reconciles them against the filesystem on every start.
+		healthy: true,
 	}
 
 	for i := 0; i < maxDevices; i++ {
@@ -194,10 +209,7 @@ func NewSocketDevicePlugin(socketName, socketDir, socket string, maxDevices int,
 			Health: pluginapi.Healthy,
 		})
 	}
-	if err := dpi.setSocketDirectoryPermissions(); err != nil {
-		return dpi, err
-	}
-	if err := dpi.setSocketPermissions(); err != nil {
+	if err := dpi.applyPermissions(); err != nil {
 		return dpi, err
 	}
 
@@ -250,15 +262,73 @@ func (dpi *SocketDevicePlugin) Allocate(ctx context.Context, r *pluginapi.Alloca
 	return &response, nil
 }
 
+// sendHealthUpdate reports a health change to ListAndWatch; unchanged health is not resent, as every send blocks the draining of the fsnotify queue.
 func (dpi *SocketDevicePlugin) sendHealthUpdate(healthy bool) {
-	if !dpi.healthChecks {
+	if !dpi.healthChecks || healthy == dpi.healthy {
 		return
 	}
+	dpi.healthy = healthy
 	if healthy {
+		log.DefaultLogger().Infof("monitored device %s became healthy", dpi.socketName)
 		dpi.health <- deviceHealth{Health: pluginapi.Healthy}
 	} else {
+		log.DefaultLogger().Infof("monitored device %s became unhealthy", dpi.socketName)
 		dpi.health <- deviceHealth{Health: pluginapi.Unhealthy}
 	}
+}
+
+// reconcileDeviceHealth re-arms the deviceDir watch and derives health from the filesystem rather than from events, which can be missed or dropped.
+// A permission failure is an error: no event would ever retry it here, so it is left to the device controller, which restarts the plugin with backoff, as at construction.
+func (dpi *SocketDevicePlugin) reconcileDeviceHealth(watcher *fsnotify.Watcher, deviceDir, devicePath string) error {
+	logger := log.DefaultLogger()
+
+	// Replaces the watch if deviceDir was recreated; a no-op if it is still alive.
+	if err := watcher.Add(deviceDir); err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			logger.Reason(err).Errorf("failed to watch the device directory '%s'", deviceDir)
+		}
+		dpi.sendHealthUpdate(false)
+		return nil
+	}
+	if _, err := os.Stat(devicePath); err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			logger.Reason(err).Errorf("could not stat the device '%s'", devicePath)
+		}
+		dpi.sendHealthUpdate(false)
+		return nil
+	}
+	// Apply permissions before advertising, so consumers don't race them; a socket without them is of no use and not advertised.
+	if err := dpi.applyPermissions(); err != nil {
+		return fmt.Errorf("failed to set permissions for socket device %s: %v", dpi.socketName, err)
+	}
+	dpi.sendHealthUpdate(true)
+	return nil
+}
+
+// armDeviceDirWatch watches the device's directory and derives the initial health from the filesystem; a missing directory or socket is unhealthy, not fatal.
+func (dpi *SocketDevicePlugin) armDeviceDirWatch(watcher *fsnotify.Watcher, deviceDir, devicePath string) error {
+	logger := log.DefaultLogger()
+
+	// Watch before the existence checks to avoid races; fsnotify passes the errno through untouched.
+	if err := watcher.Add(deviceDir); err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("failed to add the device root path to the watcher: %v", err)
+		}
+		logger.Warningf("device directory '%s' is not present, waiting for it to be created.", deviceDir)
+		dpi.sendHealthUpdate(false)
+		return nil
+	}
+	if _, err := os.Stat(devicePath); err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("could not stat the device: %v", err)
+		}
+		logger.Warningf("device '%s' is not present, the device plugin can't expose it.", dpi.socketName)
+		dpi.sendHealthUpdate(false)
+		return nil
+	}
+	logger.Infof("device '%s' is present.", devicePath)
+	// Stale health survives a plugin restart, and with the socket already present no Create event would fix it up.
+	return dpi.reconcileDeviceHealth(watcher, deviceDir, devicePath)
 }
 
 func (dpi *SocketDevicePlugin) healthCheck() error {
@@ -272,26 +342,17 @@ func (dpi *SocketDevicePlugin) healthCheck() error {
 	deviceDir := filepath.Join(dpi.socketRoot, dpi.socketDir)
 	devicePath := filepath.Join(deviceDir, dpi.socket)
 
-	// Start watching the files before we check for their existence to avoid races
-	err = watcher.Add(deviceDir)
-	if err != nil {
-		return fmt.Errorf("failed to add the device root path to the watcher: %v", err)
+	// deviceDir (typically a systemd RuntimeDirectory=) dies with service restarts, so watch its stable parent to re-arm on recreation; a missing parent is fatal.
+	if err := watcher.Add(filepath.Dir(deviceDir)); err != nil {
+		return fmt.Errorf("failed to add the parent of the device root path to the watcher: %v", err)
 	}
 
-	_, err = os.Stat(devicePath)
-	if err != nil {
-		if !errors.Is(err, os.ErrNotExist) {
-			return fmt.Errorf("could not stat the device: %v", err)
-		}
-		logger.Warningf("device '%s' is not present, the device plugin can't expose it.", dpi.socketName)
-		dpi.sendHealthUpdate(false)
+	if err := dpi.armDeviceDirWatch(watcher, deviceDir, devicePath); err != nil {
+		return err
 	}
-	logger.Infof("device '%s' is present.", devicePath)
 
-	err = watcher.Add(deviceDir)
-
-	if err != nil {
-		return fmt.Errorf("failed to add the device-plugin kubelet path to the watcher: %v", err)
+	if err := watcher.Add(filepath.Dir(dpi.socketPath)); err != nil {
+		return fmt.Errorf("failed to add the kubelet device-plugin directory to the watcher: %v", err)
 	}
 	_, err = os.Stat(dpi.socketPath)
 	if err != nil {
@@ -304,24 +365,26 @@ func (dpi *SocketDevicePlugin) healthCheck() error {
 			return nil
 		case err := <-watcher.Errors:
 			logger.Reason(err).Errorf("error watching devices and device plugin directory")
+			// The kernel drops events on queue overflow, so re-check the filesystem instead of trusting events.
+			if dpi.healthChecks {
+				if err := dpi.reconcileDeviceHealth(watcher, deviceDir, devicePath); err != nil {
+					return err
+				}
+			}
 		case event := <-watcher.Events:
 			logger.V(4).Infof("health Event: %v", event)
-			if event.Name == devicePath && dpi.healthChecks {
-				// Health in this case is if the device path actually exists
-				if event.Op == fsnotify.Create {
-					logger.Infof("monitored device %s appeared", dpi.socketName)
-					dpi.sendHealthUpdate(true)
-					if err := dpi.setSocketDirectoryPermissions(); err != nil {
-						logger.Warningf("failed to set directory permissions for socket device %s", dpi.socketName)
+			if (event.Name == devicePath || event.Name == deviceDir) && dpi.healthChecks {
+				// Health in this case is if the device path actually exists.
+				// Only these ops are handled: reacting to the Chmod from applying permissions would loop.
+				if event.Has(fsnotify.Create) {
+					if err := dpi.reconcileDeviceHealth(watcher, deviceDir, devicePath); err != nil {
+						return err
 					}
-					if err := dpi.setSocketPermissions(); err != nil {
-						logger.Warningf("failed to set socket permissions for socket device %s", dpi.socketName)
-					}
-				} else if (event.Op == fsnotify.Remove) || (event.Op == fsnotify.Rename) {
-					logger.Infof("monitored device %s disappeared", dpi.socketName)
+				} else if event.Has(fsnotify.Remove) || event.Has(fsnotify.Rename) {
+					logger.Infof("monitored device %s disappeared: %s was removed", dpi.socketName, event.Name)
 					dpi.sendHealthUpdate(false)
 				}
-			} else if event.Name == dpi.socketPath && event.Op == fsnotify.Remove {
+			} else if event.Name == dpi.socketPath && event.Has(fsnotify.Remove) {
 				logger.Infof("device socket file for device %s was removed, kubelet probably restarted.", dpi.socketName)
 				return nil
 			}

--- a/pkg/virt-handler/device-manager/socket_device.go
+++ b/pkg/virt-handler/device-manager/socket_device.go
@@ -197,16 +197,16 @@ func NewSocketDevicePlugin(socketName, socketDir, socket string, maxDevices int,
 		executor:     executor,
 		p:            p,
 		healthChecks: true,
-		// Must match the initial Healthy state of devs, or the first unhealthy report is deduplicated away.
-		// Both survive a plugin restart, so healthCheck reconciles them against the filesystem on every start.
-		healthy: true,
+		// The devices start Unhealthy: they are only advertised once the initial reconcile in healthCheck has verified the socket and applied its permissions.
+		// healthy must match their initial state, or the first report is deduplicated away; both survive a plugin restart, which the reconcile on start covers.
+		healthy: false,
 	}
 
 	for i := 0; i < maxDevices; i++ {
 		deviceId := dpi.socketName + strconv.Itoa(i)
 		dpi.devs = append(dpi.devs, &pluginapi.Device{
 			ID:     deviceId,
-			Health: pluginapi.Healthy,
+			Health: pluginapi.Unhealthy,
 		})
 	}
 	if err := dpi.applyPermissions(); err != nil {
@@ -220,6 +220,11 @@ func NewSocketDevicePlugin(socketName, socketDir, socket string, maxDevices int,
 func NewOptionalSocketDevicePlugin(socketName, socketDir, socket string, maxDevices int, executor selinux.Executor, p PermissionManager, useHostRootMount bool) *SocketDevicePlugin {
 	dpi, _ := NewSocketDevicePlugin(socketName, socketDir, socket, maxDevices, executor, p, useHostRootMount)
 	dpi.healthChecks = false
+	// With health checks disabled nothing would ever report Healthy, so the devices must start that way.
+	dpi.healthy = true
+	for _, dev := range dpi.devs {
+		dev.Health = pluginapi.Healthy
+	}
 	return dpi
 }
 
@@ -297,7 +302,7 @@ func (dpi *SocketDevicePlugin) reconcileDeviceHealth(watcher *fsnotify.Watcher, 
 		dpi.sendHealthUpdate(false)
 		return nil
 	}
-	// Apply permissions before advertising, so consumers don't race them; a socket without them is of no use and not advertised.
+	// Apply the socket's permissions before advertising it, so a newly scheduled consumer cannot race the chown; a socket whose permissions failed to apply is not advertised at all.
 	if err := dpi.applyPermissions(); err != nil {
 		return fmt.Errorf("failed to set permissions for socket device %s: %v", dpi.socketName, err)
 	}
@@ -347,16 +352,17 @@ func (dpi *SocketDevicePlugin) healthCheck() error {
 		return fmt.Errorf("failed to add the parent of the device root path to the watcher: %v", err)
 	}
 
-	if err := dpi.armDeviceDirWatch(watcher, deviceDir, devicePath); err != nil {
-		return err
-	}
-
 	if err := watcher.Add(filepath.Dir(dpi.socketPath)); err != nil {
 		return fmt.Errorf("failed to add the kubelet device-plugin directory to the watcher: %v", err)
 	}
 	_, err = os.Stat(dpi.socketPath)
 	if err != nil {
 		return fmt.Errorf("failed to stat the device-plugin socket: %v", err)
+	}
+
+	// This may block reporting the initial health until ListAndWatch drains it, so it goes last, after every watch is in place.
+	if err := dpi.armDeviceDirWatch(watcher, deviceDir, devicePath); err != nil {
+		return err
 	}
 
 	for {
@@ -366,6 +372,7 @@ func (dpi *SocketDevicePlugin) healthCheck() error {
 		case err := <-watcher.Errors:
 			logger.Reason(err).Errorf("error watching devices and device plugin directory")
 			// The kernel drops events on queue overflow, so re-check the filesystem instead of trusting events.
+			// This cannot loop back here: watcher.Add failures are returned synchronously, never sent to watcher.Errors.
 			if dpi.healthChecks {
 				if err := dpi.reconcileDeviceHealth(watcher, deviceDir, devicePath); err != nil {
 					return err

--- a/pkg/virt-handler/device-manager/socket_device_test.go
+++ b/pkg/virt-handler/device-manager/socket_device_test.go
@@ -72,9 +72,8 @@ var _ = Describe("Socket device", func() {
 		go func(errChan chan error) {
 			errChan <- dpi.healthCheck()
 		}(errChan)
-		Consistently(func() string {
-			return dpi.devs[0].Health
-		}, 500*time.Millisecond, 100*time.Millisecond).Should(Equal(pluginapi.Healthy))
+		By("waiting for the initial reconcile to advertise the intact device")
+		Eventually(dpi.health, 5*time.Second).Should(Receive(HaveField("Health", pluginapi.Healthy)))
 		Expect(os.Remove(dpi.socketPath)).To(Succeed())
 
 		Eventually(errChan, 5*time.Second).Should(Receive(BeNil()))
@@ -86,8 +85,9 @@ var _ = Describe("Socket device", func() {
 			Expect(dpi.healthCheck()).ToNot(HaveOccurred())
 		}()
 
-		By("waiting for the health check to be watching an intact device")
-		Expect(dpi.devs[0].Health).To(Equal(pluginapi.Healthy))
+		By("waiting for the initial reconcile to advertise the intact device")
+		Expect(dpi.devs[0].Health).To(Equal(pluginapi.Unhealthy))
+		Eventually(dpi.health, 5*time.Second).Should(Receive(HaveField("Health", pluginapi.Healthy)))
 		Consistently(dpi.health, 500*time.Millisecond, 100*time.Millisecond).ShouldNot(Receive())
 
 		By("Removing the (fake) device node")
@@ -123,8 +123,9 @@ var _ = Describe("Socket device", func() {
 			Expect(dpi.healthCheck()).ToNot(HaveOccurred())
 		}()
 
-		By("degrading to Unhealthy instead of erroring out")
-		Eventually(dpi.health, 5*time.Second).Should(Receive(HaveField("Health", pluginapi.Unhealthy)))
+		By("staying Unhealthy instead of erroring out; the report is deduplicated as the devices already start that way")
+		Consistently(dpi.health, 500*time.Millisecond, 100*time.Millisecond).ShouldNot(Receive())
+		Expect(dpi.devs[0].Health).To(Equal(pluginapi.Unhealthy))
 
 		By("recovering once the directory and its socket are recreated")
 		Expect(os.Mkdir(deviceDir, 0o755)).To(Succeed())
@@ -133,14 +134,17 @@ var _ = Describe("Socket device", func() {
 	})
 
 	It("Should reconcile stale health on start, as it survives a plugin restart", func() {
-		dpi.healthy = false
+		By("Simulating a restart that left stale Healthy state behind, with the socket gone")
+		dpi.healthy = true
+		dpi.devs[0].Health = pluginapi.Healthy
+		Expect(os.Remove(sockDevPath)).To(Succeed())
 
 		go func() {
 			defer GinkgoRecover()
 			Expect(dpi.healthCheck()).ToNot(HaveOccurred())
 		}()
 
-		Eventually(dpi.health, 5*time.Second).Should(Receive(HaveField("Health", pluginapi.Healthy)))
+		Eventually(dpi.health, 5*time.Second).Should(Receive(HaveField("Health", pluginapi.Unhealthy)))
 	})
 
 	It("Should error out when a device's permissions cannot be applied, so the plugin is restarted with backoff", func() {
@@ -150,6 +154,8 @@ var _ = Describe("Socket device", func() {
 		dpi.p = failingPermManager
 
 		By("Removing the (fake) device node before the health check starts")
+		// Stale Healthy state makes the initial Unhealthy report observable, as a sync point for the watch being armed.
+		dpi.healthy = true
 		Expect(os.Remove(sockDevPath)).To(Succeed())
 
 		errChan := make(chan error, 1)

--- a/pkg/virt-handler/device-manager/socket_device_test.go
+++ b/pkg/virt-handler/device-manager/socket_device_test.go
@@ -20,6 +20,7 @@
 package device_manager
 
 import (
+	"errors"
 	"os"
 	"path"
 	"path/filepath"
@@ -36,21 +37,29 @@ import (
 
 var _ = Describe("Socket device", func() {
 	var dpi *SocketDevicePlugin
+	var deviceDir string
 	var sockDevPath string
 	const socket = "fake-test.sock"
 
 	BeforeEach(func() {
 		var err error
 		workDir := GinkgoT().TempDir()
-		Expect(err).ToNot(HaveOccurred())
-		sockDevPath = path.Join(workDir, socket)
+		// The device socket lives in a directory of its own, as it does on a
+		// host where it is provided out of a service's runtime directory. The
+		// kubelet device-plugin directory is unrelated to it, so that the two
+		// watches the health check sets up are covered independently.
+		deviceDir = filepath.Join(workDir, "qgs")
+		Expect(os.Mkdir(deviceDir, 0o755)).To(Succeed())
+		sockDevPath = filepath.Join(deviceDir, socket)
 		createFile(sockDevPath)
+		kubeletDir := filepath.Join(workDir, "device-plugins")
+		Expect(os.Mkdir(kubeletDir, 0o755)).To(Succeed())
 
 		mockExec, mockPermManager := socketDeviceMocks()
-		dpi, err = NewSocketDevicePlugin("test", workDir, socket, 1, mockExec, mockPermManager, false)
+		dpi, err = NewSocketDevicePlugin("test", deviceDir, socket, 1, mockExec, mockPermManager, false)
 		Expect(err).ToNot(HaveOccurred())
 		dpi.server = grpc.NewServer([]grpc.ServerOption{}...)
-		dpi.socketPath = filepath.Join(workDir, "kubevirt-test.sock")
+		dpi.socketPath = filepath.Join(kubeletDir, "kubevirt-test.sock")
 		createFile(dpi.socketPath)
 		dpi.done = make(chan struct{})
 		stop := make(chan struct{})
@@ -68,28 +77,92 @@ var _ = Describe("Socket device", func() {
 		}, 500*time.Millisecond, 100*time.Millisecond).Should(Equal(pluginapi.Healthy))
 		Expect(os.Remove(dpi.socketPath)).To(Succeed())
 
-		Expect(<-errChan).ToNot(HaveOccurred())
+		Eventually(errChan, 5*time.Second).Should(Receive(BeNil()))
 	})
 
-	It("Should monitor health of device node", func() {
-		go dpi.healthCheck()
-		Expect(dpi.devs[0].Health).To(Equal(pluginapi.Healthy))
+	DescribeTable("Should monitor health of device node", func(remove, recreate func()) {
+		go func() {
+			defer GinkgoRecover()
+			Expect(dpi.healthCheck()).ToNot(HaveOccurred())
+		}()
 
-		By("Removing a (fake) device node")
-		os.Remove(sockDevPath)
+		By("waiting for the health check to be watching an intact device")
+		Expect(dpi.devs[0].Health).To(Equal(pluginapi.Healthy))
+		Consistently(dpi.health, 500*time.Millisecond, 100*time.Millisecond).ShouldNot(Receive())
+
+		By("Removing the (fake) device node")
+		remove()
 
 		By("waiting for healthcheck to send Unhealthy message")
-		Eventually(func() string {
-			return (<-dpi.health).Health
-		}, 5*time.Second).Should(Equal(pluginapi.Unhealthy))
+		Eventually(dpi.health, 5*time.Second).Should(Receive(HaveField("Health", pluginapi.Unhealthy)))
 
 		By("Creating a new (fake) device node")
-		createFile(sockDevPath)
+		recreate()
 
 		By("waiting for healthcheck to send Healthy message")
-		Eventually(func() string {
-			return (<-dpi.health).Health
-		}, 5*time.Second).Should(Equal(pluginapi.Healthy))
+		Eventually(dpi.health, 5*time.Second).Should(Receive(HaveField("Health", pluginapi.Healthy)))
+	},
+		Entry("when the device node itself is removed",
+			func() { Expect(os.Remove(sockDevPath)).To(Succeed()) },
+			func() { createFile(sockDevPath) },
+		),
+		Entry("when the directory holding it is removed, as systemd does for a service's RuntimeDirectory",
+			func() { Expect(os.RemoveAll(deviceDir)).To(Succeed()) },
+			func() {
+				Expect(os.Mkdir(deviceDir, 0o755)).To(Succeed())
+				createFile(sockDevPath)
+			},
+		),
+	)
+
+	It("Should degrade to Unhealthy and recover when the device directory is missing on start", func() {
+		Expect(os.RemoveAll(deviceDir)).To(Succeed())
+
+		go func() {
+			defer GinkgoRecover()
+			Expect(dpi.healthCheck()).ToNot(HaveOccurred())
+		}()
+
+		By("degrading to Unhealthy instead of erroring out")
+		Eventually(dpi.health, 5*time.Second).Should(Receive(HaveField("Health", pluginapi.Unhealthy)))
+
+		By("recovering once the directory and its socket are recreated")
+		Expect(os.Mkdir(deviceDir, 0o755)).To(Succeed())
+		createFile(sockDevPath)
+		Eventually(dpi.health, 5*time.Second).Should(Receive(HaveField("Health", pluginapi.Healthy)))
+	})
+
+	It("Should reconcile stale health on start, as it survives a plugin restart", func() {
+		dpi.healthy = false
+
+		go func() {
+			defer GinkgoRecover()
+			Expect(dpi.healthCheck()).ToNot(HaveOccurred())
+		}()
+
+		Eventually(dpi.health, 5*time.Second).Should(Receive(HaveField("Health", pluginapi.Healthy)))
+	})
+
+	It("Should error out when a device's permissions cannot be applied, so the plugin is restarted with backoff", func() {
+		failingPermManager := NewMockPermissionManager(gomock.NewController(GinkgoT()))
+		failingPermManager.EXPECT().ChownAtNoFollow(gomock.Any(), gomock.Any(), gomock.Any()).
+			Return(errors.New("no permission to give")).AnyTimes()
+		dpi.p = failingPermManager
+
+		By("Removing the (fake) device node before the health check starts")
+		Expect(os.Remove(sockDevPath)).To(Succeed())
+
+		errChan := make(chan error, 1)
+		go func(errChan chan error) {
+			errChan <- dpi.healthCheck()
+		}(errChan)
+		Eventually(dpi.health, 5*time.Second).Should(Receive(HaveField("Health", pluginapi.Unhealthy)))
+
+		By("Creating a new (fake) device node whose permissions cannot be set")
+		createFile(sockDevPath)
+
+		By("erroring out instead of advertising the device")
+		Eventually(errChan, 5*time.Second).Should(Receive(MatchError(ContainSubstring("no permission to give"))))
 	})
 })
 
@@ -129,7 +202,7 @@ var _ = Describe("Optional socket device", func() {
 		}, 500*time.Millisecond, 100*time.Millisecond).Should(Equal(pluginapi.Healthy))
 		Expect(os.Remove(dpi.socketPath)).To(Succeed())
 
-		Expect(<-errChan).ToNot(HaveOccurred())
+		Eventually(errChan, 5*time.Second).Should(Receive(BeNil()))
 	})
 
 	It("Should stay healthy when device socket is removed", func() {


### PR DESCRIPTION
### What this PR does
#### Before this PR:

The socket device plugin (which backs `devices.kubevirt.io/tdx` via the QGS socket) watches the socket's directory with fsnotify to track device health. That directory is typically a systemd `RuntimeDirectory=` (`/run/tdx-qgs` for Intel's qgsd), which systemd removes and recreates whenever the service restarts. The fsnotify watch dies with the removed inode: the plugin marks all devices Unhealthy when the directory disappears and never sees the socket come back. The node is left with `devices.kubevirt.io/tdx` capacity intact but allocatable 0, and every TDX VM fails scheduling with `Insufficient devices.kubevirt.io/tdx` until virt-handler is restarted. On a TDX node, `systemctl restart qgsd` is enough to reproduce.

Additionally, the health check added the device directory to the watcher a second time where it meant to watch the kubelet device-plugin directory (`filepath.Dir(dpi.socketPath)`, as `generic_device.go` does), so the handler for the plugin's own kubelet socket being removed could never fire. The existing unit tests didn't catch this because they place the device socket and the plugin socket in the same directory.

#### After this PR:

The plugin watches the directory's parent as well. When the directory is recreated, it re-arms the watch and derives health from the filesystem rather than from the events that follow, which covers a socket created before the watch was back in place. The same reconciliation runs when the watcher reports an error, since the kernel drops events on inotify queue overflow and one of the dropped ones may be the recreation this relies on. A directory that is missing when the health check starts degrades to Unhealthy-and-wait instead of erroring out of the health-check goroutine. The kubelet device-plugin directory is watched as intended.

Two smaller changes ride along in the same paths:

- Health that has not changed is no longer resent. Removing the directory surfaces as an event for the socket, one for the directory as seen from its parent, and one for the directory itself; each send blocks until `ListAndWatch` picks it up, which is time the health check spends not draining the fsnotify queue.
- The socket's permissions are applied before it is advertised as healthy rather than after, so a consumer scheduled on the back of the update does not race them, and a socket whose permissions could not be applied is not advertised at all. The controller already refuses to register a plugin that fails to apply them at startup (`device_controller.go`), so reporting one healthy at runtime was the odd case out. This is a no-op for TDX (a nil `PermissionManager` is passed there) and matters for the persistent-reservation plugin.

### Why we need it and why it was done in this way

Hit in production on an Intel TDX node: qgsd restarted, and from that moment every TDX VM launch failed with `Insufficient devices.kubevirt.io/tdx` (capacity 63, allocatable 0) until virt-handler was manually restarted.

The following tradeoffs were made:

Watching the parent directory adds inotify events for siblings of the socket directory (e.g. other entries under `/run`), which the event loop filters by name; this was preferred over polling, which would introduce latency and periodic wakeups. inotify is not recursive, so only direct children of the parent are seen, and the parent itself is a mount point or a directory this daemon owns — unlike the device directory, it is not expected to come and go, so failing to watch it remains fatal.

Only `Create`, `Remove` and `Rename` are acted on. Applying the socket's permissions changes its owner, and reacting to the resulting `Chmod` would loop.

The following alternatives were considered:

- Periodically re-stat-ing the socket as a fallback: rejected, polling is not needed once the parent watch makes recreation observable and the watcher's own errors trigger a reconcile.
- Treating a missing directory at startup as a fatal error (current behavior) and relying on the device controller's restart backoff: rejected, degrading to Unhealthy-and-wait keeps the plugin registered and recovers as soon as the directory appears. A restart would also clear `initialized`, which feeds the node's `kubevirt.io/schedulable` label, so a flapping QGS would repeatedly make the whole node unschedulable.

### Special notes for your reviewer

The device socket now lives in a directory of its own in every test case, and the kubelet device-plugin socket in a separate one, so the two watches the health check sets up are covered independently rather than one standing in for the other.

Against the health check as it is on main, the package fails two specs in ~15s: the new RuntimeDirectory case, and `Should stop if the device plugin socket file is deleted` for the kubelet-directory watch. Reverting only the kubelet-directory line fails the suite as well, so both halves of the fix are pinned. The `Socket device` specs were run 15 times to check for flakes.

The kubelet-directory correction changes behavior for the persistent-reservation socket plugin too: it could not return from its health check when kubelet removed the socket, and so never re-registered after a kubelet restart. This is the same behavior `generic_device.go` already has.

No e2e test is included: exercising this end to end requires a bare-metal TDX lane where qgsd can be restarted; the failure mode and fix are fully covered by the unit-level regression tests.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is not required (bug fix)
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered; none required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test (see reviewer notes on e2e)
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is not required (no user-facing API change)
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered and is not required
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md) (disclosed via `Assisted-by` commit trailer)

### Release note

```release-note
virt-handler's socket device plugin (devices.kubevirt.io/tdx) now recovers when the QGS socket directory is removed and recreated (e.g. by a qgsd restart); previously the node was left with allocatable 0 until virt-handler was restarted.
```

