### PR TITLE
virt-launcher: guard against nil MigrationState in cpudedicated

### DIFF
--- a/pkg/virt-launcher/virtwrap/cpudedicated/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/cpudedicated/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -12,5 +12,22 @@ go_library(
         "//pkg/virt-launcher/virtwrap/libvirtxml:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//vendor/libvirt.org/go/libvirtxml:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "cpudedicated_suite_test.go",
+        "cpudedicated_test.go",
+    ],
+    embed = [":go_default_library"],
+    race = "on",
+    deps = [
+        "//pkg/libvmi:go_default_library",
+        "//pkg/virt-launcher/virtwrap/api:go_default_library",
+        "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
     ],
 )

--- a/pkg/virt-launcher/virtwrap/cpudedicated/cpudedicated.go
+++ b/pkg/virt-launcher/virtwrap/cpudedicated/cpudedicated.go
@@ -20,6 +20,7 @@ package cpudedicated
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"libvirt.org/go/libvirtxml"
 
@@ -32,6 +33,10 @@ import (
 )
 
 func GenerateDomainForTargetCPUSetAndTopology(vmi *v1.VirtualMachineInstance, domSpec *api.DomainSpec) (*api.Domain, error) {
+	if vmi.Status.MigrationState == nil {
+		return nil, fmt.Errorf("cannot generate domain for target CPU set and topology until migrationState is ready")
+	}
+
 	var targetTopology cmdv1.Topology
 	targetNodeCPUSet := vmi.Status.MigrationState.TargetCPUSet
 	err := json.Unmarshal([]byte(vmi.Status.MigrationState.TargetNodeTopology), &targetTopology)

--- a/pkg/virt-launcher/virtwrap/cpudedicated/cpudedicated_suite_test.go
+++ b/pkg/virt-launcher/virtwrap/cpudedicated/cpudedicated_suite_test.go
@@ -1,0 +1,29 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ */
+
+package cpudedicated_test
+
+import (
+	"testing"
+
+	"kubevirt.io/client-go/testutils"
+)
+
+func TestCPUDedicated(t *testing.T) {
+	testutils.KubeVirtTestSuiteSetup(t)
+}

--- a/pkg/virt-launcher/virtwrap/cpudedicated/cpudedicated_test.go
+++ b/pkg/virt-launcher/virtwrap/cpudedicated/cpudedicated_test.go
@@ -1,0 +1,42 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ */
+
+package cpudedicated_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"kubevirt.io/kubevirt/pkg/libvmi"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/cpudedicated"
+)
+
+var _ = Describe("GenerateDomainForTargetCPUSetAndTopology", func() {
+	It("should return an error instead of panicking when MigrationState is nil", func() {
+		vmi := libvmi.New(libvmi.WithDedicatedCPUPlacement())
+		// MigrationState is nil by default on a freshly created VMI, e.g. before
+		// a live migration has started.
+		Expect(vmi.Status.MigrationState).To(BeNil())
+
+		domSpec := &api.DomainSpec{}
+		domain, err := cpudedicated.GenerateDomainForTargetCPUSetAndTopology(vmi, domSpec)
+		Expect(err).To(MatchError(ContainSubstring("migrationState is ready")))
+		Expect(domain).To(BeNil())
+	})
+})


### PR DESCRIPTION
Motivation:
GenerateDomainForTargetCPUSetAndTopology (pkg/virt-launcher/virtwrap/
cpudedicated/cpudedicated.go) dereferenced vmi.Status.MigrationState.
TargetCPUSet and vmi.Status.MigrationState.TargetNodeTopology as its
first operations, with no nil guard on MigrationState. MigrationState
is only populated during an active live migration, so any call made
before it is set results in a nil pointer dereference. This package
also had zero test coverage.

In the current call path (migratableDomXML in live-migration-source.go,
reached only through startMigration) MigrationState is already
guaranteed non-nil by an existing check, so this is a defensive
fix for a latent hazard rather than a reproduction of a crash hit
in normal operation. Guarding here follows the same pattern already
used in 30+ other call sites in this codebase (e.g.
live-migration-source.go's startMigration and storage/cbt.go's
isMigrationNewBackendStorage), turning a possible panic into a clear,
handleable error for any future or indirect caller.

Approach:
Add a nil check for vmi.Status.MigrationState at the top of
GenerateDomainForTargetCPUSetAndTopology, returning a descriptive
error instead of panicking. The error is already propagated
correctly by the sole caller. Add the first unit tests for the
cpudedicated package, covering this nil-guard behavior, and add
the corresponding go_test target to BUILD.bazel (hand-authored,
since gazelle/bazel are unavailable in this environment; modeled
on sibling packages' BUILD.bazel files).

Validation:
  go build ./pkg/virt-launcher/virtwrap/cpudedicated/...
  go vet ./pkg/virt-launcher/virtwrap/cpudedicated/...
  go test ./pkg/virt-launcher/virtwrap/cpudedicated/... -v

All three passed. To confirm the new test reproduces the exact
failure mode described in the issue, the fix was temporarily
reverted: the test then panicked with "runtime error: invalid
memory address or nil pointer dereference" at the documented line,
and passed again once the fix was restored. Full bazel-based
`make test` could not be run in this environment (no docker/bazel
available), so the new go_test target in BUILD.bazel should be
confirmed against `make generate` output before merge.

Fixes #16968

```release-note
virt-launcher no longer panics in GenerateDomainForTargetCPUSetAndTopology
when MigrationState has not been initialized. The function now returns a
descriptive error instead.
```

Signed-off-by: Pujitha Paladugu <10557236+pujitha24@users.noreply.github.com>

---
AI assistance: this change was drafted with Claude Code.