### PR TITLE
docs: fix label instructions in release-procedure

### DIFF
--- a/docs/release-procedure.md
+++ b/docs/release-procedure.md
@@ -165,7 +165,15 @@ second using a 'sig/' label where applicable.
 In some cases, 'kubevirt-bot' applies one or more of these labels automatically,
 however they might need to be manually applied by either the author or a reviewer of the PR.
 
-Add a label by including the ```/kind``` and ```/sig``` commands in the ```release-note-labels``` part of the PR description template. For example: ```/kind enhancement /sig security /sig compute```
+Add a label by including the ```/kind``` and ```/sig``` commands, each on its own line, in the PR description or in a comment on the PR. For example:
+
+```
+/kind enhancement
+/sig security
+/sig compute
+```
+
+Alternatively, users with the proper permissions can apply the labels directly through the GitHub UI.
 
 If a PR matches more than one 'kind/' or 'sig/' label, add all that apply. The release note will be included in whichever takes the greater priority.
 

--- a/docs/release-procedure.md
+++ b/docs/release-procedure.md
@@ -165,7 +165,7 @@ second using a 'sig/' label where applicable.
 In some cases, 'kubevirt-bot' applies one or more of these labels automatically,
 however they might need to be manually applied by either the author or a reviewer of the PR.
 
-Add a label by including the ```/kind``` and ```/sig``` commands, each on its own line, in the PR description or in a comment on the PR. For example:
+Add a label by including the `/kind` and `/sig` commands, each on its own line, in the PR description or in a comment on the PR. For example:
 
 ```
 /kind enhancement


### PR DESCRIPTION
### What this PR does

#### Before this PR:

`docs/release-procedure.md` instructed contributors to add the `/kind` and `/sig` commands in a `release-note-labels` part of the PR description template, but no such section exists in `.github/PULL_REQUEST_TEMPLATE.md`.

#### After this PR:

The doc explains that the `/kind` and `/sig` commands can be placed anywhere in the PR description or in a comment on the PR (one command per line, as required by prow), and that labels can alternatively be applied directly through the GitHub UI by users with the proper permissions. The inline one-line example was reformatted into a code block with one command per line, since prow only parses commands at the beginning of a line.

### References

Fixes #18280

### Special notes for your reviewer

Docs-only change.

### Release note

```release-note
NONE
```
