### PR TITLE
[VEP-10] feat(dra): add mdevModel attribute to allow VFIO model override

### DIFF
--- a/pkg/dra/metadata/types.go
+++ b/pkg/dra/metadata/types.go
@@ -58,6 +58,10 @@ const (
 	// MDevUUIDAttribute is the attribute for mediated device UUID (vGPUs)
 	// Note: This is not yet standardized under resource.kubernetes.io
 	MDevUUIDAttribute = resourcev1.QualifiedName("mdevUUID")
+	// MDevModelAttribute is an optional attribute set by the DRA driver to override the
+	// VFIO model used for mediated devices (e.g. "vfio-pci", "vfio-ap").
+	// When absent, KubeVirt falls back to an architecture-based default.
+	MDevModelAttribute = resourcev1.QualifiedName("mdevModel")
 )
 
 // APIVersionV1Alpha1 is the JSON apiVersion string for KEP-5304 DRA device

--- a/pkg/dra/utils.go
+++ b/pkg/dra/utils.go
@@ -94,6 +94,29 @@ func GetMDevUUIDForClaim(
 	return "", fmt.Errorf("mdevUUID not found for claim %q request %q", claimRefName, requestName)
 }
 
+// GetMDevModelForClaim returns the mdev model (e.g. "vfio-pci", "vfio-ap") set
+// by the DRA driver for a device in the given claim and request.
+// Returns ("", nil) when the attribute is absent — the caller should then apply
+// its own default (typically architecture-based).
+func GetMDevModelForClaim(
+	basePath string,
+	resourceClaims []v1.VirtualMachineInstanceResourceClaim,
+	claimRefName,
+	requestName string,
+) (string, error) {
+	device, err := resolveDevice(basePath, resourceClaims, claimRefName, requestName)
+	if err != nil {
+		return "", err
+	}
+
+	if attr, ok := device.Attributes[metadata.MDevModelAttribute]; ok {
+		if attr.StringValue != nil && *attr.StringValue != "" {
+			return *attr.StringValue, nil
+		}
+	}
+	return "", nil
+}
+
 // resolveDevice finds and reads the metadata file for a specific claim ref and
 // request, returning the single device from that request.
 func resolveDevice(

--- a/pkg/dra/utils_test.go
+++ b/pkg/dra/utils_test.go
@@ -329,6 +329,46 @@ var _ = Describe("DownwardAPIAttributes", func() {
 		})
 	})
 
