### PR TITLE
bump hermetic_launcher to v0.0.15 for s390x toolchain support

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -33,10 +33,10 @@ http_archive(
 
 http_archive(
     name = "hermetic_launcher",
-    sha256 = "f6b5dbcf4c87561d85aa2ba9b14d70bd3f619ffb2d6eb3b15d93a6825ef75a7a",
+    sha256 = "81b4204840f1fd346ec1b550153ae20bd60d28bca839e82ef95c64a585d02cea",
+    strip_prefix = "hermetic-launcher-0.0.15",
     urls = [
-        "https://github.com/hermeticbuild/hermetic-launcher/releases/download/v0.0.6/hermetic_launcher-v0.0.6.tar.gz",
-        "https://storage.googleapis.com/builddeps/f6b5dbcf4c87561d85aa2ba9b14d70bd3f619ffb2d6eb3b15d93a6825ef75a7a",
+        "https://github.com/hermeticbuild/hermetic-launcher/archive/refs/tags/v0.0.15.tar.gz",
     ],
 )
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
Native s390x builds fail with "No matching toolchains found for finalizer_toolchain_type" when building or pushing container images, because hermetic_launcher v0.0.6 lacks s390x toolchain registrations.

#### After this PR:
hermetic_launcher is bumped to v0.0.15, which includes the s390x prebuilt toolchain wiring (hermeticbuild/hermetic-launcher#71). Native s390x container image builds work correctly.

### References
- Fixes hermeticbuild/hermetic-launcher#71
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The migration to rules_img (#17598) works for x86 and arm, but s390x was broken because hermetic_launcher v0.0.6 did not wire the s390x prebuilt binaries into its toolchain registrations. v0.0.15 includes that fix upstream, so a version bump is all that's needed.

The following tradeoffs were made:

The following alternatives were considered:
- Carrying a patch (patch_cmds or fork reference) in WORKSPACE — rejected because the community requires official upstream releases.


Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
The s390x stub binaries (`http_file` entries for `finalize_stub_s390x_linux` and `runfiles_stub_s390x_linux`) were already present in WORKSPACE from the original rules_img migration. Only the hermetic_launcher archive needed updating.

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
    Bump hermetic_launcher to v0.0.15 to fix s390x container image builds.

```

