### PR TITLE
virt-api: decouple k8s and kv client

### DIFF
--- a/pkg/virt-api/BUILD.bazel
+++ b/pkg/virt-api/BUILD.bazel
@@ -41,6 +41,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
         "//vendor/k8s.io/client-go/util/certificate:go_default_library",
         "//vendor/k8s.io/client-go/util/flowcontrol:go_default_library",

--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -109,7 +109,7 @@ type VirtApi interface {
 type virtAPIApp struct {
 	service.ServiceListen
 	SubresourcesOnly bool
-	virtCli          kubecli.KubevirtClient
+	virtClient       kubecli.KubevirtClient
 	k8sClient        kubernetes.Interface
 	aggregatorClient *aggregatorclient.Clientset
 	authorizor       rest.VirtApiAuthorizor
@@ -169,7 +169,7 @@ func (app *virtAPIApp) Execute() {
 		panic(err)
 	}
 	clientConfig.RateLimiter = app.reloadableRateLimiter
-	app.virtCli, err = kubecli.GetKubevirtClientFromRESTConfig(clientConfig)
+	app.virtClient, err = kubecli.GetKubevirtClientFromRESTConfig(clientConfig)
 	if err != nil {
 		panic(err)
 	}
@@ -238,7 +238,7 @@ func (app *virtAPIApp) composeSubresources() {
 		subws.Doc(fmt.Sprintf("KubeVirt \"%s\" Subresource API.", version.Version))
 		subws.Path(definitions.GroupVersionBasePath(version))
 
-		subresourceApp := rest.NewSubresourceAPIApp(app.virtCli, app.k8sClient, app.consoleServerPort, app.handlerTLSConfiguration, app.clusterConfig)
+		subresourceApp := rest.NewSubresourceAPIApp(app.virtClient, app.k8sClient, app.consoleServerPort, app.handlerTLSConfiguration, app.clusterConfig)
 
 		restartRouteBuilder := subws.PUT(definitions.NamespacedResourcePath(subresourcesvmGVR)+definitions.SubResourcePath("restart")).
 			To(subresourceApp.RestartVMRequestHandler).
@@ -1002,7 +1002,7 @@ func (app *virtAPIApp) registerValidatingWebhooks(informers *webhooks.Informers)
 		validating_webhook.ServeVMIUpdate(w, r, app.clusterConfig, app.kubeVirtServiceAccounts)
 	})
 	http.HandleFunc(components.VMValidatePath, func(w http.ResponseWriter, r *http.Request) {
-		validating_webhook.ServeVMs(w, r, app.clusterConfig, app.virtCli, informers, app.kubeVirtServiceAccounts)
+		validating_webhook.ServeVMs(w, r, app.clusterConfig, app.virtClient, informers, app.kubeVirtServiceAccounts)
 	})
 	http.HandleFunc(components.VMIRSValidatePath, func(w http.ResponseWriter, r *http.Request) {
 		validating_webhook.ServeVMIRS(w, r, app.clusterConfig)
@@ -1014,19 +1014,19 @@ func (app *virtAPIApp) registerValidatingWebhooks(informers *webhooks.Informers)
 		validating_webhook.ServeVMIPreset(w, r)
 	})
 	http.HandleFunc(components.MigrationCreateValidatePath, func(w http.ResponseWriter, r *http.Request) {
-		validating_webhook.ServeMigrationCreate(w, r, app.clusterConfig, app.virtCli, app.kubeVirtServiceAccounts)
+		validating_webhook.ServeMigrationCreate(w, r, app.clusterConfig, app.virtClient, app.kubeVirtServiceAccounts)
 	})
 	http.HandleFunc(components.MigrationUpdateValidatePath, func(w http.ResponseWriter, r *http.Request) {
 		validating_webhook.ServeMigrationUpdate(w, r)
 	})
 	http.HandleFunc(components.VMSnapshotValidatePath, func(w http.ResponseWriter, r *http.Request) {
-		validating_webhook.ServeVMSnapshots(w, r, app.clusterConfig, app.virtCli)
+		validating_webhook.ServeVMSnapshots(w, r, app.clusterConfig, app.virtClient)
 	})
 	http.HandleFunc(components.VMRestoreValidatePath, func(w http.ResponseWriter, r *http.Request) {
-		validating_webhook.ServeVMRestores(w, r, app.clusterConfig, app.virtCli, informers)
+		validating_webhook.ServeVMRestores(w, r, app.clusterConfig, app.virtClient, informers)
 	})
 	http.HandleFunc(components.VMBackupValidatePath, func(w http.ResponseWriter, r *http.Request) {
-		validating_webhook.ServeVMBackups(w, r, app.clusterConfig, app.virtCli, informers)
+		validating_webhook.ServeVMBackups(w, r, app.clusterConfig, app.virtClient, informers)
 	})
 	http.HandleFunc(components.VMBackupTrackerValidatePath, func(w http.ResponseWriter, r *http.Request) {
 		validating_webhook.ServeVMBackupTrackers(w, r, app.clusterConfig)
@@ -1047,16 +1047,16 @@ func (app *virtAPIApp) registerValidatingWebhooks(informers *webhooks.Informers)
 		validating_webhook.ServeVmClusterPreferences(w, r)
 	})
 	http.HandleFunc(components.StatusValidatePath, func(w http.ResponseWriter, r *http.Request) {
-		validating_webhook.ServeStatusValidation(w, r, app.clusterConfig, app.virtCli, informers, app.kubeVirtServiceAccounts)
+		validating_webhook.ServeStatusValidation(w, r, app.clusterConfig, app.virtClient, informers, app.kubeVirtServiceAccounts)
 	})
 	http.HandleFunc(components.PodEvictionValidatePath, func(w http.ResponseWriter, r *http.Request) {
-		validating_webhook.ServePodEvictionInterceptor(w, r, app.clusterConfig, app.virtCli, app.k8sClient)
+		validating_webhook.ServePodEvictionInterceptor(w, r, app.clusterConfig, app.virtClient, app.k8sClient)
 	})
 	http.HandleFunc(components.MigrationPolicyCreateValidatePath, func(w http.ResponseWriter, r *http.Request) {
 		validating_webhook.ServeMigrationPolicies(w, r, app.clusterConfig)
 	})
 	http.HandleFunc(components.VMCloneCreateValidatePath, func(w http.ResponseWriter, r *http.Request) {
-		validating_webhook.ServeVirtualMachineClones(w, r, app.clusterConfig, app.virtCli)
+		validating_webhook.ServeVirtualMachineClones(w, r, app.clusterConfig, app.virtClient)
 	})
 	http.HandleFunc(components.PluginValidatePath, func(w http.ResponseWriter, r *http.Request) {
 		validating_webhook.ServePlugins(w, r, app.clusterConfig)
@@ -1066,7 +1066,7 @@ func (app *virtAPIApp) registerValidatingWebhooks(informers *webhooks.Informers)
 func (app *virtAPIApp) registerMutatingWebhook(informers *webhooks.Informers) {
 
 	http.HandleFunc(components.VMMutatePath, func(w http.ResponseWriter, r *http.Request) {
-		mutating_webhook.ServeVMs(w, r, app.clusterConfig, app.virtCli)
+		mutating_webhook.ServeVMs(w, r, app.clusterConfig, app.virtClient)
 	})
 	http.HandleFunc(components.VMIMutatePath, func(w http.ResponseWriter, r *http.Request) {
 		mutating_webhook.ServeVMIs(w, r, app.clusterConfig, informers, app.kubeVirtServiceAccounts)
@@ -1078,7 +1078,7 @@ func (app *virtAPIApp) registerMutatingWebhook(informers *webhooks.Informers) {
 		mutating_webhook.ServeClones(w, r)
 	})
 	http.HandleFunc(components.VirtLauncherPodMutatePath, func(w http.ResponseWriter, r *http.Request) {
-		mutating_webhook.ServeVirtLauncherPods(w, r, app.clusterConfig, app.virtCli)
+		mutating_webhook.ServeVirtLauncherPods(w, r, app.clusterConfig, app.virtClient)
 	})
 }
 
@@ -1201,7 +1201,7 @@ func (app *virtAPIApp) Run() {
 	app.prepareCertManager()
 
 	// Run informers for webhooks usage
-	kubeInformerFactory := controller.NewKubeInformerFactory(app.virtCli.RestClient(), app.virtCli, app.k8sClient, app.aggregatorClient, app.namespace)
+	kubeInformerFactory := controller.NewKubeInformerFactory(app.virtClient.RestClient(), app.virtClient, app.k8sClient, app.aggregatorClient, app.namespace)
 
 	kubeVirtInformer := kubeInformerFactory.KubeVirt()
 	// Wire up health check trigger

--- a/pkg/virt-api/api.go
+++ b/pkg/virt-api/api.go
@@ -41,6 +41,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 	certificate2 "k8s.io/client-go/util/certificate"
 	"k8s.io/client-go/util/flowcontrol"
@@ -109,6 +110,7 @@ type virtAPIApp struct {
 	service.ServiceListen
 	SubresourcesOnly bool
 	virtCli          kubecli.KubevirtClient
+	k8sClient        kubernetes.Interface
 	aggregatorClient *aggregatorclient.Clientset
 	authorizor       rest.VirtApiAuthorizor
 	certsDirectory   string
@@ -168,6 +170,10 @@ func (app *virtAPIApp) Execute() {
 	}
 	clientConfig.RateLimiter = app.reloadableRateLimiter
 	app.virtCli, err = kubecli.GetKubevirtClientFromRESTConfig(clientConfig)
+	if err != nil {
+		panic(err)
+	}
+	app.k8sClient, err = kubecli.GetK8sClientFromRESTConfig(clientConfig)
 	if err != nil {
 		panic(err)
 	}
@@ -232,7 +238,7 @@ func (app *virtAPIApp) composeSubresources() {
 		subws.Doc(fmt.Sprintf("KubeVirt \"%s\" Subresource API.", version.Version))
 		subws.Path(definitions.GroupVersionBasePath(version))
 
-		subresourceApp := rest.NewSubresourceAPIApp(app.virtCli, app.consoleServerPort, app.handlerTLSConfiguration, app.clusterConfig)
+		subresourceApp := rest.NewSubresourceAPIApp(app.virtCli, app.k8sClient, app.consoleServerPort, app.handlerTLSConfiguration, app.clusterConfig)
 
 		restartRouteBuilder := subws.PUT(definitions.NamespacedResourcePath(subresourcesvmGVR)+definitions.SubResourcePath("restart")).
 			To(subresourceApp.RestartVMRequestHandler).
@@ -932,7 +938,7 @@ func deserializeStrings(in string) ([]string, error) {
 }
 
 func (app *virtAPIApp) readRequestHeader() error {
-	authConfigMap, err := app.virtCli.CoreV1().ConfigMaps(metav1.NamespaceSystem).Get(context.Background(), util.ExtensionAPIServerAuthenticationConfigMap, metav1.GetOptions{})
+	authConfigMap, err := app.k8sClient.CoreV1().ConfigMaps(metav1.NamespaceSystem).Get(context.Background(), util.ExtensionAPIServerAuthenticationConfigMap, metav1.GetOptions{})
 	if err != nil {
 		return err
 	}
@@ -1044,7 +1050,7 @@ func (app *virtAPIApp) registerValidatingWebhooks(informers *webhooks.Informers)
 		validating_webhook.ServeStatusValidation(w, r, app.clusterConfig, app.virtCli, informers, app.kubeVirtServiceAccounts)
 	})
 	http.HandleFunc(components.PodEvictionValidatePath, func(w http.ResponseWriter, r *http.Request) {
-		validating_webhook.ServePodEvictionInterceptor(w, r, app.clusterConfig, app.virtCli)
+		validating_webhook.ServePodEvictionInterceptor(w, r, app.clusterConfig, app.virtCli, app.k8sClient)
 	})
 	http.HandleFunc(components.MigrationPolicyCreateValidatePath, func(w http.ResponseWriter, r *http.Request) {
 		validating_webhook.ServeMigrationPolicies(w, r, app.clusterConfig)
@@ -1195,7 +1201,7 @@ func (app *virtAPIApp) Run() {
 	app.prepareCertManager()
 
 	// Run informers for webhooks usage
-	kubeInformerFactory := controller.NewKubeInformerFactory(app.virtCli.RestClient(), app.virtCli, app.virtCli, app.aggregatorClient, app.namespace)
+	kubeInformerFactory := controller.NewKubeInformerFactory(app.virtCli.RestClient(), app.virtCli, app.k8sClient, app.aggregatorClient, app.namespace)
 
 	kubeVirtInformer := kubeInformerFactory.KubeVirt()
 	// Wire up health check trigger

--- a/pkg/virt-api/api_test.go
+++ b/pkg/virt-api/api_test.go
@@ -65,6 +65,7 @@ var _ = Describe("Virt-api", func() {
 		tmpDir, err := os.MkdirTemp("", "api_tmp_dir")
 		Expect(err).ToNot(HaveOccurred())
 		app.virtCli, _ = kubecli.GetKubevirtClientFromFlags(server.URL(), "")
+		app.k8sClient, _ = kubecli.GetK8sClientFromFlags(server.URL(), "")
 		app.certsDirectory = tmpDir
 
 		config, err := clientcmd.BuildConfigFromFlags(server.URL(), "")

--- a/pkg/virt-api/api_test.go
+++ b/pkg/virt-api/api_test.go
@@ -64,7 +64,7 @@ var _ = Describe("Virt-api", func() {
 		backend = httptest.NewServer(nil)
 		tmpDir, err := os.MkdirTemp("", "api_tmp_dir")
 		Expect(err).ToNot(HaveOccurred())
-		app.virtCli, _ = kubecli.GetKubevirtClientFromFlags(server.URL(), "")
+		app.virtClient, _ = kubecli.GetKubevirtClientFromFlags(server.URL(), "")
 		app.k8sClient, _ = kubecli.GetK8sClientFromFlags(server.URL(), "")
 		app.certsDirectory = tmpDir
 

--- a/pkg/virt-api/rest/BUILD.bazel
+++ b/pkg/virt-api/rest/BUILD.bazel
@@ -57,6 +57,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/util/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/json:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/yaml:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes:go_default_library",
         "//vendor/k8s.io/client-go/kubernetes/typed/authorization/v1:go_default_library",
         "//vendor/k8s.io/client-go/util/flowcontrol:go_default_library",
         "//vendor/k8s.io/utils/net:go_default_library",

--- a/pkg/virt-api/rest/console_test.go
+++ b/pkg/virt-api/rest/console_test.go
@@ -86,7 +86,7 @@ var _ = Describe("Console Subresource api", func() {
 		mockVirtClient.EXPECT().VirtualMachineInstance(metav1.NamespaceDefault).Return(virtClient.KubevirtV1().VirtualMachineInstances(metav1.NamespaceDefault)).AnyTimes()
 		mockVirtClient.EXPECT().VirtualMachineInstance("").Return(virtClient.KubevirtV1().VirtualMachineInstances("")).AnyTimes()
 
-		app = NewSubresourceAPIApp(mockVirtClient, backendPort, &tls.Config{InsecureSkipVerify: true}, config)
+		app = NewSubresourceAPIApp(mockVirtClient, nil, backendPort, &tls.Config{InsecureSkipVerify: true}, config)
 	})
 
 	DescribeTable("request validation", func(autoattachSerialConsole bool, phase v1.VirtualMachineInstancePhase) {

--- a/pkg/virt-api/rest/dialers.go
+++ b/pkg/virt-api/rest/dialers.go
@@ -127,7 +127,7 @@ func (app *SubresourceAPIApp) getVirtHandlerConnForVMI(vmi *v1.VirtualMachineIns
 	if !vmi.IsRunning() && !vmi.IsScheduled() {
 		return nil, fmt.Errorf("Unable to connect to VirtualMachineInstance because phase is %s instead of %s or %s", vmi.Status.Phase, v1.Running, v1.Scheduled)
 	}
-	return kubecli.NewVirtHandlerClient(app.virtCli, app.handlerHttpClient).Port(app.consoleServerPort).ForNode(vmi.Status.NodeName), nil
+	return kubecli.NewVirtHandlerClient(app.virtClient, app.handlerHttpClient).Port(app.consoleServerPort).ForNode(vmi.Status.NodeName), nil
 }
 
 // get the first available interface IP

--- a/pkg/virt-api/rest/dialers_test.go
+++ b/pkg/virt-api/rest/dialers_test.go
@@ -119,7 +119,7 @@ var _ = Describe("NetDialer", func() {
 
 		runningStatus := libvmistatus.WithStatus(libvmistatus.New(libvmistatus.WithPhase(v1.Running)))
 		vmi := libvmi.New(runningStatus)
-		app := NewSubresourceAPIApp(virtClient, int(port), nil, config)
+		app := NewSubresourceAPIApp(virtClient, k8sfakeClient, int(port), nil, config)
 		dialer := app.virtHandlerDialer(func(_ *v1.VirtualMachineInstance, _ kubecli.VirtHandlerConn) (string, error) {
 			return fullURL, nil
 		})

--- a/pkg/virt-api/rest/evacuate_cancel.go
+++ b/pkg/virt-api/rest/evacuate_cancel.go
@@ -116,7 +116,7 @@ func (app *SubresourceAPIApp) validateEvacuationNode(ctx context.Context, vmi *v
 		Effect: k8sv1.TaintEffectNoSchedule,
 	}
 
-	node, err := app.virtCli.CoreV1().Nodes().Get(ctx, evacuationNodeName, k8smetav1.GetOptions{})
+	node, err := app.k8sClient.CoreV1().Nodes().Get(ctx, evacuationNodeName, k8smetav1.GetOptions{})
 	if err != nil {
 		return errors.NewInternalError(err)
 	}

--- a/pkg/virt-api/rest/evacuate_cancel.go
+++ b/pkg/virt-api/rest/evacuate_cancel.go
@@ -80,7 +80,7 @@ func (app *SubresourceAPIApp) EvacuateCancelHandler(fetcher vmiFetcher) restful.
 			return
 		}
 
-		_, err = app.virtCli.VirtualMachineInstance(namespace).Patch(ctx, vmi.GetName(), types.JSONPatchType, patchBytes, k8smetav1.PatchOptions{DryRun: opts.DryRun})
+		_, err = app.virtClient.VirtualMachineInstance(namespace).Patch(ctx, vmi.GetName(), types.JSONPatchType, patchBytes, k8smetav1.PatchOptions{DryRun: opts.DryRun})
 		if err != nil {
 			log.Log.Object(vmi).V(2).Reason(err).Info("Failed to patching VMI")
 			writeError(errors.NewInternalError(err), response)

--- a/pkg/virt-api/rest/evacuate_cancel_test.go
+++ b/pkg/virt-api/rest/evacuate_cancel_test.go
@@ -131,9 +131,7 @@ var _ = Describe("EvacuateCancel Subresource API", func() {
 		virtClient.EXPECT().VirtualMachine(metav1.NamespaceDefault).Return(fakeKubevirtClients.VirtualMachines(metav1.NamespaceDefault)).AnyTimes()
 		virtClient.EXPECT().VirtualMachineInstance(metav1.NamespaceDefault).Return(fakeKubevirtClients.VirtualMachineInstances(metav1.NamespaceDefault)).AnyTimes()
 
-		virtClient.EXPECT().CoreV1().Return(kubeClient.CoreV1()).AnyTimes()
-
-		app = NewSubresourceAPIApp(virtClient, backendPort, &tls.Config{InsecureSkipVerify: true}, config)
+		app = NewSubresourceAPIApp(virtClient, kubeClient, backendPort, &tls.Config{InsecureSkipVerify: true}, config)
 	})
 
 	createVMI := func(vmi *v1.VirtualMachineInstance) *v1.VirtualMachineInstance {

--- a/pkg/virt-api/rest/expand_test.go
+++ b/pkg/virt-api/rest/expand_test.go
@@ -99,7 +99,7 @@ var _ = Describe("Instancetype expansion subresources", func() {
 		}
 
 		config, _, _ := testutils.NewFakeClusterConfigUsingKV(kv)
-		app = NewSubresourceAPIApp(virtClient, 0, nil, config)
+		app = NewSubresourceAPIApp(virtClient, nil, 0, nil, config)
 
 		request = restful.NewRequest(&http.Request{})
 		recorder = httptest.NewRecorder()

--- a/pkg/virt-api/rest/lifecycle.go
+++ b/pkg/virt-api/rest/lifecycle.go
@@ -50,7 +50,7 @@ func (app *SubresourceAPIApp) StartVMRequestHandler(request *restful.Request, re
 		return
 	}
 
-	vmi, err := app.virtCli.VirtualMachineInstance(namespace).Get(context.Background(), name, metav1.GetOptions{})
+	vmi, err := app.virtClient.VirtualMachineInstance(namespace).Get(context.Background(), name, metav1.GetOptions{})
 	if err != nil && !errors.IsNotFound(err) {
 		writeError(errors.NewInternalError(err), response)
 		return
@@ -106,7 +106,7 @@ func (app *SubresourceAPIApp) StartVMRequestHandler(request *restful.Request, re
 				return
 			}
 			log.Log.Object(vm).V(4).Infof(patchingVMStatusFmt, string(patchBytes))
-			_, patchErr = app.virtCli.VirtualMachine(vm.Namespace).PatchStatus(context.Background(), vm.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{DryRun: bodyStruct.DryRun})
+			_, patchErr = app.virtClient.VirtualMachine(vm.Namespace).PatchStatus(context.Background(), vm.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{DryRun: bodyStruct.DryRun})
 		} else {
 			patchBytes, err := getRunningPatch(vm, true)
 			if err != nil {
@@ -114,7 +114,7 @@ func (app *SubresourceAPIApp) StartVMRequestHandler(request *restful.Request, re
 				return
 			}
 			log.Log.Object(vm).V(4).Infof(patchingVMFmt, string(patchBytes))
-			_, patchErr = app.virtCli.VirtualMachine(namespace).Patch(context.Background(), vm.GetName(), types.JSONPatchType, patchBytes, metav1.PatchOptions{DryRun: bodyStruct.DryRun})
+			_, patchErr = app.virtClient.VirtualMachine(namespace).Patch(context.Background(), vm.GetName(), types.JSONPatchType, patchBytes, metav1.PatchOptions{DryRun: bodyStruct.DryRun})
 		}
 
 	case v1.RunStrategyRerunOnFailure, v1.RunStrategyManual:
@@ -141,7 +141,7 @@ func (app *SubresourceAPIApp) StartVMRequestHandler(request *restful.Request, re
 			return
 		}
 		log.Log.Object(vm).V(4).Infof(patchingVMStatusFmt, string(patchBytes))
-		_, patchErr = app.virtCli.VirtualMachine(vm.Namespace).PatchStatus(context.Background(), vm.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{DryRun: bodyStruct.DryRun})
+		_, patchErr = app.virtClient.VirtualMachine(vm.Namespace).PatchStatus(context.Background(), vm.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{DryRun: bodyStruct.DryRun})
 	case v1.RunStrategyAlways, v1.RunStrategyOnce:
 		writeError(errors.NewConflict(v1.Resource("virtualmachine"), name, fmt.Errorf("%v does not support manual start requests", runStrategy)), response)
 		return
@@ -190,7 +190,7 @@ func (app *SubresourceAPIApp) StopVMRequestHandler(request *restful.Request, res
 	}
 
 	hasVMI := true
-	vmi, err := app.virtCli.VirtualMachineInstance(namespace).Get(context.Background(), name, metav1.GetOptions{})
+	vmi, err := app.virtClient.VirtualMachineInstance(namespace).Get(context.Background(), name, metav1.GetOptions{})
 	if err != nil && errors.IsNotFound(err) {
 		hasVMI = false
 	} else if err != nil {
@@ -242,7 +242,7 @@ func (app *SubresourceAPIApp) StopVMRequestHandler(request *restful.Request, res
 			return
 		}
 		log.Log.Object(vm).V(4).Infof(patchingVMFmt, string(patchBytes))
-		_, patchErr = app.virtCli.VirtualMachine(namespace).Patch(context.Background(), vm.GetName(), types.JSONPatchType, patchBytes, metav1.PatchOptions{DryRun: bodyStruct.DryRun})
+		_, patchErr = app.virtClient.VirtualMachine(namespace).Patch(context.Background(), vm.GetName(), types.JSONPatchType, patchBytes, metav1.PatchOptions{DryRun: bodyStruct.DryRun})
 	}
 
 	if patchErr != nil {
@@ -440,7 +440,7 @@ func (app *SubresourceAPIApp) RestartVMRequestHandler(request *restful.Request, 
 		return
 	}
 
-	vmi, err := app.virtCli.VirtualMachineInstance(namespace).Get(context.Background(), name, metav1.GetOptions{})
+	vmi, err := app.virtClient.VirtualMachineInstance(namespace).Get(context.Background(), name, metav1.GetOptions{})
 	if err != nil {
 		if !errors.IsNotFound(err) {
 			writeError(errors.NewInternalError(err), response)
@@ -477,7 +477,7 @@ func (app *SubresourceAPIApp) RestartVMRequestHandler(request *restful.Request, 
 	}
 
 	log.Log.Object(vm).V(4).Infof(patchingVMFmt, string(patchBytes))
-	_, err = app.virtCli.VirtualMachine(vm.Namespace).PatchStatus(context.Background(), vm.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{DryRun: bodyStruct.DryRun})
+	_, err = app.virtClient.VirtualMachine(vm.Namespace).PatchStatus(context.Background(), vm.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{DryRun: bodyStruct.DryRun})
 	if err != nil {
 		if forceRestart {
 			if _, rollbackErr := app.patchVMITerminationGracePeriod(vmi, namespace, oldGracePeriodSeconds, bodyStruct.DryRun); rollbackErr != nil {
@@ -549,7 +549,7 @@ func (app *SubresourceAPIApp) MigrateVMRequestHandler(request *restful.Request, 
 	}
 
 	createMigrationJob := func() *errors.StatusError {
-		_, err := app.virtCli.VirtualMachineInstanceMigration(namespace).Create(context.Background(), &v1.VirtualMachineInstanceMigration{
+		_, err := app.virtClient.VirtualMachineInstanceMigration(namespace).Create(context.Background(), &v1.VirtualMachineInstanceMigration{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "kubevirt-migrate-vm-",
 			},
@@ -587,7 +587,7 @@ func (app *SubresourceAPIApp) patchVMITerminationGracePeriod(vmi *v1.VirtualMach
 		return 0, err
 	}
 	log.Log.Object(vmi).V(2).Infof("Patching VMI terminationGracePeriodSeconds: %s", string(patchBytes))
-	_, err = app.virtCli.VirtualMachineInstance(namespace).Patch(context.Background(), vmi.GetName(), types.JSONPatchType, patchBytes, metav1.PatchOptions{DryRun: dryRun})
+	_, err = app.virtClient.VirtualMachineInstance(namespace).Patch(context.Background(), vmi.GetName(), types.JSONPatchType, patchBytes, metav1.PatchOptions{DryRun: dryRun})
 	return oldGracePeriod, err
 }
 
@@ -599,7 +599,7 @@ func (app *SubresourceAPIApp) patchVMStatusStopped(vmi *v1.VirtualMachineInstanc
 		return nil, err
 	}
 	log.Log.Object(vm).V(4).Infof(patchingVMStatusFmt, string(patchBytes))
-	_, err = app.virtCli.VirtualMachine(vm.Namespace).PatchStatus(context.Background(), vm.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{DryRun: bodyStruct.DryRun})
+	_, err = app.virtClient.VirtualMachine(vm.Namespace).PatchStatus(context.Background(), vm.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{DryRun: bodyStruct.DryRun})
 	return err, nil
 }
 

--- a/pkg/virt-api/rest/memorydump.go
+++ b/pkg/virt-api/rest/memorydump.go
@@ -48,7 +48,7 @@ const (
 )
 
 func (app *SubresourceAPIApp) fetchPersistentVolumeClaim(name string, namespace string) (*k8sv1.PersistentVolumeClaim, *errors.StatusError) {
-	pvc, err := app.virtCli.CoreV1().PersistentVolumeClaims(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	pvc, err := app.k8sClient.CoreV1().PersistentVolumeClaims(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return nil, errors.NewNotFound(v1.Resource("persistentvolumeclaim"), name)

--- a/pkg/virt-api/rest/memorydump.go
+++ b/pkg/virt-api/rest/memorydump.go
@@ -59,7 +59,7 @@ func (app *SubresourceAPIApp) fetchPersistentVolumeClaim(name string, namespace 
 }
 
 func (app *SubresourceAPIApp) fetchCDIConfig() (*cdiv1.CDIConfig, *errors.StatusError) {
-	cdiConfig, err := app.virtCli.CdiClient().CdiV1beta1().CDIConfigs().Get(context.Background(), storagetypes.ConfigName, metav1.GetOptions{})
+	cdiConfig, err := app.virtClient.CdiClient().CdiV1beta1().CDIConfigs().Get(context.Background(), storagetypes.ConfigName, metav1.GetOptions{})
 	if errors.IsNotFound(err) {
 		return nil, nil
 	}
@@ -154,7 +154,7 @@ func (app *SubresourceAPIApp) vmMemoryDumpRequestPatchStatus(name, namespace str
 	}
 
 	log.Log.Object(vm).V(4).Infof(patchingVMFmt, string(patchBytes))
-	if _, err = app.virtCli.VirtualMachine(vm.Namespace).PatchStatus(context.Background(), vm.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{}); err != nil {
+	if _, err = app.virtClient.VirtualMachine(vm.Namespace).PatchStatus(context.Background(), vm.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{}); err != nil {
 		log.Log.Object(vm).Errorf("unable to patch vm status: %v", err)
 		if errors.IsInvalid(err) {
 			if statErr, ok := err.(*errors.StatusError); ok {

--- a/pkg/virt-api/rest/memorydump_test.go
+++ b/pkg/virt-api/rest/memorydump_test.go
@@ -152,7 +152,6 @@ var _ = Describe("Memory dump Subresource api", func() {
 		vmClient = kubecli.NewMockVirtualMachineInterface(ctrl)
 		vmiClient = kubecli.NewMockVirtualMachineInstanceInterface(ctrl)
 
-		virtClient.EXPECT().CoreV1().Return(kubeClient.CoreV1()).AnyTimes()
 		virtClient.EXPECT().VirtualMachine(metav1.NamespaceDefault).Return(vmClient).AnyTimes()
 		virtClient.EXPECT().VirtualMachine("").Return(vmClient).AnyTimes()
 		virtClient.EXPECT().VirtualMachineInstance(metav1.NamespaceDefault).Return(vmiClient).AnyTimes()
@@ -161,7 +160,7 @@ var _ = Describe("Memory dump Subresource api", func() {
 		cdiConfig := cdiConfigInit()
 		cdiClient = cdifake.NewSimpleClientset(cdiConfig)
 
-		app = NewSubresourceAPIApp(virtClient, backendPort, &tls.Config{InsecureSkipVerify: true}, config)
+		app = NewSubresourceAPIApp(virtClient, kubeClient, backendPort, &tls.Config{InsecureSkipVerify: true}, config)
 	})
 
 	AfterEach(func() {

--- a/pkg/virt-api/rest/objectgraph.go
+++ b/pkg/virt-api/rest/objectgraph.go
@@ -134,7 +134,7 @@ func (app *SubresourceAPIApp) handleObjectGraph(request *restful.Request, respon
 		return
 	}
 
-	graph, err := NewObjectGraph(app.virtCli, app.k8sClient, objectGraphOpts).GetObjectGraph(obj)
+	graph, err := NewObjectGraph(app.virtClient, app.k8sClient, objectGraphOpts).GetObjectGraph(obj)
 	if err != nil {
 		writeError(apierrors.NewInternalError(err), response)
 		return

--- a/pkg/virt-api/rest/objectgraph.go
+++ b/pkg/virt-api/rest/objectgraph.go
@@ -34,6 +34,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	k8serrors "k8s.io/apimachinery/pkg/util/errors"
 
+	"k8s.io/client-go/kubernetes"
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
@@ -60,16 +61,18 @@ const (
 )
 
 type ObjectGraph struct {
-	client   kubecli.KubevirtClient
-	graphMap map[string]schema.GroupKind
-	options  *v1.ObjectGraphOptions
+	virtClient kubecli.KubevirtClient
+	k8sClient  kubernetes.Interface
+	graphMap   map[string]schema.GroupKind
+	options    *v1.ObjectGraphOptions
 }
 
-func NewObjectGraph(client kubecli.KubevirtClient, opts *v1.ObjectGraphOptions) *ObjectGraph {
+func NewObjectGraph(virtClient kubecli.KubevirtClient, k8sClient kubernetes.Interface, opts *v1.ObjectGraphOptions) *ObjectGraph {
 	return &ObjectGraph{
-		client:   client,
-		graphMap: objectGraphMap,
-		options:  opts,
+		virtClient: virtClient,
+		k8sClient:  k8sClient,
+		graphMap:   objectGraphMap,
+		options:    opts,
 	}
 }
 
@@ -131,7 +134,7 @@ func (app *SubresourceAPIApp) handleObjectGraph(request *restful.Request, respon
 		return
 	}
 
-	graph, err := NewObjectGraph(app.virtCli, objectGraphOpts).GetObjectGraph(obj)
+	graph, err := NewObjectGraph(app.virtCli, app.k8sClient, objectGraphOpts).GetObjectGraph(obj)
 	if err != nil {
 		writeError(apierrors.NewInternalError(err), response)
 		return
@@ -316,7 +319,7 @@ func (og *ObjectGraph) buildChildrenFromVMI(vmi *v1.VirtualMachineInstance) ([]v
 
 func (og *ObjectGraph) addVolumeGraph(obj any, namespace string) ([]v1.ObjectGraphNode, error) {
 	var nodes []v1.ObjectGraphNode
-	volumes, err := storageutils.GetVolumes(obj, og.client, storageutils.WithAllVolumes)
+	volumes, err := storageutils.GetVolumes(obj, og.virtClient, storageutils.WithAllVolumes)
 	if err != nil {
 		if !storageutils.IsErrNoBackendPVC(err) {
 			return nil, err
@@ -384,7 +387,7 @@ func (og *ObjectGraph) addVolumeGraph(obj any, namespace string) ([]v1.ObjectGra
 }
 
 func (og *ObjectGraph) getLauncherPodNode(name, namespace string) (*v1.ObjectGraphNode, error) {
-	pods, err := og.client.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{
+	pods, err := og.k8sClient.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{
 		LabelSelector: fmt.Sprintf("%s=%s", v1.AppLabel, "virt-launcher"),
 	})
 	if err != nil {

--- a/pkg/virt-api/rest/objectgraph_test.go
+++ b/pkg/virt-api/rest/objectgraph_test.go
@@ -62,7 +62,6 @@ var _ = Describe("Object Graph", func() {
 		ctrl := gomock.NewController(GinkgoT())
 		kvClient = kubecli.NewMockKubevirtClient(ctrl)
 		kubeClient = fake.NewClientset()
-
 		kvClient.EXPECT().CoreV1().Return(kubeClient.CoreV1()).AnyTimes()
 
 		vm = &v1.VirtualMachine{
@@ -122,7 +121,7 @@ var _ = Describe("Object Graph", func() {
 			}
 			var config *virtconfig.ClusterConfig
 			config, _, kvStore = testutils.NewFakeClusterConfigUsingKV(kv)
-			app = NewSubresourceAPIApp(kvClient, backendPort, &tls.Config{InsecureSkipVerify: true}, config)
+			app = NewSubresourceAPIApp(kvClient, kubeClient, backendPort, &tls.Config{InsecureSkipVerify: true}, config)
 		})
 
 		disableFeatureGates := func() {
@@ -296,7 +295,7 @@ var _ = Describe("Object Graph", func() {
 				}, nil
 			})
 
-			graph := NewObjectGraph(kvClient, &v1.ObjectGraphOptions{})
+			graph := NewObjectGraph(kvClient, kubeClient, &v1.ObjectGraphOptions{})
 			graphNodes, err := graph.GetObjectGraph(vm)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(graphNodes.Children).To(HaveLen(5))
@@ -370,7 +369,7 @@ var _ = Describe("Object Graph", func() {
 				}, nil
 			})
 
-			graph := NewObjectGraph(kvClient, &v1.ObjectGraphOptions{})
+			graph := NewObjectGraph(kvClient, kubeClient, &v1.ObjectGraphOptions{})
 			graphNodes, err := graph.GetObjectGraph(vmi)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(graphNodes.ObjectReference.Name).To(Equal("test-vmi"))
@@ -394,7 +393,7 @@ var _ = Describe("Object Graph", func() {
 			kubeClient.Fake.PrependReactor("list", "pods", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
 				return true, nil, fmt.Errorf("error listing pods")
 			})
-			graph := NewObjectGraph(kvClient, &v1.ObjectGraphOptions{})
+			graph := NewObjectGraph(kvClient, kubeClient, &v1.ObjectGraphOptions{})
 			graphNodes, err := graph.GetObjectGraph(vm)
 			Expect(err).To(HaveOccurred())
 			Expect(graphNodes.Children).To(HaveLen(1))
@@ -424,7 +423,7 @@ var _ = Describe("Object Graph", func() {
 				return true, &k8sv1.PersistentVolumeClaimList{Items: []k8sv1.PersistentVolumeClaim{*pvc}}, nil
 			})
 
-			graph := NewObjectGraph(kvClient, &v1.ObjectGraphOptions{})
+			graph := NewObjectGraph(kvClient, kubeClient, &v1.ObjectGraphOptions{})
 			graphNodes, err := graph.GetObjectGraph(vm)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(graphNodes.Children).To(HaveLen(1))
@@ -439,7 +438,7 @@ var _ = Describe("Object Graph", func() {
 				},
 			}
 
-			graph := NewObjectGraph(kvClient, &v1.ObjectGraphOptions{})
+			graph := NewObjectGraph(kvClient, kubeClient, &v1.ObjectGraphOptions{})
 			graphNodes, err := graph.GetObjectGraph(pod)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(graphNodes.Children).To(BeEmpty())
@@ -465,7 +464,7 @@ var _ = Describe("Object Graph", func() {
 				},
 			}
 
-			graph := NewObjectGraph(kvClient, &v1.ObjectGraphOptions{})
+			graph := NewObjectGraph(kvClient, kubeClient, &v1.ObjectGraphOptions{})
 			graphNodes, err := graph.GetObjectGraph(vm)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(graphNodes.Children).To(HaveLen(4))
@@ -501,7 +500,7 @@ var _ = Describe("Object Graph", func() {
 				Kind: "VirtualMachineClusterPreference",
 			}
 
-			graph := NewObjectGraph(kvClient, &v1.ObjectGraphOptions{})
+			graph := NewObjectGraph(kvClient, kubeClient, &v1.ObjectGraphOptions{})
 			graphNodes, err := graph.GetObjectGraph(vm)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -543,7 +542,7 @@ var _ = Describe("Object Graph", func() {
 				},
 			}
 
-			graph := NewObjectGraph(kvClient, &v1.ObjectGraphOptions{})
+			graph := NewObjectGraph(kvClient, kubeClient, &v1.ObjectGraphOptions{})
 			graphNodes, err := graph.GetObjectGraph(vm)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -561,7 +560,7 @@ var _ = Describe("Object Graph", func() {
 		It("should handle VM without status.created", func() {
 			vm.Status.Created = false
 
-			graph := NewObjectGraph(kvClient, &v1.ObjectGraphOptions{})
+			graph := NewObjectGraph(kvClient, kubeClient, &v1.ObjectGraphOptions{})
 			graphNodes, err := graph.GetObjectGraph(vm)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(graphNodes.ObjectReference.Name).To(Equal(testVMName))
@@ -597,7 +596,7 @@ var _ = Describe("Object Graph", func() {
 				}, nil
 			})
 
-			graph := NewObjectGraph(kvClient, &v1.ObjectGraphOptions{})
+			graph := NewObjectGraph(kvClient, kubeClient, &v1.ObjectGraphOptions{})
 			graphNodes, err := graph.GetObjectGraph(vm)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -613,7 +612,7 @@ var _ = Describe("Object Graph", func() {
 				return true, &k8sv1.PodList{Items: []k8sv1.Pod{}}, nil
 			})
 
-			graph := NewObjectGraph(kvClient, &v1.ObjectGraphOptions{})
+			graph := NewObjectGraph(kvClient, kubeClient, &v1.ObjectGraphOptions{})
 			graphNodes, err := graph.GetObjectGraph(vm)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -622,7 +621,7 @@ var _ = Describe("Object Graph", func() {
 		})
 
 		It("should handle newGraphNode with invalid resource", func() {
-			graph := NewObjectGraph(kvClient, &v1.ObjectGraphOptions{})
+			graph := NewObjectGraph(kvClient, kubeClient, &v1.ObjectGraphOptions{})
 			node := graph.newGraphNode("test", "default", "invalid-resource", nil, false)
 			Expect(node).To(BeNil())
 		})
@@ -655,7 +654,7 @@ var _ = Describe("Object Graph", func() {
 			options := &v1.ObjectGraphOptions{
 				IncludeOptionalNodes: pointer.P(false),
 			}
-			graph := NewObjectGraph(kvClient, options)
+			graph := NewObjectGraph(kvClient, kubeClient, options)
 			graphNodes, err := graph.GetObjectGraph(vm)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -677,7 +676,7 @@ var _ = Describe("Object Graph", func() {
 					},
 				},
 			}
-			graph := NewObjectGraph(kvClient, options)
+			graph := NewObjectGraph(kvClient, kubeClient, options)
 			graphNodes, err := graph.GetObjectGraph(vm)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -708,7 +707,7 @@ var _ = Describe("Object Graph", func() {
 					},
 				},
 			}
-			graph := NewObjectGraph(kvClient, options)
+			graph := NewObjectGraph(kvClient, kubeClient, options)
 			graphNodes, err := graph.GetObjectGraph(vm)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -738,7 +737,7 @@ var _ = Describe("Object Graph", func() {
 				},
 			}
 
-			graph := NewObjectGraph(kvClient, &v1.ObjectGraphOptions{})
+			graph := NewObjectGraph(kvClient, kubeClient, &v1.ObjectGraphOptions{})
 			graphNodes, err := graph.GetObjectGraph(vm)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -772,7 +771,7 @@ var _ = Describe("Object Graph", func() {
 				},
 			}
 
-			graph := NewObjectGraph(kvClient, options)
+			graph := NewObjectGraph(kvClient, kubeClient, options)
 			graphNodes, err := graph.GetObjectGraph(vm)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/pkg/virt-api/rest/portforward_test.go
+++ b/pkg/virt-api/rest/portforward_test.go
@@ -86,7 +86,7 @@ var _ = Describe("PortForward Subresource api", func() {
 		mockVirtClient.EXPECT().VirtualMachineInstance(metav1.NamespaceDefault).Return(virtClient.KubevirtV1().VirtualMachineInstances(metav1.NamespaceDefault)).AnyTimes()
 		mockVirtClient.EXPECT().VirtualMachineInstance("").Return(virtClient.KubevirtV1().VirtualMachineInstances("")).AnyTimes()
 
-		app = NewSubresourceAPIApp(mockVirtClient, backendPort, &tls.Config{InsecureSkipVerify: true}, config)
+		app = NewSubresourceAPIApp(mockVirtClient, nil, backendPort, &tls.Config{InsecureSkipVerify: true}, config)
 	})
 
 	It("should fail with no 'name' path param", func() {

--- a/pkg/virt-api/rest/profiler.go
+++ b/pkg/virt-api/rest/profiler.go
@@ -54,7 +54,7 @@ func (app *SubresourceAPIApp) getAllComponentPods() ([]k8sv1.Pod, error) {
 		return nil, err
 	}
 
-	podList, err := app.virtCli.CoreV1().Pods(namespace).List(context.Background(), metav1.ListOptions{LabelSelector: "kubevirt.io"})
+	podList, err := app.k8sClient.CoreV1().Pods(namespace).List(context.Background(), metav1.ListOptions{LabelSelector: "kubevirt.io"})
 	if err != nil {
 		return nil, err
 	}
@@ -102,7 +102,7 @@ func (app *SubresourceAPIApp) getPodsNextPage(cpRequest *v1.ClusterProfilerReque
 		return nil, "", err
 	}
 
-	if podList, err = app.virtCli.CoreV1().Pods(namespace).List(context.Background(), listOptions); err != nil {
+	if podList, err = app.k8sClient.CoreV1().Pods(namespace).List(context.Background(), listOptions); err != nil {
 		return nil, "", err
 	}
 

--- a/pkg/virt-api/rest/profiler_test.go
+++ b/pkg/virt-api/rest/profiler_test.go
@@ -84,7 +84,7 @@ var _ = Describe("Cluster Profiler Subresources", func() {
 		server = ghttp.NewServer()
 		flag.Set("kubeconfig", "")
 		flag.Set("master", server.URL())
-		app.virtCli, _ = kubecli.GetKubevirtClientFromFlags(server.URL(), "")
+		app.virtClient, _ = kubecli.GetKubevirtClientFromFlags(server.URL(), "")
 		app.k8sClient, _ = kubecli.GetK8sClientFromFlags(server.URL(), "")
 		app.handlerTLSConfiguration = &tls.Config{InsecureSkipVerify: true}
 		app.clusterConfig = config

--- a/pkg/virt-api/rest/profiler_test.go
+++ b/pkg/virt-api/rest/profiler_test.go
@@ -85,6 +85,7 @@ var _ = Describe("Cluster Profiler Subresources", func() {
 		flag.Set("kubeconfig", "")
 		flag.Set("master", server.URL())
 		app.virtCli, _ = kubecli.GetKubevirtClientFromFlags(server.URL(), "")
+		app.k8sClient, _ = kubecli.GetK8sClientFromFlags(server.URL(), "")
 		app.handlerTLSConfiguration = &tls.Config{InsecureSkipVerify: true}
 		app.clusterConfig = config
 		app.profilerComponentPort = backendPort

--- a/pkg/virt-api/rest/sev.go
+++ b/pkg/virt-api/rest/sev.go
@@ -144,7 +144,7 @@ func (app *SubresourceAPIApp) SEVSetupSessionHandler(request *restful.Request, r
 	}
 
 	log.Log.Object(vmi).Infof("Patching vmi: %s", string(patch))
-	if _, err := app.virtCli.VirtualMachineInstance(vmi.Namespace).Patch(context.Background(), vmi.Name, types.JSONPatchType, patch, metav1.PatchOptions{}); err != nil {
+	if _, err := app.virtClient.VirtualMachineInstance(vmi.Namespace).Patch(context.Background(), vmi.Name, types.JSONPatchType, patch, metav1.PatchOptions{}); err != nil {
 		log.Log.Object(vmi).Reason(err).Errorf("Failed to patch vmi")
 		writeError(errors.NewInternalError(err), response)
 		return

--- a/pkg/virt-api/rest/sev_test.go
+++ b/pkg/virt-api/rest/sev_test.go
@@ -118,7 +118,7 @@ var _ = Describe("SEV Subresources", func() {
 		mockVirtClient.EXPECT().VirtualMachineInstance("").Return(virtClient.KubevirtV1().VirtualMachineInstances("")).AnyTimes()
 		mockVirtClient.EXPECT().VirtualMachineInstanceMigration(metav1.NamespaceDefault).Return(virtClient.KubevirtV1().VirtualMachineInstanceMigrations(metav1.NamespaceDefault)).AnyTimes()
 
-		app = NewSubresourceAPIApp(mockVirtClient, backendPort, &tls.Config{InsecureSkipVerify: true}, config)
+		app = NewSubresourceAPIApp(mockVirtClient, kubeClient, backendPort, &tls.Config{InsecureSkipVerify: true}, config)
 	})
 
 	AfterEach(func() {

--- a/pkg/virt-api/rest/subresource.go
+++ b/pkg/virt-api/rest/subresource.go
@@ -33,6 +33,7 @@ import (
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/json"
 	"k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/client-go/kubernetes"
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 	"kubevirt.io/client-go/log"
@@ -67,6 +68,7 @@ type instancetypeVMExpander interface {
 
 type SubresourceAPIApp struct {
 	virtCli                 kubecli.KubevirtClient
+	k8sClient               kubernetes.Interface
 	consoleServerPort       int
 	profilerComponentPort   int
 	handlerTLSConfiguration *tls.Config
@@ -75,7 +77,7 @@ type SubresourceAPIApp struct {
 	handlerHttpClient       *http.Client
 }
 
-func NewSubresourceAPIApp(virtCli kubecli.KubevirtClient, consoleServerPort int, tlsConfiguration *tls.Config, clusterConfig *virtconfig.ClusterConfig) *SubresourceAPIApp {
+func NewSubresourceAPIApp(virtCli kubecli.KubevirtClient, k8sClient kubernetes.Interface, consoleServerPort int, tlsConfiguration *tls.Config, clusterConfig *virtconfig.ClusterConfig) *SubresourceAPIApp {
 	// When this method is called from tools/openapispec.go when running 'make generate',
 	// the virtCli is nil, and accessing GeneratedKubeVirtClient() would cause nil dereference.
 	var instancetypeExpander instancetypeVMExpander
@@ -96,6 +98,7 @@ func NewSubresourceAPIApp(virtCli kubecli.KubevirtClient, consoleServerPort int,
 
 	return &SubresourceAPIApp{
 		virtCli:                 virtCli,
+		k8sClient:               k8sClient,
 		consoleServerPort:       consoleServerPort,
 		profilerComponentPort:   defaultProfilerComponentPort,
 		handlerTLSConfiguration: tlsConfiguration,

--- a/pkg/virt-api/rest/subresource.go
+++ b/pkg/virt-api/rest/subresource.go
@@ -67,7 +67,7 @@ type instancetypeVMExpander interface {
 }
 
 type SubresourceAPIApp struct {
-	virtCli                 kubecli.KubevirtClient
+	virtClient              kubecli.KubevirtClient
 	k8sClient               kubernetes.Interface
 	consoleServerPort       int
 	profilerComponentPort   int
@@ -77,15 +77,15 @@ type SubresourceAPIApp struct {
 	handlerHttpClient       *http.Client
 }
 
-func NewSubresourceAPIApp(virtCli kubecli.KubevirtClient, k8sClient kubernetes.Interface, consoleServerPort int, tlsConfiguration *tls.Config, clusterConfig *virtconfig.ClusterConfig) *SubresourceAPIApp {
+func NewSubresourceAPIApp(virtClient kubecli.KubevirtClient, k8sClient kubernetes.Interface, consoleServerPort int, tlsConfiguration *tls.Config, clusterConfig *virtconfig.ClusterConfig) *SubresourceAPIApp {
 	// When this method is called from tools/openapispec.go when running 'make generate',
-	// the virtCli is nil, and accessing GeneratedKubeVirtClient() would cause nil dereference.
+	// the virtClient is nil, and accessing GeneratedKubeVirtClient() would cause nil dereference.
 	var instancetypeExpander instancetypeVMExpander
-	if virtCli != nil {
+	if virtClient != nil {
 		instancetypeExpander = expand.New(
 			clusterConfig,
-			find.NewSpecFinder(nil, nil, nil, virtCli),
-			preferenceFind.NewSpecFinder(nil, nil, nil, virtCli),
+			find.NewSpecFinder(nil, nil, nil, virtClient),
+			preferenceFind.NewSpecFinder(nil, nil, nil, virtClient),
 		)
 	}
 
@@ -97,7 +97,7 @@ func NewSubresourceAPIApp(virtCli kubecli.KubevirtClient, k8sClient kubernetes.I
 	}
 
 	return &SubresourceAPIApp{
-		virtCli:                 virtCli,
+		virtClient:              virtClient,
 		k8sClient:               k8sClient,
 		consoleServerPort:       consoleServerPort,
 		profilerComponentPort:   defaultProfilerComponentPort,
@@ -234,7 +234,7 @@ func (app *SubresourceAPIApp) httpGetRequestBinaryHandler(request *restful.Reque
 
 func (app *SubresourceAPIApp) fetchVirtualMachine(name string, namespace string) (*v1.VirtualMachine, *errors.StatusError) {
 
-	vm, err := app.virtCli.VirtualMachine(namespace).Get(context.Background(), name, k8smetav1.GetOptions{})
+	vm, err := app.virtClient.VirtualMachine(namespace).Get(context.Background(), name, k8smetav1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return nil, errors.NewNotFound(v1.Resource("virtualmachine"), name)
@@ -247,7 +247,7 @@ func (app *SubresourceAPIApp) fetchVirtualMachine(name string, namespace string)
 // FetchVirtualMachineInstance by namespace and name
 func (app *SubresourceAPIApp) FetchVirtualMachineInstance(namespace, name string) (*v1.VirtualMachineInstance, *errors.StatusError) {
 
-	vmi, err := app.virtCli.VirtualMachineInstance(namespace).Get(context.Background(), name, k8smetav1.GetOptions{})
+	vmi, err := app.virtClient.VirtualMachineInstance(namespace).Get(context.Background(), name, k8smetav1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return nil, errors.NewNotFound(v1.Resource("virtualmachineinstance"), name)
@@ -259,7 +259,7 @@ func (app *SubresourceAPIApp) FetchVirtualMachineInstance(namespace, name string
 
 // FetchVirtualMachineInstanceForVM by namespace and name
 func (app *SubresourceAPIApp) FetchVirtualMachineInstanceForVM(namespace, name string) (*v1.VirtualMachineInstance, *errors.StatusError) {
-	vm, err := app.virtCli.VirtualMachine(namespace).Get(context.Background(), name, k8smetav1.GetOptions{})
+	vm, err := app.virtClient.VirtualMachine(namespace).Get(context.Background(), name, k8smetav1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return nil, errors.NewNotFound(v1.Resource("virtualmachine"), name)
@@ -271,7 +271,7 @@ func (app *SubresourceAPIApp) FetchVirtualMachineInstanceForVM(namespace, name s
 		return nil, errors.NewConflict(v1.Resource("virtualmachine"), vm.Name, fmt.Errorf("VMI is not started"))
 	}
 
-	vmi, err := app.virtCli.VirtualMachineInstance(namespace).Get(context.Background(), name, k8smetav1.GetOptions{})
+	vmi, err := app.virtClient.VirtualMachineInstance(namespace).Get(context.Background(), name, k8smetav1.GetOptions{})
 	if err != nil {
 		if errors.IsNotFound(err) {
 			return nil, errors.NewNotFound(v1.Resource("virtualmachineinstance"), name)

--- a/pkg/virt-api/rest/subresource_test.go
+++ b/pkg/virt-api/rest/subresource_test.go
@@ -135,6 +135,7 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 		Expect(err).ToNot(HaveOccurred())
 		app.consoleServerPort = backendPort
 		app.virtCli = virtClient
+		app.k8sClient = kubeClient
 		app.handlerTLSConfiguration = &tls.Config{InsecureSkipVerify: true}
 		app.clusterConfig = config
 		app.handlerHttpClient = &http.Client{

--- a/pkg/virt-api/rest/subresource_test.go
+++ b/pkg/virt-api/rest/subresource_test.go
@@ -134,7 +134,7 @@ var _ = Describe("VirtualMachineInstance Subresources", func() {
 		backendIP = backendAddr[0]
 		Expect(err).ToNot(HaveOccurred())
 		app.consoleServerPort = backendPort
-		app.virtCli = virtClient
+		app.virtClient = virtClient
 		app.k8sClient = kubeClient
 		app.handlerTLSConfiguration = &tls.Config{InsecureSkipVerify: true}
 		app.clusterConfig = config

--- a/pkg/virt-api/rest/vnc_test.go
+++ b/pkg/virt-api/rest/vnc_test.go
@@ -90,7 +90,7 @@ var _ = Describe("VNC Subresource api", func() {
 		mockVirtClient.EXPECT().VirtualMachineInstance(metav1.NamespaceDefault).Return(virtClient.KubevirtV1().VirtualMachineInstances(metav1.NamespaceDefault)).AnyTimes()
 		mockVirtClient.EXPECT().VirtualMachineInstance("").Return(virtClient.KubevirtV1().VirtualMachineInstances("")).AnyTimes()
 
-		app = NewSubresourceAPIApp(mockVirtClient, backendPort, &tls.Config{InsecureSkipVerify: true}, config)
+		app = NewSubresourceAPIApp(mockVirtClient, nil, backendPort, &tls.Config{InsecureSkipVerify: true}, config)
 	})
 
 	It("should fail with no 'name' path param", func() {

--- a/pkg/virt-api/rest/volumes.go
+++ b/pkg/virt-api/rest/volumes.go
@@ -199,7 +199,7 @@ func (app *SubresourceAPIApp) vmVolumePatch(name, namespace string, volumeReques
 
 	dryRunOption := getDryRunOption(volumeRequest)
 	log.Log.Object(vm).V(4).Infof("Patching VM: %s", string(patchBytes))
-	if _, err := app.virtCli.VirtualMachine(vm.Namespace).Patch(context.Background(), vm.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{DryRun: dryRunOption}); err != nil {
+	if _, err := app.virtClient.VirtualMachine(vm.Namespace).Patch(context.Background(), vm.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{DryRun: dryRunOption}); err != nil {
 		log.Log.Object(vm).Errorf("unable to patch vm: %v", err)
 		if errors.IsInvalid(err) {
 			if statErr, ok := err.(*errors.StatusError); ok {
@@ -237,7 +237,7 @@ func (app *SubresourceAPIApp) vmiVolumePatch(name, namespace string, volumeReque
 
 	dryRunOption := getDryRunOption(volumeRequest)
 	log.Log.Object(vmi).V(4).Infof("Patching VMI: %s", string(patchBytes))
-	if _, err := app.virtCli.VirtualMachineInstance(vmi.Namespace).Patch(context.Background(), vmi.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{DryRun: dryRunOption}); err != nil {
+	if _, err := app.virtClient.VirtualMachineInstance(vmi.Namespace).Patch(context.Background(), vmi.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{DryRun: dryRunOption}); err != nil {
 		log.Log.Object(vmi).Errorf("unable to patch vmi: %v", err)
 		if errors.IsInvalid(err) {
 			if statErr, ok := err.(*errors.StatusError); ok {
@@ -267,7 +267,7 @@ func (app *SubresourceAPIApp) vmVolumePatchStatus(name, namespace string, volume
 
 	dryRunOption := getDryRunOption(volumeRequest)
 	log.Log.Object(vm).V(4).Infof(patchingVMFmt, string(patchBytes))
-	if _, err = app.virtCli.VirtualMachine(vm.Namespace).PatchStatus(context.Background(), vm.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{DryRun: dryRunOption}); err != nil {
+	if _, err = app.virtClient.VirtualMachine(vm.Namespace).PatchStatus(context.Background(), vm.Name, types.JSONPatchType, patchBytes, metav1.PatchOptions{DryRun: dryRunOption}); err != nil {
 		log.Log.Object(vm).Errorf("unable to patch vm status: %v", err)
 		if errors.IsInvalid(err) {
 			if statErr, ok := err.(*errors.StatusError); ok {

--- a/pkg/virt-api/rest/volumes_test.go
+++ b/pkg/virt-api/rest/volumes_test.go
@@ -123,7 +123,7 @@ var _ = Describe("Add/Remove Volume Subresource api", func() {
 		virtClient.EXPECT().VirtualMachineInstance(metav1.NamespaceDefault).Return(vmiClient).AnyTimes()
 		virtClient.EXPECT().VirtualMachineInstance("").Return(vmiClient).AnyTimes()
 
-		app = NewSubresourceAPIApp(virtClient, backendPort, &tls.Config{InsecureSkipVerify: true}, config)
+		app = NewSubresourceAPIApp(virtClient, nil, backendPort, &tls.Config{InsecureSkipVerify: true}, config)
 	})
 
 	AfterEach(func() {

--- a/pkg/virt-api/webhooks/mutating-webhook/mutating-webhook.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutating-webhook.go
@@ -75,8 +75,8 @@ func serve(resp http.ResponseWriter, req *http.Request, m mutator) {
 	}
 }
 
-func ServeVMs(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig, virtCli kubecli.KubevirtClient) {
-	serve(resp, req, mutators.NewVMsMutator(clusterConfig, virtCli))
+func ServeVMs(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig, virtClient kubecli.KubevirtClient) {
+	serve(resp, req, mutators.NewVMsMutator(clusterConfig, virtClient))
 }
 
 func ServeVMIs(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig, informers *webhooks.Informers, kubeVirtServiceAccounts map[string]struct{}) {
@@ -91,6 +91,6 @@ func ServeClones(resp http.ResponseWriter, req *http.Request) {
 	serve(resp, req, mutators.NewCloneCreateMutator())
 }
 
-func ServeVirtLauncherPods(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig, virtCli kubecli.KubevirtClient) {
-	serve(resp, req, mutators.NewVirtLauncherPodMutator(clusterConfig, virtCli))
+func ServeVirtLauncherPods(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig, virtClient kubecli.KubevirtClient) {
+	serve(resp, req, mutators.NewVirtLauncherPodMutator(clusterConfig, virtClient))
 }

--- a/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator.go
+++ b/pkg/virt-api/webhooks/mutating-webhook/mutators/vm-mutator.go
@@ -49,11 +49,11 @@ type VMsMutator struct {
 	virtClient          kubecli.KubevirtClient
 }
 
-func NewVMsMutator(clusterConfig *virtconfig.ClusterConfig, virtCli kubecli.KubevirtClient) *VMsMutator {
+func NewVMsMutator(clusterConfig *virtconfig.ClusterConfig, virtClient kubecli.KubevirtClient) *VMsMutator {
 	return &VMsMutator{
 		ClusterConfig:       clusterConfig,
-		instancetypeMutator: instancetypeVMWebhooks.NewMutator(virtCli),
-		virtClient:          virtCli,
+		instancetypeMutator: instancetypeVMWebhooks.NewMutator(virtClient),
+		virtClient:          virtClient,
 	}
 }
 

--- a/pkg/virt-api/webhooks/validating-webhook/BUILD.bazel
+++ b/pkg/virt-api/webhooks/validating-webhook/BUILD.bazel
@@ -14,5 +14,6 @@ go_library(
         "//pkg/virt-api/webhooks/validating-webhook/admitters:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//vendor/k8s.io/client-go/kubernetes:go_default_library",
     ],
 )

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter_test.go
@@ -36,7 +36,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
-	k8sfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/tools/cache"
 
 	"kubevirt.io/client-go/api"
@@ -64,7 +63,6 @@ var _ = Describe("Validating VM Admitter", func() {
 		namespaceInformer  cache.SharedIndexInformer
 		mockVMIClient      *kubecli.MockVirtualMachineInstanceInterface
 		virtClient         *kubecli.MockKubevirtClient
-		k8sClient          *k8sfake.Clientset
 	)
 
 	enableFeatureGate := func(featureGates ...string) {
@@ -128,7 +126,6 @@ var _ = Describe("Validating VM Admitter", func() {
 
 		ctrl := gomock.NewController(GinkgoT())
 		mockVMIClient = kubecli.NewMockVirtualMachineInstanceInterface(ctrl)
-		k8sClient = k8sfake.NewSimpleClientset()
 		virtClient = kubecli.NewMockKubevirtClient(ctrl)
 
 		const kubeVirtNamespace = "kubevirt"
@@ -140,7 +137,6 @@ var _ = Describe("Validating VM Admitter", func() {
 			InstancetypeAdmitter:    instancetypeWebhooks.NewAdmitterStub(),
 			KubeVirtServiceAccounts: webhooks.KubeVirtServiceAccounts(kubeVirtNamespace),
 		}
-		virtClient.EXPECT().AuthorizationV1().Return(k8sClient.AuthorizationV1()).AnyTimes()
 	})
 
 	Context("with an invalid VM", func() {

--- a/pkg/virt-api/webhooks/validating-webhook/validating-webhook.go
+++ b/pkg/virt-api/webhooks/validating-webhook/validating-webhook.go
@@ -22,6 +22,7 @@ package validating_webhook
 import (
 	"net/http"
 
+	"k8s.io/client-go/kubernetes"
 	"kubevirt.io/client-go/kubecli"
 
 	preferencewebhooks "kubevirt.io/kubevirt/pkg/instancetype/preference/webhooks"
@@ -130,8 +131,8 @@ func ServeStatusValidation(resp http.ResponseWriter,
 	})
 }
 
-func ServePodEvictionInterceptor(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig, virtCli kubecli.KubevirtClient) {
-	validating_webhooks.Serve(resp, req, admitters.NewPodEvictionAdmitter(clusterConfig, virtCli, virtCli.GeneratedKubeVirtClient()))
+func ServePodEvictionInterceptor(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig, virtCli kubecli.KubevirtClient, k8sClient kubernetes.Interface) {
+	validating_webhooks.Serve(resp, req, admitters.NewPodEvictionAdmitter(clusterConfig, k8sClient, virtCli.GeneratedKubeVirtClient()))
 }
 
 func ServeMigrationPolicies(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig) {

--- a/pkg/virt-api/webhooks/validating-webhook/validating-webhook.go
+++ b/pkg/virt-api/webhooks/validating-webhook/validating-webhook.go
@@ -56,11 +56,11 @@ func ServeVMs(
 	resp http.ResponseWriter,
 	req *http.Request,
 	clusterConfig *virtconfig.ClusterConfig,
-	virtCli kubecli.KubevirtClient,
+	virtClient kubecli.KubevirtClient,
 	informers *webhooks.Informers,
 	kubeVirtServiceAccounts map[string]struct{},
 ) {
-	validating_webhooks.Serve(resp, req, admitters.NewVMsAdmitter(clusterConfig, virtCli, informers, kubeVirtServiceAccounts))
+	validating_webhooks.Serve(resp, req, admitters.NewVMsAdmitter(clusterConfig, virtClient, informers, kubeVirtServiceAccounts))
 }
 
 func ServeVMIRS(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig) {
@@ -75,24 +75,24 @@ func ServeVMIPreset(resp http.ResponseWriter, req *http.Request) {
 	validating_webhooks.Serve(resp, req, &admitters.VMIPresetAdmitter{})
 }
 
-func ServeMigrationCreate(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig, virtCli kubecli.KubevirtClient, kubeVirtServiceAccounts map[string]struct{}) {
-	validating_webhooks.Serve(resp, req, admitters.NewMigrationCreateAdmitter(virtCli.GeneratedKubeVirtClient(), clusterConfig, kubeVirtServiceAccounts))
+func ServeMigrationCreate(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig, virtClient kubecli.KubevirtClient, kubeVirtServiceAccounts map[string]struct{}) {
+	validating_webhooks.Serve(resp, req, admitters.NewMigrationCreateAdmitter(virtClient.GeneratedKubeVirtClient(), clusterConfig, kubeVirtServiceAccounts))
 }
 
 func ServeMigrationUpdate(resp http.ResponseWriter, req *http.Request) {
 	validating_webhooks.Serve(resp, req, &admitters.MigrationUpdateAdmitter{})
 }
 
-func ServeVMSnapshots(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig, virtCli kubecli.KubevirtClient) {
-	validating_webhooks.Serve(resp, req, storageadmitters.NewVMSnapshotAdmitter(clusterConfig, virtCli))
+func ServeVMSnapshots(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig, virtClient kubecli.KubevirtClient) {
+	validating_webhooks.Serve(resp, req, storageadmitters.NewVMSnapshotAdmitter(clusterConfig, virtClient))
 }
 
-func ServeVMRestores(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig, virtCli kubecli.KubevirtClient, informers *webhooks.Informers) {
-	validating_webhooks.Serve(resp, req, storageadmitters.NewVMRestoreAdmitter(clusterConfig, virtCli, informers.VMRestoreInformer))
+func ServeVMRestores(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig, virtClient kubecli.KubevirtClient, informers *webhooks.Informers) {
+	validating_webhooks.Serve(resp, req, storageadmitters.NewVMRestoreAdmitter(clusterConfig, virtClient, informers.VMRestoreInformer))
 }
 
-func ServeVMBackups(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig, virtCli kubecli.KubevirtClient, informers *webhooks.Informers) {
-	validating_webhooks.Serve(resp, req, storageadmitters.NewVMBackupAdmitter(clusterConfig, virtCli, informers.VMBackupInformer))
+func ServeVMBackups(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig, virtClient kubecli.KubevirtClient, informers *webhooks.Informers) {
+	validating_webhooks.Serve(resp, req, storageadmitters.NewVMBackupAdmitter(clusterConfig, virtClient, informers.VMBackupInformer))
 }
 
 func ServeVMBackupTrackers(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig) {
@@ -122,25 +122,25 @@ func ServeVmClusterPreferences(resp http.ResponseWriter, req *http.Request) {
 func ServeStatusValidation(resp http.ResponseWriter,
 	req *http.Request,
 	clusterConfig *virtconfig.ClusterConfig,
-	virtCli kubecli.KubevirtClient,
+	virtClient kubecli.KubevirtClient,
 	informers *webhooks.Informers,
 	kubeVirtServiceAccounts map[string]struct{},
 ) {
 	validating_webhooks.Serve(resp, req, &admitters.StatusAdmitter{
-		VmsAdmitter: admitters.NewVMsAdmitter(clusterConfig, virtCli, informers, kubeVirtServiceAccounts),
+		VmsAdmitter: admitters.NewVMsAdmitter(clusterConfig, virtClient, informers, kubeVirtServiceAccounts),
 	})
 }
 
-func ServePodEvictionInterceptor(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig, virtCli kubecli.KubevirtClient, k8sClient kubernetes.Interface) {
-	validating_webhooks.Serve(resp, req, admitters.NewPodEvictionAdmitter(clusterConfig, k8sClient, virtCli.GeneratedKubeVirtClient()))
+func ServePodEvictionInterceptor(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig, virtClient kubecli.KubevirtClient, k8sClient kubernetes.Interface) {
+	validating_webhooks.Serve(resp, req, admitters.NewPodEvictionAdmitter(clusterConfig, k8sClient, virtClient.GeneratedKubeVirtClient()))
 }
 
 func ServeMigrationPolicies(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig) {
 	validating_webhooks.Serve(resp, req, admitters.NewMigrationPolicyAdmitter(clusterConfig))
 }
 
-func ServeVirtualMachineClones(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig, virtCli kubecli.KubevirtClient) {
-	validating_webhooks.Serve(resp, req, admitters.NewVMCloneAdmitter(clusterConfig, virtCli))
+func ServeVirtualMachineClones(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig, virtClient kubecli.KubevirtClient) {
+	validating_webhooks.Serve(resp, req, admitters.NewVMCloneAdmitter(clusterConfig, virtClient))
 }
 
 func ServePlugins(resp http.ResponseWriter, req *http.Request, clusterConfig *virtconfig.ClusterConfig) {


### PR DESCRIPTION
### What this PR does
#### Before this PR:

`pkg/virt-api` uses a single `kubecli.KubevirtClient` for both standard
Kubernetes API calls (CoreV1, etc.) and KubeVirt-specific calls
(VirtualMachine, VirtualMachineInstance, CdiClient, etc.). The variable
is inconsistently named `virtCli` across the package.

#### After this PR:

A dedicated `kubernetes.Interface` client (`k8sClient`) is introduced
alongside the existing `KubevirtClient`. Standard Kubernetes API calls
are routed through `k8sClient`, while KubeVirt-specific calls remain on
`virtClient`. The variable name is standardized to `virtClient`.

### References

- Partially addresses #16916

### Special notes for your reviewer

This follows the same pattern as #16106 (virt-operator, merged), #18415
(virt-handler), and #18421 (virt-controller). The `ObjectGraph` struct
needed both clients since it calls `CoreV1().Pods()` directly (now via
`k8sClient`) and `storageutils.GetVolumes` which still expects a
`KubevirtClient`.

### Checklist

- [x] Design: A VEP was considered and is not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: Existing unit tests updated to reflect the new client routing
- [x] Documentation: A user-guide update is not required (internal refactor)
- [x] Community: Announcement to kubevirt-dev was considered
- [x] AI Contributions: The PR abides by the KubeVirt AI Contribution Policy

### Release note

```release-note
NONE
```
