### PR TITLE
Virt-Handler: Remove unused client certificate

### DIFF
--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -126,8 +126,6 @@ const (
 	defaultCAConfigMapName = "kubevirt-ca"
 
 	// Default certificate and key paths
-	defaultClientCertFilePath      = "/etc/virt-handler/clientcertificates/tls.crt"
-	defaultClientKeyFilePath       = "/etc/virt-handler/clientcertificates/tls.key"
 	defaultVsockClientCertFilePath = "/etc/virt-handler/vsockclientcertificates/tls.crt"
 	defaultVsockClientKeyFilePath  = "/etc/virt-handler/vsockclientcertificates/tls.key"
 	defaultTlsCertFilePath         = "/etc/virt-handler/servercertificates/tls.crt"
@@ -156,8 +154,6 @@ type virtHandlerApp struct {
 	migrationCNTypes          []string
 
 	caConfigMapName         string
-	clientCertFilePath      string
-	clientKeyFilePath       string
 	vsockClientCertFilePath string
 	vsockClientKeyFilePath  string
 	serverCertFilePath      string
@@ -169,22 +165,20 @@ type virtHandlerApp struct {
 	virtCli   kubecli.KubevirtClient
 	namespace string
 
-	migrationServerTLSConfig    *tls.Config
-	serverTLSConfig             *tls.Config
-	migrationOldClientTLSConfig *tls.Config
-	migrationClientTLSConfig    *tls.Config
-	vmStatsTLSConfig            *tls.Config
-	consoleServerPort           int
-	vmStatsServerPort           int
-	clientcertmanager           certificate.Manager
-	vsockClientCertManager      certificate.Manager
-	servercertmanager           certificate.Manager
-	migrationCertManager        certificate.Manager
-	promTLSConfig               *tls.Config
-	clusterConfig               *virtconfig.ClusterConfig
-	reloadableRateLimiter       *ratelimiter.ReloadableRateLimiter
-	caManager                   kvtls.ClientCAManager
-	enableNodeLabeller          bool
+	migrationServerTLSConfig *tls.Config
+	serverTLSConfig          *tls.Config
+	migrationClientTLSConfig *tls.Config
+	vmStatsTLSConfig         *tls.Config
+	consoleServerPort        int
+	vmStatsServerPort        int
+	vsockClientCertManager   certificate.Manager
+	servercertmanager        certificate.Manager
+	migrationCertManager     certificate.Manager
+	promTLSConfig            *tls.Config
+	clusterConfig            *virtconfig.ClusterConfig
+	reloadableRateLimiter    *ratelimiter.ReloadableRateLimiter
+	caManager                kvtls.ClientCAManager
+	enableNodeLabeller       bool
 }
 
 var (
@@ -193,7 +187,6 @@ var (
 )
 
 func (app *virtHandlerApp) prepareCertManager() (err error) {
-	app.clientcertmanager = bootstrap.NewFileCertificateManager(app.clientCertFilePath, app.clientKeyFilePath)
 	app.vsockClientCertManager = bootstrap.NewFileCertificateManager(app.vsockClientCertFilePath, app.vsockClientKeyFilePath)
 	app.servercertmanager = bootstrap.NewFileCertificateManager(app.serverCertFilePath, app.serverKeyFilePath)
 	app.migrationCertManager = bootstrap.NewFileCertificateManager(app.migrationCertFilePath, app.migrationKeyFilePath)
@@ -320,7 +313,7 @@ func (app *virtHandlerApp) Run() {
 
 	app.clusterConfig.SetConfigModifiedCallback(vsockConfigCallback)
 
-	migrationProxy := migrationproxy.NewMigrationProxyManager(app.migrationServerTLSConfig, app.migrationOldClientTLSConfig, app.migrationClientTLSConfig, app.clusterConfig)
+	migrationProxy := migrationproxy.NewMigrationProxyManager(app.migrationServerTLSConfig, app.migrationClientTLSConfig, app.clusterConfig)
 
 	stop := make(chan struct{})
 	defer close(stop)
@@ -510,7 +503,6 @@ func (app *virtHandlerApp) Run() {
 		app.VirtShareDir,
 	)
 
-	go app.clientcertmanager.Start()
 	go app.servercertmanager.Start()
 	go app.migrationCertManager.Start()
 	go app.vsockClientCertManager.Start()
@@ -748,12 +740,6 @@ func (app *virtHandlerApp) AddFlags() {
 	flag.StringVar(&app.caConfigMapName, "ca-configmap-name", defaultCAConfigMapName,
 		"The name of configmap containing CA certificates to authenticate requests presenting client certificates with matching CommonName")
 
-	flag.StringVar(&app.clientCertFilePath, "client-cert-file", defaultClientCertFilePath,
-		"Client certificate used to prove the identity of the virt-handler when it must call out during a request")
-
-	flag.StringVar(&app.clientKeyFilePath, "client-key-file", defaultClientKeyFilePath,
-		"Private key for the client certificate used to prove the identity of the virt-handler when it must call out during a request")
-
 	flag.StringVar(&app.migrationCertFilePath, "migration-client-cert-file", defaultMigrationCertFilePath,
 		"Client certificate used to prove the identity of the virt-handler when it must call out during a request")
 
@@ -816,7 +802,6 @@ func (app *virtHandlerApp) setupTLS(factory controller.KubeInformerFactory) erro
 	app.promTLSConfig = kvtls.SetupPromTLS(app.servercertmanager, app.clusterConfig)
 	app.serverTLSConfig = kvtls.SetupTLSForVirtHandlerServer(app.caManager, app.servercertmanager, app.externallyManaged, app.clusterConfig, []string{"virt-handler"})
 	app.migrationServerTLSConfig = kvtls.SetupTLSForVirtHandlerServer(app.caManager, app.servercertmanager, app.externallyManaged, app.clusterConfig, app.migrationCNTypes)
-	app.migrationOldClientTLSConfig = kvtls.SetupTLSForVirtHandlerClients(app.caManager, app.clientcertmanager, app.externallyManaged)
 	app.migrationClientTLSConfig = kvtls.SetupTLSForVirtHandlerClients(app.caManager, app.migrationCertManager, app.externallyManaged)
 	app.vmStatsTLSConfig = kvtls.SetupTLSForVirtHandlerServer(app.caManager, app.servercertmanager, app.externallyManaged, app.clusterConfig, []string{"monitoring"})
 

--- a/pkg/virt-handler/migration-proxy/migration-proxy.go
+++ b/pkg/virt-handler/migration-proxy/migration-proxy.go
@@ -64,7 +64,6 @@ type migrationProxyManager struct {
 	targetProxies      map[string][]*migrationProxy
 	managerLock        sync.Mutex
 	serverTLSConfig    *tls.Config
-	clientTLSConfig    *tls.Config
 	migrationTLSConfig *tls.Config
 
 	isShuttingDown bool
@@ -88,7 +87,6 @@ type migrationProxy struct {
 
 	listener           net.Listener
 	serverTLSConfig    *tls.Config
-	clientTLSConfig    *tls.Config
 	migrationTLSConfig *tls.Config
 
 	logger *log.FilteredLogger
@@ -116,12 +114,11 @@ func GetMigrationPortsList(isBlockMigration bool) (ports []int) {
 	return
 }
 
-func NewMigrationProxyManager(serverTLSConfig *tls.Config, clientTLSConfig, migrationTLSConfig *tls.Config, config *virtconfig.ClusterConfig) ProxyManager {
+func NewMigrationProxyManager(serverTLSConfig *tls.Config, migrationTLSConfig *tls.Config, config *virtconfig.ClusterConfig) ProxyManager {
 	return &migrationProxyManager{
 		sourceProxies:      make(map[string][]*migrationProxy),
 		targetProxies:      make(map[string][]*migrationProxy),
 		serverTLSConfig:    serverTLSConfig,
-		clientTLSConfig:    clientTLSConfig,
 		migrationTLSConfig: migrationTLSConfig,
 		config:             config,
 	}
@@ -297,10 +294,8 @@ func (m *migrationProxyManager) StartSourceListener(key string, targetAddress st
 			}
 		}
 	}
-	clientTLSConfig := m.clientTLSConfig
 	migrationTLSConfig := m.migrationTLSConfig
 	if m.config.GetMigrationConfiguration().DisableTLS != nil && *m.config.GetMigrationConfiguration().DisableTLS {
-		clientTLSConfig = nil
 		migrationTLSConfig = nil
 	}
 	proxiesList := []*migrationProxy{}
@@ -311,7 +306,7 @@ func (m *migrationProxyManager) StartSourceListener(key string, targetAddress st
 
 		os.RemoveAll(filePath)
 
-		proxy := NewSourceProxy(filePath, targetFullAddr, clientTLSConfig, migrationTLSConfig, key)
+		proxy := NewSourceProxy(filePath, targetFullAddr, migrationTLSConfig, key)
 
 		err := proxy.Start()
 		if err != nil {
@@ -347,7 +342,7 @@ func (m *migrationProxyManager) StopSourceListener(key string) {
 // SRC POD ENV(migration unix socket) <-> HOST ENV (tcp client) <-----> HOST ENV (tcp server) <-> TARGET POD ENV (virtqemud unix socket)
 
 // Source proxy exposes a unix socket server and pipes to an outbound TCP connection.
-func NewSourceProxy(unixSocketPath string, tcpTargetAddress string, clientTLSConfig, migrationTLSConfig *tls.Config, vmiUID string) *migrationProxy {
+func NewSourceProxy(unixSocketPath string, tcpTargetAddress string, migrationTLSConfig *tls.Config, vmiUID string) *migrationProxy {
 	return &migrationProxy{
 		unixSocketPath:     unixSocketPath,
 		targetAddress:      tcpTargetAddress,
@@ -355,7 +350,6 @@ func NewSourceProxy(unixSocketPath string, tcpTargetAddress string, clientTLSCon
 		stopChan:           make(chan struct{}),
 		fdChan:             make(chan net.Conn, 1),
 		listenErrChan:      make(chan error, 1),
-		clientTLSConfig:    clientTLSConfig,
 		migrationTLSConfig: migrationTLSConfig,
 		logger:             log.Log.With("uid", vmiUID).With("listening", filepath.Base(unixSocketPath)).With("outbound", tcpTargetAddress),
 	}
@@ -444,16 +438,8 @@ func (m *migrationProxy) handleConnection(fd net.Conn) {
 
 	var conn net.Conn
 	var err error
-	if m.targetProtocol == "tcp" && m.clientTLSConfig != nil {
+	if m.targetProtocol == "tcp" && m.migrationTLSConfig != nil {
 		conn, err = tls.Dial(m.targetProtocol, m.targetAddress, m.migrationTLSConfig)
-		// Check for specific error (CN missmatch), fallback to old client TLS
-		if err != nil {
-			m.logger.Reason(err).Info("fallback to old tls config")
-			conn, err = tls.Dial(m.targetProtocol, m.targetAddress, m.clientTLSConfig)
-		} else if tlsErr := conn.(*tls.Conn).Handshake(); tlsErr != nil {
-			m.logger.Reason(err).Info("handshake failed, fallback to old tls config")
-			conn, err = tls.Dial(m.targetProtocol, m.targetAddress, m.clientTLSConfig)
-		}
 	} else {
 		conn, err = net.Dial(m.targetProtocol, m.targetAddress)
 	}

--- a/pkg/virt-handler/migration-proxy/migration-proxy_test.go
+++ b/pkg/virt-handler/migration-proxy/migration-proxy_test.go
@@ -72,7 +72,7 @@ var _ = Describe("MigrationProxy", func() {
 
 				defer listener.Close()
 
-				sourceProxy := NewSourceProxy(sourceSock, "127.0.0.1:12345", tlsConfig, tlsConfig, "123")
+				sourceProxy := NewSourceProxy(sourceSock, "127.0.0.1:12345", tlsConfig, "123")
 				defer sourceProxy.Stop()
 
 				err = sourceProxy.Start()
@@ -115,7 +115,7 @@ var _ = Describe("MigrationProxy", func() {
 				defer virtqemudListener.Close()
 
 				targetProxy := NewTargetProxy("0.0.0.0", 12345, tlsConfig, virtqemudSock, "123")
-				sourceProxy := NewSourceProxy(sourceSock, "127.0.0.1:12345", tlsConfig, tlsConfig, "123")
+				sourceProxy := NewSourceProxy(sourceSock, "127.0.0.1:12345", tlsConfig, "123")
 				defer targetProxy.Stop()
 				defer sourceProxy.Stop()
 
@@ -162,7 +162,7 @@ var _ = Describe("MigrationProxy", func() {
 				config, _, _ := testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{
 					MigrationConfiguration: migrationConfig,
 				})
-				manager := NewMigrationProxyManager(tlsConfig, tlsConfig, tlsConfig, config)
+				manager := NewMigrationProxyManager(tlsConfig, tlsConfig, config)
 				manager.StartTargetListener("mykey", []string{virtqemudSock, directSock})
 				destSrcPortMap := manager.GetTargetListenerPorts("mykey")
 				manager.StartSourceListener("mykey", "127.0.0.1", destSrcPortMap, tmpDir)
@@ -231,7 +231,7 @@ var _ = Describe("MigrationProxy", func() {
 				config, _, _ := testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{
 					MigrationConfiguration: migrationConfig,
 				})
-				manager := NewMigrationProxyManager(tlsConfig, tlsConfig, tlsConfig, config)
+				manager := NewMigrationProxyManager(tlsConfig, tlsConfig, config)
 				err = manager.StartTargetListener(key1, []string{virtqemudSock, directSock})
 				Expect(err).ShouldNot(HaveOccurred())
 				destSrcPortMap := manager.GetTargetListenerPorts(key1)

--- a/pkg/virt-handler/migration-source_test.go
+++ b/pkg/virt-handler/migration-source_test.go
@@ -185,7 +185,7 @@ var _ = Describe("VirtualMachineInstance migration target", func() {
 		mockIsolationDetector := isolation.NewMockPodIsolationDetector(ctrl)
 		mockIsolationDetector.EXPECT().Detect(gomock.Any()).Return(mockIsolationResult, nil).AnyTimes()
 
-		migrationProxy := migrationproxy.NewMigrationProxyManager(tlsConfig, tlsConfig, tlsConfig, config)
+		migrationProxy := migrationproxy.NewMigrationProxyManager(tlsConfig, tlsConfig, config)
 		launcherClientManager := &launcherclients.MockLauncherClientManager{
 			Initialized: true,
 		}

--- a/pkg/virt-handler/migration-target_test.go
+++ b/pkg/virt-handler/migration-target_test.go
@@ -215,7 +215,7 @@ var _ = Describe("VirtualMachineInstance migration target", func() {
 
 		mockHotplugVolumeMounter = hotplugvolume.NewMockVolumeMounter(ctrl)
 
-		migrationProxy := migrationproxy.NewMigrationProxyManager(tlsConfig, tlsConfig, tlsConfig, config)
+		migrationProxy := migrationproxy.NewMigrationProxyManager(tlsConfig, tlsConfig, config)
 		launcherClientManager := &launcherclients.MockLauncherClientManager{
 			Initialized: true,
 		}

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -186,7 +186,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 		mockHotplugVolumeMounter = hotplugvolume.NewMockVolumeMounter(ctrl)
 		mockCgroupManager = cgroup.NewMockManager(ctrl)
 
-		migrationProxy := migrationproxy.NewMigrationProxyManager(tlsConfig, tlsConfig, tlsConfig, config)
+		migrationProxy := migrationproxy.NewMigrationProxyManager(tlsConfig, tlsConfig, config)
 		fakeDownwardMetricsManager := newFakeManager()
 
 		launcherClientManager := &launcherclients.MockLauncherClientManager{

--- a/pkg/virt-launcher/virtwrap/live-migration-target.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-target.go
@@ -257,7 +257,7 @@ func (l *LibvirtDomainManager) prepareMigrationTarget(
 			curDirectAddress := net.JoinHostPort(loopbackAddress, strconv.Itoa(port))
 			unixSocketPath := migrationproxy.SourceUnixFile(l.virtShareDir, key)
 			logger.V(2).Infof("Creating socketpath for unix migration/tcp %s", unixSocketPath)
-			migrationProxy := migrationproxy.NewSourceProxy(unixSocketPath, curDirectAddress, nil, nil, string(vmi.UID))
+			migrationProxy := migrationproxy.NewSourceProxy(unixSocketPath, curDirectAddress, nil, string(vmi.UID))
 
 			err := migrationProxy.Start()
 			if err != nil {

--- a/pkg/virt-operator/kubevirt_test.go
+++ b/pkg/virt-operator/kubevirt_test.go
@@ -2323,15 +2323,14 @@ var _ = Describe("KubeVirt Operator", func() {
 
 			kvTestData.controller.Execute()
 
-			// add one for the namespace
-			Expect(kvTestData.totalPatches).To(Equal(numGenerations + 1))
+			// +1 for the daemonset canary patch, +1 for the namespace labels
+			Expect(kvTestData.totalPatches).To(Equal(numGenerations + 2))
 
 			// all these resources should be tracked by there generation so everyone that has been added should now be patched
 			// since they where the `lastGeneration` was set to -1 on the KubeVirt CR
 			Expect(kvTestData.resourceChanges["mutatingwebhookconfigurations"][Patched]).To(Equal(kvTestData.resourceChanges["mutatingwebhookconfigurations"][Added]))
 			Expect(kvTestData.resourceChanges["validatingwebhookconfigurations"][Patched]).To(Equal(kvTestData.resourceChanges["validatingwebhookconfigurations"][Added]))
 			Expect(kvTestData.resourceChanges["deployments"][Patched]).To(Equal(kvTestData.resourceChanges["deployments"][Added]))
-			// Expecting to drop certificate
 			Expect(kvTestData.resourceChanges["daemonsets"][Patched]).To(Equal(kvTestData.resourceChanges["daemonsets"][Added]))
 		})
 

--- a/pkg/virt-operator/kubevirt_test.go
+++ b/pkg/virt-operator/kubevirt_test.go
@@ -1660,28 +1660,6 @@ func (k *KubeVirtTestData) makeHandlerReady() {
 	}
 }
 
-func (k *KubeVirtTestData) makeHandlerComplete() {
-	exists := false
-	var obj interface{}
-	// we need to wait until the daemonset exists
-	for !exists {
-		obj, exists, _ = k.controller.stores.DaemonSetCache.GetByKey(NAMESPACE + "/virt-handler")
-		if exists {
-			handler, _ := obj.(*appsv1.DaemonSet)
-			handlerNew := handler.DeepCopy()
-			maxUnavailable := intstr.FromInt(1)
-			handlerNew.Spec.UpdateStrategy.RollingUpdate = &appsv1.RollingUpdateDaemonSet{
-				MaxUnavailable: &maxUnavailable,
-			}
-			handlerNew.Spec.Template.Spec.Containers[0].Args = append(handlerNew.Spec.Template.Spec.Containers[0].Args, "migration-cn-types")
-			k.controller.stores.DaemonSetCache.Update(handlerNew)
-			key, err := kubecontroller.KeyFunc(handlerNew)
-			Expect(err).To(Not(HaveOccurred()))
-			k.mockQueue.Add(key)
-		}
-	}
-}
-
 func (k *KubeVirtTestData) addDummyValidationWebhook() {
 	version := fmt.Sprintf("rand-%s", rand.String(10))
 	registry := fmt.Sprintf("rand-%s", rand.String(10))
@@ -2308,7 +2286,6 @@ var _ = Describe("KubeVirt Operator", func() {
 			kvTestData.addPodsAndPodDisruptionBudgets(kvTestData.defaultConfig, kv)
 			kvTestData.makeDeploymentsReady(kv)
 			kvTestData.makeHandlerReady()
-			kvTestData.makeHandlerComplete()
 
 			kvTestData.fakeNamespaceModificationEvent()
 			kvTestData.shouldExpectNamespacePatch()

--- a/pkg/virt-operator/resource/apply/apps.go
+++ b/pkg/virt-operator/resource/apply/apps.go
@@ -222,10 +222,6 @@ func (r *Reconciler) processCanaryUpgrade(cachedDaemonSet, newDS *appsv1.DaemonS
 	if hasTLS(cachedDaemonSet) && !hasTLS(newDS) {
 		insertTLS(newDS)
 	}
-	if !hasCertificateSecret(&cachedDaemonSet.Spec.Template.Spec, components.VirtHandlerCertSecretName) &&
-		hasCertificateSecret(&newDS.Spec.Template.Spec, components.VirtHandlerCertSecretName) {
-		unattachCertificateSecret(&newDS.Spec.Template.Spec, components.VirtHandlerCertSecretName)
-	}
 	log := log.Log.With("resource", fmt.Sprintf("ds/%s", cachedDaemonSet.Name))
 
 	desiredReadyPods := cachedDaemonSet.Status.DesiredNumberScheduled
@@ -282,15 +278,6 @@ func (r *Reconciler) processCanaryUpgrade(cachedDaemonSet, newDS *appsv1.DaemonS
 				SetGeneration(&r.kv.Status.Generations, newDS)
 				return false, nil, waiting
 			}
-			if hasCertificateSecret(&newDS.Spec.Template.Spec, components.VirtHandlerCertSecretName) {
-				unattachCertificateSecret(&newDS.Spec.Template.Spec, components.VirtHandlerCertSecretName)
-				newDS, err = r.patchDaemonSet(cachedDaemonSet, newDS)
-				if err != nil {
-					return false, err, failed
-				}
-				SetGeneration(&r.kv.Status.Generations, newDS)
-				return false, nil, waiting
-			}
 		}
 		// rollout has completed and all virt-handlers are ready revert
 		// maxUnavailable to default value
@@ -331,32 +318,6 @@ func hasTLS(daemonSet *appsv1.DaemonSet) bool {
 	return false
 }
 
-func hasCertificateSecret(spec *corev1.PodSpec, secretName string) bool {
-	for _, volume := range spec.Volumes {
-		if volume.Name == secretName {
-			return true
-		}
-	}
-	return false
-}
-
-func unattachCertificateSecret(spec *corev1.PodSpec, secretName string) {
-	newVolumes := []corev1.Volume{}
-	for _, volume := range spec.Volumes {
-		if volume.Name != secretName {
-			newVolumes = append(newVolumes, volume)
-		}
-	}
-	spec.Volumes = newVolumes
-	newVolumeMounts := []corev1.VolumeMount{}
-	for _, volumeMount := range spec.Containers[0].VolumeMounts {
-		if volumeMount.Name != secretName {
-			newVolumeMounts = append(newVolumeMounts, volumeMount)
-		}
-	}
-	spec.Containers[0].VolumeMounts = newVolumeMounts
-}
-
 func getMaxUnavailable(daemonSet *appsv1.DaemonSet) int {
 	update := daemonSet.Spec.UpdateStrategy.RollingUpdate
 
@@ -392,7 +353,6 @@ func (r *Reconciler) syncDaemonSet(daemonSet *appsv1.DaemonSet) (bool, error) {
 		r.expectations.DaemonSet.RaiseExpectations(r.kvKey, 1, 0)
 		if supportsTLS(daemonSet) && !hasTLS(daemonSet) {
 			insertTLS(daemonSet)
-			unattachCertificateSecret(&daemonSet.Spec.Template.Spec, components.VirtHandlerCertSecretName)
 		}
 
 		origDaemonSet := daemonSet

--- a/pkg/virt-operator/resource/apply/apps.go
+++ b/pkg/virt-operator/resource/apply/apps.go
@@ -3,7 +3,6 @@ package apply
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/openshift/library-go/pkg/operator/resource/resourcemerge"
 	jsonpatch "gopkg.in/evanphx/json-patch.v4"
@@ -219,9 +218,6 @@ func daemonHasDefaultRolloutStrategy(daemonSet *appsv1.DaemonSet) bool {
 func (r *Reconciler) processCanaryUpgrade(cachedDaemonSet, newDS *appsv1.DaemonSet, objectChanged bool) (bool, error, canaryUpgradeStatus) {
 	var updatedAndReadyPods int32
 
-	if hasTLS(cachedDaemonSet) && !hasTLS(newDS) {
-		insertTLS(newDS)
-	}
 	log := log.Log.With("resource", fmt.Sprintf("ds/%s", cachedDaemonSet.Name))
 
 	desiredReadyPods := cachedDaemonSet.Status.DesiredNumberScheduled
@@ -267,22 +263,10 @@ func (r *Reconciler) processCanaryUpgrade(cachedDaemonSet, newDS *appsv1.DaemonS
 		log.V(4).Infof("waiting for all pods of daemonSet %v to be ready", newDS.GetName())
 		return false, nil, waiting
 	case updatedAndReadyPods > 0 && updatedAndReadyPods == desiredReadyPods:
-		var err error
-		if supportsTLS(cachedDaemonSet) {
-			if !hasTLS(cachedDaemonSet) {
-				insertTLS(newDS)
-				newDS, err = r.patchDaemonSet(cachedDaemonSet, newDS)
-				if err != nil {
-					return false, err, failed
-				}
-				SetGeneration(&r.kv.Status.Generations, newDS)
-				return false, nil, waiting
-			}
-		}
 		// rollout has completed and all virt-handlers are ready revert
 		// maxUnavailable to default value
 		setMaxUnavailable(newDS, daemonSetDefaultMaxUnavailable)
-		newDS, err = r.patchDaemonSet(cachedDaemonSet, newDS)
+		newDS, err := r.patchDaemonSet(cachedDaemonSet, newDS)
 		if err != nil {
 			return false, err, failed
 		}
@@ -294,28 +278,6 @@ func (r *Reconciler) processCanaryUpgrade(cachedDaemonSet, newDS *appsv1.DaemonS
 		log.Errorf("%s", err)
 		return false, err, failed
 	}
-}
-
-func supportsTLS(daemonSet *appsv1.DaemonSet) bool {
-	if daemonSet.Labels == nil {
-		return false
-	}
-	value, ok := daemonSet.Labels[components.SupportsMigrationCNsValidation]
-	return ok && value == "true"
-}
-
-func insertTLS(daemonSet *appsv1.DaemonSet) {
-	daemonSet.Spec.Template.Spec.Containers[0].Args = append(daemonSet.Spec.Template.Spec.Containers[0].Args, "--migration-cn-types", "migration")
-}
-
-func hasTLS(daemonSet *appsv1.DaemonSet) bool {
-	container := &daemonSet.Spec.Template.Spec.Containers[0]
-	for _, arg := range container.Args {
-		if strings.Contains(arg, "migration-cn-types") {
-			return true
-		}
-	}
-	return false
 }
 
 func getMaxUnavailable(daemonSet *appsv1.DaemonSet) int {
@@ -351,9 +313,6 @@ func (r *Reconciler) syncDaemonSet(daemonSet *appsv1.DaemonSet) (bool, error) {
 
 	if !exists {
 		r.expectations.DaemonSet.RaiseExpectations(r.kvKey, 1, 0)
-		if supportsTLS(daemonSet) && !hasTLS(daemonSet) {
-			insertTLS(daemonSet)
-		}
 
 		origDaemonSet := daemonSet
 		daemonSet, err := apps.DaemonSets(kv.Namespace).Create(context.Background(), daemonSet, metav1.CreateOptions{})

--- a/pkg/virt-operator/resource/apply/apps_test.go
+++ b/pkg/virt-operator/resource/apply/apps_test.go
@@ -463,9 +463,6 @@ var _ = Describe("Apply Apps", func() {
 				currentDs := daemonSet.DeepCopy()
 				addCustomTargetDeployment(kv, currentDs)
 				currentDs.Status = daemonSet.Status
-				currentDs.Spec.Template.Spec.Containers[0].Args = append(currentDs.Spec.Template.Spec.Containers[0].Args,
-					"--migration-cn-types",
-				)
 
 				mockDSCacheStore.get = daemonSet
 				SetGeneration(&kv.Status.Generations, currentDs)
@@ -728,9 +725,6 @@ var _ = Describe("Apply Apps", func() {
 						currentDs.Spec.UpdateStrategy.RollingUpdate = &appsv1.RollingUpdateDaemonSet{
 							MaxUnavailable: &maxUnavailable,
 						}
-						currentDs.Spec.Template.Spec.Containers[0].Args = append(currentDs.Spec.Template.Spec.Containers[0].Args,
-							"--migration-cn-types",
-						)
 						return currentDs, newDs
 					},
 					func(kv *v1.KubeVirt, daemonSet *appsv1.DaemonSet) {
@@ -741,30 +735,6 @@ var _ = Describe("Apply Apps", func() {
 						Expect(rollingUpdate.MaxUnavailable.IntValue()).To(Equal(1))
 					},
 					successful, true, false, true, false,
-				),
-				Entry("should switch to tls rollout",
-					func(kv *v1.KubeVirt, currentDs *appsv1.DaemonSet) (*appsv1.DaemonSet, *appsv1.DaemonSet) {
-						maxUnavailable := intstr.FromInt(1)
-						currentDs.Spec.UpdateStrategy.RollingUpdate = &appsv1.RollingUpdateDaemonSet{
-							MaxUnavailable: &maxUnavailable,
-						}
-						newDs := daemonSet.DeepCopy()
-						addCustomTargetDeployment(kv, newDs)
-						addCustomTargetDeployment(kv, currentDs)
-						markHandlerReady(daemonSet)
-						currentDs.Status = daemonSet.Status
-
-						return currentDs, newDs
-					},
-					func(kv *v1.KubeVirt, daemonSet *appsv1.DaemonSet) {
-						Expect(util.DaemonSetIsUpToDate(kv, daemonSet)).To(BeTrue())
-						rollingUpdate := daemonSet.Spec.UpdateStrategy.RollingUpdate
-						Expect(rollingUpdate).ToNot(BeNil())
-						Expect(rollingUpdate.MaxUnavailable).ToNot(BeNil())
-						Expect(rollingUpdate.MaxUnavailable.IntValue()).To(Equal(1))
-						Expect(daemonSet.Spec.Template.Spec.Containers[0].Args).To(ContainElements("--migration-cn-types", "migration"))
-					},
-					waiting, false, false, true, false,
 				),
 			)
 		})

--- a/pkg/virt-operator/resource/apply/apps_test.go
+++ b/pkg/virt-operator/resource/apply/apps_test.go
@@ -466,7 +466,6 @@ var _ = Describe("Apply Apps", func() {
 				currentDs.Spec.Template.Spec.Containers[0].Args = append(currentDs.Spec.Template.Spec.Containers[0].Args,
 					"--migration-cn-types",
 				)
-				unattachCertificateSecret(&currentDs.Spec.Template.Spec, components.VirtHandlerCertSecretName)
 
 				mockDSCacheStore.get = daemonSet
 				SetGeneration(&kv.Status.Generations, currentDs)
@@ -732,7 +731,6 @@ var _ = Describe("Apply Apps", func() {
 						currentDs.Spec.Template.Spec.Containers[0].Args = append(currentDs.Spec.Template.Spec.Containers[0].Args,
 							"--migration-cn-types",
 						)
-						unattachCertificateSecret(&currentDs.Spec.Template.Spec, components.VirtHandlerCertSecretName)
 						return currentDs, newDs
 					},
 					func(kv *v1.KubeVirt, daemonSet *appsv1.DaemonSet) {
@@ -743,33 +741,6 @@ var _ = Describe("Apply Apps", func() {
 						Expect(rollingUpdate.MaxUnavailable.IntValue()).To(Equal(1))
 					},
 					successful, true, false, true, false,
-				),
-
-				Entry("should unattach secret before complete rollout",
-					func(kv *v1.KubeVirt, currentDs *appsv1.DaemonSet) (*appsv1.DaemonSet, *appsv1.DaemonSet) {
-						maxUnavailable := intstr.FromInt(1)
-						currentDs.Spec.UpdateStrategy.RollingUpdate = &appsv1.RollingUpdateDaemonSet{
-							MaxUnavailable: &maxUnavailable,
-						}
-						newDs := daemonSet.DeepCopy()
-						addCustomTargetDeployment(kv, newDs)
-						addCustomTargetDeployment(kv, currentDs)
-						markHandlerReady(daemonSet)
-
-						currentDs.Spec.Template.Spec.Containers[0].Args = append(currentDs.Spec.Template.Spec.Containers[0].Args,
-							"--migration-cn-types",
-						)
-						return currentDs, newDs
-					},
-					func(kv *v1.KubeVirt, daemonSet *appsv1.DaemonSet) {
-						Expect(util.DaemonSetIsUpToDate(kv, daemonSet)).To(BeTrue())
-						rollingUpdate := daemonSet.Spec.UpdateStrategy.RollingUpdate
-						Expect(rollingUpdate).ToNot(BeNil())
-						Expect(rollingUpdate.MaxUnavailable).ToNot(BeNil())
-						Expect(rollingUpdate.MaxUnavailable.IntValue()).To(Equal(1))
-						hasCertificateSecret(&daemonSet.Spec.Template.Spec, components.VirtHandlerCertSecretName)
-					},
-					waiting, false, false, true, false,
 				),
 				Entry("should switch to tls rollout",
 					func(kv *v1.KubeVirt, currentDs *appsv1.DaemonSet) (*appsv1.DaemonSet, *appsv1.DaemonSet) {

--- a/pkg/virt-operator/resource/generate/components/daemonsets.go
+++ b/pkg/virt-operator/resource/generate/components/daemonsets.go
@@ -307,7 +307,6 @@ func NewHandlerDaemonSet(config *operatorutil.KubeVirtDeploymentConfig, productN
 		mountPath        string
 		mountPropagation *corev1.MountPropagationMode
 	}
-	attachCertificateSecret(pod, VirtHandlerCertSecretName, "/etc/virt-handler/clientcertificates")
 	attachCertificateSecret(pod, VirtHandlerServerCertSecretName, "/etc/virt-handler/servercertificates")
 	attachCertificateSecret(pod, VirtHandlerMigrationClientCertSecretName, "/etc/virt-handler/migrationservercertificates")
 	attachCertificateSecret(pod, VirtHandlerVsockClientCertSecretName, "/etc/virt-handler/vsockclientcertificates")

--- a/pkg/virt-operator/resource/generate/components/daemonsets.go
+++ b/pkg/virt-operator/resource/generate/components/daemonsets.go
@@ -21,15 +21,14 @@ import (
 )
 
 const (
-	VirtHandlerName                = "virt-handler"
-	kubeletPodsPath                = util.KubeletRoot + "/pods"
-	runtimesPath                   = "/var/run/kubevirt-libvirt-runtimes"
-	PrHelperName                   = "pr-helper"
-	prVolumeName                   = "pr-helper-socket-vol"
-	devDirVol                      = "dev-dir"
-	SidecarShimName                = "sidecar-shim"
-	etcMultipath                   = "etc-multipath"
-	SupportsMigrationCNsValidation = "kubevirt.io/supports-migration-cn-types"
+	VirtHandlerName = "virt-handler"
+	kubeletPodsPath = util.KubeletRoot + "/pods"
+	runtimesPath    = "/var/run/kubevirt-libvirt-runtimes"
+	PrHelperName    = "pr-helper"
+	prVolumeName    = "pr-helper-socket-vol"
+	devDirVol       = "dev-dir"
+	SidecarShimName = "sidecar-shim"
+	etcMultipath    = "etc-multipath"
 )
 
 func RenderPrHelperContainer(image string, pullPolicy corev1.PullPolicy) corev1.Container {
@@ -106,8 +105,7 @@ func NewHandlerDaemonSet(config *operatorutil.KubeVirtDeploymentConfig, productN
 			Namespace: config.GetNamespace(),
 			Name:      VirtHandlerName,
 			Labels: map[string]string{
-				virtv1.AppLabel:                VirtHandlerName,
-				SupportsMigrationCNsValidation: "true",
+				virtv1.AppLabel: VirtHandlerName,
 			},
 		},
 		Spec: appsv1.DaemonSetSpec{
@@ -227,6 +225,8 @@ func NewHandlerDaemonSet(config *operatorutil.KubeVirtDeploymentConfig, productN
 		"8187",
 		"--graceful-shutdown-seconds",
 		fmt.Sprintf("%d", handlerGracePeriod),
+		"--migration-cn-types",
+		"migration",
 		"-v",
 		config.GetVerbosity(),
 	}


### PR DESCRIPTION
### What this PR does
Removes the old client certificate (`kubevirt-virt-handler-certs`) code from virt-handler and the migration proxy. This is the follow-up cleanup to PR #15949 which introduced a dedicated migration certificate and had the operator drop the old client cert volume from the DaemonSet.

The operator-side change landed in #15949, but the handler-side cleanup (originally PR #16331 by @xpivarc) was put on hold pending a release and eventually auto-closed due to inactivity. This PR rebases that work onto current main and also removes the leftover dead constants, struct fields, and flag registrations.

#### Before this PR:
- virt-handler still loaded the old client cert from `/etc/virt-handler/clientcertificates/`, logging errors every minute since the operator no longer mounts that volume
- The migration proxy carried a fallback TLS config that was never populated

#### After this PR:
- The old client cert manager, TLS config, and fallback dial logic are removed
- No more per-minute error logs about missing certificates
- The migration proxy uses only the dedicated migration certificate

### References
- Upstream issue: https://github.com/kubevirt/kubevirt/issues/16264
- Original migration cert PR: https://github.com/kubevirt/kubevirt/pull/15949
- Original handler cleanup PR (auto-closed): https://github.com/kubevirt/kubevirt/pull/16331

### Release note
```release-note
NONE
```