### PR TITLE
Reuse mounters

### DIFF
--- a/cmd/virt-handler/BUILD.bazel
+++ b/cmd/virt-handler/BUILD.bazel
@@ -38,6 +38,7 @@ go_library(
         "//pkg/virt-handler/cmd-client:go_default_library",
         "//pkg/virt-handler/container-disk:go_default_library",
         "//pkg/virt-handler/dmetrics-manager:go_default_library",
+        "//pkg/virt-handler/hotplug-disk:go_default_library",
         "//pkg/virt-handler/isolation:go_default_library",
         "//pkg/virt-handler/ksm:go_default_library",
         "//pkg/virt-handler/launcher-clients:go_default_library",

--- a/cmd/virt-handler/BUILD.bazel
+++ b/cmd/virt-handler/BUILD.bazel
@@ -36,6 +36,7 @@ go_library(
         "//pkg/virt-handler:go_default_library",
         "//pkg/virt-handler/cache:go_default_library",
         "//pkg/virt-handler/cmd-client:go_default_library",
+        "//pkg/virt-handler/container-disk:go_default_library",
         "//pkg/virt-handler/dmetrics-manager:go_default_library",
         "//pkg/virt-handler/isolation:go_default_library",
         "//pkg/virt-handler/ksm:go_default_library",

--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -80,6 +80,7 @@ import (
 	virthandler "kubevirt.io/kubevirt/pkg/virt-handler"
 	virtcache "kubevirt.io/kubevirt/pkg/virt-handler/cache"
 	cmdclient "kubevirt.io/kubevirt/pkg/virt-handler/cmd-client"
+	hcontainerdisk "kubevirt.io/kubevirt/pkg/virt-handler/container-disk"
 	dmetricsmanager "kubevirt.io/kubevirt/pkg/virt-handler/dmetrics-manager"
 	"kubevirt.io/kubevirt/pkg/virt-handler/isolation"
 	launcherclients "kubevirt.io/kubevirt/pkg/virt-handler/launcher-clients"
@@ -433,6 +434,13 @@ func (app *virtHandlerApp) Run() {
 		panic(err)
 	}
 
+	containerDiskState := filepath.Join(app.VirtPrivateDir, "container-disk-mount-state")
+	if err := os.MkdirAll(containerDiskState, 0o700); err != nil {
+		panic(err)
+	}
+
+	cdMounter := hcontainerdisk.NewMounter(podIsolationDetector, containerDiskState, app.clusterConfig)
+
 	migrationTargetController, err := virthandler.NewMigrationTargetController(
 		recorder,
 		app.virtClient,
@@ -454,6 +462,7 @@ func (app *virtHandlerApp) Run() {
 		passtRepairHandler,
 		pluginInformer.GetStore(),
 		nodeHookManager,
+		cdMounter,
 	)
 	if err != nil {
 		panic(err)
@@ -485,6 +494,7 @@ func (app *virtHandlerApp) Run() {
 		cbtHandler,
 		pluginInformer.GetStore(),
 		nodeHookManager,
+		cdMounter,
 	)
 	if err != nil {
 		panic(err)

--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -82,6 +82,7 @@ import (
 	cmdclient "kubevirt.io/kubevirt/pkg/virt-handler/cmd-client"
 	hcontainerdisk "kubevirt.io/kubevirt/pkg/virt-handler/container-disk"
 	dmetricsmanager "kubevirt.io/kubevirt/pkg/virt-handler/dmetrics-manager"
+	hotplugvolume "kubevirt.io/kubevirt/pkg/virt-handler/hotplug-disk"
 	"kubevirt.io/kubevirt/pkg/virt-handler/isolation"
 	launcherclients "kubevirt.io/kubevirt/pkg/virt-handler/launcher-clients"
 	migrationproxy "kubevirt.io/kubevirt/pkg/virt-handler/migration-proxy"
@@ -441,12 +442,17 @@ func (app *virtHandlerApp) Run() {
 
 	cdMounter := hcontainerdisk.NewMounter(podIsolationDetector, containerDiskState, app.clusterConfig)
 
+	hotplugState := filepath.Join(app.VirtPrivateDir, "hotplug-volume-mount-state")
+	if err := os.MkdirAll(hotplugState, 0o700); err != nil {
+		panic(err)
+	}
+
+	hvMounter := hotplugvolume.NewVolumeMounter(hotplugState, app.KubeletPodsDir, app.HostOverride)
+
 	migrationTargetController, err := virthandler.NewMigrationTargetController(
 		recorder,
 		app.virtClient,
 		app.HostOverride,
-		app.VirtPrivateDir,
-		app.KubeletPodsDir,
 		migrationIpAddress,
 		launcherClientsManager,
 		vmiTargetInformer,
@@ -463,6 +469,7 @@ func (app *virtHandlerApp) Run() {
 		pluginInformer.GetStore(),
 		nodeHookManager,
 		cdMounter,
+		hvMounter,
 	)
 	if err != nil {
 		panic(err)
@@ -476,8 +483,6 @@ func (app *virtHandlerApp) Run() {
 		app.k8sClient,
 		nodeInformer.GetStore(),
 		app.HostOverride,
-		app.VirtPrivateDir,
-		app.KubeletPodsDir,
 		launcherClientsManager,
 		vmiSourceInformer,
 		vmiInformer.GetStore(),
@@ -495,6 +500,7 @@ func (app *virtHandlerApp) Run() {
 		pluginInformer.GetStore(),
 		nodeHookManager,
 		cdMounter,
+		hvMounter,
 	)
 	if err != nil {
 		panic(err)

--- a/pkg/virt-handler/migration-target.go
+++ b/pkg/virt-handler/migration-target.go
@@ -113,6 +113,7 @@ func NewMigrationTargetController(
 	passtRepairHandler passtRepairTargetHandler,
 	pluginStore cache.Store,
 	pluginExecutor plugins.NodeHookExecutor,
+	cdMounter containerdisk.Mounter,
 ) (*MigrationTargetController, error) {
 	queue := workqueue.NewTypedRateLimitingQueueWithConfig[string](
 		workqueue.DefaultTypedControllerRateLimiter[string](),
@@ -144,11 +145,6 @@ func NewMigrationTargetController(
 		return nil, err
 	}
 
-	containerDiskState := filepath.Join(virtPrivateDir, "container-disk-mount-state")
-	if err := os.MkdirAll(containerDiskState, 0o700); err != nil {
-		return nil, err
-	}
-
 	hotplugState := filepath.Join(virtPrivateDir, "hotplug-volume-mount-state")
 	if err := os.MkdirAll(hotplugState, 0o700); err != nil {
 		return nil, err
@@ -157,7 +153,7 @@ func NewMigrationTargetController(
 	c := &MigrationTargetController{
 		BaseController:                   baseCtrl,
 		capabilities:                     capabilities,
-		containerDiskMounter:             containerdisk.NewMounter(podIsolationDetector, containerDiskState, clusterConfig),
+		containerDiskMounter:             cdMounter,
 		hotplugVolumeMounter:             hotplugvolume.NewVolumeMounter(hotplugState, kubeletPodsDir, host),
 		migrationIpAddress:               migrationIpAddress,
 		netBindingPluginMemoryCalculator: netBindingPluginMemoryCalculator,

--- a/pkg/virt-handler/migration-target.go
+++ b/pkg/virt-handler/migration-target.go
@@ -24,7 +24,6 @@ import (
 	"encoding/json"
 	goerror "errors"
 	"fmt"
-	"os"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -96,8 +95,6 @@ func NewMigrationTargetController(
 	recorder record.EventRecorder,
 	virtClient kubecli.KubevirtClient,
 	host string,
-	virtPrivateDir string,
-	kubeletPodsDir string,
 	migrationIpAddress string,
 	launcherClients launcherclients.LauncherClientsManager,
 	vmiInformer cache.SharedIndexInformer,
@@ -114,6 +111,7 @@ func NewMigrationTargetController(
 	pluginStore cache.Store,
 	pluginExecutor plugins.NodeHookExecutor,
 	cdMounter containerdisk.Mounter,
+	hvMounter hotplugvolume.VolumeMounter,
 ) (*MigrationTargetController, error) {
 	queue := workqueue.NewTypedRateLimitingQueueWithConfig[string](
 		workqueue.DefaultTypedControllerRateLimiter[string](),
@@ -145,16 +143,11 @@ func NewMigrationTargetController(
 		return nil, err
 	}
 
-	hotplugState := filepath.Join(virtPrivateDir, "hotplug-volume-mount-state")
-	if err := os.MkdirAll(hotplugState, 0o700); err != nil {
-		return nil, err
-	}
-
 	c := &MigrationTargetController{
 		BaseController:                   baseCtrl,
 		capabilities:                     capabilities,
 		containerDiskMounter:             cdMounter,
-		hotplugVolumeMounter:             hotplugvolume.NewVolumeMounter(hotplugState, kubeletPodsDir, host),
+		hotplugVolumeMounter:             hvMounter,
 		migrationIpAddress:               migrationIpAddress,
 		netBindingPluginMemoryCalculator: netBindingPluginMemoryCalculator,
 		netConf:                          netConf,

--- a/pkg/virt-handler/migration-target_test.go
+++ b/pkg/virt-handler/migration-target_test.go
@@ -61,6 +61,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 	virtcache "kubevirt.io/kubevirt/pkg/virt-handler/cache"
 	cmdclient "kubevirt.io/kubevirt/pkg/virt-handler/cmd-client"
+	containerdisk "kubevirt.io/kubevirt/pkg/virt-handler/container-disk"
 	hotplugvolume "kubevirt.io/kubevirt/pkg/virt-handler/hotplug-disk"
 	"kubevirt.io/kubevirt/pkg/virt-handler/isolation"
 	launcherclients "kubevirt.io/kubevirt/pkg/virt-handler/launcher-clients"
@@ -239,6 +240,7 @@ var _ = Describe("VirtualMachineInstance migration target", func() {
 			migrationTargetPasstRepairHandler,
 			nil,
 			nil,
+			containerdisk.NewMounter(mockIsolationDetector, GinkgoT().TempDir(), config),
 		)
 
 		controller.hotplugVolumeMounter = mockHotplugVolumeMounter

--- a/pkg/virt-handler/migration-target_test.go
+++ b/pkg/virt-handler/migration-target_test.go
@@ -155,7 +155,6 @@ var _ = Describe("VirtualMachineInstance migration target", func() {
 		stop = make(chan struct{})
 		eventChan = make(chan watch.Event, 100)
 		shareDir := GinkgoT().TempDir()
-		privateDir := GinkgoT().TempDir()
 		podsDir, err := os.MkdirTemp("", "")
 		Expect(err).ToNot(HaveOccurred())
 		DeferCleanup(os.RemoveAll, podsDir)
@@ -223,8 +222,6 @@ var _ = Describe("VirtualMachineInstance migration target", func() {
 			recorder,
 			virtClient,
 			host,
-			privateDir,
-			podsDir,
 			"127.1.1.1", // migration ip address
 			launcherClientManager,
 			vmiInformer,
@@ -241,9 +238,8 @@ var _ = Describe("VirtualMachineInstance migration target", func() {
 			nil,
 			nil,
 			containerdisk.NewMounter(mockIsolationDetector, GinkgoT().TempDir(), config),
+			mockHotplugVolumeMounter,
 		)
-
-		controller.hotplugVolumeMounter = mockHotplugVolumeMounter
 
 		vmiTestUUID = uuid.NewUUID()
 		podTestUUID = uuid.NewUUID()

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -152,6 +152,7 @@ func NewVirtualMachineController(
 	cbtHandler *CBTHandler,
 	pluginStore cache.Store,
 	pluginExecutor plugins.NodeHookExecutor,
+	cdMounter containerdisk.Mounter,
 ) (*VirtualMachineController, error) {
 
 	queue := workqueue.NewTypedRateLimitingQueueWithConfig[string](
@@ -184,11 +185,6 @@ func NewVirtualMachineController(
 		return nil, err
 	}
 
-	containerDiskState := filepath.Join(virtPrivateDir, "container-disk-mount-state")
-	if err := os.MkdirAll(containerDiskState, 0700); err != nil {
-		return nil, err
-	}
-
 	hotplugState := filepath.Join(virtPrivateDir, "hotplug-volume-mount-state")
 	if err := os.MkdirAll(hotplugState, 0700); err != nil {
 		return nil, err
@@ -198,7 +194,7 @@ func NewVirtualMachineController(
 		BaseController:           baseCtrl,
 		capabilities:             capabilities,
 		virtClient:               virtClient,
-		containerDiskMounter:     containerdisk.NewMounter(podIsolationDetector, containerDiskState, clusterConfig),
+		containerDiskMounter:     cdMounter,
 		downwardMetricsManager:   downwardMetricsManager,
 		hotplugVolumeMounter:     hotplugvolume.NewVolumeMounter(hotplugState, kubeletPodsDir, host),
 		hostCpuModel:             hostCpuModel,

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -134,8 +134,6 @@ func NewVirtualMachineController(
 	k8sClient kubernetes.Interface,
 	nodeStore cache.Store,
 	host string,
-	virtPrivateDir string,
-	kubeletPodsDir string,
 	launcherClients launcherclients.LauncherClientsManager,
 	vmiInformer cache.SharedIndexInformer,
 	vmiGlobalStore cache.Store,
@@ -153,6 +151,7 @@ func NewVirtualMachineController(
 	pluginStore cache.Store,
 	pluginExecutor plugins.NodeHookExecutor,
 	cdMounter containerdisk.Mounter,
+	hvMounter hotplugvolume.VolumeMounter,
 ) (*VirtualMachineController, error) {
 
 	queue := workqueue.NewTypedRateLimitingQueueWithConfig[string](
@@ -185,18 +184,13 @@ func NewVirtualMachineController(
 		return nil, err
 	}
 
-	hotplugState := filepath.Join(virtPrivateDir, "hotplug-volume-mount-state")
-	if err := os.MkdirAll(hotplugState, 0700); err != nil {
-		return nil, err
-	}
-
 	c := &VirtualMachineController{
 		BaseController:           baseCtrl,
 		capabilities:             capabilities,
 		virtClient:               virtClient,
 		containerDiskMounter:     cdMounter,
 		downwardMetricsManager:   downwardMetricsManager,
-		hotplugVolumeMounter:     hotplugvolume.NewVolumeMounter(hotplugState, kubeletPodsDir, host),
+		hotplugVolumeMounter:     hvMounter,
 		hostCpuModel:             hostCpuModel,
 		ioErrorRetryManager:      NewFailRetryManager("io-error-retry", 10*time.Second, 3*time.Minute, 30*time.Second),
 		heartBeatInterval:        1 * time.Minute,

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -219,6 +219,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 			cbtHandler,
 			nil,
 			&noopNodeHookExecutor{},
+			containerdisk.NewMounter(mockIsolationDetector, GinkgoT().TempDir(), config),
 		)
 
 		controller.hotplugVolumeMounter = mockHotplugVolumeMounter

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -126,7 +126,6 @@ var _ = Describe("VirtualMachineInstance", func() {
 		stop = make(chan struct{})
 		eventChan = make(chan watch.Event, 100)
 		shareDir := GinkgoT().TempDir()
-		privateDir := GinkgoT().TempDir()
 		podsDir, err := os.MkdirTemp("", "")
 		Expect(err).ToNot(HaveOccurred())
 		DeferCleanup(os.RemoveAll, podsDir)
@@ -201,8 +200,6 @@ var _ = Describe("VirtualMachineInstance", func() {
 			k8sfakeClient,
 			fakeNodeStore,
 			host,
-			privateDir,
-			podsDir,
 			launcherClientManager,
 			vmiInformer,
 			vmiInformer.GetStore(),
@@ -220,9 +217,8 @@ var _ = Describe("VirtualMachineInstance", func() {
 			nil,
 			&noopNodeHookExecutor{},
 			containerdisk.NewMounter(mockIsolationDetector, GinkgoT().TempDir(), config),
+			mockHotplugVolumeMounter,
 		)
-
-		controller.hotplugVolumeMounter = mockHotplugVolumeMounter
 
 		vmiTestUUID = uuid.NewUUID()
 		podTestUUID = uuid.NewUUID()


### PR DESCRIPTION
### What this PR does
Reverts https://github.com/kubevirt/kubevirt/pull/14705 split of mounters into multiple instances. This makes sure that migration and core controller share the same cache that both mounters use. Constructing the instance one also reduce mistake of different on-disk state.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

