### PR TITLE
tests/migration: add descriptive failure messages to assertions

### DIFF
--- a/tests/migration/evacuation.go
+++ b/tests/migration/evacuation.go
@@ -248,7 +248,7 @@ var _ = Describe(SIG("VM Live Migration triggered by evacuation", decorators.Req
 				By("Verifying that VMI is marked for eviction")
 				vmi, err = kubevirt.Client().VirtualMachineInstance(vmi.Namespace).Get(ctx, vmi.Name, metav1.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
-				Expect(vmi.IsMarkedForEviction()).To(BeTrue())
+				Expect(vmi.IsMarkedForEviction()).To(BeTrue(), "VMI should be marked for eviction after the evict API call")
 				Expect(vmi.Status.EvacuationNodeName).To(Equal(virtLauncherPod.Spec.NodeName))
 
 				By("Waiting for a migration to be scheduled and to succeed")
@@ -301,7 +301,7 @@ var _ = Describe(SIG("VM Live Migration triggered by evacuation", decorators.Req
 					By("Verifying VMI remains marked for eviction")
 					vmi, err = kubevirt.Client().VirtualMachineInstance(vmi.Namespace).Get(ctx, vmi.Name, metav1.GetOptions{})
 					Expect(err).NotTo(HaveOccurred())
-					Expect(vmi.IsMarkedForEviction()).To(BeTrue())
+					Expect(vmi.IsMarkedForEviction()).To(BeTrue(), "VMI should remain marked for eviction after the migration failed")
 					Expect(vmi.Status.EvacuationNodeName).To(Equal(virtLauncherPod.Spec.NodeName))
 				})
 			})

--- a/tests/migration/eviction_strategy.go
+++ b/tests/migration/eviction_strategy.go
@@ -98,7 +98,7 @@ var _ = Describe(SIG("Live Migration", decorators.RequiresTwoSchedulableNodes, f
 
 				By("Evicting the VMI")
 				err = virtClient.CoreV1().Pods(vmi.Namespace).EvictV1(context.Background(), &policyv1.Eviction{ObjectMeta: metav1.ObjectMeta{Name: pod.Name}})
-				Expect(errors.IsTooManyRequests(err)).To(BeTrue())
+				Expect(errors.IsTooManyRequests(err)).To(BeTrue(), "eviction of the virt-launcher pod should be blocked with a TooManyRequests error, got: %v", err)
 
 				By("Ensuring the VMI has migrated and lives on another node")
 				Eventually(matcher.ThisVMI(vmi)).WithTimeout(time.Minute).WithPolling(time.Second).Should(
@@ -546,7 +546,7 @@ var _ = Describe(SIG("Live Migration", decorators.RequiresTwoSchedulableNodes, f
 					pod, err := libpod.GetPodByVirtualMachineInstance(vmi, vmi.Namespace)
 					Expect(err).NotTo(HaveOccurred())
 					err = virtClient.CoreV1().Pods(vmi.Namespace).EvictV1(context.Background(), &policyv1.Eviction{ObjectMeta: metav1.ObjectMeta{Name: pod.Name}})
-					Expect(errors.IsTooManyRequests(err)).To(BeTrue())
+					Expect(errors.IsTooManyRequests(err)).To(BeTrue(), "eviction of the virt-launcher pod should be blocked with a TooManyRequests error, got: %v", err)
 
 					By("Ensuring the VMI has migrated and lives on another node")
 					Eventually(func() error {

--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -1461,7 +1461,7 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 						Expect(err.Error()).To(Or(ContainSubstring("remote error: tls: unknown certificate authority"), Or(ContainSubstring("remote error: tls: bad certificate")), ContainSubstring("EOF")))
 					}
 
-					Expect(tlsErrorFound).To(BeTrue())
+					Expect(tlsErrorFound).To(BeTrue(), "at least one connection attempt should have been rejected with a TLS error")
 				})
 			})
 		})
@@ -1890,7 +1890,7 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 					}
 					return false
 
