### PR TITLE
virt-launcher, migration: Graduate LibvirtHooksServerAndClient to GA

### DIFF
--- a/cmd/virt-launcher/BUILD.bazel
+++ b/cmd/virt-launcher/BUILD.bazel
@@ -157,16 +157,6 @@ pkg_tar(
     package_dir = "/etc",
 )
 
-pkg_tar(
-    name = "qemu-hook-tar",
-    srcs = [
-        ":qemu",
-    ],
-    mode = "0755",
-    owner = "107.107",
-    package_dir = "/etc/libvirt/hooks",
-)
-
 # Symlink /var/run -> ../run for compatibility with libvirt socket paths
 # In CentOS Stream 10+, libvirt creates sockets in /run/libvirt/ but
 # KubeVirt expects them at /var/run/libvirt/
@@ -181,14 +171,17 @@ pkg_tar(
     },
 )
 
-# Go binary for advanced qemu hook (used when LibvirtHooksServerAndClient is enabled)
-# This binary is placed in /usr/bin and replaces /etc/libvirt/hooks/qemu at runtime
 pkg_tar(
-    name = "libvirt-hook-client-tar",
+    name = "qemu-hook-tar",
     srcs = [
         "//cmd/virt-launcher/libvirt-hook-client",
     ],
-    package_dir = "/usr/bin",
+    mode = "0755",
+    owner = "107.107",
+    package_dir = "/etc/libvirt/hooks",
+    remap_paths = {
+        "/libvirt-hook-client": "/qemu",
+    },
 )
 
 # Workaround for https://github.com/moby/moby/issues/44106
@@ -250,11 +243,6 @@ layer_from_tar(
 )
 
 layer_from_tar(
-    name = "libvirt-hook-client-layer",
-    src = ":libvirt-hook-client-tar",
-)
-
-layer_from_tar(
     name = "qemu-kvm-modules-dir-layer",
     src = ":qemu-kvm-modules-dir-tar",
 )
@@ -284,7 +272,6 @@ image_manifest(
             ":passwd-layer",
             ":nsswitch-layer",
             ":qemu-hook-layer",
-            ":libvirt-hook-client-layer",
             ":qemu-kvm-modules-dir-layer",
             ":var-run-symlink-layer",
         ],
@@ -295,7 +282,6 @@ image_manifest(
             ":passwd-layer",
             ":nsswitch-layer",
             ":qemu-hook-layer",
-            ":libvirt-hook-client-layer",
             ":qemu-kvm-modules-dir-layer",
             ":var-run-symlink-layer",
         ],
@@ -306,7 +292,6 @@ image_manifest(
             ":passwd-layer",
             ":nsswitch-layer",
             ":qemu-hook-layer",
-            ":libvirt-hook-client-layer",
             ":qemu-kvm-modules-dir-layer",
             ":var-run-symlink-layer",
         ],

--- a/cmd/virt-launcher/qemu
+++ b/cmd/virt-launcher/qemu
@@ -1,6 +1,0 @@
-#!/bin/bash
-if [ "$2" != "release" ] || [ "$3" != "end" ] || [ "$4" != "migrated" ]; then
-	exit
-fi
-touch /run/kubevirt-private/backend-storage-meta/migrated
-chmod 0644 /run/kubevirt-private/backend-storage-meta/migrated

--- a/cmd/virt-launcher/virt-launcher.go
+++ b/cmd/virt-launcher/virt-launcher.go
@@ -21,7 +21,6 @@ package main
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -483,10 +482,6 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	if err := replaceQemuHookWithCustomClient(); err != nil {
-		panic(err)
-	}
-
 	// Start the virt-launcher command service.
 	// Clients can use this service to tell virt-launcher
 	// to start/stop virtual machines
@@ -567,32 +562,4 @@ func main() {
 	<-preMigrationHookServer.Done()
 
 	log.Log.Info("Exiting...")
-}
-
-const (
-	// libvirtQemuHookPath is the path where libvirt expects the qemu hook script
-	libvirtQemuHookPath = "/etc/libvirt/hooks/qemu"
-	// libvirtHookClientPath is the Go binary that replaces the shell script
-	libvirtHookClientPath = "/usr/bin/libvirt-hook-client"
-)
-
-// replaceQemuHookWithCustomClient replaces the default qemu hook shell script
-// with the Go binary that can communicate with the pre-migration hook server.
-func replaceQemuHookWithCustomClient() error {
-	// Check if the Go binary exists
-	if _, err := os.Stat(libvirtHookClientPath); err != nil {
-		return fmt.Errorf("libvirt hook client binary not found at %s: %w", libvirtHookClientPath, err)
-	}
-
-	// Remove the existing hook script
-	if err := os.Remove(libvirtQemuHookPath); err != nil && !errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("failed to remove existing qemu hook: %w", err)
-	}
-
-	// Create a symlink from the qemu hook path to the Go binary
-	if err := os.Symlink(libvirtHookClientPath, libvirtQemuHookPath); err != nil {
-		return fmt.Errorf("failed to create symlink for qemu hook: %w", err)
-	}
-
-	return nil
 }