+	Context("GetMDevModelForClaim", func() {
+		It("should return the model when the mdevModel attribute is present", func() {
+			model := "vfio-ap"
+			createMetadataFile("mdev-model-claim", "req1", metadataWithStringAttribute(
+				"mdev-model-claim", "req1", metadata.MDevModelAttribute, model,
+			))
+
+			resourceClaims := []v1.VirtualMachineInstanceResourceClaim{{
+				Name:              "my-vgpu",
+				ResourceClaimName: ptr.To("mdev-model-claim"),
+			}}
+
+			result, err := GetMDevModelForClaim(tempDir, resourceClaims, "my-vgpu", "req1")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(model))
+		})
+
+		It("should return empty string when the mdevModel attribute is absent", func() {
+			uuid := "abcd1234-0000-0000-0000-000000000000"
+			createMetadataFile("mdev-no-model", "req1", metadataWithStringAttribute(
+				"mdev-no-model", "req1", metadata.MDevUUIDAttribute, uuid,
+			))
+
+			resourceClaims := []v1.VirtualMachineInstanceResourceClaim{{
+				Name:              "my-vgpu",
+				ResourceClaimName: ptr.To("mdev-no-model"),
+			}}
+
+			result, err := GetMDevModelForClaim(tempDir, resourceClaims, "my-vgpu", "req1")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(Equal(""))
+		})
+
+		It("should return error when claim ref not found", func() {
+			_, err := GetMDevModelForClaim(tempDir, nil, "nonexistent", "req1")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("metadata not found"))
+		})
+	})
+
 	Context("multiple claims and requests", func() {
 		It("should handle multiple claims with different device types", func() {
 			pciAddr := pciAddr0400

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/dra/generic_hostdev.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/dra/generic_hostdev.go
@@ -78,9 +78,15 @@ func createHostDeviceForHostDevice(hd v1.HostDevice, basePath string, vmiSpecs v
 	mdevUUID, mdevErr := drautil.GetMDevUUIDForClaim(basePath, resourceClaims, claimName, requestName)
 	if mdevErr == nil {
 		log.Log.V(2).Infof("Adding DRA MDEV HostDevice for %s", hd.Name)
-		model := "vfio-pci"
-		if vmiSpecs.Architecture == "s390x" {
-			model = "vfio-ap"
+		model, err := drautil.GetMDevModelForClaim(basePath, resourceClaims, claimName, requestName)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get mdev model for %s: %v", hd.Name, err)
+		}
+		if model == "" {
+			model = "vfio-pci"
+			if vmiSpecs.Architecture == "s390x" {
+				model = "vfio-ap"
+			}
 		}
 		return &api.HostDevice{
 			Alias: api.NewUserDefinedAlias(DRAHostDeviceAliasPrefix + hd.Name),

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/dra/generic_hostdev_test.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/dra/generic_hostdev_test.go
@@ -226,6 +226,210 @@ var _ = Describe("CreateDRAHostDevices", func() {
 		})
 	})
 
+	Context("when the DRA driver provides an mdevModel attribute", func() {
+		It("should use the driver-provided model over the architecture default", func() {
+			uuid := "abcd1234-1111-2222-3333-444455556666"
+			driverModel := "vfio-ap"
+
+			createMetadataFile("claim1", "req1", "mdev.example.com", &metadata.DeviceMetadata{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "DeviceMetadata",
+					APIVersion: metadata.APIVersionV1Alpha1,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "claim1",
+				},
+				Requests: []metadata.DeviceMetadataRequest{{
+					Name: "req1",
+					Devices: []metadata.Device{{
+						Driver: "mdev.example.com",
+						Pool:   "mdev-pool",
+						Name:   "device1",
+						Attributes: map[resourcev1.QualifiedName]resourcev1.DeviceAttribute{
+							metadata.MDevUUIDAttribute:  {StringValue: &uuid},
+							metadata.MDevModelAttribute: {StringValue: &driverModel},
+						},
+					}},
+				}},
+			})
+
+			// Architecture is amd64 (default "vfio-pci"), but driver says "vfio-ap".
+			vmi := &v1.VirtualMachineInstance{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "vmi"},
+				Spec: v1.VirtualMachineInstanceSpec{
+					ResourceClaims: []v1.VirtualMachineInstanceResourceClaim{{
+						Name:              "claim1",
+						ResourceClaimName: ptr.To("claim1"),
+					}},
+					Domain: v1.DomainSpec{
+						Devices: v1.Devices{
+							HostDevices: []v1.HostDevice{{
+								Name:         "vhd1",
+								ClaimRequest: &v1.ClaimRequest{ClaimName: "claim1", RequestName: "req1"},
+							}},
+						},
+					},
+					Architecture: "amd64",
+				},
+			}
+
+			hostDevs, err := CreateDRAHostDevices(vmi, tempDir)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(hostDevs).To(HaveLen(1))
+			Expect(hostDevs[0].Model).To(Equal(driverModel))
+		})
+
+		It("should use the driver-provided model over the architecture default (s390x)", func() {
+			uuid := "abcd1234-1111-2222-3333-444455556666"
+			driverModel := "vfio-pci"
+
+			createMetadataFile("claim1", "req1", "mdev.example.com", &metadata.DeviceMetadata{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "DeviceMetadata",
+					APIVersion: metadata.APIVersionV1Alpha1,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "claim1",
+				},
+				Requests: []metadata.DeviceMetadataRequest{{
+					Name: "req1",
+					Devices: []metadata.Device{{
+						Driver: "mdev.example.com",
+						Pool:   "mdev-pool",
+						Name:   "device1",
+						Attributes: map[resourcev1.QualifiedName]resourcev1.DeviceAttribute{
+							metadata.MDevUUIDAttribute:  {StringValue: &uuid},
+							metadata.MDevModelAttribute: {StringValue: &driverModel},
+						},
+					}},
+				}},
+			})
+
+			// Architecture is s390x (default "vfio-ap"), but driver says "vfio-pci".
+			vmi := &v1.VirtualMachineInstance{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "vmi"},
+				Spec: v1.VirtualMachineInstanceSpec{
+					ResourceClaims: []v1.VirtualMachineInstanceResourceClaim{{
+						Name:              "claim1",
+						ResourceClaimName: ptr.To("claim1"),
+					}},
+					Domain: v1.DomainSpec{
+						Devices: v1.Devices{
+							HostDevices: []v1.HostDevice{{
+								Name:         "vhd1",
+								ClaimRequest: &v1.ClaimRequest{ClaimName: "claim1", RequestName: "req1"},
+							}},
+						},
+					},
+					Architecture: "s390x",
+				},
+			}
+
+			hostDevs, err := CreateDRAHostDevices(vmi, tempDir)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(hostDevs).To(HaveLen(1))
+			Expect(hostDevs[0].Model).To(Equal(driverModel))
+		})
+
+		It("should use vfio-pci arch default when mdevModel attribute is absent", func() {
+			uuid := "abcd1234-1111-2222-3333-000000000000"
+
+			createMetadataFile("claim1", "req1", "mdev.example.com", &metadata.DeviceMetadata{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "DeviceMetadata",
+					APIVersion: metadata.APIVersionV1Alpha1,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "claim1",
+				},
+				Requests: []metadata.DeviceMetadataRequest{{
+					Name: "req1",
+					Devices: []metadata.Device{{
+						Driver: "mdev.example.com",
+						Pool:   "mdev-pool",
+						Name:   "device1",
+						Attributes: map[resourcev1.QualifiedName]resourcev1.DeviceAttribute{
+							metadata.MDevUUIDAttribute: {StringValue: &uuid},
+						},
+					}},
+				}},
+			})
+
+			vmi := &v1.VirtualMachineInstance{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "vmi"},
+				Spec: v1.VirtualMachineInstanceSpec{
+					ResourceClaims: []v1.VirtualMachineInstanceResourceClaim{{
+						Name:              "claim1",
+						ResourceClaimName: ptr.To("claim1"),
+					}},
+					Domain: v1.DomainSpec{
+						Devices: v1.Devices{
+							HostDevices: []v1.HostDevice{{
+								Name:         "vhd1",
+								ClaimRequest: &v1.ClaimRequest{ClaimName: "claim1", RequestName: "req1"},
+							}},
+						},
+					},
+					Architecture: "amd64",
+				},
+			}
+
+			hostDevs, err := CreateDRAHostDevices(vmi, tempDir)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(hostDevs).To(HaveLen(1))
+			Expect(hostDevs[0].Model).To(Equal("vfio-pci"))
+		})
+
+		It("should use vfio-ap arch default when mdevModel attribute is absent (s390x)", func() {
+			uuid := "abcd1234-1111-2222-3333-000000000000"
+
+			createMetadataFile("claim1", "req1", "mdev.example.com", &metadata.DeviceMetadata{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "DeviceMetadata",
+					APIVersion: metadata.APIVersionV1Alpha1,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "claim1",
+				},
+				Requests: []metadata.DeviceMetadataRequest{{
+					Name: "req1",
+					Devices: []metadata.Device{{
+						Driver: "mdev.example.com",
+						Pool:   "mdev-pool",
+						Name:   "device1",
+						Attributes: map[resourcev1.QualifiedName]resourcev1.DeviceAttribute{
+							metadata.MDevUUIDAttribute: {StringValue: &uuid},
+						},
+					}},
+				}},
+			})
+
+			vmi := &v1.VirtualMachineInstance{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "vmi"},
+				Spec: v1.VirtualMachineInstanceSpec{
+					ResourceClaims: []v1.VirtualMachineInstanceResourceClaim{{
+						Name:              "claim1",
+						ResourceClaimName: ptr.To("claim1"),
+					}},
+					Domain: v1.DomainSpec{
+						Devices: v1.Devices{
+							HostDevices: []v1.HostDevice{{
+								Name:         "vhd1",
+								ClaimRequest: &v1.ClaimRequest{ClaimName: "claim1", RequestName: "req1"},
+							}},
+						},
+					},
+					Architecture: "s390x",
+				},
+			}
+
+			hostDevs, err := CreateDRAHostDevices(vmi, tempDir)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(hostDevs).To(HaveLen(1))
+			Expect(hostDevs[0].Model).To(Equal("vfio-ap"))
+		})
+	})
+
 	Context("validation mismatch", func() {
 		It("should error when metadata is missing for a DRA host device", func() {
 			pci := "0000:03:00.1"


### PR DESCRIPTION
Introduce MDevModellAttribute ("mdevModel") in the DRA metadata attribute constants, allowing DRA drivers to explicitly specify the VFIO model to use for mediated devices (e.g. "vfio-pci", "vfio-ap").

When the attribute is absent, the function GetMDevModelForClaim() returns an empty string, preserving the existing architecture based fallback ("vfio-ap" on s390x, "vfio-pci" otherwise) in createHostDeviceForHostDevice.

This decouples the VFIO model selection from architecture detection, enabling heterogeneous clusters where a driver may attach an mdevModel attribute that differs from the architecure default.

Assisted-by: IBM Bob

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

