### PR TITLE
[release-1.5] tests/infrastructure/prometheus: quarantine test_id:4145

### DIFF
--- a/tests/infrastructure/prometheus.go
+++ b/tests/infrastructure/prometheus.go
@@ -477,7 +477,7 @@ var _ = DescribeSerialInfra("[rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com
 		Entry("[test_id:6240] vmi unused memory by IPv6", k8sv1.IPv6Protocol, "kubevirt_vmi_memory_unused_bytes", ">="),
 	)
 
-	DescribeTable("should include VMI infos for a running VM", func(family k8sv1.IPFamily) {
+	DescribeTable("[QUARANTINE] should include VMI infos for a running VM", decorators.Quarantine, func(family k8sv1.IPFamily) {
 		libnet.SkipWhenClusterNotSupportIPFamily(family)
 
 		ip := libnet.GetIP(handlerMetricIPs, family)


### PR DESCRIPTION
### What this PR does
Quarantine the "should include VMI infos for a running VM" test (test_id:4145 and test_id:6241) in the release-1.5 branch.

This test has a fundamental design flaw: it validates labels on all `kubevirt_vmi_*` metrics but assumes they all carry domainstats-style labels (`node`, `namespace`, `name`). Any new `kubevirt_vmi_*` metric registered outside the domainstats collector with a different label set breaks the test.

#### Before this PR:
- The test runs and fails whenever a new `kubevirt_vmi_*` metric is added that doesn't conform to the domainstats label schema

#### After this PR:
- The test is quarantined so it no longer blocks CI

### References
- [PR #17221](https://github.com/kubevirt/kubevirt/pull/17221) - test removed from main
- [PR #16476](https://github.com/kubevirt/kubevirt/pull/16476) - original quarantine and refactor
- [PR #16773](https://github.com/kubevirt/kubevirt/pull/16773) - rewrite attempt that was broken again by new metrics

### Release note
```release-note
NONE
```