### PR TITLE
client-go: Handle libvirt logs without position

### DIFF
--- a/staging/src/kubevirt.io/client-go/log/log.go
+++ b/staging/src/kubevirt.io/client-go/log/log.go
@@ -389,7 +389,10 @@ func LogLibvirtLogLine(logger *FilteredLogger, line string) {
 	}
 	thread := strings.TrimSpace(fragments[1])
 	pos := strings.TrimSpace(fragments[3])
-	msg := strings.TrimSpace(fragments[4])
+	msg := pos
+	if len(fragments) == 5 {
+		msg = strings.TrimSpace(fragments[4])
+	}
 
 	//TODO: implement proper behavior for unsupported GA commands
 	// by either considering the GA version as unsupported or just don't
@@ -404,14 +407,16 @@ func LogLibvirtLogLine(logger *FilteredLogger, line string) {
 
 	// check if we really got a position
 	isPos := false
-	if split := strings.Split(pos, ":"); len(split) == 2 {
+	if split := strings.Split(pos, ":"); len(fragments) == 5 && len(split) == 2 {
 		if _, err := strconv.Atoi(split[1]); err == nil {
 			isPos = true
 		}
 	}
 
 	if !isPos {
-		msg = strings.TrimSpace(fragments[3] + ": " + fragments[4])
+		if len(fragments) == 5 {
+			msg = strings.TrimSpace(fragments[3] + ": " + fragments[4])
+		}
 		logger.logger.Log(
 			"level", severity,
 			"timestamp", t.Format(logTimestampFormat),

--- a/staging/src/kubevirt.io/client-go/log/log_test.go
+++ b/staging/src/kubevirt.io/client-go/log/log_test.go
@@ -83,6 +83,18 @@ func TestMockLogger(t *testing.T) {
 	tearDown()
 }
 
+func TestLogLibvirtLogLineWithoutPosition(t *testing.T) {
+	setUp()
+	defer tearDown()
+
+	LogLibvirtLogLine(MakeLogger(MockLogger{}), "2018-10-04 09:20:33.702+0000: 38: error : plain error:42")
+
+	logEntry := logParams[0].([]interface{})
+	assert(t, logEntry[1] == "error", "Log entry did not preserve severity")
+	assert(t, logEntry[9] == "38", "Log entry did not preserve thread")
+	assert(t, logEntry[11] == "plain error:42", "Log entry did not preserve message")
+}
+
 func TestBadLevel(t *testing.T) {
 	setUp()
 	l := Logger("test")


### PR DESCRIPTION
### What this PR does
#### Before this PR:
A valid libvirt log line containing timestamp, thread, severity, and a message without a source position split into four fragments. `LogLibvirtLogLine` unconditionally indexed a fifth fragment and panicked.

#### After this PR:
Four-fragment lines are logged without a source position while preserving severity, thread, and message. Position detection remains limited to five-fragment lines.

### Why we need it and why it was done in this way
Virt-launcher feeds virtqemud stderr directly to this shared parser. Handling the valid four-fragment form in the parser fixes the crash at its single boundary.

The regression uses a message containing a colon without a following space, proving it remains a message rather than being misclassified as a source position. It panics against the original implementation.

### Special notes for your reviewer
This is a draft to validate the issue and approach with maintainers.

### Testing
`go test ./staging/src/kubevirt.io/client-go/log -count=1`

### Checklist
- [x] Design: no VEP is required for this parser guard.
- [x] Upgrade and documentation: no API change is involved.
- [x] Testing: focused regression coverage is included and the complete log package passes.
- [x] AI Contributions: AI assistance is disclosed in the commit trailer.

### Release note
```release-note
NONE
```