-				}, timeout, 1*time.Second).Should(BeTrue())
+				}, timeout, 1*time.Second).Should(BeTrue(), "migration should reach the Running phase before it completes")
 
 				By("Cancelling a Migration")
 				Expect(virtClient.VirtualMachineInstanceMigration(migration.Namespace).Delete(context.Background(), migration.Name, metav1.DeleteOptions{})).To(Succeed())
@@ -2293,9 +2293,9 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 				mc := vmi.Status.MigrationState.VMIMConfigurationOptions
 				Expect(mc).ToNot(BeNil())
 				Expect(mc.AllowAutoConverge).ToNot(BeNil())
-				Expect(*mc.AllowAutoConverge).To(BeTrue())
+				Expect(*mc.AllowAutoConverge).To(BeTrue(), "AllowAutoConverge should match the value set in the migration policy")
 				Expect(mc.AllowPostCopy).ToNot(BeNil())
-				Expect(*mc.AllowPostCopy).To(BeTrue())
+				Expect(*mc.AllowPostCopy).To(BeTrue(), "AllowPostCopy should match the value set in the migration policy")
 				Expect(mc.ExperimentalMigrationOptions).ToNot(BeNil())
 				Expect(mc.ExperimentalMigrationOptions.Compression).ToNot(BeNil())
 				Expect(*mc.ExperimentalMigrationOptions.Compression).To(Equal(v1.MigrationCompressionZstd))

--- a/tests/migration/namespace.go
+++ b/tests/migration/namespace.go
@@ -495,7 +495,7 @@ var _ = Describe(SIG("Live Migration across namespaces", decorators.RequiresDece
 				config := getCurrentKvConfig(virtClient)
 				currentBackendStorageClass = config.VMStateStorageClass
 				sc, exist := libstorage.GetRWOFileSystemStorageClass()
-				Expect(exist).To(BeTrue())
+				Expect(exist).To(BeTrue(), "an RWO filesystem storage class must be present to test backend-storage")
 				By(fmt.Sprintf("Changing the backend storage class from %s to %s", currentBackendStorageClass, sc))
 				config.VMStateStorageClass = sc
 				kvconfig.UpdateKubeVirtConfigValueAndWait(config)
@@ -632,7 +632,7 @@ var _ = Describe(SIG("Live Migration across namespaces", decorators.RequiresDece
 					}
 				}
 				return false
-			}).WithTimeout(timeout * time.Second).WithPolling(500 * time.Millisecond).Should(BeTrue())
+			}).WithTimeout(timeout * time.Second).WithPolling(500 * time.Millisecond).Should(BeTrue(), "source migration should reach the Running phase before it completes")
 
 			By("cancelling a migration")
 			Expect(virtClient.VirtualMachineInstanceMigration(migrationToDelete.Namespace).Delete(context.Background(), migrationToDelete.Name, metav1.DeleteOptions{})).To(Succeed())
@@ -687,7 +687,7 @@ var _ = Describe(SIG("Live Migration across namespaces", decorators.RequiresDece
 					}
 				}
 				return false
-			}).WithTimeout(timeout * time.Second).WithPolling(500 * time.Millisecond).Should(BeTrue())
+			}).WithTimeout(timeout * time.Second).WithPolling(500 * time.Millisecond).Should(BeTrue(), "source migration should reach the Running phase before it completes")
 
 			By("force stopping the source pod")
 			sourcePod, err := libpod.GetPodByVirtualMachineInstance(sourceVMI, sourceVMI.Namespace)

