### PR TITLE
Surface CreateContainerError for ORAS artifacts with annotation hint

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -110,6 +110,9 @@ const (
 	// ImagePullBackOffReason is set when an error has occurred while pulling an image for a containerDisk VM volume,
 	// and that kubelet is backing off before retrying.
 	ImagePullBackOffReason = "ImagePullBackOff"
+	// CreateContainerErrorReason is set when CRI fails to create a container from a containerDisk image,
+	// typically because the image is an OCI artifact that is not a valid container image.
+	CreateContainerErrorReason = "CreateContainerError"
 	// NoSuitableNodesForHostModelMigration is set when a VMI with host-model CPU mode tries to migrate but no node
 	// is suitable for migration (since CPU model / required features are not supported)
 	NoSuitableNodesForHostModelMigration = "NoSuitableNodesForHostModelMigration"

--- a/pkg/virt-controller/watch/vmi/lifecycle.go
+++ b/pkg/virt-controller/watch/vmi/lifecycle.go
@@ -988,6 +988,21 @@ func checkForContainerImageError(pod *k8sv1.Pod) common.SyncError {
 			return common.NewSyncError(fmt.Errorf("%s", containerStatus.State.Waiting.Message), reason)
 		}
 	}
+
+	for _, containerStatus := range pod.Status.InitContainerStatuses {
+		if containerStatus.State.Waiting == nil {
+			continue
+		}
+		if containerStatus.State.Waiting.Reason == controller.CreateContainerErrorReason && strings.HasPrefix(containerStatus.Name, "volume") {
+			return common.NewSyncError(
+				fmt.Errorf("init container %s failed: %s. "+
+					"If the containerDisk image is an OCI artifact (e.g. pushed with ORAS), "+
+					"set the annotation %s: \"true\" on the VMI",
+					containerStatus.Name, containerStatus.State.Waiting.Message,
+					virtv1.ImageVolumeSkipDigestResolutionAnnotation),
+				controller.CreateContainerErrorReason)
+		}
+	}
 	return nil
 }
 

--- a/pkg/virt-controller/watch/vmi/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi/vmi_test.go
@@ -2141,6 +2141,35 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			Entry("ImagePullBackOff in compute container", false, kvcontroller.ImagePullBackOffReason),
 		)
 
+		It("should surface CreateContainerError on volume init container with annotation hint", func() {
+			vmi := newPendingVirtualMachine("testvmi")
+			vmi.Status.Phase = virtv1.Scheduling
+			pod := newPodForVirtualMachine(vmi, k8sv1.PodPending)
+
+			pod.Status.InitContainerStatuses = []k8sv1.ContainerStatus{{
+				Name: "volumerootdisk",
+				State: k8sv1.ContainerState{
+					Waiting: &k8sv1.ContainerStateWaiting{
+						Reason:  kvcontroller.CreateContainerErrorReason,
+						Message: "image not known",
+					},
+				},
+			}}
+
+			addVirtualMachine(vmi)
+			addPod(pod)
+
+			sanityExecute()
+			expectVMIWithMatcherConditions(vmi.Namespace, vmi.Name, ContainElement(MatchFields(IgnoreExtras,
+				Fields{
+					"Type":    Equal(virtv1.VirtualMachineInstanceSynchronized),
+					"Status":  Equal(k8sv1.ConditionFalse),
+					"Reason":  Equal(kvcontroller.CreateContainerErrorReason),
+					"Message": ContainSubstring(virtv1.ImageVolumeSkipDigestResolutionAnnotation),
+				})),
+			)
+		})
+
 		DescribeTable("should override Synchronized=False condition reason when it's already set", func(prevReason, newReason string) {
 			vmi := newPendingVirtualMachine("testvmi")
 			vmi.Status.Phase = virtv1.Scheduling


### PR DESCRIPTION
### What this PR does
#### Before this PR:

When a containerDisk image is an OCI artifact (e.g. pushed with ORAS), the digest-resolving init container fails with `CreateContainerError` because CRI-O cannot create a container from a non-container OCI artifact. The VMI silently stays stuck in `Scheduling` with no indication of what went wrong — users have to dig into pod events with `kubectl describe pod` to find the error.

#### After this PR:

The `CreateContainerError` on `volume*` init containers is detected and surfaced as a `Synchronized=False` condition on the VMI with a message that tells the user to set the `kubevirt.io/image-volume-skip-digest-resolution` annotation.

Example VMI condition after the fix:
```
Synchronized: False
Reason: CreateContainerError
Message: init container volumerootdisk failed: image not known.
  If the containerDisk image is an OCI artifact (e.g. pushed with ORAS),
  set the annotation kubevirt.io/image-volume-skip-digest-resolution: "true" on the VMI
```

### References

- Follow-up to #18491 which added ORAS artifact support with the annotation

### Why we need it and why it was done in this way

Without this, users have no way to know why their VMI is stuck when using an ORAS artifact without the annotation. The fix extends the existing `checkForContainerImageError` function which already handles `ErrImagePull` and `ImagePullBackOff`.

### Checklist

- [x] Code: Simple extension to existing error detection
- [x] Testing: Unit test added
- [x] PR: Description is clear

### Release note
```release-note
Surface a helpful error message when a containerDisk OCI artifact fails to start without the image-volume-skip-digest-resolution annotation
```