### PR TITLE
[DNM][release-1.9] Dequarantine test_id:3145 y-1 upgrade tests with instrumentation

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -715,8 +715,34 @@ if [[ $TARGET =~ sig-storage ]]; then
 fi
 
 
-# Run functional tests
-FUNC_TEST_ARGS=$ginko_params FUNC_TEST_LABEL_FILTER="--label-filter=(!flake-check)&&(${label_filter})" make functest
+# Run functional tests — soak loop until 10 failures for test_id:3145
+SOAK_MAX_FAILURES=10
+SOAK_TIMEOUT_SECS=21600
+deadline=$((SECONDS + SOAK_TIMEOUT_SECS))
+echo "Soak mode: loop until $SOAK_MAX_FAILURES failures, timeout ${SOAK_TIMEOUT_SECS}s"
+failures=0
+completed=0
+while ((failures < SOAK_MAX_FAILURES)); do
+    if ((SECONDS >= deadline)); then
+        echo "Soak timeout reached after $completed runs ($failures failures)"
+        break
+    fi
+    completed=$((completed + 1))
+    echo "Soak run: $completed (failures so far: $failures)"
+    if ! FUNC_TEST_ARGS="$ginko_params --focus=from\\sprevious\\sy\\srelease" \
+         FUNC_TEST_LABEL_FILTER="--label-filter=(${label_filter})" \
+         make functest; then
+        failures=$((failures + 1))
+        echo "Soak run: $completed FAILED (failure $failures of $SOAK_MAX_FAILURES)"
+        if [[ -d "${ARTIFACTS_PATH}/k8s-reporter" ]]; then
+            mv "${ARTIFACTS_PATH}/k8s-reporter" "${ARTIFACTS_PATH}/k8s-reporter-run-${completed}"
+            echo "Preserved k8s-reporter artifacts in k8s-reporter-run-${completed}"
+        fi
+        cp "${ARTIFACTS_PATH}/junit.functest.xml" "${ARTIFACTS_PATH}/junit.functest-run-${completed}.xml" 2>/dev/null || true
+    fi
+done
+echo "Soak complete: $failures failures in $completed runs"
+exit 1
 
 # Run REST API coverage based on k8s audit log and openapi spec
 if [ -n "$RUN_REST_COVERAGE" ]; then

--- a/automation/test.sh
+++ b/automation/test.sh
@@ -715,8 +715,29 @@ if [[ $TARGET =~ sig-storage ]]; then
 fi
 
 
-# Run functional tests
-FUNC_TEST_ARGS=$ginko_params FUNC_TEST_LABEL_FILTER="--label-filter=(!flake-check)&&(${label_filter})" make functest
+# Run functional tests — soak loop until 10 failures for test_id:3145
+SOAK_MAX_FAILURES=10
+SOAK_TIMEOUT_SECS=21600
+deadline=$((SECONDS + SOAK_TIMEOUT_SECS))
+echo "Soak mode: loop until $SOAK_MAX_FAILURES failures, timeout ${SOAK_TIMEOUT_SECS}s"
+failures=0
+completed=0
+while ((failures < SOAK_MAX_FAILURES)); do
+    if ((SECONDS >= deadline)); then
+        echo "Soak timeout reached after $completed runs ($failures failures)"
+        break
+    fi
+    completed=$((completed + 1))
+    echo "Soak run: $completed (failures so far: $failures)"
+    if ! FUNC_TEST_ARGS="$ginko_params --focus=from\\sprevious\\sy\\srelease" \
+         FUNC_TEST_LABEL_FILTER="--label-filter=(${label_filter})" \
+         make functest; then
+        failures=$((failures + 1))
+        echo "Soak run: $completed FAILED (failure $failures of $SOAK_MAX_FAILURES)"
+    fi
+done
+echo "Soak complete: $failures failures in $completed runs"
+exit 1
 
 # Run REST API coverage based on k8s audit log and openapi spec
 if [ -n "$RUN_REST_COVERAGE" ]; then