--- a/cmd/virt-launcher/virt-launcher.go
+++ b/cmd/virt-launcher/virt-launcher.go
@@ -357,7 +357,6 @@ func main() {
 	allowCrossArchEmulation := pflag.Bool("allow-cross-arch-emulation", false, "Allow cross-architecture software emulation via QEMU TCG")
 	runWithNonRoot := pflag.Bool("run-as-nonroot", false, "Run virtqemud with the 'virt' user")
 	imageVolumeEnabled := pflag.Bool("image-volume", false, "Generated with ImageVolume instead of containerDisk") //remove this once ImageVolume is GAed
-	libvirtHooksServerAndClientEnabled := pflag.Bool("libvirt-hook-server-and-client", false, "Enable pre-migration hooks on the target virt-launcher pod")
 	ifacesOrdinalNamingUpgradeEnabled := pflag.Bool("upgrade-ordinal-ifaces", false, "Enable upgrade of ordinal ifaces naming scheme")
 	vGPUDedicatedHookEnabled := pflag.Bool("vgpu-dedicated-hook", false, "Enable target mdev UUID mutation for vGPU live migration")
 	vmStatsCollectorEnabled := pflag.Bool("vm-stats-collector", false, "Enable additional guest agent polling workers for VMStats monitoring data collection")
@@ -473,7 +472,6 @@ func main() {
 		*diskMemoryLimitBytes,
 		util.GetPodCPUSet,
 		*imageVolumeEnabled,
-		*libvirtHooksServerAndClientEnabled,
 		preMigrationHookServer,
 		*hypervisor,
 		nbdclient.RegisterNBDServer,
@@ -485,12 +483,8 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	if *libvirtHooksServerAndClientEnabled {
-		// TODO: replaceQemuHookWithCustomClient This code should be removed once the LibvirtHooksServerAndClient feature is GA.
-		// Instead of overriding the script at runtime, we can include the custom binary in the launcher image at build time.
-		if err := replaceQemuHookWithCustomClient(); err != nil {
-			panic(err)
-		}
+	if err := replaceQemuHookWithCustomClient(); err != nil {
+		panic(err)
 	}
 
 	// Start the virt-launcher command service.

--- a/docs/devel/migration-premigration-hooks.md
+++ b/docs/devel/migration-premigration-hooks.md
@@ -11,8 +11,10 @@ one. If a bug fix is applied to the XML modification logic, it will not take
 effect until the source pod is also updated, which may not happen until the
 second migration or restart.
 
-To address this, VEP-141 introduces **target-side pre-migration hooks**,
-built on top of [libvirt's QEMU hook mechanism](https://libvirt.org/hooks.html).
+VEP-141 introduced **target-side pre-migration hooks**, built on top of
+[libvirt's QEMU hook mechanism](https://libvirt.org/hooks.html). This
+mechanism is GA since v1.10 and is always enabled.
+
 Libvirt invokes the `/etc/libvirt/hooks/qemu` executable on the destination host
 with the `migrate` operation at the beginning of incoming migration, passing
 the domain XML via stdin and reading the modified XML from stdout. KubeVirt

--- a/docs/network/ordinal-naming-scheme-upgrade.md
+++ b/docs/network/ordinal-naming-scheme-upgrade.md
@@ -30,7 +30,8 @@ This feature requires the following
 - `PodSecondaryInterfaceNamingUpgrade` - controls the naming scheme upgrade
   logic. Introduced in v1.8 at Beta stage, it must be explicitly enabled.
 - `LibvirtHooksServerAndClient` - enables the domain mutation hook mechanism
-  used to adjust tap device names during migration. Must be explicitly enabled.
+  used to adjust tap device names during migration. GA since v1.10, always
+  enabled.
 
 ## How It Works
 
@@ -62,9 +63,9 @@ not affected.
 
 ## Upgrading a VM
 
-To upgrade a VM's interface naming scheme, ensure both the
-`PodSecondaryInterfaceNamingUpgrade` and `LibvirtHooksServerAndClient` feature
-gates are enabled, then live migrate the VM:
+To upgrade a VM's interface naming scheme, ensure the
+`PodSecondaryInterfaceNamingUpgrade` feature gate is enabled, then live
+migrate the VM:
 
 ```bash
 cat <<EOF | kubectl apply -f -

--- a/pkg/virt-config/feature-gates.go
+++ b/pkg/virt-config/feature-gates.go
@@ -135,10 +135,6 @@ func (config *ClusterConfig) ImageVolumeEnabled() bool {
 	return config.isFeatureGateEnabled(featuregate.ImageVolume)
 }
 
-func (config *ClusterConfig) LibvirtHooksServerAndClientEnabled() bool {
-	return config.isFeatureGateEnabled(featuregate.LibvirtHooksServerAndClient)
-}
-
 func (config *ClusterConfig) NodeRestrictionEnabled() bool {
 	return config.isFeatureGateEnabled(featuregate.NodeRestrictionGate)
 }

--- a/pkg/virt-config/featuregate/active.go
+++ b/pkg/virt-config/featuregate/active.go
@@ -73,15 +73,6 @@ const (
 	// bind mounts in virt-handler.
 	ImageVolume = "ImageVolume"
 
-	// Owner: @Barakmor1
-	// Alpha: v1.8.0
-	// Beta: v1.9.0
-	//
-	// LibvirtHooksServerAndClient The LibvirtHooksServerAndClient FG enables running pre-migration
-	// hooks on the target virt-launcher pod, allowing domain XML mutations to be applied
-	// on the target before migration starts.
-	LibvirtHooksServerAndClient = "LibvirtHooksServerAndClient"
-
 	// Owner: @shellyka13
 	// Alpha: v1.6.0
 	//
@@ -295,7 +286,6 @@ const (
 )
 
 func init() {
-	RegisterFeatureGate(FeatureGate{Name: LibvirtHooksServerAndClient, State: Beta})
 	RegisterFeatureGate(FeatureGate{Name: ImageVolume, State: Beta})
 	RegisterFeatureGate(FeatureGate{Name: CPUManager, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: IgnitionGate, State: Alpha})

--- a/pkg/virt-config/featuregate/inactive.go
+++ b/pkg/virt-config/featuregate/inactive.go
@@ -195,6 +195,16 @@ const (
 	//
 	// VmiMemoryOverheadReport enables reporting the memory overhead in the VMI status.
 	VmiMemoryOverheadReport = "VmiMemoryOverheadReport"
+
+	// Owner: sig-compute
+	// Alpha: v1.8.0
+	// Beta: v1.9.0
+	// GA: v1.10.0
+	//
+	// LibvirtHooksServerAndClient The LibvirtHooksServerAndClient FG enables running pre-migration
+	// hooks on the target virt-launcher pod, allowing domain XML mutations to be applied
+	// on the target before migration starts.
+	LibvirtHooksServerAndClient = "LibvirtHooksServerAndClient"
 )
 
 func init() {
@@ -240,4 +250,5 @@ func init() {
 	RegisterFeatureGate(FeatureGate{Name: SecureExecution, State: GA})
 	RegisterFeatureGate(FeatureGate{Name: MigrationPriorityQueue, State: GA})
 	RegisterFeatureGate(FeatureGate{Name: VmiMemoryOverheadReport, State: GA})
+	RegisterFeatureGate(FeatureGate{Name: LibvirtHooksServerAndClient, State: GA})
 }

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -478,9 +478,6 @@ func (t *TemplateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 		if t.clusterConfig.ImageVolumeEnabled() {
 			args = append(args, "--image-volume")
 		}
-		if t.clusterConfig.LibvirtHooksServerAndClientEnabled() {
-			args = append(args, "--libvirt-hook-server-and-client")
-		}
 		if t.clusterConfig.PodSecondaryInterfaceNamingUpgradeEnabled() {
 			args = append(args, "--upgrade-ordinal-ifaces")
 		}

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -599,7 +599,6 @@ var _ = Describe("Template", func() {
 					"--ovmf-path", ovmfPath,
 					"--disk-memory-limit", strconv.Itoa(virtconfig.DefaultDiskVerificationMemoryLimitBytes),
 					"--hypervisor", config.GetHypervisor().Name,
-					"--libvirt-hook-server-and-client",
 				}))
 				Expect(pod.Spec.Containers[1].Name).To(Equal("hook-sidecar-0"))
 				Expect(pod.Spec.Containers[1].Image).To(Equal("some-image:v1"))
@@ -1203,7 +1202,6 @@ var _ = Describe("Template", func() {
 					"--ovmf-path", ovmfPath,
 					"--disk-memory-limit", strconv.Itoa(virtconfig.DefaultDiskVerificationMemoryLimitBytes),
 					"--hypervisor", config.GetHypervisor().Name,
-					"--libvirt-hook-server-and-client",
 				}))
 				Expect(pod.Spec.Containers[1].Name).To(Equal("hook-sidecar-0"))
 				Expect(pod.Spec.Containers[1].Image).To(Equal("some-image:v1"))

--- a/pkg/virt-launcher/virtwrap/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/BUILD.bazel
@@ -62,7 +62,6 @@ go_library(
         "//pkg/virt-launcher/virtwrap/converter/arch:go_default_library",
         "//pkg/virt-launcher/virtwrap/converter/types:go_default_library",
         "//pkg/virt-launcher/virtwrap/converter/vcpu:go_default_library",
-        "//pkg/virt-launcher/virtwrap/cpudedicated:go_default_library",
         "//pkg/virt-launcher/virtwrap/device/hostdevice:go_default_library",
         "//pkg/virt-launcher/virtwrap/device/hostdevice/dra:go_default_library",
         "//pkg/virt-launcher/virtwrap/device/hostdevice/generic:go_default_library",

--- a/pkg/virt-launcher/virtwrap/cpudedicated/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/cpudedicated/BUILD.bazel
@@ -6,11 +6,8 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/cpudedicated",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/handler-launcher-com/cmd/v1:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
-        "//pkg/virt-launcher/virtwrap/converter/vcpu:go_default_library",
         "//pkg/virt-launcher/virtwrap/libvirtxml:go_default_library",
-        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//vendor/libvirt.org/go/libvirtxml:go_default_library",
     ],
 )

--- a/pkg/virt-launcher/virtwrap/cpudedicated/cpudedicated.go
+++ b/pkg/virt-launcher/virtwrap/cpudedicated/cpudedicated.go
@@ -19,49 +19,11 @@
 package cpudedicated
 
 import (
-	"encoding/json"
-
 	"libvirt.org/go/libvirtxml"
 
-	v1 "kubevirt.io/api/core/v1"
-
-	cmdv1 "kubevirt.io/kubevirt/pkg/handler-launcher-com/cmd/v1"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
-	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter/vcpu"
 	convxml "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/libvirtxml"
 )
-
-func GenerateDomainForTargetCPUSetAndTopology(vmi *v1.VirtualMachineInstance, domSpec *api.DomainSpec) (*api.Domain, error) {
-	var targetTopology cmdv1.Topology
-	targetNodeCPUSet := vmi.Status.MigrationState.TargetCPUSet
-	err := json.Unmarshal([]byte(vmi.Status.MigrationState.TargetNodeTopology), &targetTopology)
-	if err != nil {
-		return nil, err
-	}
-
-	domain := api.NewMinimalDomain(vmi.Name)
-	domain.Spec = *domSpec
-	cpuTopology := vcpu.GetCPUTopology(vmi)
-	cpuCount := vcpu.CalculateRequestedVCPUs(cpuTopology)
-
-	// update cpu count to maximum hot plugable CPUs
-	vmiCPU := vmi.Spec.Domain.CPU
-	if vmiCPU != nil && vmiCPU.MaxSockets != 0 {
-		cpuTopology.Sockets = vmiCPU.MaxSockets
-		cpuCount = vcpu.CalculateRequestedVCPUs(cpuTopology)
-	}
-	domain.Spec.CPU.Topology = cpuTopology
-	domain.Spec.VCPU = &api.VCPU{
-		Placement: "static",
-		CPUs:      cpuCount,
-	}
-	err = vcpu.AdjustDomainForTopologyAndCPUSet(domain, vmi, &targetTopology, targetNodeCPUSet)
-	if err != nil {
-		return nil, err
-	}
-
-	return domain, err
-}
 
 func ConvertCPUDedicatedFields(domain *api.Domain, domcfg *libvirtxml.Domain) error {
 	if domcfg.CPU == nil {

--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -20,7 +20,6 @@
 package virtwrap
 
 import (
-	"encoding/xml"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -47,10 +46,8 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/cli"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter/vcpu"
-	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/cpudedicated"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/device/hostdevice"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/device/hostdevice/sriov"
-	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/disksource"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/stats"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/statsconv"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/util"
@@ -187,10 +184,7 @@ func hotUnplugHostDevices(virConn cli.Connection, dom cli.VirDomain) error {
 
 // This returns domain xml without the metadata section, as it is only relevant to the source domain
 // Note: Unfortunately we can't just use UnMarshall + Marshall here, as that leads to unwanted XML alterations
-func migratableDomXML(dom cli.VirDomain, vmi *v1.VirtualMachineInstance, domSpec *api.DomainSpec, libvirtHooksEnabled bool) (string, error) {
-	var domain *api.Domain
-	var err error
-
+func migratableDomXML(dom cli.VirDomain, vmi *v1.VirtualMachineInstance) (string, error) {
 	xmlstr, err := dom.GetXMLDesc(libvirt.DOMAIN_XML_MIGRATABLE)
 	if err != nil {
 		log.Log.Object(vmi).Reason(err).Error("Live migration failed. Failed to get XML.")
@@ -200,31 +194,6 @@ func migratableDomXML(dom cli.VirDomain, vmi *v1.VirtualMachineInstance, domSpec
 	if err := domcfg.Unmarshal(xmlstr); err != nil {
 		return "", err
 	}
-	// TODO: Once LibvirtHooksServerAndClient feature gate is GA, remove
-	// convertDisks, replaced by DiskSourcePathHook on the target.
-	if !libvirtHooksEnabled {
-		if err = convertDisks(domSpec, domcfg); err != nil {
-			return "", err
-		}
-	}
-	// TODO: Once the LibvirtHooksServerAndClient feature gate is GA,
-	// this logic in the source can be removed, as XML modifications
-	// for dedicated CPUs will always be handled on the target side.
-	if !libvirtHooksEnabled && vmi.IsCPUDedicated() {
-		// If the VMI has dedicated CPUs, we need to replace the old CPUs that were
-		// assigned in the source node with the new CPUs assigned in the target node
-		err = xml.Unmarshal([]byte(xmlstr), &domain)
-		if err != nil {
-			return "", err
-		}
-		domain, err := cpudedicated.GenerateDomainForTargetCPUSetAndTopology(vmi, domSpec)
-		if err != nil {
-			return "", err
-		}
-		if err = cpudedicated.ConvertCPUDedicatedFields(domain, domcfg); err != nil {
-			return "", err
-		}
-	}
 	// set slice size for local disks to migrate
 	if err := configureLocalDiskToMigrate(domcfg, vmi); err != nil {
 		log.Log.Object(vmi).Reason(err).Error("Failed to set size for local disk.")
@@ -232,35 +201,6 @@ func migratableDomXML(dom cli.VirDomain, vmi *v1.VirtualMachineInstance, domSpec
 	}
 
 	return domcfg.Marshal()
-}
-
-func convertDisks(domSpec *api.DomainSpec, domcfg *libvirtxml.Domain) error {
-	if domcfg == nil || domcfg.Devices == nil || domSpec == nil {
-		return nil
-	}
-	if len(domSpec.Devices.Disks) != len(domcfg.Devices.Disks) {
-		return fmt.Errorf("spec and domain have different disks count")
-	}
-	for i, disk := range domSpec.Devices.Disks {
-		domcfgDisk := (&domcfg.Devices.Disks[i])
-		diskName := disk.Alias.GetName()
-
-		if disk.Source.File != "" {
-			if domcfgDisk.Source == nil || domcfgDisk.Source.File == nil {
-				return fmt.Errorf("disk %s: spec has file source but domain is missing it", diskName)
-			}
-			log.Log.Infof("Updating disk %s source file from %s to %s", diskName, domcfgDisk.Source.File.File, disk.Source.File)
-			domcfgDisk.Source.File.File = disk.Source.File
-		}
-		if disk.Source.DataStore != nil && disk.Source.DataStore.Source != nil && disk.Source.DataStore.Source.File != "" {
-			if domcfgDisk.Source == nil || domcfgDisk.Source.DataStore == nil || domcfgDisk.Source.DataStore.Source == nil || domcfgDisk.Source.DataStore.Source.File == nil {
-				return fmt.Errorf("disk %s: spec has DataStore file source but domain is missing it", diskName)
-			}
-			log.Log.Infof("Updating disk %s datastore backend from %s to %s", diskName, domcfgDisk.Source.DataStore.Source.File.File, disk.Source.DataStore.Source.File)
-			domcfgDisk.Source.DataStore.Source.File.File = disk.Source.DataStore.Source.File
-		}
-	}
-	return nil
 }
 
 func (d *migrationDisks) isSharedVolume(name string) bool {
@@ -1130,42 +1070,13 @@ func generateDomainName(vmi *v1.VirtualMachineInstance) string {
 	return domainName
 }
 
-func updateFilePathsToNewDomain(vmi *v1.VirtualMachineInstance, domSpec *api.DomainSpec) {
-	if vmi.Status.MigrationState != nil && vmi.Status.MigrationState.TargetState != nil && vmi.Status.MigrationState.TargetState.DomainNamespace != nil {
-		targetNS := *vmi.Status.MigrationState.TargetState.DomainNamespace
-		// Modify the domain XML to update paths to the target volumes to match the new domain
-		for i, disk := range domSpec.Devices.Disks {
-			if disk.Source.DataStore != nil &&
-				disk.Source.DataStore.Source != nil &&
-				strings.Contains(disk.Source.DataStore.Source.File, vmi.Namespace) {
-				oldPath := disk.Source.DataStore.Source.File
-				domSpec.Devices.Disks[i].Source.DataStore.Source.File = strings.Replace(disk.Source.DataStore.Source.File, vmi.Namespace, targetNS, 1)
-				log.Log.Object(vmi).V(4).Infof("Updated disk %s datastore backend path from %s to %s", disk.Alias.GetName(), oldPath, domSpec.Devices.Disks[i].Source.DataStore.Source.File)
-			}
-			if disk.Source.File != "" && strings.Contains(disk.Source.File, vmi.Namespace) {
-				oldPath := disk.Source.File
-				domSpec.Devices.Disks[i].Source.File = strings.Replace(disk.Source.File, vmi.Namespace, targetNS, 1)
-				log.Log.Object(vmi).V(4).Infof("Updated disk %s source path from %s to %s", disk.Alias.GetName(), oldPath, domSpec.Devices.Disks[i].Source.File)
-			}
-			if bp := disksource.Resolve(domSpec.Devices.Disks[i]).BackendPath(); bp != "" {
-				log.Log.Object(vmi).V(4).Infof("Paths of disk %s: %s", disk.Alias.GetName(), bp)
-			}
-		}
-	}
-}
-
-func generateMigrationParams(dom cli.VirDomain, vmi *v1.VirtualMachineInstance, options *cmdclient.MigrationOptions, virtShareDir string, domSpec *api.DomainSpec, libvirtHooksEnabled bool) (*libvirt.DomainMigrateParameters, error) {
+func generateMigrationParams(dom cli.VirDomain, vmi *v1.VirtualMachineInstance, options *cmdclient.MigrationOptions, virtShareDir string) (*libvirt.DomainMigrateParameters, error) {
 	bandwidth, err := vcpu.QuantityToMebiByte(options.Bandwidth)
 	if err != nil {
 		return nil, err
 	}
 
-	// TODO: Once LibvirtHooksServerAndClient feature gate is GA, remove
-	// updateFilePathsToNewDomain, replaced by DiskSourcePathHook on the target.
-	if !libvirtHooksEnabled {
-		updateFilePathsToNewDomain(vmi, domSpec)
-	}
-	xmlstr, err := migratableDomXML(dom, vmi, domSpec, libvirtHooksEnabled)
+	xmlstr, err := migratableDomXML(dom, vmi)
 	if err != nil {
 		return nil, err
 	}
@@ -1430,11 +1341,7 @@ func (l *LibvirtDomainManager) migrateHelper(vmi *v1.VirtualMachineInstance, opt
 		if err := prepareDomainForMigration(l.virConn, dom); err != nil {
 			return fmt.Errorf("error encountered during preparing domain for migration: %v", err)
 		}
-		domSpec, err := l.getDomainSpec(dom)
-		if err != nil {
-			return fmt.Errorf("failed to get domain spec: %v", err)
-		}
-		params, err = generateMigrationParams(dom, vmi, options, l.virtShareDir, domSpec, l.libvirtHooksServerAndClientEnabled)
+		params, err = generateMigrationParams(dom, vmi, options, l.virtShareDir)
 		if err != nil {
 			return fmt.Errorf("error encountered while generating migration parameters: %v", err)
 		}

--- a/pkg/virt-launcher/virtwrap/live-migration-source_test.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source_test.go
@@ -20,8 +20,6 @@
 package virtwrap
 
 import (
-	"encoding/json"
-	"encoding/xml"
 	"fmt"
 	"math"
 	"time"
@@ -36,7 +34,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"libvirt.org/go/libvirt"
 
-	cmdv1 "kubevirt.io/kubevirt/pkg/handler-launcher-com/cmd/v1"
 	cmdclient "kubevirt.io/kubevirt/pkg/virt-handler/cmd-client"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 
@@ -99,7 +96,6 @@ var _ = Describe("Live migration source", func() {
 			virtconfig.DefaultDiskVerificationMemoryLimitBytes,
 			fakeCpuSetGetter,
 			false, // image volume enabled
-			false, // libvirt hooks server and client enabled
 			nil,
 			v1.KvmHypervisorName,
 			nil,
@@ -206,7 +202,6 @@ var _ = Describe("Live migration source", func() {
 				virtconfig.DefaultDiskVerificationMemoryLimitBytes,
 				fakeCpuSetGetter,
 				false, // image volume enabled
-				false, // libvirt hooks server and client enabled
 				nil,
 				v1.KvmHypervisorName,
 				nil,
@@ -354,161 +349,6 @@ var _ = Describe("Live migration source", func() {
 
 			Entry("returns error when no path is set in source",
 				&libvirtxml.DomainDiskSource{}, "", true),
-		)
-	})
-
-	Context("updateFilePathsToNewDomain", func() {
-		targetNS := "target-ns"
-		vmi := &v1.VirtualMachineInstance{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace: "source-ns",
-			},
-			Status: v1.VirtualMachineInstanceStatus{
-				MigrationState: &v1.VirtualMachineInstanceMigrationState{
-					TargetState: &v1.VirtualMachineInstanceMigrationTargetState{
-						VirtualMachineInstanceCommonMigrationState: v1.VirtualMachineInstanceCommonMigrationState{
-							DomainNamespace: &targetNS,
-						},
-					},
-				},
-			},
-		}
-
-		DescribeTable("namespace replacement in disk file paths",
-			func(source api.DiskSource, expectedFile, expectedDataStoreFile string) {
-				domSpec := &api.DomainSpec{
-					Devices: api.Devices{
-						Disks: []api.Disk{
-							{Alias: api.NewUserDefinedAlias("disk0"), Source: source},
-						},
-					},
-				}
-				updateFilePathsToNewDomain(vmi, domSpec)
-				Expect(domSpec.Devices.Disks[0].Source.File).To(Equal(expectedFile))
-				if expectedDataStoreFile != "" {
-					Expect(domSpec.Devices.Disks[0].Source.DataStore.Source.File).To(Equal(expectedDataStoreFile))
-				}
-			},
-			Entry("plain file path containing source namespace is rewritten to target namespace",
-				api.DiskSource{File: "source-ns/my-vm/disk.img"},
-				"target-ns/my-vm/disk.img", ""),
-
-			Entry("plain file path without namespace is left unchanged",
-				api.DiskSource{File: "disk.img"},
-				"disk.img", ""),
-
-			Entry("overlay disk: overlay qcow2 file containing namespace is rewritten",
-				api.DiskSource{
-					File: "source-ns/cbt/vol.qcow2",
-					DataStore: &api.DataStore{
-						Source: &api.DiskSource{File: "/var/run/kubevirt-private/vmi-disks/vol/disk.img"},
-					},
-				},
-				"target-ns/cbt/vol.qcow2",
-				"/var/run/kubevirt-private/vmi-disks/vol/disk.img"),
-
-			Entry("overlay disk: DataStore backing file containing namespace is rewritten",
-				api.DiskSource{
-					File: "/var/lib/libvirt/qemu/cbt/vol.qcow2",
-					DataStore: &api.DataStore{
-						Source: &api.DiskSource{File: "source-ns/vol/disk.img"},
-					},
-				},
-				"/var/lib/libvirt/qemu/cbt/vol.qcow2",
-				"target-ns/vol/disk.img"),
-
-			Entry("overlay disk: both qcow2 and DataStore backing file contain namespace, both rewritten",
-				api.DiskSource{
-					File: "source-ns/cbt/vol.qcow2",
-					DataStore: &api.DataStore{
-						Source: &api.DiskSource{File: "source-ns/vol/disk.img"},
-					},
-				},
-				"target-ns/cbt/vol.qcow2",
-				"target-ns/vol/disk.img"),
-
-			Entry("overlay disk: DataStore backing file without namespace is left unchanged",
-				api.DiskSource{
-					File: "/var/lib/libvirt/qemu/cbt/vol.qcow2",
-					DataStore: &api.DataStore{
-						Source: &api.DiskSource{File: "/var/run/kubevirt-private/vmi-disks/vol/disk.img"},
-					},
-				},
-				"/var/lib/libvirt/qemu/cbt/vol.qcow2",
-				"/var/run/kubevirt-private/vmi-disks/vol/disk.img"),
-		)
-	})
-
-	Context("convertDisks", func() {
-		DescribeTable("syncing spec file paths into migratable libvirt XML",
-			func(specSource api.DiskSource, libvirtSource *libvirtxml.DomainDiskSource,
-				expectedFile, expectedDataStoreFile, expectedDataStoreBlockDev string) {
-				domSpec := &api.DomainSpec{
-					Devices: api.Devices{
-						Disks: []api.Disk{
-							{Alias: api.NewUserDefinedAlias("disk0"), Source: specSource},
-						},
-					},
-				}
-				domcfg := &libvirtxml.Domain{
-					Devices: &libvirtxml.DomainDeviceList{
-						Disks: []libvirtxml.DomainDisk{
-							{Alias: &libvirtxml.DomainAlias{Name: "ua-disk0"}, Source: libvirtSource},
-						},
-					},
-				}
-				Expect(convertDisks(domSpec, domcfg)).To(Succeed())
-				Expect(domcfg.Devices.Disks[0].Source.File.File).To(Equal(expectedFile))
-				if expectedDataStoreFile != "" {
-					Expect(domcfg.Devices.Disks[0].Source.DataStore.Source.File.File).To(Equal(expectedDataStoreFile))
-				}
-				if expectedDataStoreBlockDev != "" {
-					Expect(domcfg.Devices.Disks[0].Source.DataStore.Source.Block).NotTo(BeNil())
-					Expect(domcfg.Devices.Disks[0].Source.DataStore.Source.Block.Dev).To(Equal(expectedDataStoreBlockDev))
-					Expect(domcfg.Devices.Disks[0].Source.DataStore.Source.File).To(BeNil())
-				}
-			},
-			Entry("plain file disk: spec path overwrites stale libvirt XML path",
-				api.DiskSource{File: "/var/run/kubevirt-private/vmi-disks/vol/disk.img"},
-				&libvirtxml.DomainDiskSource{
-					File: &libvirtxml.DomainDiskSourceFile{File: "/var/run/kubevirt-private/vmi-disks/vol/old-disk.img"},
-				},
-				"/var/run/kubevirt-private/vmi-disks/vol/disk.img", "", ""),
-
-			Entry("CBT overlay disk with file backend: both qcow2 and backing store overwrite stale libvirt XML",
-				api.DiskSource{
-					File: "/var/lib/libvirt/qemu/cbt/vol.qcow2",
-					DataStore: &api.DataStore{
-						Source: &api.DiskSource{File: "/var/run/kubevirt-private/vmi-disks/vol/disk.img"},
-					},
-				},
-				&libvirtxml.DomainDiskSource{
-					File: &libvirtxml.DomainDiskSourceFile{File: "/var/lib/libvirt/qemu/cbt/old-vol.qcow2"},
-					DataStore: &libvirtxml.DomainDiskDataStore{
-						Source: &libvirtxml.DomainDiskSource{
-							File: &libvirtxml.DomainDiskSourceFile{File: "/var/run/kubevirt-private/vmi-disks/vol/old-disk.img"},
-						},
-					},
-				},
-				"/var/lib/libvirt/qemu/cbt/vol.qcow2",
-				"/var/run/kubevirt-private/vmi-disks/vol/disk.img", ""),
-
-			Entry("CBT overlay disk with block backend: only qcow2 overwritten, block backend unchanged",
-				api.DiskSource{
-					File: "/var/lib/libvirt/qemu/cbt/vol.qcow2",
-					DataStore: &api.DataStore{
-						Source: &api.DiskSource{Dev: "/dev/vol"},
-					},
-				},
-				&libvirtxml.DomainDiskSource{
-					File: &libvirtxml.DomainDiskSourceFile{File: "/var/lib/libvirt/qemu/cbt/old-vol.qcow2"},
-					DataStore: &libvirtxml.DomainDiskDataStore{
-						Source: &libvirtxml.DomainDiskSource{
-							Block: &libvirtxml.DomainDiskSourceBlock{Dev: "/dev/vol"},
-						},
-					},
-				},
-				"/var/lib/libvirt/qemu/cbt/vol.qcow2", "", "/dev/vol"),
 		)
 	})
 
@@ -1687,13 +1527,11 @@ var _ = Describe("migratableDomXML", func() {
 </domain>`
 		vmi := newVMI("testns", "kubevirt")
 		mockLibvirt.DomainEXPECT().GetXMLDesc(libvirt.DOMAIN_XML_MIGRATABLE).MaxTimes(1).Return(domXML, nil)
-		domSpec := &api.DomainSpec{}
-		Expect(xml.Unmarshal([]byte(domXML), domSpec)).To(Succeed())
-		newXML, err := migratableDomXML(mockLibvirt.VirtDomain, vmi, domSpec, false)
+		newXML, err := migratableDomXML(mockLibvirt.VirtDomain, vmi)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(newXML).To(Equal(expectedXML))
 	})
-	It("should change CPU pinning according to migration metadata", func() {
+	It("should not modify CPU pinning (handled by premigration hook server)", func() {
 		domXML := `<domain type="kvm" id="1">
   <name>kubevirt</name>
   <vcpu placement="static">2</vcpu>
@@ -1702,60 +1540,18 @@ var _ = Describe("migratableDomXML", func() {
     <vcpupin vcpu="1" cpuset="5"></vcpupin>
   </cputune>
 </domain>`
-		// migratableDomXML() removes the migration block but not its ident, which is its own token, hence the blank line below
-		expectedXML := `<domain type="kvm" id="1">
-  <name>kubevirt</name>
-  <vcpu placement="static">2</vcpu>
-  <cputune>
-    <vcpupin vcpu="0" cpuset="6"></vcpupin>
-    <vcpupin vcpu="1" cpuset="7"></vcpupin>
-  </cputune>
-  <cpu>
-    <topology sockets="1" cores="2" threads="1"></topology>
-  </cpu>
-</domain>`
+		expectedXML := domXML
 
-		By("creating a VMI with dedicated CPU cores")
 		vmi := newVMI("testns", "kubevirt")
 		vmi.Spec.Domain.CPU = &v1.CPU{
 			Cores:                 2,
 			DedicatedCPUPlacement: true,
 		}
 
-		By("making up a target topology")
-		topology := &cmdv1.Topology{NumaCells: []*cmdv1.Cell{{
-			Id: 0,
-			Cpus: []*cmdv1.CPU{
-				{
-					Id:       6,
-					Siblings: []uint32{6},
-				},
-				{
-					Id:       7,
-					Siblings: []uint32{7},
-				},
-			},
-		}}}
-		targetNodeTopology, err := json.Marshal(topology)
-		Expect(err).NotTo(HaveOccurred(), "failed to marshall the topology")
-
-		By("saving that topology in the migration state of the VMI")
-		vmi.Status.MigrationState = &v1.VirtualMachineInstanceMigrationState{
-			TargetCPUSet:       []int{6, 7},
-			TargetNodeTopology: string(targetNodeTopology),
-		}
-
-		By("generated the domain XML for a migration to that target")
 		mockLibvirt.DomainEXPECT().GetXMLDesc(libvirt.DOMAIN_XML_MIGRATABLE).MaxTimes(1).Return(domXML, nil)
-		domSpec := &api.DomainSpec{}
-		Expect(xml.Unmarshal([]byte(domXML), domSpec)).To(Succeed())
-		Expect(domSpec.VCPU).NotTo(BeNil())
-		Expect(domSpec.CPUTune).NotTo(BeNil())
-		newXML, err := migratableDomXML(mockLibvirt.VirtDomain, vmi, domSpec, false)
-		Expect(err).ToNot(HaveOccurred(), "failed to generate target domain XML")
-
-		By("ensuring the generated XML is accurate")
-		Expect(newXML).To(Equal(expectedXML), "the target XML is not as expected")
+		newXML, err := migratableDomXML(mockLibvirt.VirtDomain, vmi)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(newXML).To(Equal(expectedXML))
 	})
 	DescribeTable("slices section", func(domXML string) {
 		retDiskSize := func(disk *libvirtxml.DomainDisk) (int64, error) {
@@ -1808,9 +1604,7 @@ var _ = Describe("migratableDomXML", func() {
 			},
 		}
 		mockLibvirt.DomainEXPECT().GetXMLDesc(libvirt.DOMAIN_XML_MIGRATABLE).MaxTimes(1).Return(domXML, nil)
-		domSpec := &api.DomainSpec{}
-		Expect(xml.Unmarshal([]byte(domXML), domSpec)).To(Succeed())
-		newXML, err := migratableDomXML(mockLibvirt.VirtDomain, vmi, domSpec, false)
+		newXML, err := migratableDomXML(mockLibvirt.VirtDomain, vmi)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(newXML).To(Equal(expectedXML))
 	},
@@ -1877,9 +1671,7 @@ var _ = Describe("migratableDomXML", func() {
 		networkData := "FakeNetwork"
 		addCloudInitDisk(vmi, userData, networkData)
 		mockLibvirt.DomainEXPECT().GetXMLDesc(libvirt.DOMAIN_XML_MIGRATABLE).MaxTimes(1).Return(domXML, nil)
-		domSpec := &api.DomainSpec{}
-		Expect(xml.Unmarshal([]byte(domXML), domSpec)).To(Succeed())
-		newXML, err := migratableDomXML(mockLibvirt.VirtDomain, vmi, domSpec, false)
+		newXML, err := migratableDomXML(mockLibvirt.VirtDomain, vmi)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(newXML).To(Equal(expectedXML))
 	})

--- a/pkg/virt-launcher/virtwrap/live-migration-target.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-target.go
@@ -175,11 +175,9 @@ func (l *LibvirtDomainManager) prepareMigrationTarget(
 		return fmt.Errorf("Failed to generate libvirt domain from VMI spec: %v", err)
 	}
 
-	if l.libvirtHooksServerAndClientEnabled {
-		if l.hookServer != nil {
-			if err := l.hookServer.Start(c); err != nil {
-				return err
-			}
+	if l.hookServer != nil {
+		if err := l.hookServer.Start(c); err != nil {
+			return err
 		}
 	}
 

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -243,11 +243,10 @@ type LibvirtDomainManager struct {
 	devAliasMap  map[string]string
 	devAliasLock sync.RWMutex
 
-	cpuSetGetter                       func() ([]int, error)
-	imageVolumeFeatureGateEnabled      bool
-	libvirtHooksServerAndClientEnabled bool
-	firmwareAutoSelectionEnabled       bool
-	setTimeOnce                        sync.Once
+	cpuSetGetter                  func() ([]int, error)
+	imageVolumeFeatureGateEnabled bool
+	firmwareAutoSelectionEnabled  bool
+	setTimeOnce                   sync.Once
 
 	// Premigration hook server for VMI updates during migration
 	hookServer *premigrationhookserver.PreMigrationHookServer
@@ -301,7 +300,6 @@ func NewLibvirtDomainManager(
 	diskMemoryLimitBytes int64,
 	cpuSetGetter func() ([]int, error),
 	imageVolumeEnabled bool,
-	libvirtHooksServerAndClientEnabled bool,
 	hookServer *premigrationhookserver.PreMigrationHookServer,
 	hypervisorName string,
 	registerNBD storage.RegisterNBDFunc,
@@ -324,7 +322,6 @@ func NewLibvirtDomainManager(
 		diskMemoryLimitBytes,
 		cpuSetGetter,
 		imageVolumeEnabled,
-		libvirtHooksServerAndClientEnabled,
 		hookServer,
 		hypervisorName,
 		registerNBD,
@@ -347,7 +344,6 @@ func newLibvirtDomainManager(
 	diskMemoryLimitBytes int64,
 	cpuSetGetter func() ([]int, error),
 	imageVolumeEnabled bool,
-	libvirtHooksServerAndClientEnabled bool,
 	hookServer *premigrationhookserver.PreMigrationHookServer,
 	hypervisorName string,
 	registerNBD storage.RegisterNBDFunc,
@@ -386,17 +382,16 @@ func newLibvirtDomainManager(
 		guestDiskSizes:       map[string]int64{},
 		domainInfoStats:      &stats.DomainJobInfo{},
 
-		metadataCache:                      metadataCache,
-		cpuSetGetter:                       cpuSetGetter,
-		setTimeOnce:                        sync.Once{},
-		imageVolumeFeatureGateEnabled:      imageVolumeEnabled,
-		libvirtHooksServerAndClientEnabled: libvirtHooksServerAndClientEnabled,
-		firmwareAutoSelectionEnabled:       firmwareAutoSelectionEnabled,
-		hookServer:                         hookServer,
-		hypervisorName:                     hypervisorName,
-		hypervisorDeviceAvailable:          hypervisorDeviceAvailable,
-		iommuFD:                            -1,
-		allowCrossArchEmulation:            allowCrossArchEmulation,
+		metadataCache:                 metadataCache,
+		cpuSetGetter:                  cpuSetGetter,
+		setTimeOnce:                   sync.Once{},
+		imageVolumeFeatureGateEnabled: imageVolumeEnabled,
+		firmwareAutoSelectionEnabled:  firmwareAutoSelectionEnabled,
+		hookServer:                    hookServer,
+		hypervisorName:                hypervisorName,
+		hypervisorDeviceAvailable:     hypervisorDeviceAvailable,
+		iommuFD:                       -1,
+		allowCrossArchEmulation:       allowCrossArchEmulation,
 	}
 
 	manager.hotplugHostDevicesInProgress = make(chan struct{}, maxConcurrentHotplugHostDevices)
@@ -1397,9 +1392,6 @@ func (l *LibvirtDomainManager) generateConverterContext(vmi *v1.VirtualMachineIn
 		if len(gpuDevices) > 1 && gpuDevices[0].Type == api.HostDeviceMDev {
 			return nil, fmt.Errorf("vGPU live migration currently only supports a single vGPU, found %d for vmi %s", len(gpuDevices), vmi.Name)
 		} else if len(gpuDevices) == 1 && gpuDevices[0].Type == api.HostDeviceMDev {
-			if !l.libvirtHooksServerAndClientEnabled {
-				return nil, fmt.Errorf("vGPU live migration requires LibvirtHooksServerAndClient feature gate for vmi %s", vmi.Name)
-			}
 			c.GPUHostDevices = gpuDevices
 		}
 	}

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -113,7 +113,7 @@ var _ = Describe("Manager", func() {
 	testDomainName := fmt.Sprintf("%s_%s", testNamespace, testVmName)
 	ephemeralDiskCreatorMock := &fake.MockEphemeralDiskImageCreator{}
 	newLibvirtDomainManagerDefault := func() (DomainManager, error) {
-		return NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
+		return NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
 	}
 
 	BeforeEach(func() {
@@ -691,7 +691,7 @@ var _ = Describe("Manager", func() {
 				func() {
 					isFreeCalled <- true
 				})
-			manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, "fake", "fake", nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
+			manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, "fake", "fake", nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
 			Expect(manager.UnpauseVMI(vmi)).To(Succeed())
 			Eventually(func() bool {
 				select {
@@ -783,7 +783,7 @@ var _ = Describe("Manager", func() {
 			mockLibvirt.DomainEXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).MaxTimes(3).Return(string(xmlDomain), nil)
 			mockLibvirt.DomainEXPECT().GetXMLDesc(libvirt.DOMAIN_XML_INACTIVE).MaxTimes(1).Return(string(xmlDomain), nil)
 
-			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, "fake", "fake", nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
+			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, "fake", "fake", nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
 			newspec, err := manager.SyncVMI(vmi, true, &cmdv1.VirtualMachineOptions{
 				VirtualMachineSMBios: &cmdv1.SMBios{},
 				PreallocatedVolumes:  []string{"permvolume1"},
@@ -914,7 +914,7 @@ var _ = Describe("Manager", func() {
 			mockLibvirt.DomainEXPECT().AttachDeviceFlags(strings.ToLower(string(attachBytes)), affectDeviceLiveAndConfigLibvirtFlags)
 			mockLibvirt.DomainEXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).MaxTimes(3).Return(string(xmlDomain2), nil)
 
-			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
+			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
 			newspec, err := manager.SyncVMI(vmi, true, &cmdv1.VirtualMachineOptions{VirtualMachineSMBios: &cmdv1.SMBios{}})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(newspec).ToNot(BeNil())
@@ -1023,7 +1023,7 @@ var _ = Describe("Manager", func() {
 			mockLibvirt.DomainEXPECT().DetachDeviceFlags(strings.ToLower(string(detachBytes)), affectDeviceLiveAndConfigLibvirtFlags)
 			mockLibvirt.DomainEXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).MaxTimes(3).Return(string(xmlDomain), nil)
 			mockLibvirt.DomainEXPECT().GetXMLDesc(libvirt.DOMAIN_XML_INACTIVE).MaxTimes(1).Return(string(xmlDomain), nil)
-			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
+			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
 			newspec, err := manager.SyncVMI(vmi, true, &cmdv1.VirtualMachineOptions{VirtualMachineSMBios: &cmdv1.SMBios{}})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(newspec).ToNot(BeNil())
@@ -1097,7 +1097,7 @@ var _ = Describe("Manager", func() {
 			}
 			mockLibvirt.DomainEXPECT().GetState().Return(libvirt.DOMAIN_SHUTDOWN, 1, nil)
 			mockLibvirt.DomainEXPECT().CreateWithFlags(libvirt.DOMAIN_NONE).Return(nil)
-			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
+			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
 			newspec, err := manager.SyncVMI(vmi, true, &cmdv1.VirtualMachineOptions{VirtualMachineSMBios: &cmdv1.SMBios{}})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(newspec).ToNot(BeNil())
@@ -1198,7 +1198,7 @@ var _ = Describe("Manager", func() {
 			mockLibvirt.DomainEXPECT().CreateWithFlags(libvirt.DOMAIN_NONE).Return(nil)
 			mockLibvirt.DomainEXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).MaxTimes(3).Return(string(xmlDomain2), nil)
 
-			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
+			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
 			newspec, err := manager.SyncVMI(vmi, true, &cmdv1.VirtualMachineOptions{VirtualMachineSMBios: &cmdv1.SMBios{}})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(newspec).ToNot(BeNil())
@@ -1337,7 +1337,7 @@ var _ = Describe("Manager", func() {
 			mockLibvirt.DomainEXPECT().UpdateDeviceFlags(strings.ToLower(string(updateBytes)), affectDeviceLiveAndConfigLibvirtFlags)
 			mockLibvirt.DomainEXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).MaxTimes(3).Return(string(xmlDomain2), nil)
 
-			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
+			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
 			newspec, err := manager.SyncVMI(vmi, true, &cmdv1.VirtualMachineOptions{VirtualMachineSMBios: &cmdv1.SMBios{}})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(newspec).ToNot(BeNil())
@@ -1467,7 +1467,7 @@ var _ = Describe("Manager", func() {
 			mockLibvirt.DomainEXPECT().UpdateDeviceFlags(strings.ToLower(string(updateBytes)), affectDeviceLiveAndConfigLibvirtFlags)
 			mockLibvirt.DomainEXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).MaxTimes(3).Return(string(xmlDomain2), nil)
 
-			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
+			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
 			newspec, err := manager.SyncVMI(vmi, true, &cmdv1.VirtualMachineOptions{VirtualMachineSMBios: &cmdv1.SMBios{}})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(newspec).ToNot(BeNil())
@@ -1545,7 +1545,7 @@ var _ = Describe("Manager", func() {
 			defer os.RemoveAll(ovmfDir)
 			err = os.WriteFile(filepath.Join(ovmfDir, efi.EFICodeSEV), loaderBytes, 0644)
 			Expect(err).ToNot(HaveOccurred())
-			manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, ovmfDir, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
+			manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, ovmfDir, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
 			sevMeasurementInfo, err := manager.GetLaunchMeasurement(vmi)
 			if runtime.GOARCH == "amd64" {
 				Expect(err).ToNot(HaveOccurred())
@@ -1862,7 +1862,7 @@ var _ = Describe("Manager", func() {
 				Physical: 20 * 1024 * 1024 * 1024,
 			}, nil)
 
-			manager, err := NewLibvirtDomainManager(localMockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
+			manager, err := NewLibvirtDomainManager(localMockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
 			Expect(err).ToNot(HaveOccurred())
 			newspec, err := manager.SyncVMI(vmi, true, &cmdv1.VirtualMachineOptions{VirtualMachineSMBios: &cmdv1.SMBios{}})
 			Expect(err).ToNot(HaveOccurred())
@@ -2767,7 +2767,7 @@ var _ = Describe("Manager", func() {
 				options := &cmdv1.VirtualMachineOptions{
 					ClusterConfig: &cmdv1.ClusterConfig{VGPULiveMigrationEnabled: true},
 				}
-				manager, err := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, true, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
+				manager, err := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
 				Expect(err).ToNot(HaveOccurred())
 				libvirtManager := manager.(*LibvirtDomainManager)
 
@@ -2813,7 +2813,7 @@ var _ = Describe("Manager", func() {
 			func(state libvirt.DomainState) {
 				mockLibvirt.ConnectionEXPECT().LookupDomainByName(testDomainName).DoAndReturn(mockDomainWithFreeExpectation)
 				mockLibvirt.DomainEXPECT().UndefineFlags(libvirt.DOMAIN_UNDEFINE_KEEP_NVRAM | libvirt.DOMAIN_UNDEFINE_CHECKPOINTS_METADATA).Return(nil)
-				manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, "fake", "fake", nil, "/usr/share/", ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
+				manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, "fake", "fake", nil, "/usr/share/", ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
 				Expect(manager.DeleteVMI(newVMI(testNamespace, testVmName))).To(Succeed())
 			},
 			Entry("crashed", libvirt.DOMAIN_CRASHED),
@@ -3023,7 +3023,7 @@ var _ = Describe("Manager", func() {
 
 			BeforeEach(func() {
 				agentStore = agentpoller.NewAsyncAgentStore()
-				libvirtmanager, _ = NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
+				libvirtmanager, _ = NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
 			})
 
 			It("should report nil when no OS info exists in the cache", func() {
@@ -3047,7 +3047,7 @@ var _ = Describe("Manager", func() {
 
 			BeforeEach(func() {
 				agentStore = agentpoller.NewAsyncAgentStore()
-				libvirtmanager, _ = NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
+				libvirtmanager, _ = NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
 			})
 
 			It("should return nil when no interfaces exists in the cache", func() {
@@ -3091,7 +3091,7 @@ var _ = Describe("Manager", func() {
 				},
 			},
 		})
-		manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
+		manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
 
 		// we need the non-typecast object to make the function we want to test available
 		libvirtmanager := manager.(*LibvirtDomainManager)
@@ -3127,7 +3127,7 @@ var _ = Describe("Manager", func() {
 			},
 		})
 
-		manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
+		manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
 
 		// we need the non-typecast object to make the function we want to test available
 		libvirtmanager := manager.(*LibvirtDomainManager)
@@ -3154,7 +3154,7 @@ var _ = Describe("Manager", func() {
 			},
 		})
 
-		manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
+		manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
 
 		// we need the non-typecast object to make the function we want to test available
 		libvirtmanager := manager.(*LibvirtDomainManager)
@@ -3181,7 +3181,7 @@ var _ = Describe("Manager", func() {
 			},
 		})
 
-		manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
+		manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
 
 		// we need the non-typecast object to make the function we want to test available
 		libvirtmanager := manager.(*LibvirtDomainManager)
@@ -3227,7 +3227,7 @@ var _ = Describe("Manager", func() {
 			},
 		})
 
-		manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
+		manager, _ := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, &agentStore, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, nil, v1.KvmHypervisorName, nil, "", false, false, false, nil)
 
 		// we need the non-typecast object to make the function we want to test available
 		libvirtmanager := manager.(*LibvirtDomainManager)
@@ -3615,7 +3615,7 @@ var _ = Describe("Manager", func() {
 		})
 
 		It("should use firmware auto-selection for standard secure boot when feature gate is enabled", func() {
-			manager, err := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, true, false, nil)
+			manager, err := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, nil, v1.KvmHypervisorName, nil, "", false, true, false, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			options := &cmdv1.VirtualMachineOptions{
@@ -3642,7 +3642,7 @@ var _ = Describe("Manager", func() {
 			Expect(os.WriteFile(filepath.Join(ovmfDir, efiCodeFile), []byte("code"), 0644)).To(Succeed())
 			Expect(os.WriteFile(filepath.Join(ovmfDir, efiVarsFile), []byte("vars"), 0644)).To(Succeed())
 
-			manager, err := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, ovmfDir, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, firmwareAutoSelection, false, nil)
+			manager, err := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, ovmfDir, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, nil, v1.KvmHypervisorName, nil, "", false, firmwareAutoSelection, false, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			libvirtManager := manager.(*LibvirtDomainManager)
@@ -3678,7 +3678,7 @@ var _ = Describe("Manager", func() {
 				Expect(os.WriteFile(filepath.Join(ovmfDir, f), []byte("data"), 0644)).To(Succeed())
 			}
 
-			manager, err := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, ovmfDir, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, true, false, nil)
+			manager, err := NewLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, ovmfDir, ephemeralDiskCreatorMock, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, nil, v1.KvmHypervisorName, nil, "", false, true, false, nil)
 			Expect(err).ToNot(HaveOccurred())
 
 			libvirtManager := manager.(*LibvirtDomainManager)


### PR DESCRIPTION
### What this PR does

Graduate the `LibvirtHooksServerAndClient` feature gate (VEP-141) to GA.

### References

- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/141

### Special notes for your reviewer

Per https://github.com/kubevirt/enhancements/pull/368#issuecomment-5119244026,
also updates `docs/devel/migration-premigration-hooks.md`.

### Release note
```release-note
Graduate LibvirtHooksServerAndClient feature gate to GA
```

/sig compute