### PR TITLE
tests: fix transient flakes in operator cert verification

### DIFF
--- a/tests/infrastructure/certificates.go
+++ b/tests/infrastructure/certificates.go
@@ -68,8 +68,9 @@ var _ = Describe(SIGSerial("[rfe_id:4102][crit:medium][vendor:cnv-qe@redhat.com]
 
 	It("[test_id:4099] should be rotated when a new CA is created", decorators.WgS390x, func() {
 		By("checking that the config-map gets the new CA bundle attached")
-		Eventually(func() int {
-			_, crts := libinfra.GetBundleFromConfigMap(context.Background(), components.KubeVirtCASecretName)
+		Eventually(func(g Gomega) int {
+			_, crts, err := libinfra.GetBundleFromConfigMap(context.Background(), components.KubeVirtCASecretName)
+			g.Expect(err).ToNot(HaveOccurred())
 			return len(crts)
 		}, 10*time.Second, 1*time.Second).Should(BeNumerically(">", 0))
 
@@ -93,8 +94,10 @@ var _ = Describe(SIGSerial("[rfe_id:4102][crit:medium][vendor:cnv-qe@redhat.com]
 
 		By("checking that one of the CAs in the config-map is the new one")
 		var caBundle []byte
-		Eventually(func() bool {
-			caBundle, _ = libinfra.GetBundleFromConfigMap(context.Background(), components.KubeVirtCASecretName)
+		Eventually(func(g Gomega) bool {
+			var err error
+			caBundle, _, err = libinfra.GetBundleFromConfigMap(context.Background(), components.KubeVirtCASecretName)
+			g.Expect(err).ToNot(HaveOccurred())
 			return libinfra.ContainsCrt(caBundle, newCA)
 		}, 10*time.Second, 1*time.Second).Should(BeTrue(), "the new CA should be added to the config-map")
 

--- a/tests/libinfra/certificates.go
+++ b/tests/libinfra/certificates.go
@@ -53,16 +53,20 @@ func ContainsCrt(bundle []byte, containedCrt []byte) bool {
 	return attached
 }
 
-func GetBundleFromConfigMap(ctx context.Context, configMapName string) ([]byte, []*x509.Certificate) {
+func GetBundleFromConfigMap(ctx context.Context, configMapName string) ([]byte, []*x509.Certificate, error) {
 	virtClient := kubevirt.Client()
 	configMap, err := virtClient.CoreV1().ConfigMaps(flags.KubeVirtInstallNamespace).Get(ctx, configMapName, v1.GetOptions{})
-	gomega.Expect(err).ToNot(gomega.HaveOccurred())
+	if err != nil {
+		return nil, nil, err
+	}
 	if rawBundle, ok := configMap.Data[components.CABundleKey]; ok {
 		crts, err := cert.ParseCertsPEM([]byte(rawBundle))
-		gomega.Expect(err).ToNot(gomega.HaveOccurred())
-		return []byte(rawBundle), crts
+		if err != nil {
+			return nil, nil, err
+		}
+		return []byte(rawBundle), crts, nil
 	}
-	return nil, nil
+	return nil, nil, nil
 }
 
 // EnsurePodsCertIsSynced waits until new certificates are rolled out to all pods

--- a/tests/libpod/certs.go
+++ b/tests/libpod/certs.go
@@ -83,17 +83,16 @@ func getCert(pod *k8sv1.Pod, port string) []byte {
 
 	var certificate []byte
 	const offset = 2
-	EventuallyWithOffset(offset, func() []byte {
+	EventuallyWithOffset(offset, func(g Gomega) []byte {
 		stopChan := make(chan struct{})
 		defer close(stopChan)
 		const timeout = 10
 		localPort, err := ForwardPorts(pod, []string{"0:" + port}, stopChan, timeout*time.Second)
-		ExpectWithOffset(offset, err).ToNot(HaveOccurred())
+		g.Expect(err).ToNot(HaveOccurred())
 
 		conn, err := (&tls.Dialer{Config: conf}).DialContext(context.Background(), "tcp4", fmt.Sprintf("localhost:%d", localPort))
-		if err == nil {
-			defer conn.Close()
-		}
+		g.Expect(err).ToNot(HaveOccurred())
+		defer conn.Close()
 		mutex.Lock()
 		defer mutex.Unlock()
 		certificate = make([]byte, len(rawCert))

--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -2603,20 +2603,22 @@ func serviceMonitorEnabled() bool {
 // verifyOperatorWebhookCertificate can be used when inside tests doing reinstalls of kubevirt, to ensure that virt-operator already got the new certificate.
 // This is necessary, since it can take up to a minute to get the fresh certificates when secrets are updated.
 func verifyOperatorWebhookCertificate() {
-	caBundle, _ := libinfra.GetBundleFromConfigMap(context.Background(), components.KubeVirtCASecretName)
-	certPool := x509.NewCertPool()
-	certPool.AppendCertsFromPEM(caBundle)
-	// ensure that the state is fully restored before each test
-	Eventually(func() error {
+	Eventually(func(g Gomega) {
+		caBundle, _, err := libinfra.GetBundleFromConfigMap(context.Background(), components.KubeVirtCASecretName)
+		g.Expect(err).ToNot(HaveOccurred())
+		certPool := x509.NewCertPool()
+		certPool.AppendCertsFromPEM(caBundle)
+
 		currentCert, err := libpod.GetCertsForPods(fmt.Sprintf("%s=%s", v1.AppLabel, "virt-operator"), flags.KubeVirtInstallNamespace, "8444")
-		Expect(err).ToNot(HaveOccurred())
+		g.Expect(err).ToNot(HaveOccurred())
+		g.Expect(currentCert).ToNot(BeEmpty())
 		crt, err := x509.ParseCertificate(currentCert[0])
-		Expect(err).ToNot(HaveOccurred())
+		g.Expect(err).ToNot(HaveOccurred())
 		_, err = crt.Verify(x509.VerifyOptions{
 			Roots: certPool,
 		})
-		return err
-	}, 90*time.Second, 1*time.Second).Should(Not(HaveOccurred()), "bundle and certificate are still not in sync after 90 seconds")
+		g.Expect(err).ToNot(HaveOccurred())
+	}, 90*time.Second, 1*time.Second).Should(Succeed(), "bundle and certificate are still not in sync after 90 seconds")
 	// we got the first pod with the new certificate, now let's wait until every pod sees it
 	// this can take additional time since nodes are not synchronizing at the same moment
 	libinfra.EnsurePodsCertIsSynced(fmt.Sprintf("%s=%s", v1.AppLabel, "virt-operator"), flags.KubeVirtInstallNamespace, "8444")


### PR DESCRIPTION
### What this PR does
Fixes intermittent test failures in `[sig-operator]Operator should reconcile components` tests (`[test_id:6308]` daemonsets and `[test_id:6309]` service reconcile) caused by transient network errors during certificate verification in BeforeEach/AfterEach.

The `verifyOperatorWebhookCertificate()` function had two retry bugs:
- `GetBundleFromConfigMap` used hard `gomega.Expect` assertions internally, so a transient API server error (e.g. TLS handshake timeout) would immediately fail the test with no retry, even when called inside `Eventually` blocks.
- `getCert` used `ExpectWithOffset` on port-forward errors inside an `EventuallyWithOffset` callback, which aborted the test instead of allowing the retry loop to continue.

#### Before this PR:
- A single TLS handshake timeout when fetching the CA configmap kills the test immediately
- A single port-forward timeout in `getCert` kills the test immediately despite being inside an `Eventually` loop
- These tests fail repeatedly across CI runs due to transient network conditions

#### After this PR:
- `GetBundleFromConfigMap` returns errors instead of hard-asserting, allowing callers inside `Eventually` blocks to retry on transient failures
- `getCert` returns nil on port-forward failure, allowing its `EventuallyWithOffset` to retry via the `Should(Not(BeEmpty()))` matcher
- `verifyOperatorWebhookCertificate` moves the configmap fetch inside the `Eventually` block so transient API server errors are retried along with certificate verification

### References


### Release note
```release-note
NONE
```