--- a/tests/migration/priority.go
+++ b/tests/migration/priority.go
@@ -162,11 +162,11 @@ var _ = Describe(SIG("Live Migrations with priority", decorators.RequiresTwoSche
 
 		// - Expect vmis[3] and vmis[4] are the first 2 migrations
 		// vmis[3] and vmis[4] have the same priority and we cannot assert anything
-		Expect(migrationStarTimestamp[vmis[3].Name].Before(migrationStarTimestamp[vmis[1].Name])).To(BeTrue())
-		Expect(migrationStarTimestamp[vmis[3].Name].Before(migrationStarTimestamp[vmis[2].Name])).To(BeTrue())
+		Expect(migrationStarTimestamp[vmis[3].Name].Before(migrationStarTimestamp[vmis[1].Name])).To(BeTrue(), "migration of the higher priority vmi %s should have started before the one of %s", vmis[3].Name, vmis[1].Name)
+		Expect(migrationStarTimestamp[vmis[3].Name].Before(migrationStarTimestamp[vmis[2].Name])).To(BeTrue(), "migration of the higher priority vmi %s should have started before the one of %s", vmis[3].Name, vmis[2].Name)
 
-		Expect(migrationStarTimestamp[vmis[4].Name].Before(migrationStarTimestamp[vmis[1].Name])).To(BeTrue())
-		Expect(migrationStarTimestamp[vmis[4].Name].Before(migrationStarTimestamp[vmis[2].Name])).To(BeTrue())
+		Expect(migrationStarTimestamp[vmis[4].Name].Before(migrationStarTimestamp[vmis[1].Name])).To(BeTrue(), "migration of the higher priority vmi %s should have started before the one of %s", vmis[4].Name, vmis[1].Name)
+		Expect(migrationStarTimestamp[vmis[4].Name].Before(migrationStarTimestamp[vmis[2].Name])).To(BeTrue(), "migration of the higher priority vmi %s should have started before the one of %s", vmis[4].Name, vmis[2].Name)
 
 	})
 }))

--- a/tests/migration/recovery.go
+++ b/tests/migration/recovery.go
@@ -64,7 +64,7 @@ var _ = Describe("[sig-compute]Migration recovery", decorators.SigCompute, decor
 			kv := getCurrentKvConfig(virtClient)
 			var exists bool
 			kv.VMStateStorageClass, exists = libstorage.GetRWOFileSystemStorageClass()
-			Expect(exists).To(BeTrue())
+			Expect(exists).To(BeTrue(), "an RWO filesystem storage class must be present to test migration recovery")
 			config.UpdateKubeVirtConfigValueAndWait(kv)
 		}
 
@@ -157,7 +157,7 @@ var _ = Describe("[sig-compute]Migration recovery", decorators.SigCompute, decor
 
 func createPVCFor(virtClient kubecli.KubevirtClient, vm *v1.VirtualMachine) *k8score.PersistentVolumeClaim {
 	storageClass, exists := libstorage.GetRWOFileSystemStorageClass()
-	Expect(exists).To(BeTrue())
+	Expect(exists).To(BeTrue(), "an RWO filesystem storage class must be present to create the backend-storage PVC")
 	mode := k8score.PersistentVolumeFilesystem
 	accessMode := k8score.ReadWriteOnce
 	ownerReferences := []k8smeta.OwnerReference{


### PR DESCRIPTION
**What this PR does**

Before this PR:

Boolean assertions like `Expect(...).To(BeTrue())` in `tests/migration` only produced `Expected <bool>: false to be true` on failure, giving no hint about what actually went wrong or where to start debugging.

After this PR:

All message-less boolean assertions in `tests/migration` (18 spots across 6 files) carry a descriptive failure message. Where useful, the message includes runtime context (e.g. the actual eviction error, the VMI names being compared in migration priority checks).

Follow-up of the effort started in `tests/storage` (#17150, #17877), taking the `tests/migration` area as discussed in the issue.

**Which issue(s) this PR fixes**:

Related to #10347

**Special notes for your reviewer**:

Test-only change; no functional code is touched. Verified with `GOOS=linux go build ./tests/migration/`.

**Release note**:

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved migration test diagnostics with clearer failure messages.
  * Added details for eviction behavior, TLS rejection, migration states, policy combinations, storage requirements, cancellation, failure propagation, priority ordering, and recovery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->