### PR TITLE
tests/network: use pod affinity instead of node name

### DIFF
--- a/pkg/libvmi/selector.go
+++ b/pkg/libvmi/selector.go
@@ -96,6 +96,22 @@ func WithRequiredPodAffinity(term k8sv1.PodAffinityTerm) Option {
 	}
 }
 
+func WithRequiredPodAntiAffinity(term k8sv1.PodAffinityTerm) Option {
+	return func(vmi *v1.VirtualMachineInstance) {
+		if vmi.Spec.Affinity == nil {
+			vmi.Spec.Affinity = &k8sv1.Affinity{}
+		}
+
+		if vmi.Spec.Affinity.PodAntiAffinity == nil {
+			vmi.Spec.Affinity.PodAntiAffinity = &k8sv1.PodAntiAffinity{}
+		}
+
+		vmi.Spec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution = append(
+			vmi.Spec.Affinity.PodAntiAffinity.RequiredDuringSchedulingIgnoredDuringExecution, term,
+		)
+	}
+}
+
 func WithPreferredPodAffinity(term k8sv1.WeightedPodAffinityTerm) Option {
 	return func(vmi *v1.VirtualMachineInstance) {
 		if vmi.Spec.Affinity == nil {

--- a/tests/network/bindingplugin.go
+++ b/tests/network/bindingplugin.go
@@ -36,7 +36,6 @@ import (
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/libkubevirt/config"
 	"kubevirt.io/kubevirt/tests/libnet"
-	"kubevirt.io/kubevirt/tests/libnode"
 	"kubevirt.io/kubevirt/tests/libregistry"
 	"kubevirt.io/kubevirt/tests/libvmifact"
 	"kubevirt.io/kubevirt/tests/libwait"
@@ -200,9 +199,6 @@ var _ = Describe(SIG("network binding plugin", Serial, decorators.NetCustomBindi
 				serverCIDR     = serverIPAddr + "/24"
 				clientCIDR     = "10.1.1.101/24"
 			)
-			nodeList := libnode.GetAllSchedulableNodes(kubevirt.Client())
-			Expect(nodeList.Items).NotTo(BeEmpty(), "schedulable kubernetes nodes must be present")
-			nodeName := nodeList.Items[0].Name
 
 			const linuxBridgeNADName = "bridge0"
 			namespace := testsuite.GetTestNamespace(nil)
@@ -226,24 +222,24 @@ var _ = Describe(SIG("network binding plugin", Serial, decorators.NetCustomBindi
 					},
 				},
 			}
-			serverVMI := libvmifact.NewAlpineWithTestTooling(
+			vmiOpts := []libvmi.Option{
+				libvmi.WithNetwork(&primaryNetwork),
+				withGroupAffinity("managed-tap-peers"),
+			}
+			serverVMI := libvmifact.NewAlpineWithTestTooling(append(vmiOpts,
 				libvmi.WithInterface(libvmi.NewInterface(
 					"mynet1",
 					libvmi.WithBindingPlugin(v1.PluginBinding{Name: bindingName}),
 					libvmi.WithMac("de:ad:00:00:be:af"),
 				)),
-				libvmi.WithNetwork(&primaryNetwork),
-				libvmi.WithNodeAffinityFor(nodeName),
-			)
-			clientVMI := libvmifact.NewAlpineWithTestTooling(
+			)...)
+			clientVMI := libvmifact.NewAlpineWithTestTooling(append(vmiOpts,
 				libvmi.WithInterface(libvmi.NewInterface(
 					"mynet1",
 					libvmi.WithBindingPlugin(v1.PluginBinding{Name: bindingName}),
 					libvmi.WithMac("de:ad:00:00:be:aa"),
 				)),
-				libvmi.WithNetwork(&primaryNetwork),
-				libvmi.WithNodeAffinityFor(nodeName),
-			)
+			)...)
 
 			ns := testsuite.GetTestNamespace(nil)
 			serverVMI, err = kubevirt.Client().VirtualMachineInstance(ns).Create(context.Background(), serverVMI, metav1.CreateOptions{})

--- a/tests/network/bindingplugin_macvtap.go
+++ b/tests/network/bindingplugin_macvtap.go
@@ -39,7 +39,6 @@ import (
 	"kubevirt.io/kubevirt/tests/libkubevirt/config"
 	"kubevirt.io/kubevirt/tests/libmigration"
 	"kubevirt.io/kubevirt/tests/libnet"
-	"kubevirt.io/kubevirt/tests/libnode"
 	"kubevirt.io/kubevirt/tests/libpod"
 	"kubevirt.io/kubevirt/tests/libvmifact"
 	"kubevirt.io/kubevirt/tests/libwait"
@@ -85,17 +84,11 @@ var _ = Describe(SIG("VirtualMachineInstance with macvtap network binding plugin
 			serverCIDR     = serverIPAddr + "/24"
 			clientCIDR     = "192.0.2.101/24"
 		)
-		nodeList := libnode.GetAllSchedulableNodes(kubevirt.Client())
-		Expect(nodeList.Items).NotTo(BeEmpty(), "schedulable kubernetes nodes must be present")
-		nodeName := nodeList.Items[0].Name
 
 		opts := []libvmi.Option{
-			libvmi.WithInterface(libvmi.NewInterface(
-				macvtapNetworkName,
-				libvmi.WithBindingPlugin(v1.PluginBinding{Name: "macvtap"}),
-			)),
+			libvmi.WithInterface(libvmi.InterfaceWithMacvtapBindingPlugin(macvtapNetworkName)),
 			libvmi.WithNetwork(libvmi.MultusNetwork(macvtapNetworkName, macvtapNetworkName)),
-			libvmi.WithNodeAffinityFor(nodeName),
+			withGroupAffinity("macvtap-peers"),
 		}
 		serverVMI := libvmifact.NewAlpineWithTestTooling(opts...)
 		clientVMI := libvmifact.NewAlpineWithTestTooling(opts...)

--- a/tests/network/framework.go
+++ b/tests/network/framework.go
@@ -20,9 +20,42 @@
 package network
 
 import (
+	k8sv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/kubevirt/pkg/libvmi"
 	"kubevirt.io/kubevirt/tests/decorators"
 )
 
 func SIG(text string, args ...interface{}) (extendedText string, newArgs []interface{}) {
 	return decorators.SIG("[sig-network]", text, decorators.SigNetwork, args)
+}
+
+const (
+	testAffinityLabel     = "kubevirt.io/test-affinity"
+	testAntiAffinityLabel = "kubevirt.io/test-anti-affinity"
+)
+
+func podAffinityTerm(label, group string) k8sv1.PodAffinityTerm {
+	return k8sv1.PodAffinityTerm{
+		LabelSelector: &metav1.LabelSelector{
+			MatchLabels: map[string]string{label: group},
+		},
+		TopologyKey: k8sv1.LabelHostname,
+	}
+}
+
+func withGroupAffinity(group string) libvmi.Option {
+	return func(vmi *v1.VirtualMachineInstance) {
+		libvmi.WithLabel(testAffinityLabel, group)(vmi)
+		libvmi.WithRequiredPodAffinity(podAffinityTerm(testAffinityLabel, group))(vmi)
+	}
+}
+
+func withGroupAntiAffinity(group string) libvmi.Option {
+	return func(vmi *v1.VirtualMachineInstance) {
+		libvmi.WithLabel(testAntiAffinityLabel, group)(vmi)
+		libvmi.WithRequiredPodAntiAffinity(podAffinityTerm(testAntiAffinityLabel, group))(vmi)
+	}
 }

--- a/tests/network/hotplug_sriov.go
+++ b/tests/network/hotplug_sriov.go
@@ -50,13 +50,6 @@ var _ = Describe(SIG(" SRIOV nic-hotplug", Serial, decorators.SRIOV, func() {
 	sriovResourceName := readSRIOVResourceName()
 
 	BeforeEach(func() {
-		// Check if the hardware supports SRIOV
-		Expect(validateSRIOVSetup(sriovResourceName, 1)).To(Succeed(),
-			"Sriov is not enabled in this environment: %v. Skip these tests using - export FUNC_TEST_ARGS='--label-filter=!SRIOV'")
-
-	})
-
-	BeforeEach(func() {
 		virtClient := kubevirt.Client()
 		updateStrategy := &v1.KubeVirtWorkloadUpdateStrategy{
 			WorkloadUpdateMethods: []v1.WorkloadUpdateMethod{v1.WorkloadUpdateMethodLiveMigrate},

--- a/tests/network/nad_live_update.go
+++ b/tests/network/nad_live_update.go
@@ -25,8 +25,8 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"kubevirt.io/client-go/kubecli"
 
+	k8sv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -44,7 +44,6 @@ import (
 	"kubevirt.io/kubevirt/tests/libkubevirt/config"
 	"kubevirt.io/kubevirt/tests/libnet"
 	"kubevirt.io/kubevirt/tests/libnet/cloudinit"
-	"kubevirt.io/kubevirt/tests/libnode"
 	"kubevirt.io/kubevirt/tests/libvmifact"
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
@@ -57,16 +56,16 @@ var _ = Describe(SIG("NAD name live update", decorators.RequiresTwoSchedulableNo
 		targetNAD       = "nad-2"
 		pollingInterval = 2 * time.Second
 		timeoutInterval = 5 * time.Minute
+
+		staticVMI1Name = "static-vmi-1"
+		staticVMI1IP   = "10.1.1.10"
+		staticVMI2Name = "static-vmi-2"
+		staticVMI2IP   = "10.1.1.20"
+		subnetMask     = "/24"
 	)
-	var (
-		testNamespace  string
-		virtClient     kubecli.KubevirtClient
-		sourceNodeName string
-	)
+	var testNamespace string
 
 	BeforeEach(func() {
-		virtClient = kubevirt.Client()
-
 		updateStrategy := &v1.KubeVirtWorkloadUpdateStrategy{
 			WorkloadUpdateMethods: []v1.WorkloadUpdateMethod{v1.WorkloadUpdateMethodLiveMigrate},
 		}
@@ -77,7 +76,7 @@ var _ = Describe(SIG("NAD name live update", decorators.RequiresTwoSchedulableNo
 		)
 		Expect(err).ToNot(HaveOccurred())
 
-		currentKv := libkubevirt.GetCurrentKv(virtClient)
+		currentKv := libkubevirt.GetCurrentKv(kubevirt.Client())
 		config.WaitForConfigToBePropagatedToComponent(
 			"kubevirt.io=virt-controller",
 			currentKv.ResourceVersion,
@@ -99,22 +98,12 @@ var _ = Describe(SIG("NAD name live update", decorators.RequiresTwoSchedulableNo
 	})
 
 	BeforeEach(func() {
-		nodes := libnode.GetAllSchedulableNodes(kubevirt.Client())
-		const minNoOfNodesNeeded = 2
-		Expect(len(nodes.Items)).To(BeNumerically(">=", minNoOfNodesNeeded))
-		sourceNodeName = nodes.Items[0].Name
-
-		const (
-			staticVMI1Name = "static-vmi-1"
-			staticVMI1IP   = "10.1.1.10"
-			subnetMask     = "/24"
-		)
-
-		staticVMI1, err := newVMIWithAffinity(
+		staticVMI1, err := newVMI(
 			staticVMI1Name,
 			sourceNAD,
 			staticVMI1IP+subnetMask,
-			sourceNodeName,
+			withGroupAntiAffinity("static-vms"),
+			libvmi.WithLabel(testAffinityLabel, staticVMI1Name),
 		)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -122,12 +111,25 @@ var _ = Describe(SIG("NAD name live update", decorators.RequiresTwoSchedulableNo
 			Create(context.Background(), staticVMI1, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
 
+		staticVMI2, err := newVMI(
+			staticVMI2Name,
+			targetNAD,
+			staticVMI2IP+subnetMask,
+			withGroupAntiAffinity("static-vms"),
+			libvmi.WithLabel(testAffinityLabel, staticVMI2Name),
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		staticVMI2, err = kubevirt.Client().VirtualMachineInstance(testNamespace).
+			Create(context.Background(), staticVMI2, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
 		var vmi *v1.VirtualMachineInstance
-		vmi, err = newVMIWithAffinity(
+		vmi, err = newVMI(
 			vmName,
 			sourceNAD,
 			vmIP+subnetMask,
-			sourceNodeName,
+			libvmi.WithRequiredPodAffinity(podAffinityTerm(testAffinityLabel, staticVMI1Name)),
 		)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -136,6 +138,9 @@ var _ = Describe(SIG("NAD name live update", decorators.RequiresTwoSchedulableNo
 		Expect(err).NotTo(HaveOccurred())
 
 		Eventually(matcher.ThisVMI(staticVMI1)).WithTimeout(timeoutInterval).WithPolling(pollingInterval).
+			Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
+
+		Eventually(matcher.ThisVMI(staticVMI2)).WithTimeout(timeoutInterval).WithPolling(pollingInterval).
 			Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 
 		Eventually(matcher.ThisVM(vm)).WithTimeout(timeoutInterval).WithPolling(pollingInterval).
@@ -150,7 +155,7 @@ var _ = Describe(SIG("NAD name live update", decorators.RequiresTwoSchedulableNo
 		vm, err := kubevirt.Client().VirtualMachine(testNamespace).Get(context.Background(), vmName, metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
 
-		err = updateNADNameAndRemoveAffinityRules(vm, targetNAD)
+		err = updateNADNameAndAffinity(vm, targetNAD, staticVMI2Name)
 		Expect(err).NotTo(HaveOccurred())
 
 		var vmi *v1.VirtualMachineInstance
@@ -168,42 +173,8 @@ var _ = Describe(SIG("NAD name live update", decorators.RequiresTwoSchedulableNo
 			WithPolling(pollingInterval).
 			Should(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineInstanceMigrationRequired))
 
-		Eventually(func() (string, error) {
-			vmi, err = kubevirt.Client().VirtualMachineInstance(testNamespace).Get(context.Background(), vmName, metav1.GetOptions{})
-			if err != nil {
-				return "", err
-			}
-			return vmi.Status.NodeName, nil
-		}).
-			WithTimeout(timeoutInterval).
-			WithPolling(pollingInterval).
-			Should(SatisfyAll(
-				Not(BeEmpty()),
-				Not(Equal(sourceNodeName)),
-			))
-
-		targetNode := vmi.Status.NodeName
-
-		var staticVMI2 *v1.VirtualMachineInstance
-		const (
-			staticVMI2Name = "static-vmi-2"
-			staticVMI2IP   = "10.1.1.20"
-			subnetMask     = "/24"
-		)
-		staticVMI2, err = newVMIWithAffinity(
-			staticVMI2Name,
-			targetNAD,
-			staticVMI2IP+subnetMask,
-			targetNode,
-		)
+		staticVMI2, err := kubevirt.Client().VirtualMachineInstance(testNamespace).Get(context.Background(), staticVMI2Name, metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
-
-		staticVMI2, err = kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(staticVMI2)).
-			Create(context.Background(), staticVMI2, metav1.CreateOptions{})
-		Expect(err).ToNot(HaveOccurred())
-
-		Eventually(matcher.ThisVMI(staticVMI2)).WithTimeout(timeoutInterval).WithPolling(pollingInterval).
-			Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 
 		Expect(console.LoginToAlpine(staticVMI2)).To(Succeed())
 
@@ -211,9 +182,17 @@ var _ = Describe(SIG("NAD name live update", decorators.RequiresTwoSchedulableNo
 	})
 }))
 
-func updateNADNameAndRemoveAffinityRules(vm *v1.VirtualMachine, targetNAD string) error {
+func updateNADNameAndAffinity(vm *v1.VirtualMachine, targetNAD, targetPeer string) error {
+	affinityToTarget := &k8sv1.Affinity{
+		PodAffinity: &k8sv1.PodAffinity{
+			RequiredDuringSchedulingIgnoredDuringExecution: []k8sv1.PodAffinityTerm{
+				podAffinityTerm(testAffinityLabel, targetPeer),
+			},
+		},
+	}
+
 	patchData, err := patch.New(
-		patch.WithRemove("/spec/template/spec/affinity"),
+		patch.WithReplace("/spec/template/spec/affinity", affinityToTarget),
 		patch.WithReplace("/spec/template/spec/networks/0/multus/networkName", targetNAD),
 	).GeneratePayload()
 	if err != nil {
@@ -224,9 +203,9 @@ func updateNADNameAndRemoveAffinityRules(vm *v1.VirtualMachine, targetNAD string
 	return err
 }
 
-func newVMIWithAffinity(name, nad, ip, node string) (*v1.VirtualMachineInstance, error) {
+func newVMI(name, nad, ip string, opts ...libvmi.Option) (*v1.VirtualMachineInstance, error) {
 	const ifaceName = "net1"
-	networkData1, err := cloudinit.NewNetworkData(
+	networkData, err := cloudinit.NewNetworkData(
 		cloudinit.WithEthernet("eth0",
 			cloudinit.WithAddresses(ip),
 		),
@@ -234,12 +213,11 @@ func newVMIWithAffinity(name, nad, ip, node string) (*v1.VirtualMachineInstance,
 	if err != nil {
 		return nil, err
 	}
-	vmi := libvmifact.NewAlpineWithTestTooling(
+	vmi := libvmifact.NewAlpineWithTestTooling(append(opts,
 		libvmi.WithName(name),
 		libvmi.WithInterface(libvmi.NewInterface(ifaceName, libvmi.WithBridgeBinding())),
 		libvmi.WithNetwork(libvmi.MultusNetwork(ifaceName, nad)),
-		libvmi.WithNodeAffinityFor(node),
-		libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(networkData1)),
-	)
+		libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(networkData)),
+	)...)
 	return vmi, nil
 }

--- a/tests/network/sriov.go
+++ b/tests/network/sriov.go
@@ -68,7 +68,6 @@ import (
 	"kubevirt.io/kubevirt/tests/libmigration"
 	"kubevirt.io/kubevirt/tests/libnet"
 	netcloudinit "kubevirt.io/kubevirt/tests/libnet/cloudinit"
-	"kubevirt.io/kubevirt/tests/libnode"
 	"kubevirt.io/kubevirt/tests/libpod"
 	"kubevirt.io/kubevirt/tests/libvmifact"
 	"kubevirt.io/kubevirt/tests/libwait"
@@ -97,9 +96,6 @@ var _ = Describe(SIG("SRIOV", Serial, decorators.SRIOV, func() {
 
 	BeforeEach(func() {
 		virtClient = kubevirt.Client()
-
-		Expect(validateSRIOVSetup(sriovResourceName, 1)).To(Succeed(),
-			"Sriov is not enabled in this environment: %v. Skip these tests using - export FUNC_TEST_ARGS='--label-filter=!SRIOV'")
 
 		checks.FailTestIfNoFeatureGate(featuregate.ExternalNetResourceInjection)
 	})
@@ -260,11 +256,6 @@ var _ = Describe(SIG("SRIOV", Serial, decorators.SRIOV, func() {
 		})
 
 		Context("migration", decorators.RequiresTwoSchedulableNodes, func() {
-			BeforeEach(func() {
-				Expect(validateSRIOVSetup(sriovResourceName, 2)).To(Succeed(),
-					"Migration tests require at least 2 nodes with SR-IOV resources")
-			})
-
 			var vmi *v1.VirtualMachineInstance
 
 			const mac = "de:ad:00:00:be:ef"
@@ -621,32 +612,6 @@ func getInterfaceNetworkNameByMAC(vmi *v1.VirtualMachineInstance, macAddress str
 	}
 
 	return ""
-}
-
-func validateSRIOVSetup(sriovResourceName string, minRequiredNodes int) error {
-	sriovNodes := getNodesWithAllocatedResource(sriovResourceName)
-	if len(sriovNodes) < minRequiredNodes {
-		return fmt.Errorf("not enough compute nodes with SR-IOV support detected")
-	}
-	return nil
-}
-
-func getNodesWithAllocatedResource(resourceName string) []k8sv1.Node {
-	nodes := libnode.GetAllSchedulableNodes(kubevirt.Client())
-	filteredNodes := []k8sv1.Node{}
-	for _, node := range nodes.Items {
-		resourceList := node.Status.Allocatable
-		for k, v := range resourceList {
-			if string(k) == resourceName {
-				if v.Value() > 0 {
-					filteredNodes = append(filteredNodes, node)
-					break
-				}
-			}
-		}
-	}
-
-	return filteredNodes
 }
 
 func defaultCloudInitNetworkData() string {

--- a/tests/network/sriov.go
+++ b/tests/network/sriov.go
@@ -38,7 +38,6 @@ import (
 	k8sv1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	v1 "kubevirt.io/api/core/v1"
@@ -363,11 +362,11 @@ var _ = Describe(SIG("SRIOV", Serial, decorators.SRIOV, func() {
 
 				vm := libvmi.NewVirtualMachine(vmi, libvmi.WithRunStrategy(v1.RunStrategyAlways))
 
-				vm, err := kubevirt.Client().VirtualMachine(testsuite.GetTestNamespace(nil)).Create(context.Background(), vm, metav1.CreateOptions{})
+				vm, err := kubevirt.Client().VirtualMachine(testsuite.GetTestNamespace(nil)).Create(context.Background(), vm, k8smetav1.CreateOptions{})
 				Expect(err).NotTo(HaveOccurred())
 
 				Eventually(matcher.ThisVM(vm)).WithTimeout(6 * time.Minute).WithPolling(3 * time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
-				vmi, err = kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Get(context.Background(), vm.Name, metav1.GetOptions{})
+				vmi, err = kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(nil)).Get(context.Background(), vm.Name, k8smetav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(console.LoginToAlpine(vmi)).To(Succeed())
 
@@ -490,14 +489,6 @@ var _ = Describe(SIG("SRIOV", Serial, decorators.SRIOV, func() {
 	})
 
 	Context("VMI connected to link-enabled SRIOV network", func() {
-		var sriovNode string
-
-		BeforeEach(func() {
-			var err error
-			sriovNode, err = sriovNodeName(sriovResourceName)
-			Expect(err).ToNot(HaveOccurred())
-		})
-
 		BeforeEach(func() {
 			netAttachDef := libnet.NewSriovNetAttachDef(sriovnetLinkEnabled, defaultVLAN, withLinkState())
 			netAttachDef.Annotations = map[string]string{libnet.ResourceNameAnnotation: sriovResourceName}
@@ -514,10 +505,10 @@ var _ = Describe(SIG("SRIOV", Serial, decorators.SRIOV, func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			// create two vms on the same sriov network
-			vmi1, err := createSRIOVVmiOnNode(sriovNode, sriovnetLinkEnabled, cidrA)
+			vmi1, err := createSRIOVVmi(sriovnetLinkEnabled, cidrA, withGroupAffinity("sriov-peers"))
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(deleteVMI, vmi1)
-			vmi2, err := createSRIOVVmiOnNode(sriovNode, sriovnetLinkEnabled, cidrB)
+			vmi2, err := createSRIOVVmi(sriovnetLinkEnabled, cidrB, withGroupAffinity("sriov-peers"))
 			Expect(err).ToNot(HaveOccurred())
 			DeferCleanup(deleteVMI, vmi2)
 
@@ -553,10 +544,10 @@ var _ = Describe(SIG("SRIOV", Serial, decorators.SRIOV, func() {
 			})
 
 			It("should be able to ping between two VMIs with the same VLAN over SRIOV network", func() {
-				vlanedVMI1, err := createSRIOVVmiOnNode(sriovNode, sriovnetVlanned, cidrVlaned1)
+				vlanedVMI1, err := createSRIOVVmi(sriovnetVlanned, cidrVlaned1, withGroupAffinity("sriov-peers"))
 				Expect(err).ToNot(HaveOccurred())
 				DeferCleanup(deleteVMI, vlanedVMI1)
-				vlanedVMI2, err := createSRIOVVmiOnNode(sriovNode, sriovnetVlanned, "192.168.0.2/24")
+				vlanedVMI2, err := createSRIOVVmi(sriovnetVlanned, "192.168.0.2/24", withGroupAffinity("sriov-peers"))
 				Expect(err).ToNot(HaveOccurred())
 				DeferCleanup(deleteVMI, vlanedVMI2)
 
@@ -572,10 +563,10 @@ var _ = Describe(SIG("SRIOV", Serial, decorators.SRIOV, func() {
 			})
 
 			It("should NOT be able to ping between Vlaned VMI and a non Vlaned VMI", func() {
-				vlanedVMI, err := createSRIOVVmiOnNode(sriovNode, sriovnetVlanned, cidrVlaned1)
+				vlanedVMI, err := createSRIOVVmi(sriovnetVlanned, cidrVlaned1, withGroupAffinity("sriov-peers"))
 				Expect(err).ToNot(HaveOccurred())
 				DeferCleanup(deleteVMI, vlanedVMI)
-				nonVlanedVMI, err := createSRIOVVmiOnNode(sriovNode, sriovnetLinkEnabled, "192.168.0.3/24")
+				nonVlanedVMI, err := createSRIOVVmi(sriovnetLinkEnabled, "192.168.0.3/24", withGroupAffinity("sriov-peers"))
 				Expect(err).ToNot(HaveOccurred())
 				DeferCleanup(deleteVMI, nonVlanedVMI)
 
@@ -759,7 +750,7 @@ func createVMIAndWait(vmi *v1.VirtualMachineInstance) (*v1.VirtualMachineInstanc
 	virtClient := kubevirt.Client()
 
 	var err error
-	vmi, err = virtClient.VirtualMachineInstance(testsuite.NamespaceTestDefault).Create(context.Background(), vmi, metav1.CreateOptions{})
+	vmi, err = virtClient.VirtualMachineInstance(testsuite.NamespaceTestDefault).Create(context.Background(), vmi, k8smetav1.CreateOptions{})
 	if err != nil {
 		return nil, err
 	}
@@ -842,8 +833,7 @@ func checkDefaultInterfaceInPod(vmi *v1.VirtualMachineInstance) error {
 	return nil
 }
 
-// createSRIOVVmiOnNode creates a VMI on the specified node, connected to the specified SR-IOV network.
-func createSRIOVVmiOnNode(nodeName, networkName, cidr string) (*v1.VirtualMachineInstance, error) {
+func createSRIOVVmi(networkName, cidr string, opts ...libvmi.Option) (*v1.VirtualMachineInstance, error) {
 	// Explicitly choose different random mac addresses instead of relying on kubemacpool to do it:
 	// 1) we don't at the moment deploy kubemacpool in kind providers
 	// 2) even if we would do, it's probably a good idea to have the suite not depend on this fact
@@ -858,23 +848,16 @@ func createSRIOVVmiOnNode(nodeName, networkName, cidr string) (*v1.VirtualMachin
 	// manually configure IP/link on sriov interfaces because there is
 	// no DHCP server to serve the address to the guest
 	networkData := netcloudinit.CreateNetworkDataWithStaticIPsByMac(networkName, mac.String(), cidr)
-	vmi := newSRIOVVmi([]string{networkName}, libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(networkData)))
-	libvmi.WithNodeAffinityFor(nodeName)(vmi)
+	vmi := newSRIOVVmi([]string{networkName}, append(opts,
+		libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(networkData)),
+	)...)
 	const secondaryInterfaceIndex = 1
 	vmi.Spec.Domain.Devices.Interfaces[secondaryInterfaceIndex].MacAddress = mac.String()
 
 	virtCli := kubevirt.Client()
-	vmi, err = virtCli.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi, metav1.CreateOptions{})
+	vmi, err = virtCli.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi, k8smetav1.CreateOptions{})
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 	return vmi, nil
-}
-
-func sriovNodeName(sriovResourceName string) (string, error) {
-	sriovNodes := getNodesWithAllocatedResource(sriovResourceName)
-	if len(sriovNodes) == 0 {
-		return "", fmt.Errorf("failed to detect nodes with allocatable resources (%s)", sriovResourceName)
-	}
-	return sriovNodes[0].Name, nil
 }
 
 func mountGuestDevice(vmi *v1.VirtualMachineInstance, devName string) error {

--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -31,7 +31,6 @@ import (
 	expect "github.com/google/goexpect"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	k8sv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"kubevirt.io/kubevirt/tests/exec"
@@ -47,7 +46,6 @@ import (
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/libnet"
 	"kubevirt.io/kubevirt/tests/libnet/cloudinit"
-	"kubevirt.io/kubevirt/tests/libnode"
 	"kubevirt.io/kubevirt/tests/libpod"
 	"kubevirt.io/kubevirt/tests/libvmifact"
 	"kubevirt.io/kubevirt/tests/libwait"
@@ -89,10 +87,8 @@ var _ = Describe(SIG("Multus", Serial, decorators.Multus, func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 
-	var nodes *k8sv1.NodeList
-
-	linuxBridgeInterface := libvmi.NewInterface(linuxBridgeIfaceName, libvmi.WithBridgeBinding())
-	linuxBridgeInterfaceWithIPAM := libvmi.NewInterface(linuxBridgeWithIPAMIfaceName, libvmi.WithBridgeBinding())
+	linuxBridgeInterface := libvmi.InterfaceDeviceWithBridgeBinding(linuxBridgeIfaceName)
+	linuxBridgeInterfaceWithIPAM := libvmi.InterfaceDeviceWithBridgeBinding(linuxBridgeWithIPAMIfaceName)
 
 	linuxBridgeNetwork := v1.Network{
 		Name: linuxBridgeIfaceName,
@@ -114,9 +110,6 @@ var _ = Describe(SIG("Multus", Serial, decorators.Multus, func() {
 
 	BeforeEach(func() {
 		virtClient = kubevirt.Client()
-
-		nodes = libnode.GetAllSchedulableNodes(virtClient)
-		Expect(nodes.Items).NotTo(BeEmpty())
 
 		const vlanID100 = 100
 		Expect(createBridgeNetworkAttachmentDefinition(testsuite.GetTestNamespace(nil), linuxBridgeVlan100Network,
@@ -546,7 +539,7 @@ var _ = Describe(SIG("Multus", Serial, decorators.Multus, func() {
 						libvmi.WithInterface(linuxBridgeInterfaceWithCustomMac),
 						libvmi.WithNetwork(libvmi.MultusNetwork(linuxBridgeWithMACSpoofCheckNetwork, linuxBridgeWithMACSpoofCheckNetwork)),
 						libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(networkData)),
-						libvmi.WithNodeAffinityFor(nodes.Items[0].Name),
+						withGroupAffinity("mac-spoof-check"),
 					)
 					vmiUnderTest, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmiUnderTest)).Create(context.Background(), vmiUnderTest, metav1.CreateOptions{})
 					ExpectWithOffset(1, err).ToNot(HaveOccurred())
@@ -564,7 +557,7 @@ var _ = Describe(SIG("Multus", Serial, decorators.Multus, func() {
 							linuxBridgeWithMACSpoofCheckNetwork, libvmi.WithBridgeBinding())),
 						libvmi.WithNetwork(libvmi.MultusNetwork(linuxBridgeWithMACSpoofCheckNetwork, linuxBridgeWithMACSpoofCheckNetwork)),
 						libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(targetNetworkData)),
-						libvmi.WithNodeAffinityFor(nodes.Items[0].Name),
+						withGroupAffinity("mac-spoof-check"),
 					)
 					targetVmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(targetVmi)).Create(context.Background(), targetVmi, metav1.CreateOptions{})
 					ExpectWithOffset(1, err).ToNot(HaveOccurred())

--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -367,7 +367,7 @@ var _ = Describe(SIG("Multus", Serial, decorators.Multus, func() {
 					libvmi.WithInterface(linuxBridgeInterface),
 					libvmi.WithNetwork(&linuxBridgeNetwork),
 					libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(networkData)),
-					libvmi.WithNodeAffinityFor(nodes.Items[0].Name),
+					withGroupAffinity("custom-mac"),
 				)
 				vmiTwo, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmiTwo)).Create(context.Background(), vmiTwo, metav1.CreateOptions{})
 				Expect(err).ToNot(HaveOccurred())
@@ -394,7 +394,7 @@ var _ = Describe(SIG("Multus", Serial, decorators.Multus, func() {
 					libvmi.WithInterface(linuxBridgeInterfaceWithCustomMac),
 					libvmi.WithNetwork(&linuxBridgeNetwork),
 					libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(networkData)),
-					libvmi.WithNodeAffinityFor(nodes.Items[0].Name),
+					withGroupAffinity("custom-mac"),
 				)
 
 				vmi, err = virtClient.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi, metav1.CreateOptions{})

--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -85,19 +85,6 @@ const (
 	bridge10MacSpoofCheck = false
 )
 
-func withCoLocationAffinity(group string) libvmi.Option {
-	const coLocationLabel = "kubevirt.io/test-co-location"
-	return func(vmi *v1.VirtualMachineInstance) {
-		libvmi.WithLabel(coLocationLabel, group)(vmi)
-		libvmi.WithRequiredPodAffinity(k8sv1.PodAffinityTerm{
-			LabelSelector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{coLocationLabel: group},
-			},
-			TopologyKey: k8sv1.LabelHostname,
-		})(vmi)
-	}
-}
-
 var _ = Describe(SIG("Multus", Serial, decorators.Multus, func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
@@ -305,7 +292,7 @@ var _ = Describe(SIG("Multus", Serial, decorators.Multus, func() {
 					[]libvmi.Option{
 						libvmi.WithInterface(linuxBridgeInterface),
 						libvmi.WithNetwork(&linuxBridgeNetwork),
-						withCoLocationAffinity("linux-bridge-ping"),
+						withGroupAffinity("linux-bridge-ping"),
 					},
 					"eth0",
 				),
@@ -315,7 +302,7 @@ var _ = Describe(SIG("Multus", Serial, decorators.Multus, func() {
 						libvmi.WithInterface(linuxBridgeInterface),
 						libvmi.WithNetwork(v1.DefaultPodNetwork()),
 						libvmi.WithNetwork(&linuxBridgeNetwork),
-						withCoLocationAffinity("linux-bridge-ping"),
+						withGroupAffinity("linux-bridge-ping"),
 					},
 					"eth1",
 				),
@@ -332,7 +319,7 @@ var _ = Describe(SIG("Multus", Serial, decorators.Multus, func() {
 						libvmi.WithInterface(linuxBridgeInterfaceWithIPAM),
 						libvmi.WithNetwork(v1.DefaultPodNetwork()),
 						libvmi.WithNetwork(&linuxBridgeWithIPAMNetwork),
-						withCoLocationAffinity("linux-bridge-ipam"),
+						withGroupAffinity("linux-bridge-ipam"),
 					)
 				}
 				ns := testsuite.GetTestNamespace(nil)


### PR DESCRIPTION
## Summary

Network tests in this package previously worked by listing all schedulable
nodes and hard-coding the name of a specific node into each VMI via
`WithNodeAffinityFor`. This creates unnecessary coupling to node topology and
prevents tests from expressing what they actually need.

This series replaces node-name pinning with pod affinity / anti-affinity rules:

- A new `withGroupAffinity(group)` helper in `framework.go` labels a VMI and
  adds a required pod-affinity term, so the scheduler co-locates all VMIs in
  the same group on one node.
- A companion `withGroupAntiAffinity(group)` spreads VMIs in the same group
  across different nodes.
- The underlying `podAffinityTerm(label, group)` helper is shared by both.
- `WithRequiredPodAntiAffinity` is added to `pkg/libvmi` following the
  existing `WithRequiredPodAffinity` pattern.

The NAD live-update test gets a more substantial restructure: `staticVMI2` is
now created upfront (before migration) and labeled directly by VMI name, so
the migrating VM can express "affinity to staticVMI1" and then switch to
"affinity to staticVMI2" via a patch, driving the live migration to the right
node without ever inspecting node names.

The `validateSRIOVSetup` runtime check is removed in the last commit; the
`decorators.SRIOV` label gate is the correct architectural mechanism.

## Test plan

- [ ] Existing network e2e tests pass (SR-IOV, multus, macvtap, binding plugin, NAD live update)
- [ ] `go vet ./pkg/libvmi/... ./tests/network/...` clean
- [ ] `gofmt` clean in every commit