### PR TITLE
virt-api: Guard empty volume dry-run options

### DIFF
--- a/pkg/virt-api/rest/volumes.go
+++ b/pkg/virt-api/rest/volumes.go
@@ -281,9 +281,9 @@ func (app *SubresourceAPIApp) vmVolumePatchStatus(name, namespace string, volume
 
 func getDryRunOption(volumeRequest *v1.VirtualMachineVolumeRequest) []string {
 	var dryRunOption []string
-	if options := volumeRequest.AddVolumeOptions; options != nil && options.DryRun != nil && options.DryRun[0] == metav1.DryRunAll {
+	if options := volumeRequest.AddVolumeOptions; options != nil && len(options.DryRun) > 0 && options.DryRun[0] == metav1.DryRunAll {
 		dryRunOption = volumeRequest.AddVolumeOptions.DryRun
-	} else if options := volumeRequest.RemoveVolumeOptions; options != nil && options.DryRun != nil && options.DryRun[0] == metav1.DryRunAll {
+	} else if options := volumeRequest.RemoveVolumeOptions; options != nil && len(options.DryRun) > 0 && options.DryRun[0] == metav1.DryRunAll {
 		dryRunOption = volumeRequest.RemoveVolumeOptions.DryRun
 	}
 	return dryRunOption

--- a/pkg/virt-api/rest/volumes_test.go
+++ b/pkg/virt-api/rest/volumes_test.go
@@ -53,6 +53,18 @@ import (
 )
 
 var _ = Describe("Add/Remove Volume Subresource api", func() {
+	It("handles empty dry-run options", func() {
+		addOptions := &v1.AddVolumeOptions{}
+		Expect(json.Unmarshal([]byte(`{"dryRun":[]}`), addOptions)).To(Succeed())
+		Expect(addOptions.DryRun).ToNot(BeNil())
+		Expect(getDryRunOption(&v1.VirtualMachineVolumeRequest{AddVolumeOptions: addOptions})).To(BeNil())
+
+		removeOptions := &v1.RemoveVolumeOptions{}
+		Expect(json.Unmarshal([]byte(`{"dryRun":[]}`), removeOptions)).To(Succeed())
+		Expect(removeOptions.DryRun).ToNot(BeNil())
+		Expect(getDryRunOption(&v1.VirtualMachineVolumeRequest{RemoveVolumeOptions: removeOptions})).To(BeNil())
+	})
+
 	var (
 		request    *restful.Request
 		response   *restful.Response


### PR DESCRIPTION
### What this PR does
#### Before this PR:
An add- or remove-volume request containing `"dryRun": []` decoded to a non-nil empty slice. The shared `getDryRunOption` helper indexed element zero and panicked.

#### After this PR:
Empty dry-run options are treated as no dry-run directive without panicking.

### Why we need it and why it was done in this way
The VM and VMI add/remove paths all use `getDryRunOption`, so guarding the slice in that helper fixes every caller with the smallest change.

The regression test decodes the actual JSON request shape for both add and remove options. It panics against the original implementation.

### Special notes for your reviewer
This is a draft to validate the issue and approach with maintainers.

### Testing
`go test ./pkg/virt-api/rest -run TestRest -ginkgo.focus="handles empty dry-run options" -count=1`

### Checklist
- [x] Design: no VEP is required for this guard.
- [x] Upgrade and documentation: no API or behavior change beyond preventing the panic.
- [x] Testing: focused regression coverage is included.
- [x] AI Contributions: AI assistance is disclosed in the commit trailer.

### Release note
```release-note
NONE
```