--- a/pkg/virt-operator/kubevirt.go
+++ b/pkg/virt-operator/kubevirt.go
@@ -21,6 +21,7 @@ package virt_operator
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"sync/atomic"
@@ -819,14 +820,21 @@ func (c *KubeVirtController) execute(key string) error {
 	kv := obj.(*v1.KubeVirt)
 	logger := log.Log.Object(kv)
 
+	logger.Infof("DEBUG execute: kv resourceVersion=%s generation=%d phase=%s observedID=%s targetID=%s",
+		kv.ResourceVersion, kv.Generation, kv.Status.Phase,
+		kv.Status.ObservedDeploymentID, kv.Status.TargetDeploymentID)
+
 	// this must be first step in execution. Writing the object
 	// when api version changes ensures our api stored version is updated.
 	if !controller.ObservedLatestApiVersionAnnotation(kv) {
 		kv := kv.DeepCopy()
 		controller.SetLatestApiVersionAnnotation(kv)
-		_, err = c.virtClient.KubeVirt(kv.ObjectMeta.Namespace).Update(context.Background(), kv, metav1.UpdateOptions{})
+		logger.Infof("DEBUG execute: updating KV for api version annotation, sending resourceVersion=%s", kv.ResourceVersion)
+		updated, err := c.virtClient.KubeVirt(kv.ObjectMeta.Namespace).Update(context.Background(), kv, metav1.UpdateOptions{})
 		if err != nil {
 			logger.Reason(err).Errorf("Could not update the KubeVirt resource.")
+		} else {
+			logger.Infof("DEBUG execute: KV updated, new resourceVersion=%s generation=%d", updated.ResourceVersion, updated.Generation)
 		}
 
 		return err
@@ -1039,6 +1047,10 @@ func (c *KubeVirtController) syncInstallation(kv *v1.KubeVirt) error {
 	logger := log.Log.Object(kv)
 	logger.Infof("Handling deployment")
 
+	specBytes, _ := json.Marshal(kv.Spec)
+	specHash := fmt.Sprintf("%x", sha256.Sum256(specBytes))
+	logger.Infof("DEBUG syncInstallation: kv.Spec hash=%s resourceVersion=%s generation=%d", specHash[:16], kv.ResourceVersion, kv.Generation)
+
 	config := operatorutil.GetTargetConfigFromKV(kv)
 
 	// Record current operator version to status section
@@ -1046,6 +1058,8 @@ func (c *KubeVirtController) syncInstallation(kv *v1.KubeVirt) error {
 
 	// Record the version we're targeting to install
 	config.SetTargetDeploymentConfig(kv)
+	logger.Infof("DEBUG syncInstallation: TargetDeploymentID=%s ObservedDeploymentID=%s Phase=%s",
+		kv.Status.TargetDeploymentID, kv.Status.ObservedDeploymentID, kv.Status.Phase)
 
 	// Set the default architecture
 	operatorutil.SetDefaultArchitecture(kv)
@@ -1118,6 +1132,7 @@ func (c *KubeVirtController) syncInstallation(kv *v1.KubeVirt) error {
 			// keeping Available=True during the transition instead of flipping to
 			// Available=False (DeploymentInProgress).
 			config.SetObservedDeploymentConfig(kv)
+			logger.Infof("DEBUG syncInstallation: SetObservedDeploymentConfig called, ObservedDeploymentID=%s", kv.Status.ObservedDeploymentID)
 			logger.Info("All KubeVirt components ready")
 			kv.Status.Phase = v1.KubeVirtPhaseDeployed
 			util.UpdateConditionsAvailable(kv)

--- a/pkg/virt-operator/resource/apply/apps.go
+++ b/pkg/virt-operator/resource/apply/apps.go
@@ -230,6 +230,8 @@ func (r *Reconciler) processCanaryUpgrade(cachedDaemonSet, newDS *appsv1.DaemonS
 
 	desiredReadyPods := cachedDaemonSet.Status.DesiredNumberScheduled
 	updatedAndReadyPods = r.howManyUpdatedAndReadyPods(cachedDaemonSet)
+	log.Infof("DEBUG processCanaryUpgrade %s: objectChanged=%v updatedAndReadyPods=%d desiredReadyPods=%d defaultStrategy=%v",
+		cachedDaemonSet.Name, objectChanged, updatedAndReadyPods, desiredReadyPods, daemonHasDefaultRolloutStrategy(cachedDaemonSet))
 
 	switch {
 	case objectChanged:
@@ -416,6 +418,20 @@ func (r *Reconciler) syncDaemonSet(daemonSet *appsv1.DaemonSet) (bool, error) {
 	specChanged := !util.DaemonSetIsUpToDate(r.kv, cachedDaemonSet) || *objectMetaModified
 	generationUnknown := existingCopy.GetGeneration() != GetExpectedGeneration(daemonSet, kv.Status.Generations)
 	ongoingRollout := !daemonHasDefaultRolloutStrategy(cachedDaemonSet)
+
+	log.Log.Infof("DEBUG syncDaemonSet %s: specChanged=%v (upToDate=%v objectMetaModified=%v) generationUnknown=%v (cached=%d expected=%d) ongoingRollout=%v",
+		daemonSet.GetName(),
+		specChanged, util.DaemonSetIsUpToDate(r.kv, cachedDaemonSet), *objectMetaModified,
+		generationUnknown, existingCopy.GetGeneration(), GetExpectedGeneration(daemonSet, kv.Status.Generations),
+		ongoingRollout)
+	log.Log.Infof("DEBUG syncDaemonSet %s: cached annotations: version=%s registry=%s id=%s",
+		daemonSet.GetName(),
+		cachedDaemonSet.Annotations[v1.InstallStrategyVersionAnnotation],
+		cachedDaemonSet.Annotations[v1.InstallStrategyRegistryAnnotation],
+		cachedDaemonSet.Annotations[v1.InstallStrategyIdentifierAnnotation])
+	log.Log.Infof("DEBUG syncDaemonSet %s: target: version=%s registry=%s id=%s",
+		daemonSet.GetName(),
+		r.kv.Status.TargetKubeVirtVersion, r.kv.Status.TargetKubeVirtRegistry, r.kv.Status.TargetDeploymentID)
 
 	if !specChanged && !ongoingRollout && !generationUnknown {
 		log.Log.V(4).Infof("daemonset %v is up-to-date", daemonSet.GetName())

--- a/pkg/virt-operator/util/config.go
+++ b/pkg/virt-operator/util/config.go
@@ -678,9 +678,11 @@ func (c *KubeVirtDeploymentConfig) generateInstallStrategyID() {
 	// reason: sha1 is not used for encryption but for creating a hash value
 	hasher := sha1.New()
 	values := getStringFromFields(*c)
+	log.Log.Infof("DEBUG generateInstallStrategyID input length=%d hash_input=%q", len(values), values)
 	hasher.Write([]byte(values))
 
 	c.ID = hex.EncodeToString(hasher.Sum(nil))
+	log.Log.Infof("DEBUG generateInstallStrategyID result=%s", c.ID)
 }
 
 // use KubeVirtDeploymentConfig by value because we modify sth just for the ID

--- a/pkg/virt-operator/util/readycheck.go
+++ b/pkg/virt-operator/util/readycheck.go
@@ -60,7 +60,12 @@ func DaemonsetIsReady(kv *v1.KubeVirt, daemonset *appsv1.DaemonSet, stores Store
 			}
 
 			if !PodIsUpToDate(pod, kv) {
-				log.Log.Infof("DaemonSet %v waiting for out of date pods to terminate.", daemonset.Name)
+				log.Log.Infof("DaemonSet %v waiting for out of date pods to terminate. pod=%s podVersion=%s podRegistry=%s podID=%s targetVersion=%s targetRegistry=%s targetID=%s",
+					daemonset.Name, pod.Name,
+					pod.Annotations[v1.InstallStrategyVersionAnnotation],
+					pod.Annotations[v1.InstallStrategyRegistryAnnotation],
+					pod.Annotations[v1.InstallStrategyIdentifierAnnotation],
+					kv.Status.TargetKubeVirtVersion, kv.Status.TargetKubeVirtRegistry, kv.Status.TargetDeploymentID)
 				return false
 			}
 

--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -1046,8 +1046,8 @@ var _ = Describe("[sig-operator]Operator", Serial, decorators.SigOperator, func(
 			By("Deleting KubeVirt object")
 			deleteAllKvAndWait(false, originalKv.Name)
 		},
-			Entry("from previous y release by patching KubeVirt CR", fromY, false),
-			Entry("from previous y release by updating virt-operator", fromY, true),
+			Entry("from previous y release by patching KubeVirt CR", decorators.FlakeCheck, fromY, false),
+			Entry("from previous y release by updating virt-operator", decorators.FlakeCheck, fromY, true),
 			Entry("from previous z release by patching KubeVirt CR", fromZ, false),
 			Entry("from previous z release by updating virt-operator", fromZ, true),
 		)


### PR DESCRIPTION
### What this PR does

#### Before this PR:

No operator instrumentation for debugging the y-1 upgrade test flake on release-1.9.

#### After this PR:

The y-1 upgrade tests are marked with the `FlakeCheck` decorator (so the dequarantine lane detects and runs them), and DEBUG instrumentation is added to the virt-operator to collect timing data during the soak test.

### References

* Release-1.9 counterpart of #18675
* Partially addresses #18396
* Partially addresses #18670
* Related fix: #18397

### Why we need it and why it was done in this way

This is a Do Not Merge PR for data collection on the release-1.9 branch. The y-1 upgrade tests were never quarantined on release-1.9, so the `FlakeCheck` decorator is used to ensure the dequarantine lane detects and runs them. The dequarantine lane's label filter includes `(flake-check)||(..)`, so tests with this decorator are always selected.

The dequarantine lane uses a shell-level retry loop instead of Ginkgo `--flake-attempts` because `--flake-attempts` masks failures from `JustAfterEach` cleanup nodes, preventing the k8s-reporter from collecting cluster state artifacts on flake failures.

See #18675 for full details on the instrumentation points and soak test methodology.

### Special notes for your reviewer

Do not merge. This PR exists solely to trigger `/test pull-kubevirt-check-dequarantine-test` for data collection on release-1.9.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors

### Release note

```release-note
NONE
```