### PR TITLE
Graduate VmiMemoryOverheadReport feature gate to GA

### DIFF
--- a/pkg/virt-config/featuregate/active.go
+++ b/pkg/virt-config/featuregate/active.go
@@ -184,14 +184,6 @@ const (
 	// Beta: v1.9.0
 	Template = "Template"
 
-	// Owner: @bmordeha
-	// Alpha: v1.8.0
-	// Beta: v1.9.0
-	//
-	// VmiMemoryOverheadReport enables reporting the memory overhead in the VMI status.
-	// When enabled, the memory overhead is calculated and set in the VMI status.Memory.MemoryOverhead field.
-	VmiMemoryOverheadReport = "VmiMemoryOverheadReport"
-
 	// Owner: sig-storage / @mhenriks
 	// Alpha: v1.8.0
 	//
@@ -336,7 +328,6 @@ func init() {
 	RegisterFeatureGate(FeatureGate{Name: ExternalNetResourceInjection, State: Beta})
 	RegisterFeatureGate(FeatureGate{Name: RebootPolicy, State: Beta})
 	RegisterFeatureGate(FeatureGate{Name: Template, State: Beta})
-	RegisterFeatureGate(FeatureGate{Name: VmiMemoryOverheadReport, State: Beta})
 	RegisterFeatureGate(FeatureGate{Name: ContainerPathVolumesGate, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: ReservedOverheadMemlock, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: OptOutRoleAggregation, State: Beta})

--- a/pkg/virt-config/featuregate/inactive.go
+++ b/pkg/virt-config/featuregate/inactive.go
@@ -187,6 +187,14 @@ const (
 	// Beta: v1.8.0
 	// GA: v1.9.0
 	MigrationPriorityQueue = "MigrationPriorityQueue"
+
+	// Owner: @bmordeha
+	// Alpha: v1.8.0
+	// Beta: v1.9.0
+	// GA: v1.10.0
+	//
+	// VmiMemoryOverheadReport enables reporting the memory overhead in the VMI status.
+	VmiMemoryOverheadReport = "VmiMemoryOverheadReport"
 )
 
 func init() {
@@ -231,4 +239,5 @@ func init() {
 	RegisterFeatureGate(FeatureGate{Name: VideoConfig, State: GA})
 	RegisterFeatureGate(FeatureGate{Name: SecureExecution, State: GA})
 	RegisterFeatureGate(FeatureGate{Name: MigrationPriorityQueue, State: GA})
+	RegisterFeatureGate(FeatureGate{Name: VmiMemoryOverheadReport, State: GA})
 }


### PR DESCRIPTION
### What this PR does
#### Before this PR:
VmiMemoryOverheadReport is a Beta feature gate.

#### After this PR:
VmiMemoryOverheadReport is GA.

### References
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/156

### Release note
```release-note
Graduate VmiMemoryOverheadReport feature gate to GA
```