### PR TITLE
storage, cbt, backup: replace CheckpointRedefinitionRequired

### DIFF
--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -459,7 +459,7 @@ func (app *virtHandlerApp) Run() {
 		panic(err)
 	}
 
-	cbtHandler := virthandler.NewCBTHandler(app.virtClient, backupTrackerInformer)
+	cbtHandler := virthandler.NewCBTHandler(backupTrackerInformer)
 
 	vmController, err := virthandler.NewVirtualMachineController(
 		recorder,

--- a/pkg/storage/cbt/backup.go
+++ b/pkg/storage/cbt/backup.go
@@ -237,8 +237,9 @@ func (ctrl *VMBackupController) handleUpdateVMI(oldObj, newObj interface{}) {
 		return
 	}
 
-	// For each tracker, find all backups that reference it
 	for _, trackerKey := range trackerKeys {
+		ctrl.trackerQueue.Add(trackerKey)
+
 		backupKeys, err := ctrl.backupInformer.GetIndexer().IndexKeys("backupTracker", trackerKey)
 		if err != nil {
 			continue
@@ -261,9 +262,7 @@ func (ctrl *VMBackupController) handleBackupTracker(obj interface{}) {
 
 	key := types.NamespacedName{Namespace: tracker.Namespace, Name: tracker.Name}.String()
 
-	// Enqueue tracker for checkpoint redefinition if needed
-	if trackerNeedsCheckpointRedefinition(tracker) {
-		log.Log.V(3).Infof("enqueued tracker %q for checkpoint redefinition", key)
+	if trackerHasCheckpoint(tracker) {
 		ctrl.trackerQueue.Add(key)
 	}
 
@@ -537,7 +536,7 @@ func (ctrl *VMBackupController) checkPrerequisites(backup *backupv1.VirtualMachi
 	if reason := ctrl.verifyVMIEligibleForBackup(vmi); reason != "" {
 		return reason, nil
 	}
-	if trackerNeedsCheckpointRedefinition(backupTracker) {
+	if trackerNeedsRedefinitionForPod(backupTracker, vmi) {
 		return fmt.Sprintf(trackerCheckpointRedefinitionPending, backupTracker.Name), nil
 	}
 	if migrations.IsMigrating(vmi) {
@@ -584,7 +583,7 @@ func (ctrl *VMBackupController) reconcileActive(backup *backupv1.VirtualMachineB
 
 func (ctrl *VMBackupController) reconcileCompleted(backup *backupv1.VirtualMachineBackup, vmi *v1.VirtualMachineInstance, backupTracker *backupv1.VirtualMachineBackupTracker, backupStatus *v1.VirtualMachineInstanceBackupStatus) error {
 	if backupTracker != nil && backupStatus.CheckpointName != nil && !backupStatus.Failed {
-		if err := ctrl.updateBackupTracker(backup.Namespace, backupTracker, backupStatus); err != nil {
+		if err := ctrl.updateBackupTracker(backup.Namespace, backupTracker, vmi, backupStatus); err != nil {
 			log.Log.Object(backup).Reason(err).Error("Failed to update BackupTracker")
 			return err
 		}
@@ -902,10 +901,12 @@ func (ctrl *VMBackupController) resolveCompletion(backup *backupv1.VirtualMachin
 	ctrl.recorder.Eventf(backup, corev1.EventTypeNormal, backupCompletedEvent, backupCompleted)
 }
 
-func (ctrl *VMBackupController) updateBackupTracker(namespace string, tracker *backupv1.VirtualMachineBackupTracker, backupStatus *v1.VirtualMachineInstanceBackupStatus) error {
+func (ctrl *VMBackupController) updateBackupTracker(namespace string, tracker *backupv1.VirtualMachineBackupTracker, vmi *v1.VirtualMachineInstance, backupStatus *v1.VirtualMachineInstanceBackupStatus) error {
 	if tracker == nil {
 		return nil
 	}
+
+	podUID := ActivePodUID(vmi)
 
 	newCheckpoint := backupv1.BackupCheckpoint{
 		Name:         *backupStatus.CheckpointName,
@@ -913,15 +914,23 @@ func (ctrl *VMBackupController) updateBackupTracker(namespace string, tracker *b
 		Volumes:      toBackupVolumeInfo(backupStatus.Volumes),
 	}
 
-	newStatus := &backupv1.VirtualMachineBackupTrackerStatus{
-		LatestCheckpoint: &newCheckpoint,
-	}
-
 	patchSet := patch.New()
-	if tracker.Status == nil || tracker.Status.LatestCheckpoint == nil || tracker.Status.LatestCheckpoint.Name == "" {
+	if tracker.Status == nil {
+		newStatus := &backupv1.VirtualMachineBackupTrackerStatus{
+			LatestCheckpoint: &newCheckpoint,
+		}
+		if podUID != "" {
+			newStatus.LastTrackedPodUID = &podUID
+		}
 		patchSet.AddOption(patch.WithAdd("/status", newStatus))
 	} else {
-		patchSet.AddOption(patch.WithReplace("/status/latestCheckpoint", &newCheckpoint))
+		patchSet.AddOption(patch.WithAdd("/status/latestCheckpoint", &newCheckpoint))
+		if podUID != "" {
+			if tracker.Status.LastTrackedPodUID != nil {
+				patchSet.AddOption(patch.WithTest("/status/lastTrackedPodUID", *tracker.Status.LastTrackedPodUID))
+			}
+			patchSet.AddOption(patch.WithAdd("/status/lastTrackedPodUID", podUID))
+		}
 	}
 
 	patchBytes, err := patchSet.GeneratePayload()

--- a/pkg/storage/cbt/backup_test.go
+++ b/pkg/storage/cbt/backup_test.go
@@ -431,7 +431,7 @@ var _ = Describe("Backup Controller", func() {
 
 	It("should wait when backupTracker needs checkpoint redefinition", func() {
 		backupTracker := createBackupTracker(backupTrackerName, vmName, "existing-checkpoint")
-		backupTracker.Status.CheckpointRedefinitionRequired = pointer.P(true)
+		backupTracker.Status.LastTrackedPodUID = new(types.UID("stale-pod-uid"))
 		controller.backupTrackerInformer.GetStore().Add(backupTracker)
 
 		backup := createBackupWithTracker(backupName, vmName, pvcName)
@@ -441,6 +441,8 @@ var _ = Describe("Backup Controller", func() {
 		controller.vmStore.Add(vm)
 
 		vmi := createVMIWithPVCAttached()
+		vmi.Status.NodeName = "test-node"
+		vmi.Status.ActivePods = map[types.UID]string{types.UID("current-pod-uid"): "test-node"}
 		controller.vmiStore.Add(vmi)
 
 		statusUpdated := false
@@ -1699,7 +1701,7 @@ var _ = Describe("Backup Controller", func() {
 			Expect(backupCopy.Status.IncludedVolumes[1].VolumeName).To(Equal("datadisk"))
 		},
 		Entry("when tracker has no previous checkpoint", "", "\"op\":\"add\""),
-		Entry("when tracker already has a checkpoint", "old-checkpoint", "\"op\":\"replace\""),
+		Entry("when tracker already has a checkpoint", "old-checkpoint", "\"op\":\"add\""),
 	)
 
 	It("should update backupTracker even when cleanup returns early", func() {

--- a/pkg/storage/cbt/backuptracker.go
+++ b/pkg/storage/cbt/backuptracker.go
@@ -29,18 +29,37 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	backupv1 "kubevirt.io/api/backup/v1alpha1"
+	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
 
 	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
 )
 
-func trackerNeedsCheckpointRedefinition(tracker *backupv1.VirtualMachineBackupTracker) bool {
+func trackerHasCheckpoint(tracker *backupv1.VirtualMachineBackupTracker) bool {
 	return tracker != nil &&
 		tracker.Status != nil &&
-		tracker.Status.CheckpointRedefinitionRequired != nil &&
-		*tracker.Status.CheckpointRedefinitionRequired &&
 		tracker.Status.LatestCheckpoint != nil &&
 		tracker.Status.LatestCheckpoint.Name != ""
+}
+
+func trackerNeedsRedefinitionForPod(tracker *backupv1.VirtualMachineBackupTracker, vmi *v1.VirtualMachineInstance) bool {
+	if !trackerHasCheckpoint(tracker) {
+		return false
+	}
+	podUID := ActivePodUID(vmi)
+	if podUID == "" {
+		return false
+	}
+	return tracker.Status.LastTrackedPodUID == nil || *tracker.Status.LastTrackedPodUID != podUID
+}
+
+func ActivePodUID(vmi *v1.VirtualMachineInstance) types.UID {
+	for uid, nodeName := range vmi.Status.ActivePods {
+		if nodeName == vmi.Status.NodeName {
+			return uid
+		}
+	}
+	return ""
 }
 
 func (ctrl *VMBackupController) runTrackerWorker() {
@@ -86,36 +105,46 @@ func (ctrl *VMBackupController) executeTracker(key string) error {
 		return fmt.Errorf("unexpected resource %+v", storeObj)
 	}
 
-	if !trackerNeedsCheckpointRedefinition(tracker) {
+	if !trackerHasCheckpoint(tracker) {
 		return nil
 	}
 
-	return ctrl.handleCheckpointRedefinition(tracker)
+	vmiName := tracker.Spec.Source.Name
+	vmi, vmiExists, err := ctrl.getVMI(tracker.Namespace, vmiName)
+	if err != nil {
+		return fmt.Errorf("failed to get VMI %s/%s: %w", tracker.Namespace, vmiName, err)
+	}
+	if !vmiExists || vmi == nil {
+		return fmt.Errorf("VMI %s/%s not found", tracker.Namespace, vmiName)
+	}
+
+	podUID := ActivePodUID(vmi)
+	if podUID == "" {
+		return nil
+	}
+
+	if tracker.Status.LastTrackedPodUID != nil && *tracker.Status.LastTrackedPodUID == podUID {
+		return nil
+	}
+
+	return ctrl.handleCheckpointRedefinition(tracker, podUID)
 }
 
-func (ctrl *VMBackupController) handleCheckpointRedefinition(tracker *backupv1.VirtualMachineBackupTracker) error {
+func (ctrl *VMBackupController) handleCheckpointRedefinition(tracker *backupv1.VirtualMachineBackupTracker, podUID types.UID) error {
 	logger := log.Log.With("VirtualMachineBackupTracker", tracker.Name)
 	logger.Infof("Handling checkpoint redefinition for tracker %s/%s", tracker.Namespace, tracker.Name)
 
 	vmiName := tracker.Spec.Source.Name
-	vmi, exists, err := ctrl.getVMI(tracker.Namespace, vmiName)
-	if err != nil {
-		return fmt.Errorf("failed to get VMI %s/%s: %w", tracker.Namespace, vmiName, err)
-	}
-	if !exists || vmi == nil {
-		return fmt.Errorf("VMI %s/%s not found", tracker.Namespace, vmiName)
-	}
-
 	checkpoint := tracker.Status.LatestCheckpoint
 	logger.Infof("Calling RedefineCheckpoint for VMI %s with checkpoint %s", vmiName, checkpoint.Name)
 
-	err = ctrl.client.VirtualMachineInstance(tracker.Namespace).RedefineCheckpoint(context.Background(), vmiName, checkpoint)
+	err := ctrl.client.VirtualMachineInstance(tracker.Namespace).RedefineCheckpoint(context.Background(), vmiName, checkpoint)
 	if err != nil {
 		return ctrl.handleRedefinitionError(tracker, err)
 	}
 
 	logger.Infof("Checkpoint redefinition successful for tracker %s/%s", tracker.Namespace, tracker.Name)
-	return ctrl.clearRedefinitionFlag(tracker)
+	return ctrl.updateLastTrackedPodUID(tracker, podUID)
 }
 
 func (ctrl *VMBackupController) handleRedefinitionError(tracker *backupv1.VirtualMachineBackupTracker, err error) error {
@@ -126,7 +155,7 @@ func (ctrl *VMBackupController) handleRedefinitionError(tracker *backupv1.Virtua
 		ctrl.recorder.Eventf(tracker, corev1.EventTypeWarning, "CheckpointRedefinitionFailed",
 			"Failed to redefine checkpoint %s: %v. Checkpoint cleared, next backup will be full.",
 			tracker.Status.LatestCheckpoint.Name, err)
-		return ctrl.clearCheckpointAndFlag(tracker)
+		return ctrl.clearCheckpointAndTrackedPod(tracker)
 	}
 
 	logger.Errorf("Checkpoint redefinition failed: %v", err)
@@ -141,15 +170,26 @@ func isCheckpointInvalidError(err error) bool {
 	return strings.Contains(errStr, "422") && strings.Contains(errStr, "Unprocessable Entity")
 }
 
-func (ctrl *VMBackupController) clearRedefinitionFlag(tracker *backupv1.VirtualMachineBackupTracker) error {
-	return ctrl.patchTrackerStatus(tracker, patch.WithRemove("/status/checkpointRedefinitionRequired"))
+func (ctrl *VMBackupController) updateLastTrackedPodUID(tracker *backupv1.VirtualMachineBackupTracker, podUID types.UID) error {
+	if tracker.Status.LastTrackedPodUID != nil {
+		return ctrl.patchTrackerStatus(tracker,
+			patch.WithTest("/status/lastTrackedPodUID", *tracker.Status.LastTrackedPodUID),
+			patch.WithReplace("/status/lastTrackedPodUID", podUID),
+		)
+	}
+	return ctrl.patchTrackerStatus(tracker,
+		patch.WithAdd("/status/lastTrackedPodUID", podUID),
+	)
 }
 
-func (ctrl *VMBackupController) clearCheckpointAndFlag(tracker *backupv1.VirtualMachineBackupTracker) error {
-	return ctrl.patchTrackerStatus(tracker,
-		patch.WithRemove("/status/checkpointRedefinitionRequired"),
+func (ctrl *VMBackupController) clearCheckpointAndTrackedPod(tracker *backupv1.VirtualMachineBackupTracker) error {
+	opts := []patch.PatchOption{
 		patch.WithRemove("/status/latestCheckpoint"),
-	)
+	}
+	if tracker.Status.LastTrackedPodUID != nil {
+		opts = append(opts, patch.WithRemove("/status/lastTrackedPodUID"))
+	}
+	return ctrl.patchTrackerStatus(tracker, opts...)
 }
 
 func (ctrl *VMBackupController) patchTrackerStatus(tracker *backupv1.VirtualMachineBackupTracker, opts ...patch.PatchOption) error {

--- a/pkg/storage/cbt/backuptracker_test.go
+++ b/pkg/storage/cbt/backuptracker_test.go
@@ -29,6 +29,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
 
@@ -50,21 +51,34 @@ var _ = Describe("VMBackupController", func() {
 		kubevirtCli *kubevirtfake.Clientset
 	)
 
+	const (
+		testNodeName = "test-node"
+	)
+
+	var (
+		testPodUID  = types.UID("test-pod-uid-123")
+		stalePodUID = types.UID("stale-pod-uid-456")
+	)
+
 	BeforeEach(func() {
 		mockCtrl = gomock.NewController(GinkgoT())
 		kubevirtCli = kubevirtfake.NewSimpleClientset()
 		virtClient = kubecli.NewMockKubevirtClient(mockCtrl)
 	})
 
-	Context("trackerNeedsCheckpointRedefinition", func() {
-		DescribeTable("should correctly identify trackers needing redefinition",
+	setActivePod := func(vmi *v1.VirtualMachineInstance, podUID types.UID) {
+		vmi.Status.NodeName = testNodeName
+		vmi.Status.ActivePods = map[types.UID]string{podUID: testNodeName}
+	}
+
+	Context("trackerHasCheckpoint", func() {
+		DescribeTable("should correctly identify trackers with checkpoints",
 			func(tracker *backupv1.VirtualMachineBackupTracker, expected bool) {
-				Expect(trackerNeedsCheckpointRedefinition(tracker)).To(Equal(expected))
+				Expect(trackerHasCheckpoint(tracker)).To(Equal(expected))
 			},
-			Entry("needs redefinition when all conditions met",
+			Entry("has checkpoint",
 				&backupv1.VirtualMachineBackupTracker{
 					Status: &backupv1.VirtualMachineBackupTrackerStatus{
-						CheckpointRedefinitionRequired: pointer.P(true),
 						LatestCheckpoint: &backupv1.BackupCheckpoint{
 							Name: "checkpoint-1",
 						},
@@ -72,51 +86,27 @@ var _ = Describe("VMBackupController", func() {
 				},
 				true,
 			),
-			Entry("does not need redefinition when tracker is nil",
+			Entry("tracker is nil",
 				nil,
 				false,
 			),
-			Entry("does not need redefinition when status is nil",
+			Entry("status is nil",
 				&backupv1.VirtualMachineBackupTracker{
 					Status: nil,
 				},
 				false,
 			),
-			Entry("does not need redefinition when flag is nil",
+			Entry("checkpoint is nil",
 				&backupv1.VirtualMachineBackupTracker{
 					Status: &backupv1.VirtualMachineBackupTrackerStatus{
-						CheckpointRedefinitionRequired: nil,
-						LatestCheckpoint: &backupv1.BackupCheckpoint{
-							Name: "checkpoint-1",
-						},
+						LatestCheckpoint: nil,
 					},
 				},
 				false,
 			),
-			Entry("does not need redefinition when flag is false",
+			Entry("checkpoint name is empty",
 				&backupv1.VirtualMachineBackupTracker{
 					Status: &backupv1.VirtualMachineBackupTrackerStatus{
-						CheckpointRedefinitionRequired: pointer.P(false),
-						LatestCheckpoint: &backupv1.BackupCheckpoint{
-							Name: "checkpoint-1",
-						},
-					},
-				},
-				false,
-			),
-			Entry("does not need redefinition when checkpoint is nil",
-				&backupv1.VirtualMachineBackupTracker{
-					Status: &backupv1.VirtualMachineBackupTrackerStatus{
-						CheckpointRedefinitionRequired: pointer.P(true),
-						LatestCheckpoint:               nil,
-					},
-				},
-				false,
-			),
-			Entry("does not need redefinition when checkpoint name is empty",
-				&backupv1.VirtualMachineBackupTracker{
-					Status: &backupv1.VirtualMachineBackupTrackerStatus{
-						CheckpointRedefinitionRequired: pointer.P(true),
 						LatestCheckpoint: &backupv1.BackupCheckpoint{
 							Name: "",
 						},
@@ -127,42 +117,129 @@ var _ = Describe("VMBackupController", func() {
 		)
 	})
 
-	Context("clearRedefinitionFlag", func() {
-		var (
-			ctrl    *VMBackupController
-			tracker *backupv1.VirtualMachineBackupTracker
-		)
-
-		BeforeEach(func() {
-			ctrl = &VMBackupController{
-				client: virtClient,
-			}
-
-			tracker = createTracker("tracker1", "test-vmi", true, true)
-			_, err := kubevirtCli.BackupV1alpha1().VirtualMachineBackupTrackers(testNamespace).Create(
-				context.Background(), tracker, metav1.CreateOptions{})
-			Expect(err).ToNot(HaveOccurred())
+	Context("ActivePodUID", func() {
+		It("should return the UID of the pod matching NodeName", func() {
+			vmi := libvmi.New(libvmi.WithNamespace(testNamespace), libvmi.WithName("test-vmi"))
+			setActivePod(vmi, testPodUID)
+			Expect(ActivePodUID(vmi)).To(Equal(testPodUID))
 		})
 
-		It("should clear only the redefinition flag", func() {
-			virtClient.EXPECT().VirtualMachineBackupTracker(testNamespace).
-				Return(kubevirtCli.BackupV1alpha1().VirtualMachineBackupTrackers(testNamespace))
+		It("should return empty when ActivePods is empty", func() {
+			vmi := libvmi.New(libvmi.WithNamespace(testNamespace), libvmi.WithName("test-vmi"))
+			vmi.Status.NodeName = testNodeName
+			Expect(ActivePodUID(vmi)).To(Equal(types.UID("")))
+		})
 
-			err := ctrl.clearRedefinitionFlag(tracker)
-			Expect(err).ToNot(HaveOccurred())
+		It("should return empty when no pod matches NodeName", func() {
+			vmi := libvmi.New(libvmi.WithNamespace(testNamespace), libvmi.WithName("test-vmi"))
+			vmi.Status.NodeName = testNodeName
+			vmi.Status.ActivePods = map[types.UID]string{
+				testPodUID: "other-node",
+			}
+			Expect(ActivePodUID(vmi)).To(Equal(types.UID("")))
+		})
 
-			updated, err := kubevirtCli.BackupV1alpha1().VirtualMachineBackupTrackers(testNamespace).Get(
-				context.Background(), "tracker1", metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			// Flag should be cleared
-			Expect(updated.Status.CheckpointRedefinitionRequired).To(BeNil())
-			// Checkpoint should still exist
-			Expect(updated.Status.LatestCheckpoint).ToNot(BeNil())
-			Expect(updated.Status.LatestCheckpoint.Name).To(Equal("checkpoint-1"))
+		It("should return correct UID during migration with two active pods", func() {
+			sourceNodeName := "source-node"
+			targetNodeName := "target-node"
+			sourcePodUID := types.UID("source-pod-uid")
+			targetPodUID := types.UID("target-pod-uid")
+
+			vmi := libvmi.New(libvmi.WithNamespace(testNamespace), libvmi.WithName("test-vmi"))
+			vmi.Status.ActivePods = map[types.UID]string{
+				sourcePodUID: sourceNodeName,
+				targetPodUID: targetNodeName,
+			}
+
+			vmi.Status.NodeName = sourceNodeName
+			Expect(ActivePodUID(vmi)).To(Equal(sourcePodUID))
+
+			vmi.Status.NodeName = targetNodeName
+			Expect(ActivePodUID(vmi)).To(Equal(targetPodUID))
+		})
+
+		It("should return empty when NodeName is not set", func() {
+			vmi := libvmi.New(libvmi.WithNamespace(testNamespace), libvmi.WithName("test-vmi"))
+			vmi.Status.ActivePods = map[types.UID]string{testPodUID: testNodeName}
+			Expect(ActivePodUID(vmi)).To(Equal(types.UID("")))
 		})
 	})
 
-	Context("clearCheckpointAndFlag", func() {
+	Context("trackerNeedsRedefinitionForPod", func() {
+		DescribeTable("with an active pod",
+			func(hasCheckpoint bool, trackedPodUID *types.UID, expected bool) {
+				tracker := createTracker("tracker1", "test-vmi", hasCheckpoint, trackedPodUID)
+				vmi := libvmi.New(libvmi.WithNamespace(testNamespace), libvmi.WithName("test-vmi"))
+				setActivePod(vmi, testPodUID)
+				Expect(trackerNeedsRedefinitionForPod(tracker, vmi)).To(Equal(expected))
+			},
+			Entry("nil LastTrackedPodUID", true, nil, true),
+			Entry("stale LastTrackedPodUID", true, new(stalePodUID), true),
+			Entry("matching LastTrackedPodUID", true, new(testPodUID), false),
+			Entry("no checkpoint", false, nil, false),
+		)
+
+		It("does not need redefinition when VMI has no active pod", func() {
+			tracker := createTracker("tracker1", "test-vmi", true, nil)
+			vmi := libvmi.New(libvmi.WithNamespace(testNamespace), libvmi.WithName("test-vmi"))
+			Expect(trackerNeedsRedefinitionForPod(tracker, vmi)).To(BeFalse())
+		})
+	})
+
+	Context("updateLastTrackedPodUID", func() {
+		var (
+			ctrl    *VMBackupController
+			tracker *backupv1.VirtualMachineBackupTracker
+		)
+
+		BeforeEach(func() {
+			ctrl = &VMBackupController{
+				client: virtClient,
+			}
+		})
+
+		It("should add LastTrackedPodUID when nil", func() {
+			tracker = createTracker("tracker1", "test-vmi", true, nil)
+			_, err := kubevirtCli.BackupV1alpha1().VirtualMachineBackupTrackers(testNamespace).Create(
+				context.Background(), tracker, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			virtClient.EXPECT().VirtualMachineBackupTracker(testNamespace).
+				Return(kubevirtCli.BackupV1alpha1().VirtualMachineBackupTrackers(testNamespace))
+
+			err = ctrl.updateLastTrackedPodUID(tracker, testPodUID)
+			Expect(err).ToNot(HaveOccurred())
+
+			updated, err := kubevirtCli.BackupV1alpha1().VirtualMachineBackupTrackers(testNamespace).Get(
+				context.Background(), "tracker1", metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updated.Status.LastTrackedPodUID).ToNot(BeNil())
+			Expect(*updated.Status.LastTrackedPodUID).To(Equal(testPodUID))
+			Expect(updated.Status.LatestCheckpoint).ToNot(BeNil())
+			Expect(updated.Status.LatestCheckpoint.Name).To(Equal("checkpoint-1"))
+		})
+
+		It("should replace LastTrackedPodUID when already set", func() {
+			tracker = createTracker("tracker1", "test-vmi", true, pointer.P(stalePodUID))
+			_, err := kubevirtCli.BackupV1alpha1().VirtualMachineBackupTrackers(testNamespace).Create(
+				context.Background(), tracker, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			virtClient.EXPECT().VirtualMachineBackupTracker(testNamespace).
+				Return(kubevirtCli.BackupV1alpha1().VirtualMachineBackupTrackers(testNamespace))
+
+			err = ctrl.updateLastTrackedPodUID(tracker, testPodUID)
+			Expect(err).ToNot(HaveOccurred())
+
+			updated, err := kubevirtCli.BackupV1alpha1().VirtualMachineBackupTrackers(testNamespace).Get(
+				context.Background(), "tracker1", metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updated.Status.LastTrackedPodUID).ToNot(BeNil())
+			Expect(*updated.Status.LastTrackedPodUID).To(Equal(testPodUID))
+		})
+	})
+
+	Context("clearCheckpointAndTrackedPod", func() {
 		var (
 			ctrl    *VMBackupController
 			tracker *backupv1.VirtualMachineBackupTracker
@@ -173,23 +250,23 @@ var _ = Describe("VMBackupController", func() {
 				client: virtClient,
 			}
 
-			tracker = createTracker("tracker1", "test-vmi", true, true)
+			tracker = createTracker("tracker1", "test-vmi", true, pointer.P(testPodUID))
 			_, err := kubevirtCli.BackupV1alpha1().VirtualMachineBackupTrackers(testNamespace).Create(
 				context.Background(), tracker, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("should clear both checkpoint and redefinition flag", func() {
+		It("should clear both checkpoint and LastTrackedPodUID", func() {
 			virtClient.EXPECT().VirtualMachineBackupTracker(testNamespace).
 				Return(kubevirtCli.BackupV1alpha1().VirtualMachineBackupTrackers(testNamespace))
 
-			err := ctrl.clearCheckpointAndFlag(tracker)
+			err := ctrl.clearCheckpointAndTrackedPod(tracker)
 			Expect(err).ToNot(HaveOccurred())
 
 			updated, err := kubevirtCli.BackupV1alpha1().VirtualMachineBackupTrackers(testNamespace).Get(
 				context.Background(), "tracker1", metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			Expect(updated.Status.CheckpointRedefinitionRequired).To(BeNil())
+			Expect(updated.Status.LastTrackedPodUID).To(BeNil())
 			Expect(updated.Status.LatestCheckpoint).To(BeNil())
 		})
 	})
@@ -226,33 +303,44 @@ var _ = Describe("VMBackupController", func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("should return nil when tracker no longer needs redefinition", func() {
-			// Tracker without redefinition flag set
-			tracker := createTracker("tracker1", "test-vmi", false, false)
+		It("should return nil when tracker has no checkpoint", func() {
+			tracker := createTracker("tracker1", "test-vmi", false, nil)
 			Expect(trackerInformer.GetStore().Add(tracker)).To(Succeed())
+
+			err := ctrl.executeTracker(testNamespace + "/tracker1")
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should return nil when LastTrackedPodUID already matches", func() {
+			tracker := createTracker("tracker1", "test-vmi", true, pointer.P(testPodUID))
+			Expect(trackerInformer.GetStore().Add(tracker)).To(Succeed())
+
+			testVMI := libvmi.New(libvmi.WithNamespace(testNamespace), libvmi.WithName("test-vmi"))
+			setActivePod(testVMI, testPodUID)
+			Expect(vmiInformer.GetStore().Add(testVMI)).To(Succeed())
 
 			err := ctrl.executeTracker(testNamespace + "/tracker1")
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		It("should return error when VMI not found", func() {
-			tracker := createTracker("tracker1", "test-vmi", true, true)
+			tracker := createTracker("tracker1", "test-vmi", true, nil)
 			Expect(trackerInformer.GetStore().Add(tracker)).To(Succeed())
-			// Don't add VMI to store
 
 			err := ctrl.executeTracker(testNamespace + "/tracker1")
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("not found"))
 		})
 
-		It("should call RedefineCheckpoint and clear flag on success", func() {
-			tracker := createTracker("tracker1", "test-vmi", true, true)
+		It("should call RedefineCheckpoint and set LastTrackedPodUID on success", func() {
+			tracker := createTracker("tracker1", "test-vmi", true, nil)
 			Expect(trackerInformer.GetStore().Add(tracker)).To(Succeed())
 			_, err := kubevirtCli.BackupV1alpha1().VirtualMachineBackupTrackers(testNamespace).Create(
 				context.Background(), tracker, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			testVMI := libvmi.New(libvmi.WithNamespace(testNamespace), libvmi.WithName("test-vmi"))
+			setActivePod(testVMI, testPodUID)
 			Expect(vmiInformer.GetStore().Add(testVMI)).To(Succeed())
 
 			virtClient.EXPECT().VirtualMachineInstance(testNamespace).Return(vmiInterface)
@@ -263,23 +351,49 @@ var _ = Describe("VMBackupController", func() {
 			err = ctrl.executeTracker(testNamespace + "/tracker1")
 			Expect(err).ToNot(HaveOccurred())
 
-			// Verify flag was cleared
 			updated, err := kubevirtCli.BackupV1alpha1().VirtualMachineBackupTrackers(testNamespace).Get(
 				context.Background(), "tracker1", metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			Expect(updated.Status.CheckpointRedefinitionRequired).To(BeNil())
-			// Checkpoint should still exist
+			Expect(updated.Status.LastTrackedPodUID).ToNot(BeNil())
+			Expect(*updated.Status.LastTrackedPodUID).To(Equal(testPodUID))
 			Expect(updated.Status.LatestCheckpoint).ToNot(BeNil())
 		})
 
-		It("should clear checkpoint on permanent error (HTTP 422)", func() {
-			tracker := createTracker("tracker1", "test-vmi", true, true)
+		It("should redefine when LastTrackedPodUID is stale", func() {
+			tracker := createTracker("tracker1", "test-vmi", true, pointer.P(stalePodUID))
 			Expect(trackerInformer.GetStore().Add(tracker)).To(Succeed())
 			_, err := kubevirtCli.BackupV1alpha1().VirtualMachineBackupTrackers(testNamespace).Create(
 				context.Background(), tracker, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			testVMI := libvmi.New(libvmi.WithNamespace(testNamespace), libvmi.WithName("test-vmi"))
+			setActivePod(testVMI, testPodUID)
+			Expect(vmiInformer.GetStore().Add(testVMI)).To(Succeed())
+
+			virtClient.EXPECT().VirtualMachineInstance(testNamespace).Return(vmiInterface)
+			vmiInterface.EXPECT().RedefineCheckpoint(gomock.Any(), "test-vmi", gomock.Any()).Return(nil)
+			virtClient.EXPECT().VirtualMachineBackupTracker(testNamespace).
+				Return(kubevirtCli.BackupV1alpha1().VirtualMachineBackupTrackers(testNamespace))
+
+			err = ctrl.executeTracker(testNamespace + "/tracker1")
+			Expect(err).ToNot(HaveOccurred())
+
+			updated, err := kubevirtCli.BackupV1alpha1().VirtualMachineBackupTrackers(testNamespace).Get(
+				context.Background(), "tracker1", metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updated.Status.LastTrackedPodUID).ToNot(BeNil())
+			Expect(*updated.Status.LastTrackedPodUID).To(Equal(testPodUID))
+		})
+
+		It("should clear checkpoint on permanent error (HTTP 422)", func() {
+			tracker := createTracker("tracker1", "test-vmi", true, pointer.P(stalePodUID))
+			Expect(trackerInformer.GetStore().Add(tracker)).To(Succeed())
+			_, err := kubevirtCli.BackupV1alpha1().VirtualMachineBackupTrackers(testNamespace).Create(
+				context.Background(), tracker, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			testVMI := libvmi.New(libvmi.WithNamespace(testNamespace), libvmi.WithName("test-vmi"))
+			setActivePod(testVMI, testPodUID)
 			Expect(vmiInformer.GetStore().Add(testVMI)).To(Succeed())
 
 			invalidErr := errors.New("unexpected return code 422 (422 Unprocessable Entity), message: RedefineCheckpoint failed: virError(Code=109, Domain=10, Message='checkpoint inconsistent: missing or broken bitmap')")
@@ -292,25 +406,24 @@ var _ = Describe("VMBackupController", func() {
 			err = ctrl.executeTracker(testNamespace + "/tracker1")
 			Expect(err).ToNot(HaveOccurred())
 
-			// Verify both checkpoint and flag were cleared
 			updated, err := kubevirtCli.BackupV1alpha1().VirtualMachineBackupTrackers(testNamespace).Get(
 				context.Background(), "tracker1", metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			Expect(updated.Status.CheckpointRedefinitionRequired).To(BeNil())
+			Expect(updated.Status.LastTrackedPodUID).To(BeNil())
 			Expect(updated.Status.LatestCheckpoint).To(BeNil())
 
-			// Verify event was emitted
 			Eventually(recorder.Events).Should(Receive(ContainSubstring("CheckpointRedefinitionFailed")))
 		})
 
 		It("should return error for requeue on transient error (HTTP 503)", func() {
-			tracker := createTracker("tracker1", "test-vmi", true, true)
+			tracker := createTracker("tracker1", "test-vmi", true, pointer.P(stalePodUID))
 			Expect(trackerInformer.GetStore().Add(tracker)).To(Succeed())
 			_, err := kubevirtCli.BackupV1alpha1().VirtualMachineBackupTrackers(testNamespace).Create(
 				context.Background(), tracker, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 
 			testVMI := libvmi.New(libvmi.WithNamespace(testNamespace), libvmi.WithName("test-vmi"))
+			setActivePod(testVMI, testPodUID)
 			Expect(vmiInformer.GetStore().Add(testVMI)).To(Succeed())
 
 			transientErr := apierrors.NewServiceUnavailable("service temporarily unavailable")
@@ -322,15 +435,13 @@ var _ = Describe("VMBackupController", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(apierrors.IsServiceUnavailable(err)).To(BeTrue())
 
-			// Verify tracker was NOT modified
 			updated, err := kubevirtCli.BackupV1alpha1().VirtualMachineBackupTrackers(testNamespace).Get(
 				context.Background(), "tracker1", metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
-			Expect(updated.Status.CheckpointRedefinitionRequired).ToNot(BeNil())
-			Expect(*updated.Status.CheckpointRedefinitionRequired).To(BeTrue())
+			Expect(updated.Status.LastTrackedPodUID).ToNot(BeNil())
+			Expect(*updated.Status.LastTrackedPodUID).To(Equal(stalePodUID))
 			Expect(updated.Status.LatestCheckpoint).ToNot(BeNil())
 
-			// Verify no event was emitted
 			Consistently(recorder.Events).ShouldNot(Receive())
 		})
 	})
@@ -351,7 +462,7 @@ var _ = Describe("VMBackupController", func() {
 				recorder: recorder,
 			}
 
-			tracker = createTracker("tracker1", "test-vmi", true, true)
+			tracker = createTracker("tracker1", "test-vmi", true, pointer.P(stalePodUID))
 			_, err := kubevirtCli.BackupV1alpha1().VirtualMachineBackupTrackers(testNamespace).Create(
 				context.Background(), tracker, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
@@ -364,13 +475,11 @@ var _ = Describe("VMBackupController", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(apierrors.IsServiceUnavailable(err)).To(BeTrue())
 
-			// Verify checkpoint was NOT cleared (tracker unchanged in fake client)
 			updated, err := kubevirtCli.BackupV1alpha1().VirtualMachineBackupTrackers(testNamespace).Get(
 				context.Background(), "tracker1", metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(updated.Status.LatestCheckpoint).ToNot(BeNil())
 
-			// Verify no event was emitted
 			Consistently(recorder.Events).ShouldNot(Receive())
 		})
 
@@ -381,13 +490,11 @@ var _ = Describe("VMBackupController", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(Equal("some transient network error"))
 
-			// Verify checkpoint was NOT cleared
 			updated, err := kubevirtCli.BackupV1alpha1().VirtualMachineBackupTrackers(testNamespace).Get(
 				context.Background(), "tracker1", metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(updated.Status.LatestCheckpoint).ToNot(BeNil())
 
-			// Verify no event was emitted
 			Consistently(recorder.Events).ShouldNot(Receive())
 		})
 
@@ -403,14 +510,14 @@ var _ = Describe("VMBackupController", func() {
 				context.Background(), "tracker1", metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(updated.Status.LatestCheckpoint).To(BeNil())
-			Expect(updated.Status.CheckpointRedefinitionRequired).To(BeNil())
+			Expect(updated.Status.LastTrackedPodUID).To(BeNil())
 
 			Eventually(recorder.Events).Should(Receive(ContainSubstring("CheckpointRedefinitionFailed")))
 		})
 	})
 })
 
-func createTracker(name, vmName string, hasCheckpoint bool, redefinitionRequired bool) *backupv1.VirtualMachineBackupTracker {
+func createTracker(name, vmName string, hasCheckpoint bool, syncedPodUID *types.UID) *backupv1.VirtualMachineBackupTracker {
 	tracker := &backupv1.VirtualMachineBackupTracker{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -429,7 +536,7 @@ func createTracker(name, vmName string, hasCheckpoint bool, redefinitionRequired
 			LatestCheckpoint: &backupv1.BackupCheckpoint{
 				Name: "checkpoint-1",
 			},
-			CheckpointRedefinitionRequired: pointer.P(redefinitionRequired),
+			LastTrackedPodUID: syncedPodUID,
 		}
 	}
 	return tracker

--- a/pkg/virt-api/rest/lifecycle.go
+++ b/pkg/virt-api/rest/lifecycle.go
@@ -667,9 +667,9 @@ func (app *SubresourceAPIApp) BackupVMIRequestHandler(request *restful.Request, 
 func (app *SubresourceAPIApp) RedefineCheckpointVMIRequestHandler(request *restful.Request, response *restful.Response) {
 	validate := func(vmi *v1.VirtualMachineInstance) *errors.StatusError {
 		if vmi.Status.ChangedBlockTracking == nil ||
-			vmi.Status.ChangedBlockTracking.State != v1.ChangedBlockTrackingEnabled {
+			vmi.Status.ChangedBlockTracking.State != v1.ChangedBlockTrackingInitializing {
 			return errors.NewConflict(v1.Resource("virtualmachineinstance"), vmi.Name,
-				fmt.Errorf("ChangedBlockTracking is not enabled"))
+				fmt.Errorf("ChangedBlockTracking is not initializing"))
 		}
 		return nil
 	}

--- a/pkg/virt-handler/cbt.go
+++ b/pkg/virt-handler/cbt.go
@@ -20,39 +20,33 @@
 package virthandler
 
 import (
-	"context"
 	"fmt"
+	"slices"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
 	backupv1 "kubevirt.io/api/backup/v1alpha1"
 	v1 "kubevirt.io/api/core/v1"
-	"kubevirt.io/client-go/kubecli"
-	"kubevirt.io/client-go/log"
 
 	"kubevirt.io/kubevirt/pkg/storage/cbt"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )
 
 type CBTHandler struct {
-	virtClient      kubecli.KubevirtClient
 	trackerInformer cache.SharedIndexInformer
 }
 
 func NewCBTHandler(
-	virtClient kubecli.KubevirtClient,
 	trackerInformer cache.SharedIndexInformer,
 ) *CBTHandler {
 	return &CBTHandler{
-		virtClient:      virtClient,
 		trackerInformer: trackerInformer,
 	}
 }
 
 // HandleChangedBlockTracking updates CBT status based on domain state.
-// If CBT is transitioning from Initializing to Enabled and there are trackers with checkpoints,
-// they will be marked for redefinition before enabling CBT.
+// If CBT is Initializing and all disks have DataStore, it transitions to
+// Enabled only after all trackers with checkpoints have been synced for
+// the current pod lifecycle.
 func (h *CBTHandler) HandleChangedBlockTracking(vmi *v1.VirtualMachineInstance, domain *api.Domain) error {
 	if domain == nil || !cbt.CBTStateInitializing(vmi.Status.ChangedBlockTracking) {
 		return nil
@@ -62,11 +56,12 @@ func (h *CBTHandler) HandleChangedBlockTracking(vmi *v1.VirtualMachineInstance, 
 		return nil
 	}
 
-	// Before transitioning from Initializing to Enabled, mark trackers with checkpoints for redefinition
-	if cbt.CompareCBTState(vmi.Status.ChangedBlockTracking, v1.ChangedBlockTrackingInitializing) {
-		if err := h.markTrackersForRedefinition(vmi); err != nil {
-			return err
-		}
+	needsRedefinition, err := h.anyTrackerNeedsRedefinition(vmi)
+	if err != nil {
+		return err
+	}
+	if needsRedefinition {
+		return nil
 	}
 
 	cbt.SetCBTState(&vmi.Status.ChangedBlockTracking, v1.ChangedBlockTrackingEnabled)
@@ -95,16 +90,15 @@ func (h *CBTHandler) allDisksHaveDataStore(vmi *v1.VirtualMachineInstance, domai
 	return true
 }
 
-func (h *CBTHandler) backupTrackersForVMI(vmi *v1.VirtualMachineInstance) []*backupv1.VirtualMachineBackupTracker {
+func (h *CBTHandler) backupTrackersForVMI(vmi *v1.VirtualMachineInstance) ([]*backupv1.VirtualMachineBackupTracker, error) {
 	if h.trackerInformer == nil {
-		return nil
+		return nil, nil
 	}
 
 	key := fmt.Sprintf("%s/%s", vmi.Namespace, vmi.Name)
 	objs, err := h.trackerInformer.GetIndexer().ByIndex("vmi", key)
 	if err != nil {
-		log.Log.Object(vmi).Reason(err).Warning("Failed to get backup trackers from informer index")
-		return nil
+		return nil, fmt.Errorf("failed to get backup trackers from informer index: %w", err)
 	}
 
 	var trackers []*backupv1.VirtualMachineBackupTracker
@@ -113,38 +107,22 @@ func (h *CBTHandler) backupTrackersForVMI(vmi *v1.VirtualMachineInstance) []*bac
 			trackers = append(trackers, tracker)
 		}
 	}
-	return trackers
+	return trackers, nil
 }
 
-func (h *CBTHandler) markTrackersForRedefinition(vmi *v1.VirtualMachineInstance) error {
-	if h.trackerInformer == nil || h.virtClient == nil {
-		return fmt.Errorf("tracker informer or virtClient is nil")
+func (h *CBTHandler) anyTrackerNeedsRedefinition(vmi *v1.VirtualMachineInstance) (bool, error) {
+	podUID := cbt.ActivePodUID(vmi)
+	if podUID == "" {
+		return false, nil
 	}
-
-	trackers := h.backupTrackersForVMI(vmi)
-
-	for _, tracker := range trackers {
-		if tracker.Status == nil || tracker.Status.LatestCheckpoint == nil {
-			continue
-		}
-		if tracker.Status.CheckpointRedefinitionRequired != nil && *tracker.Status.CheckpointRedefinitionRequired {
-			continue
-		}
-
-		patch := []byte(`{"status":{"checkpointRedefinitionRequired":true}}`)
-		_, err := h.virtClient.VirtualMachineBackupTracker(tracker.Namespace).Patch(
-			context.Background(),
-			tracker.Name,
-			types.MergePatchType,
-			patch,
-			metav1.PatchOptions{},
-			"status",
-		)
-		if err != nil {
-			log.Log.Object(vmi).Reason(err).Warningf("Failed to mark tracker %s for checkpoint redefinition", tracker.Name)
-			return fmt.Errorf("failed to mark tracker %s for checkpoint redefinition: %w", tracker.Name, err)
-		}
-		log.Log.Object(vmi).Infof("Marked tracker %s for checkpoint redefinition after VM restart", tracker.Name)
+	trackers, err := h.backupTrackersForVMI(vmi)
+	if err != nil {
+		return false, err
 	}
-	return nil
+	return slices.ContainsFunc(trackers, func(t *backupv1.VirtualMachineBackupTracker) bool {
+		return t.Status != nil &&
+			t.Status.LatestCheckpoint != nil &&
+			t.Status.LatestCheckpoint.Name != "" &&
+			(t.Status.LastTrackedPodUID == nil || *t.Status.LastTrackedPodUID != podUID)
+	}), nil
 }

--- a/pkg/virt-handler/cbt_test.go
+++ b/pkg/virt-handler/cbt_test.go
@@ -20,20 +20,16 @@
 package virthandler
 
 import (
-	"context"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"go.uber.org/mock/gomock"
 	corev1 "k8s.io/api/core/v1"
 	k8sv1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
 
 	backupv1 "kubevirt.io/api/backup/v1alpha1"
 	v1 "kubevirt.io/api/core/v1"
-	"kubevirt.io/client-go/kubecli"
-	kubevirtfake "kubevirt.io/client-go/kubevirt/fake"
 
 	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/libvmi"
@@ -45,26 +41,25 @@ import (
 
 var _ = Describe("CBTHandler", func() {
 	var (
-		mockCtrl        *gomock.Controller
 		vmi             *v1.VirtualMachineInstance
-		virtClient      *kubecli.MockKubevirtClient
-		kubevirtCli     *kubevirtfake.Clientset
 		trackerInformer cache.SharedIndexInformer
 		handler         *CBTHandler
 	)
 
-	const testNamespace = "test-ns"
+	const (
+		testNamespace = "test-ns"
+		testNodeName  = "test-node"
+		testPodUID    = "test-pod-uid"
+		stalePodUID   = "stale-pod-uid"
+	)
 
 	BeforeEach(func() {
-		mockCtrl = gomock.NewController(GinkgoT())
 		vmi = libvmi.New(libvmi.WithNamespace(testNamespace), libvmi.WithName("test-vmi"))
-		kubevirtCli = kubevirtfake.NewSimpleClientset()
-		virtClient = kubecli.NewMockKubevirtClient(mockCtrl)
 		trackerInformer, _ = testutils.NewFakeInformerWithIndexersFor(&backupv1.VirtualMachineBackupTracker{}, controller.GetVirtualMachineBackupTrackerInformerIndexers())
-		handler = NewCBTHandler(virtClient, trackerInformer)
+		handler = NewCBTHandler(trackerInformer)
 	})
 
-	createTracker := func(name, vmName string, hasCheckpoint bool, alreadyMarked bool) *backupv1.VirtualMachineBackupTracker {
+	createTracker := func(name, vmName string, hasCheckpoint bool, syncedPodUID *types.UID) *backupv1.VirtualMachineBackupTracker {
 		tracker := &backupv1.VirtualMachineBackupTracker{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      name,
@@ -83,17 +78,19 @@ var _ = Describe("CBTHandler", func() {
 				LatestCheckpoint: &backupv1.BackupCheckpoint{
 					Name: "checkpoint-1",
 				},
-				CheckpointRedefinitionRequired: pointer.P(alreadyMarked),
+				LastTrackedPodUID: syncedPodUID,
 			}
 		}
 		return tracker
 	}
 
 	addTracker := func(tracker *backupv1.VirtualMachineBackupTracker) {
-		_, err := kubevirtCli.BackupV1alpha1().VirtualMachineBackupTrackers(testNamespace).Create(
-			context.Background(), tracker, metav1.CreateOptions{})
-		ExpectWithOffset(1, err).ToNot(HaveOccurred())
 		ExpectWithOffset(1, trackerInformer.GetStore().Add(tracker)).To(Succeed())
+	}
+
+	setActivePod := func(vmi *v1.VirtualMachineInstance, podUID types.UID) {
+		vmi.Status.NodeName = testNodeName
+		vmi.Status.ActivePods = map[types.UID]string{podUID: testNodeName}
 	}
 
 	pvcVolume := func(name, claimName string) v1.Volume {
@@ -153,6 +150,30 @@ var _ = Describe("CBTHandler", func() {
 				v1.ChangedBlockTrackingInitializing),
 		)
 
+		It("should stay Initializing when a tracker needs redefinition", func() {
+			setActivePod(vmi, testPodUID)
+			addTracker(createTracker("tracker1", "test-vmi", true, nil))
+
+			vmi.Spec.Volumes = []v1.Volume{pvcVolume("pvc1", "test-pvc")}
+			domain := &api.Domain{Spec: api.DomainSpec{Devices: api.Devices{Disks: []api.Disk{diskWithDataStore("pvc1", true)}}}}
+
+			err := handler.HandleChangedBlockTracking(vmi, domain)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cbt.CBTState(vmi.Status.ChangedBlockTracking)).To(Equal(v1.ChangedBlockTrackingInitializing))
+		})
+
+		It("should enable when tracker has matching LastTrackedPodUID", func() {
+			setActivePod(vmi, testPodUID)
+			addTracker(createTracker("tracker1", "test-vmi", true, new(types.UID(testPodUID))))
+
+			vmi.Spec.Volumes = []v1.Volume{pvcVolume("pvc1", "test-pvc")}
+			domain := &api.Domain{Spec: api.DomainSpec{Devices: api.Devices{Disks: []api.Disk{diskWithDataStore("pvc1", true)}}}}
+
+			err := handler.HandleChangedBlockTracking(vmi, domain)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cbt.CBTState(vmi.Status.ChangedBlockTracking)).To(Equal(v1.ChangedBlockTrackingEnabled))
+		})
+
 		DescribeTable("should not update VMI CBT state when",
 			func(cbtState *v1.ChangedBlockTrackingState, domainIsNil bool) {
 				if cbtState != nil {
@@ -186,148 +207,86 @@ var _ = Describe("CBTHandler", func() {
 		)
 	})
 
-	Context("markTrackersForRedefinition", func() {
-		It("should return error when informer is nil", func() {
-			handler := NewCBTHandler(virtClient, nil)
-			vmi.Status.ChangedBlockTracking = &v1.ChangedBlockTrackingStatus{State: v1.ChangedBlockTrackingInitializing}
-			err := handler.markTrackersForRedefinition(vmi)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("tracker informer or virtClient is nil"))
-		})
-
-		It("should return error when virtClient is nil", func() {
-			handler := NewCBTHandler(nil, trackerInformer)
-			vmi.Status.ChangedBlockTracking = &v1.ChangedBlockTrackingStatus{State: v1.ChangedBlockTrackingInitializing}
-			err := handler.markTrackersForRedefinition(vmi)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("tracker informer or virtClient is nil"))
-		})
-
-		DescribeTable("should skip trackers that don't need redefinition",
-			func(modifyTracker func(*backupv1.VirtualMachineBackupTracker)) {
-				if modifyTracker != nil {
-					tracker := createTracker("tracker1", "test-vmi", false, false)
-					modifyTracker(tracker)
-					addTracker(tracker)
-				}
-				// expect no patch calls to the tracker
-				virtClient.EXPECT().VirtualMachineBackupTracker(testNamespace).
-					Return(kubevirtCli.BackupV1alpha1().VirtualMachineBackupTrackers(testNamespace)).Times(0)
-
-				err := handler.markTrackersForRedefinition(vmi)
+	Context("anyTrackerNeedsRedefinition", func() {
+		DescribeTable("with a single tracker and active pod",
+			func(hasCheckpoint bool, trackedPodUID *types.UID, expected bool) {
+				setActivePod(vmi, testPodUID)
+				addTracker(createTracker("tracker1", "test-vmi", hasCheckpoint, trackedPodUID))
+				needsRedefinition, err := handler.anyTrackerNeedsRedefinition(vmi)
 				Expect(err).ToNot(HaveOccurred())
+				Expect(needsRedefinition).To(Equal(expected))
 			},
-			Entry("when no trackers exist", nil),
-			Entry("without status", func(t *backupv1.VirtualMachineBackupTracker) {
-				t.Status = nil
-			}),
-			Entry("without latest checkpoint", func(t *backupv1.VirtualMachineBackupTracker) {
-				t.Status = &backupv1.VirtualMachineBackupTrackerStatus{
-					LatestCheckpoint: nil,
-				}
-			}),
-			Entry("already marked for redefinition", func(t *backupv1.VirtualMachineBackupTracker) {
-				t.Status = &backupv1.VirtualMachineBackupTrackerStatus{
-					LatestCheckpoint: &backupv1.BackupCheckpoint{
-						Name: "checkpoint-1",
-					},
-					CheckpointRedefinitionRequired: pointer.P(true),
-				}
-			}),
+			Entry("no checkpoint", false, nil, false),
+			Entry("untracked checkpoint", true, nil, true),
+			Entry("stale tracked pod", true, new(types.UID(stalePodUID)), true),
+			Entry("current tracked pod", true, new(types.UID(testPodUID)), false),
 		)
 
-		It("should mark multiple trackers for redefinition", func() {
-			tracker1 := createTracker("tracker1", "test-vmi", true, false)
-			tracker2 := createTracker("tracker2", "test-vmi", true, false)
-			addTracker(tracker1)
-			addTracker(tracker2)
-
-			virtClient.EXPECT().VirtualMachineBackupTracker(testNamespace).
-				Return(kubevirtCli.BackupV1alpha1().VirtualMachineBackupTrackers(testNamespace)).Times(2)
-
-			err := handler.markTrackersForRedefinition(vmi)
+		It("does not need redefinition without trackers", func() {
+			setActivePod(vmi, testPodUID)
+			needsRedefinition, err := handler.anyTrackerNeedsRedefinition(vmi)
 			Expect(err).ToNot(HaveOccurred())
-
-			// Verify both trackers were marked
-			updated1, err := kubevirtCli.BackupV1alpha1().VirtualMachineBackupTrackers(testNamespace).Get(
-				context.Background(), "tracker1", metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			Expect(updated1.Status.CheckpointRedefinitionRequired).ToNot(BeNil())
-			Expect(*updated1.Status.CheckpointRedefinitionRequired).To(BeTrue())
-
-			updated2, err := kubevirtCli.BackupV1alpha1().VirtualMachineBackupTrackers(testNamespace).Get(
-				context.Background(), "tracker2", metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			Expect(updated2.Status.CheckpointRedefinitionRequired).ToNot(BeNil())
-			Expect(*updated2.Status.CheckpointRedefinitionRequired).To(BeTrue())
+			Expect(needsRedefinition).To(BeFalse())
 		})
 
-		It("should only mark trackers that need redefinition", func() {
-			// tracker1 has checkpoint and needs marking
-			tracker1 := createTracker("tracker1", "test-vmi", true, false)
-			// tracker2 is already marked, should be skipped
-			tracker2 := createTracker("tracker2", "test-vmi", true, true)
-			// tracker3 has no checkpoint, should be skipped
-			tracker3 := createTracker("tracker3", "test-vmi", false, false)
-			addTracker(tracker1)
-			addTracker(tracker2)
-			addTracker(tracker3)
-
-			// Only one call expected since tracker2 and tracker3 should be skipped
-			virtClient.EXPECT().VirtualMachineBackupTracker(testNamespace).
-				Return(kubevirtCli.BackupV1alpha1().VirtualMachineBackupTrackers(testNamespace)).Times(1)
-
-			err := handler.markTrackersForRedefinition(vmi)
+		It("does not need redefinition when VMI has no active pods", func() {
+			addTracker(createTracker("tracker1", "test-vmi", true, nil))
+			needsRedefinition, err := handler.anyTrackerNeedsRedefinition(vmi)
 			Expect(err).ToNot(HaveOccurred())
+			Expect(needsRedefinition).To(BeFalse())
+		})
 
-			// Verify tracker1 was marked
-			updated1, err := kubevirtCli.BackupV1alpha1().VirtualMachineBackupTrackers(testNamespace).Get(
-				context.Background(), "tracker1", metav1.GetOptions{})
+		It("detects redefinition after migration with stale source pod", func() {
+			vmi.Status.NodeName = "target-node"
+			vmi.Status.ActivePods = map[types.UID]string{
+				types.UID("target-pod-uid"): "target-node",
+			}
+			addTracker(createTracker("tracker1", "test-vmi", true, new(types.UID("source-pod-uid"))))
+			needsRedefinition, err := handler.anyTrackerNeedsRedefinition(vmi)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(updated1.Status.CheckpointRedefinitionRequired).ToNot(BeNil())
-			Expect(*updated1.Status.CheckpointRedefinitionRequired).To(BeTrue())
+			Expect(needsRedefinition).To(BeTrue())
+		})
 
-			// Verify tracker2 was not updated (still has its original state)
-			updated2, err := kubevirtCli.BackupV1alpha1().VirtualMachineBackupTrackers(testNamespace).Get(
-				context.Background(), "tracker2", metav1.GetOptions{})
+		It("needs redefinition when at least one tracker is stale", func() {
+			setActivePod(vmi, testPodUID)
+			addTracker(createTracker("tracker1", "test-vmi", true, new(types.UID(testPodUID))))
+			addTracker(createTracker("tracker2", "test-vmi", true, new(types.UID(stalePodUID))))
+			needsRedefinition, err := handler.anyTrackerNeedsRedefinition(vmi)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(updated2.Status.CheckpointRedefinitionRequired).ToNot(BeNil())
-			Expect(*updated2.Status.CheckpointRedefinitionRequired).To(BeTrue())
-
-			// Verify tracker3 has no status (was skipped)
-			updated3, err := kubevirtCli.BackupV1alpha1().VirtualMachineBackupTrackers(testNamespace).Get(
-				context.Background(), "tracker3", metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
-			Expect(updated3.Status).To(BeNil())
+			Expect(needsRedefinition).To(BeTrue())
 		})
 	})
 
 	Context("backupTrackersForVMI", func() {
 		It("should return empty list when no trackers exist", func() {
-			trackers := handler.backupTrackersForVMI(vmi)
+			trackers, err := handler.backupTrackersForVMI(vmi)
+			Expect(err).ToNot(HaveOccurred())
 			Expect(trackers).To(BeEmpty())
 		})
 
 		It("should return trackers matching VMI namespace/name", func() {
-			tracker := createTracker("tracker1", "test-vmi", false, false)
+			tracker := createTracker("tracker1", "test-vmi", false, nil)
 			Expect(trackerInformer.GetStore().Add(tracker)).To(Succeed())
 
-			trackers := handler.backupTrackersForVMI(vmi)
+			trackers, err := handler.backupTrackersForVMI(vmi)
+			Expect(err).ToNot(HaveOccurred())
 			Expect(trackers).To(HaveLen(1))
 			Expect(trackers[0].Name).To(Equal("tracker1"))
 		})
 
 		It("should not return trackers for different VMI", func() {
-			tracker := createTracker("tracker1", "different-vmi", false, false)
+			tracker := createTracker("tracker1", "different-vmi", false, nil)
 			Expect(trackerInformer.GetStore().Add(tracker)).To(Succeed())
 
-			trackers := handler.backupTrackersForVMI(vmi)
+			trackers, err := handler.backupTrackersForVMI(vmi)
+			Expect(err).ToNot(HaveOccurred())
 			Expect(trackers).To(BeEmpty())
 		})
 
 		It("should return nil when informer is nil", func() {
-			handler := NewCBTHandler(virtClient, nil)
-			trackers := handler.backupTrackersForVMI(vmi)
+			handler := NewCBTHandler(nil)
+			trackers, err := handler.backupTrackersForVMI(vmi)
+			Expect(err).ToNot(HaveOccurred())
 			Expect(trackers).To(BeNil())
 		})
 	})

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -48,6 +48,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/client-go/util/workqueue"
 
+	backupv1 "kubevirt.io/api/backup/v1alpha1"
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
@@ -229,6 +230,21 @@ func NewVirtualMachineController(
 	})
 	if err != nil {
 		return nil, err
+	}
+
+	if cbtHandler.trackerInformer != nil {
+		_, err = cbtHandler.trackerInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+			UpdateFunc: func(_, newObj interface{}) {
+				tracker, ok := newObj.(*backupv1.VirtualMachineBackupTracker)
+				if !ok {
+					return
+				}
+				queue.Add(tracker.Namespace + "/" + tracker.Spec.Source.Name)
+			},
+		})
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	permissions := "rw"

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -194,7 +194,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 		fakeNodeInformer, _ := testutils.NewFakeInformerFor(&k8sv1.Node{})
 		fakeNodeStore := fakeNodeInformer.GetStore()
 		fakeBackupTrackerInformer, _ := testutils.NewFakeInformerFor(&backupv1.VirtualMachineBackupTracker{})
-		cbtHandler := NewCBTHandler(virtClient, fakeBackupTrackerInformer)
+		cbtHandler := NewCBTHandler(fakeBackupTrackerInformer)
 		controller, _ = NewVirtualMachineController(
 			recorder,
 			virtClient,

--- a/pkg/virt-launcher/virtwrap/cmd-server/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/cmd-server/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     deps = [
         "//pkg/handler-launcher-com/cmd/info:go_default_library",
         "//pkg/handler-launcher-com/cmd/v1:go_default_library",
+        "//pkg/storage/cbt:go_default_library",
         "//pkg/util/net/grpc:go_default_library",
         "//pkg/virt-handler/cmd-client:go_default_library",
         "//pkg/virt-launcher/notify-client:go_default_library",

--- a/pkg/virt-launcher/virtwrap/cmd-server/server.go
+++ b/pkg/virt-launcher/virtwrap/cmd-server/server.go
@@ -38,6 +38,7 @@ import (
 	"kubevirt.io/client-go/log"
 
 	cmdv1 "kubevirt.io/kubevirt/pkg/handler-launcher-com/cmd/v1"
+	"kubevirt.io/kubevirt/pkg/storage/cbt"
 	grpcutil "kubevirt.io/kubevirt/pkg/util/net/grpc"
 	cmdclient "kubevirt.io/kubevirt/pkg/virt-handler/cmd-client"
 	notifyclient "kubevirt.io/kubevirt/pkg/virt-launcher/notify-client"
@@ -974,11 +975,11 @@ func (l *Launcher) RedefineCheckpoint(_ context.Context, request *cmdv1.Redefine
 		}, nil
 	}
 
-	if !storage.IsChangedBlockTrackingEnabled(vmi) {
+	if !cbt.CBTStateInitializing(vmi.Status.ChangedBlockTracking) {
 		return &cmdv1.RedefineCheckpointResponse{
 			Response: &cmdv1.Response{
 				Success: false,
-				Message: "Redefine checkpoint failed: ChangedBlockTracking is not enabled",
+				Message: "Redefine checkpoint failed: ChangedBlockTracking is not initializing",
 			},
 			CheckpointInvalid: false,
 		}, nil

--- a/pkg/virt-launcher/virtwrap/cmd-server/server_test.go
+++ b/pkg/virt-launcher/virtwrap/cmd-server/server_test.go
@@ -356,7 +356,7 @@ var _ = Describe("Virt remote commands", func() {
 			BeforeEach(func() {
 				vmi = v1.NewVMIReferenceFromName("testvmi")
 				vmi.Status.ChangedBlockTracking = &v1.ChangedBlockTrackingStatus{
-					State: v1.ChangedBlockTrackingEnabled,
+					State: v1.ChangedBlockTrackingInitializing,
 				}
 				creationTime := metav1.Unix(1234567890, 0)
 				checkpoint = &backupv1.BackupCheckpoint{
@@ -403,12 +403,12 @@ var _ = Describe("Virt remote commands", func() {
 				Expect(checkpointInvalid).To(BeTrue())
 			})
 
-			It("should fail when CBT is not enabled", func() {
+			It("should fail when CBT is not initializing", func() {
 				vmi.Status.ChangedBlockTracking = nil
 
 				checkpointInvalid, err := client.RedefineCheckpoint(vmi, checkpoint)
 				Expect(err).To(HaveOccurred())
-				Expect(err.Error()).To(ContainSubstring("ChangedBlockTracking is not enabled"))
+				Expect(err.Error()).To(ContainSubstring("ChangedBlockTracking is not initializing"))
 				Expect(checkpointInvalid).To(BeFalse())
 			})
 		})

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -9851,12 +9851,13 @@ var CRDsValidation map[string]string = map[string]string{
         rule: self == oldSelf
     status:
       properties:
-        checkpointRedefinitionRequired:
+        lastTrackedPodUID:
           description: |-
-            CheckpointRedefinitionRequired is set to true by virt-handler when the VM
-            restarts and has a checkpoint that needs to be redefined in libvirt.
-            virt-controller will process this flag, attempt redefinition, and clear it.
-          type: boolean
+            LastTrackedPodUID is the UID of the virt-launcher pod associated with
+            the VMI being tracked for which checkpoints were last defined in libvirt.
+            After a VM restart, the new pod UID will differ, signaling that checkpoint
+            redefinition is needed before backups can resume.
+          type: string
         latestCheckpoint:
           description: |-
             LatestCheckpoint is the metadata of the checkpoint of

--- a/staging/src/kubevirt.io/api/backup/v1alpha1/deepcopy_generated.go
+++ b/staging/src/kubevirt.io/api/backup/v1alpha1/deepcopy_generated.go
@@ -355,9 +355,9 @@ func (in *VirtualMachineBackupTrackerStatus) DeepCopyInto(out *VirtualMachineBac
 		*out = new(BackupCheckpoint)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.CheckpointRedefinitionRequired != nil {
-		in, out := &in.CheckpointRedefinitionRequired, &out.CheckpointRedefinitionRequired
-		*out = new(bool)
+	if in.LastTrackedPodUID != nil {
+		in, out := &in.LastTrackedPodUID, &out.LastTrackedPodUID
+		*out = new(types.UID)
 		**out = **in
 	}
 	return

--- a/staging/src/kubevirt.io/api/backup/v1alpha1/types.go
+++ b/staging/src/kubevirt.io/api/backup/v1alpha1/types.go
@@ -124,10 +124,11 @@ type VirtualMachineBackupTrackerStatus struct {
 	LatestCheckpoint *BackupCheckpoint `json:"latestCheckpoint,omitempty"`
 
 	// +optional
-	// CheckpointRedefinitionRequired is set to true by virt-handler when the VM
-	// restarts and has a checkpoint that needs to be redefined in libvirt.
-	// virt-controller will process this flag, attempt redefinition, and clear it.
-	CheckpointRedefinitionRequired *bool `json:"checkpointRedefinitionRequired,omitempty"`
+	// LastTrackedPodUID is the UID of the virt-launcher pod associated with
+	// the VMI being tracked for which checkpoints were last defined in libvirt.
+	// After a VM restart, the new pod UID will differ, signaling that checkpoint
+	// redefinition is needed before backups can resume.
+	LastTrackedPodUID *types.UID `json:"lastTrackedPodUID,omitempty"`
 }
 
 // VirtualMachineBackupTrackerList is a list of VirtualMachineBackupTracker resources

--- a/staging/src/kubevirt.io/api/backup/v1alpha1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/backup/v1alpha1/types_swagger_generated.go
@@ -39,8 +39,8 @@ func (VirtualMachineBackupTrackerSpec) SwaggerDoc() map[string]string {
 
 func (VirtualMachineBackupTrackerStatus) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"latestCheckpoint":               "+optional\nLatestCheckpoint is the metadata of the checkpoint of\nthe latest performed backup",
-		"checkpointRedefinitionRequired": "+optional\nCheckpointRedefinitionRequired is set to true by virt-handler when the VM\nrestarts and has a checkpoint that needs to be redefined in libvirt.\nvirt-controller will process this flag, attempt redefinition, and clear it.",
+		"latestCheckpoint":  "+optional\nLatestCheckpoint is the metadata of the checkpoint of\nthe latest performed backup",
+		"lastTrackedPodUID": "+optional\nLastTrackedPodUID is the UID of the virt-launcher pod associated with\nthe VMI being tracked for which checkpoints were last defined in libvirt.\nAfter a VM restart, the new pod UID will differ, signaling that checkpoint\nredefinition is needed before backups can resume.",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -17810,10 +17810,10 @@ func schema_kubevirtio_api_backup_v1alpha1_VirtualMachineBackupTrackerStatus(ref
 							Ref:         ref("kubevirt.io/api/backup/v1alpha1.BackupCheckpoint"),
 						},
 					},
-					"checkpointRedefinitionRequired": {
+					"lastTrackedPodUID": {
 						SchemaProps: spec.SchemaProps{
-							Description: "CheckpointRedefinitionRequired is set to true by virt-handler when the VM restarts and has a checkpoint that needs to be redefined in libvirt. virt-controller will process this flag, attempt redefinition, and clear it.",
-							Type:        []string{"boolean"},
+							Description: "LastTrackedPodUID is the UID of the virt-launcher pod associated with the VMI being tracked for which checkpoints were last defined in libvirt. After a VM restart, the new pod UID will differ, signaling that checkpoint redefinition is needed before backups can resume.",
+							Type:        []string{"string"},
 							Format:      "",
 						},
 					},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
Previously both virt-handler and virt-controller were mutating the CheckpointRedefinitionRequired boolean field of a VMBT which resulted in an API boundary violation and lack of extensibility.

#### After this PR:
This PR replaces CheckpointRedefinitionRequired and derives checkpoint redefinition need by comparing the VMBT's LastTrackedPodUID against the VMI's active pod UID thus adhering to the single-writer principle.

In turn, it also solves a race where previously VMI CBT state could progress from Initializing to Enabled before all checkpoints were redefined.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
The race in question: https://search.ci.kubevirt.io/?search=perform+incremental+backup+after+live+migration+%5C%5Bsig-storage%5C%5D+RWO+backend+storage&maxAge=336h&context=1&type=bug%2Bissue%2Bjunit&name=&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

