### PR TITLE
tests/automation: fix wg-s390x test lane for kubevirtci provider

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -169,6 +169,8 @@ case "$TARGET" in
     ;;
   *wg-s390x*)
     export KUBEVIRT_PROVIDER=${TARGET/-wg-s390x}
+    export KUBEVIRT_WITH_CNAO=true
+    export KUBEVIRT_DEPLOY_PROMETHEUS=true
     ;;
   *wg-arm64*)
     export KUBEVIRT_PROVIDER=${TARGET/-wg-arm64}

--- a/tests/testsuite/kubevirtresource.go
+++ b/tests/testsuite/kubevirtresource.go
@@ -46,6 +46,7 @@ import (
 	"kubevirt.io/kubevirt/tests/framework/checks"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/libkubevirt"
+	"kubevirt.io/kubevirt/tests/libnode"
 	"kubevirt.io/kubevirt/tests/libstorage"
 )
 
@@ -103,13 +104,11 @@ func AdjustKubeVirtResource() {
 			},
 		},
 	}
-	// Disable CPUManager Featuregate for s390x as it is not supported.
-	if translateBuildArch() != "s390x" {
-		kv.Spec.Configuration.DeveloperConfiguration.FeatureGates = append(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates,
-			featuregate.CPUManager,
-		)
-	}
-	kv.Spec.Configuration.DeveloperConfiguration.FeatureGates = append(kv.Spec.Configuration.DeveloperConfiguration.FeatureGates,
+	arch := libnode.GetArch()
+	unsupportedGates := unsupportedFeatureGatesForArch(arch)
+
+	for _, gate := range []string{
+		featuregate.CPUManager,
 		featuregate.IgnitionGate,
 		featuregate.SidecarGate,
 		featuregate.IncrementalBackupGate,
@@ -123,7 +122,12 @@ func AdjustKubeVirtResource() {
 		featuregate.UtilityVolumesGate,
 		featuregate.RebootPolicy,
 		featuregate.ContainerPathVolumesGate,
-	)
+	} {
+		if !unsupportedGates[gate] {
+			kv.Spec.Configuration.DeveloperConfiguration.FeatureGates = append(
+				kv.Spec.Configuration.DeveloperConfiguration.FeatureGates, gate)
+		}
+	}
 
 	// ImageVolume is enabled by default for k8s 1.35+ (image volume feature gate in kubelet).
 	// Disable it on older clusters to avoid CI failures.
@@ -251,25 +255,19 @@ func UpdateKubeVirtConfigValue(kvConfig v1.KubeVirtConfiguration) *v1.KubeVirt {
 	return kv
 }
 
-/*
-translateBuildArch translates the build_arch to arch
-
-	case1:
-	  build_arch is crossbuild-s390x, which will be translated to s390x arch
-	case2:
-	  build_arch is s390x, which will be translated to s390x arch
-*/
-func translateBuildArch() string {
-	buildArch := os.Getenv("BUILD_ARCH")
-
-	if buildArch == "" {
-		return ""
+// unsupportedFeatureGatesForArch returns the set of feature gates that must not
+// be enabled on the given architecture because the underlying hardware or
+// platform capability does not exist (e.g. AMD SEV on s390x).
+func unsupportedFeatureGatesForArch(arch string) map[string]bool {
+	switch arch {
+	case "s390x":
+		return map[string]bool{
+			featuregate.CPUManager:            true,
+			featuregate.WorkloadEncryptionSEV: true,
+		}
+	default:
+		return nil
 	}
-	archElements := strings.Split(buildArch, "-")
-	if len(archElements) == 2 {
-		return archElements[1]
-	}
-	return archElements[0]
 }
 
 func parseVerbosityEnv() (*v1.LogVerbosity, error) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
- Detect cluster architecture from node metadata instead of requiring the
  `BUILD_ARCH` environment variable, so the test suite auto-discovers the
  target platform and disables unsupported feature gates accordingly.
- Enable CNAO and Prometheus for the wg-s390x target when using a
  kubevirtci-provisioned cluster, fixing 11 sig-network and 1 sig-monitoring
  test failures caused by missing infrastructure. The periodic CI job using
  an external provider is unaffected.

#### Before this PR:
- The test suite required `BUILD_ARCH` to be manually set to detect the cluster
  architecture and disable unsupported feature gates on s390x.
- Running `automation/test.sh` with `TARGET=k8s-1.34-wg-s390x` failed 12 tests
  because the kubevirtci cluster was provisioned without CNAO or Prometheus.

#### After this PR:
- The test suite auto-detects cluster architecture from node metadata, eliminating
  the `BUILD_ARCH` dependency.
- CNAO and Prometheus are enabled for wg-s390x on kubevirtci, fixing sig-network
  and sig-monitoring test failures. 

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
When running `automation/test.sh` with `TARGET=k8s-1.34-wg-s390x` (kubevirtci provider):
1. The test suite couldn't detect the cluster arch without `BUILD_ARCH` being manually set
2. The cluster was provisioned without CNAO/Prometheus, causing 11 sig-network and
   1 sig-monitoring test failures that pass on the periodic external-provider CI job
Both issues are fixed, making the kubevirtci-based wg-s390x lane fully functional.

The following alternatives were considered:
- Keeping `BUILD_ARCH` with a `runtime.GOARCH` fallback — rejected because when
  tests are cross-compiled for a different arch than the target cluster,
  `runtime.GOARCH` gives the wrong answer and still requires the env var.
- Skipping the network/monitoring tests from the wg-s390x label filter — rejected
  because these tests should run on s390x; the issue was missing infrastructure,
  not test incompatibility.


Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
- The `automation/test.sh` change only affects kubevirtci-provisioned clusters.
  The periodic CI job (`periodic-kubevirt-e2e-test-S390X`) uses `TARGET=external-wg-s390x`
  with a pre-provisioned cluster and is not affected by this change.
- Verified locally: all 356 tests pass with 0 failures after this fix.

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
     None.

```

