### PR TITLE
Checkpoint: atomic write

### DIFF
--- a/cmd/virt-handler/BUILD.bazel
+++ b/cmd/virt-handler/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
     deps = [
         "//pkg/apimachinery/wait:go_default_library",
         "//pkg/certificates/bootstrap:go_default_library",
+        "//pkg/checkpoint:go_default_library",
         "//pkg/container-disk:go_default_library",
         "//pkg/controller:go_default_library",
         "//pkg/downwardmetrics/scraper:go_default_library",

--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -291,7 +291,7 @@ func (app *virtHandlerApp) Run() {
 	// We keep a record on disk of every VMI virt-handler starts.
 	// That record isn't deleted from this node until the VMI
 	// is completely torn down.
-	_ = virtcache.InitializeGhostRecordCache(virtcache.NewIterableCheckpointManager(checkpointPath))
+	_ = virtcache.InitializeGhostRecordCache(virtcache.NewIterableCheckpointManager(checkpointPath, checkpointPathTmp))
 
 	cmdclient.SetPodsBaseDir("/pods")
 	containerdisk.SetKubeletPodsDirectory(app.KubeletPodsDir)

--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -36,6 +36,7 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"libvirt.org/go/libvirtxml"
 
+	"kubevirt.io/kubevirt/pkg/checkpoint"
 	netresources "kubevirt.io/kubevirt/pkg/network/resources"
 	"kubevirt.io/kubevirt/pkg/virt-handler/ksm"
 
@@ -277,7 +278,13 @@ func (app *virtHandlerApp) Run() {
 	domainSharedInformer := virtcache.NewSharedInformer(app.VirtShareDir, int(app.WatchdogTimeoutDuration.Seconds()), recorder, vmiInformer.GetStore(), time.Duration(app.domainResyncPeriodSeconds)*time.Second)
 
 	checkpointPath := filepath.Join(app.VirtPrivateDir, "ghost-records")
+	checkpointPathTmp := filepath.Join(app.VirtPrivateDir, "ghost-records-temp")
 	err = util.MkdirAllWithNosec(checkpointPath)
+	if err != nil {
+		panic(err)
+	}
+
+	err = util.MkdirAllWithNosec(checkpointPathTmp)
 	if err != nil {
 		panic(err)
 	}
@@ -433,14 +440,29 @@ func (app *virtHandlerApp) Run() {
 		panic(err)
 	}
 
-	cdMounter := hcontainerdisk.NewMounter(podIsolationDetector, containerDiskState, app.clusterConfig)
+	containerDiskStateTmp := filepath.Join(app.VirtPrivateDir, "container-disk-mount-state-temp")
+	if err := os.MkdirAll(containerDiskStateTmp, 0700); err != nil {
+		panic(err)
+	}
+
+	cdMounter := hcontainerdisk.NewMounter(podIsolationDetector,
+		checkpoint.NewSimpleCheckpointManager(containerDiskState, containerDiskStateTmp),
+		app.clusterConfig,
+	)
 
 	hotplugState := filepath.Join(app.VirtPrivateDir, "hotplug-volume-mount-state")
 	if err := os.MkdirAll(hotplugState, 0o700); err != nil {
 		panic(err)
 	}
+	hotplugStateTmp := filepath.Join(app.VirtPrivateDir, "hotplug-volume-mount-state-temp")
+	if err := os.MkdirAll(hotplugStateTmp, 0o700); err != nil {
+		panic(err)
+	}
 
-	hvMounter := hotplugvolume.NewVolumeMounter(hotplugState, app.KubeletPodsDir, app.HostOverride)
+	hvMounter := hotplugvolume.NewVolumeMounter(
+		checkpoint.NewSimpleCheckpointManager(hotplugState, hotplugStateTmp),
+		app.KubeletPodsDir, app.HostOverride,
+	)
 
 	migrationTargetController, err := virthandler.NewMigrationTargetController(
 		recorder,

--- a/pkg/checkpoint/checkpoint.go
+++ b/pkg/checkpoint/checkpoint.go
@@ -47,7 +47,7 @@ type simpleCheckpointManager struct {
 	basePath string
 }
 
-func (cp *simpleCheckpointManager) Get(key string, value interface{}) error {
+func (cp *simpleCheckpointManager) Get(key string, value any) error {
 	b, err := os.ReadFile(filepath.Join(cp.basePath, key))
 	if err != nil {
 		return err
@@ -55,7 +55,7 @@ func (cp *simpleCheckpointManager) Get(key string, value interface{}) error {
 	return json.Unmarshal(b, value)
 }
 
-func (cp *simpleCheckpointManager) Store(key string, value interface{}) error {
+func (cp *simpleCheckpointManager) Store(key string, value any) error {
 	b, err := json.Marshal(value)
 	if err != nil {
 		return err

--- a/pkg/checkpoint/checkpoint.go
+++ b/pkg/checkpoint/checkpoint.go
@@ -18,6 +18,7 @@ package checkpoint
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 )
@@ -37,14 +38,18 @@ type CheckpointManager interface {
 // within provided directory. The manager uses std json package to
 // encode/decode the stucts.
 // This is thread-safe per key which is usual usage.
-func NewSimpleCheckpointManager(path string) *simpleCheckpointManager {
-	return &simpleCheckpointManager{path}
+func NewSimpleCheckpointManager(path, tempPath string) *simpleCheckpointManager {
+	return &simpleCheckpointManager{
+		basePath: path,
+		tempPath: tempPath,
+	}
 }
 
 var _ CheckpointManager = &simpleCheckpointManager{}
 
 type simpleCheckpointManager struct {
 	basePath string
+	tempPath string
 }
 
 func (cp *simpleCheckpointManager) Get(key string, value any) error {
@@ -55,12 +60,44 @@ func (cp *simpleCheckpointManager) Get(key string, value any) error {
 	return json.Unmarshal(b, value)
 }
 
-func (cp *simpleCheckpointManager) Store(key string, value any) error {
+func (cp *simpleCheckpointManager) Store(key string, value any) (err error) {
 	b, err := json.Marshal(value)
 	if err != nil {
 		return err
 	}
-	return os.WriteFile(filepath.Join(cp.basePath, key), b, 0600)
+
+	tempFile, err := os.CreateTemp(cp.tempPath, key)
+	if err != nil {
+		return err
+	}
+
+	close := true
+	defer func() {
+		if close {
+			tempFile.Close()
+		}
+		if err != nil {
+			if removeErr := os.Remove(tempFile.Name()); removeErr != nil {
+				err = fmt.Errorf("failed to remove %s, %s, previous error %s", tempFile.Name(), removeErr, err)
+			}
+		}
+	}()
+
+	_, err = tempFile.Write(b)
+	if err != nil {
+		return err
+	}
+
+	if err = tempFile.Sync(); err != nil {
+		return err
+	}
+
+	close = false
+	if err = tempFile.Close(); err != nil {
+		return err
+	}
+
+	return os.Rename(tempFile.Name(), filepath.Join(cp.basePath, key))
 }
 
 func (cp *simpleCheckpointManager) Delete(key string) error {

--- a/pkg/checkpoint/checkpoint_test.go
+++ b/pkg/checkpoint/checkpoint_test.go
@@ -30,7 +30,7 @@ type record struct {
 var _ = Describe("Simple checkpoint manager", func() {
 	It("should be able to check and retrieve", func() {
 		r := &record{"Hi"}
-		cp := NewSimpleCheckpointManager(GinkgoT().TempDir())
+		cp := NewSimpleCheckpointManager(GinkgoT().TempDir(), GinkgoT().TempDir())
 
 		Expect(cp.Store("win", r)).To(Succeed())
 
@@ -42,7 +42,7 @@ var _ = Describe("Simple checkpoint manager", func() {
 
 	It("should override if checkpoint already exists", func() {
 		r := &record{"Hi"}
-		cp := NewSimpleCheckpointManager(GinkgoT().TempDir())
+		cp := NewSimpleCheckpointManager(GinkgoT().TempDir(), GinkgoT().TempDir())
 
 		Expect(cp.Store("win", r)).To(Succeed())
 
@@ -55,7 +55,7 @@ var _ = Describe("Simple checkpoint manager", func() {
 	})
 
 	It("should return ErrNotExist when asked for non-existing key", func() {
-		cp := NewSimpleCheckpointManager(GinkgoT().TempDir())
+		cp := NewSimpleCheckpointManager(GinkgoT().TempDir(), GinkgoT().TempDir())
 
 		r := &record{}
 		Expect(cp.Get("win", r)).To(MatchError(os.ErrNotExist))
@@ -63,7 +63,7 @@ var _ = Describe("Simple checkpoint manager", func() {
 
 	It("should remove key", func() {
 		r := &record{"Hi"}
-		cp := NewSimpleCheckpointManager(GinkgoT().TempDir())
+		cp := NewSimpleCheckpointManager(GinkgoT().TempDir(), GinkgoT().TempDir())
 
 		Expect(cp.Store("win", r)).To(Succeed())
 
@@ -78,7 +78,7 @@ var _ = Describe("Simple checkpoint manager", func() {
 	})
 
 	It("remove non-existing key should return not found", func() {
-		cp := NewSimpleCheckpointManager(GinkgoT().TempDir())
+		cp := NewSimpleCheckpointManager(GinkgoT().TempDir(), GinkgoT().TempDir())
 
 		Expect(cp.Delete("win")).To(MatchError(os.ErrNotExist))
 	})

--- a/pkg/virt-handler/BUILD.bazel
+++ b/pkg/virt-handler/BUILD.bazel
@@ -102,6 +102,7 @@ go_test(
     tags = ["cov"],
     deps = [
         "//pkg/certificates:go_default_library",
+        "//pkg/checkpoint:go_default_library",
         "//pkg/controller:go_default_library",
         "//pkg/controller/testing:go_default_library",
         "//pkg/ephemeral-disk-utils:go_default_library",

--- a/pkg/virt-handler/cache/cache.go
+++ b/pkg/virt-handler/cache/cache.go
@@ -69,10 +69,10 @@ func (icp *iterableCheckpointManager) ListKeys() []string {
 
 }
 
-func NewIterableCheckpointManager(base string) IterableCheckpointManager {
+func NewIterableCheckpointManager(base, tempPath string) IterableCheckpointManager {
 	return &iterableCheckpointManager{
 		base,
-		checkpoint.NewSimpleCheckpointManager(base),
+		checkpoint.NewSimpleCheckpointManager(base, tempPath),
 	}
 }
 

--- a/pkg/virt-handler/cache/cache_test.go
+++ b/pkg/virt-handler/cache/cache_test.go
@@ -57,7 +57,7 @@ var _ = Describe("Domain informer", func() {
 		ghostCacheDir, err = os.MkdirTemp("", "")
 		Expect(err).ToNot(HaveOccurred())
 
-		ghostRecordStore = InitializeGhostRecordCache(NewIterableCheckpointManager(ghostCacheDir))
+		ghostRecordStore = InitializeGhostRecordCache(NewIterableCheckpointManager(ghostCacheDir, GinkgoT().TempDir()))
 
 	})
 
@@ -93,7 +93,7 @@ var _ = Describe("Domain informer", func() {
 			err = ghostRecordStore.Add("test2-namespace", "test2", "somefile2", "1234-2")
 			Expect(err).ToNot(HaveOccurred())
 
-			ghostRecordStore = InitializeGhostRecordCache(NewIterableCheckpointManager(ghostCacheDir))
+			ghostRecordStore = InitializeGhostRecordCache(NewIterableCheckpointManager(ghostCacheDir, GinkgoT().TempDir()))
 
 			record, exists := ghostRecordStore.cache["test1-namespace/test1"]
 			Expect(exists).To(BeTrue())
@@ -492,7 +492,7 @@ var _ = Describe("Domain watcher ListerWatcher", func() {
 
 var _ = Describe("Iterable checkpoint manager", func() {
 	It("should list all keys", func() {
-		icp := NewIterableCheckpointManager(GinkgoT().TempDir())
+		icp := NewIterableCheckpointManager(GinkgoT().TempDir(), GinkgoT().TempDir())
 
 		Expect(icp.Store("one", "hi")).To(Succeed())
 		Expect(icp.Store("two", "hey")).To(Succeed())
@@ -507,7 +507,7 @@ var _ = Describe("List", func() {
 
 	BeforeEach(func() {
 		ghostCacheDir = GinkgoT().TempDir()
-		InitializeGhostRecordCache(NewIterableCheckpointManager(ghostCacheDir))
+		InitializeGhostRecordCache(NewIterableCheckpointManager(ghostCacheDir, GinkgoT().TempDir()))
 	})
 
 	It("should return domain with Unknown status when socket exists but connection fails", func() {

--- a/pkg/virt-handler/cache/domain-watcher_test.go
+++ b/pkg/virt-handler/cache/domain-watcher_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Domain Watcher", func() {
 
 			ghostCacheDir := GinkgoT().TempDir()
 
-			ghostRecordStore := InitializeGhostRecordCache(NewIterableCheckpointManager(ghostCacheDir))
+			ghostRecordStore := InitializeGhostRecordCache(NewIterableCheckpointManager(ghostCacheDir, GinkgoT().TempDir()))
 
 			err := ghostRecordStore.Add("test-ns", "test-domain", socketPath, podUID)
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/virt-handler/container-disk/mount.go
+++ b/pkg/virt-handler/container-disk/mount.go
@@ -93,11 +93,11 @@ type kernelArtifacts struct {
 	initrd *safepath.Path
 }
 
-func NewMounter(isoDetector isolation.PodIsolationDetector, mountStateDir string, clusterConfig *virtconfig.ClusterConfig) Mounter {
+func NewMounter(isoDetector isolation.PodIsolationDetector, checkpointManager checkpoint.CheckpointManager, clusterConfig *virtconfig.ClusterConfig) Mounter {
 	return &mounter{
 		mountRecords:               make(map[types.UID]*vmiMountTargetRecord),
 		podIsolationDetector:       isoDetector,
-		checkpointManager:          checkpoint.NewSimpleCheckpointManager(mountStateDir),
+		checkpointManager:          checkpointManager,
 		suppressWarningTimeout:     1 * time.Minute,
 		needsBindMountFunc:         newNeedsBindMountFunc(""),
 		socketPathGetter:           containerdisk.NewSocketPathGetter(""),

--- a/pkg/virt-handler/container-disk/mount_test.go
+++ b/pkg/virt-handler/container-disk/mount_test.go
@@ -62,7 +62,7 @@ var _ = Describe("ContainerDisk", func() {
 
 		m = &mounter{
 			mountRecords:           make(map[types.UID]*vmiMountTargetRecord),
-			checkpointManager:      checkpoint.NewSimpleCheckpointManager(tmpDir),
+			checkpointManager:      checkpoint.NewSimpleCheckpointManager(tmpDir, GinkgoT().TempDir()),
 			suppressWarningTimeout: 1 * time.Minute,
 			socketPathGetter:       containerdisk.NewSocketPathGetter(""),
 			clusterConfig:          config,

--- a/pkg/virt-handler/hotplug-disk/mount.go
+++ b/pkg/virt-handler/hotplug-disk/mount.go
@@ -194,10 +194,10 @@ func (r *vmiMountTargetRecord) appendPath(path string) bool {
 }
 
 // NewVolumeMounter creates a new VolumeMounter
-func NewVolumeMounter(mountStateDir string, kubeletPodsDir string, host string) VolumeMounter {
+func NewVolumeMounter(checkpointManager checkpoint.CheckpointManager, kubeletPodsDir string, host string) VolumeMounter {
 	return &volumeMounter{
 		mountRecords:       make(map[types.UID]*vmiMountTargetRecord),
-		checkpointManager:  checkpoint.NewSimpleCheckpointManager(mountStateDir),
+		checkpointManager:  checkpointManager,
 		hotplugDiskManager: hotplugdisk.NewHotplugDiskManager(kubeletPodsDir),
 		ownershipManager:   diskutils.DefaultOwnershipManager,
 		kubeletPodsDir:     kubeletPodsDir,

--- a/pkg/virt-handler/hotplug-disk/mount_test.go
+++ b/pkg/virt-handler/hotplug-disk/mount_test.go
@@ -169,7 +169,7 @@ var _ = Describe("HotplugVolume", func() {
 
 			m = &volumeMounter{
 				mountRecords:       make(map[types.UID]*vmiMountTargetRecord),
-				checkpointManager:  checkpoint.NewSimpleCheckpointManager(tempDir),
+				checkpointManager:  checkpoint.NewSimpleCheckpointManager(tempDir, GinkgoT().TempDir()),
 				hotplugDiskManager: hotplugdisk.NewHotplugDiskWithOptions(tempDir),
 			}
 			record = &vmiMountTargetRecord{
@@ -290,7 +290,7 @@ var _ = Describe("HotplugVolume", func() {
 
 			m = &volumeMounter{
 				mountRecords:       make(map[types.UID]*vmiMountTargetRecord),
-				checkpointManager:  checkpoint.NewSimpleCheckpointManager(tempDir),
+				checkpointManager:  checkpoint.NewSimpleCheckpointManager(tempDir, GinkgoT().TempDir()),
 				skipSafetyCheck:    true,
 				hotplugDiskManager: hotplugdisk.NewHotplugDiskWithOptions(tempDir),
 				ownershipManager:   ownershipManager,
@@ -748,7 +748,7 @@ var _ = Describe("HotplugVolume", func() {
 
 			m = &volumeMounter{
 				mountRecords:       make(map[types.UID]*vmiMountTargetRecord),
-				checkpointManager:  checkpoint.NewSimpleCheckpointManager(tempDir),
+				checkpointManager:  checkpoint.NewSimpleCheckpointManager(tempDir, GinkgoT().TempDir()),
 				hotplugDiskManager: hotplugdisk.NewHotplugDiskWithOptions(tempDir),
 				ownershipManager:   ownershipManager,
 			}
@@ -997,7 +997,7 @@ var _ = Describe("HotplugVolume", func() {
 
 			m = &volumeMounter{
 				mountRecords:       make(map[types.UID]*vmiMountTargetRecord),
-				checkpointManager:  checkpoint.NewSimpleCheckpointManager(tempDir),
+				checkpointManager:  checkpoint.NewSimpleCheckpointManager(tempDir, GinkgoT().TempDir()),
 				skipSafetyCheck:    true,
 				hotplugDiskManager: hotplugdisk.NewHotplugDiskWithOptions(tempDir),
 				ownershipManager:   ownershipManager,

--- a/pkg/virt-handler/migration-source_test.go
+++ b/pkg/virt-handler/migration-source_test.go
@@ -130,7 +130,7 @@ var _ = Describe("VirtualMachineInstance migration target", func() {
 		vmiShareDir := GinkgoT().TempDir()
 		ghostCacheDir := GinkgoT().TempDir()
 
-		_ = virtcache.InitializeGhostRecordCache(virtcache.NewIterableCheckpointManager(ghostCacheDir))
+		_ = virtcache.InitializeGhostRecordCache(virtcache.NewIterableCheckpointManager(ghostCacheDir, GinkgoT().TempDir()))
 
 		Expect(os.MkdirAll(filepath.Join(vmiShareDir, "var", "run", "kubevirt"), 0755)).To(Succeed())
 

--- a/pkg/virt-handler/migration-target_test.go
+++ b/pkg/virt-handler/migration-target_test.go
@@ -164,7 +164,7 @@ var _ = Describe("VirtualMachineInstance migration target", func() {
 		vmiShareDir := GinkgoT().TempDir()
 		ghostCacheDir := GinkgoT().TempDir()
 
-		_ = virtcache.InitializeGhostRecordCache(virtcache.NewIterableCheckpointManager(ghostCacheDir))
+		_ = virtcache.InitializeGhostRecordCache(virtcache.NewIterableCheckpointManager(ghostCacheDir, GinkgoT().TempDir()))
 
 		Expect(os.MkdirAll(filepath.Join(vmiShareDir, "var", "run", "kubevirt"), 0755)).To(Succeed())
 
@@ -238,7 +238,7 @@ var _ = Describe("VirtualMachineInstance migration target", func() {
 			migrationTargetPasstRepairHandler,
 			nil,
 			nil,
-			container_disk.NewMounter(mockIsolationDetector, checkpoint.NewSimpleCheckpointManager(GinkgoT().TempDir()), config),
+			container_disk.NewMounter(mockIsolationDetector, checkpoint.NewSimpleCheckpointManager(GinkgoT().TempDir(), GinkgoT().TempDir()), config),
 			mockHotplugVolumeMounter,
 		)
 

--- a/pkg/virt-handler/migration-target_test.go
+++ b/pkg/virt-handler/migration-target_test.go
@@ -50,6 +50,7 @@ import (
 	kubevirtfake "kubevirt.io/client-go/kubevirt/fake"
 
 	"kubevirt.io/kubevirt/pkg/certificates"
+	"kubevirt.io/kubevirt/pkg/checkpoint"
 	virtcontroller "kubevirt.io/kubevirt/pkg/controller"
 	controllertesting "kubevirt.io/kubevirt/pkg/controller/testing"
 	diskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
@@ -61,7 +62,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 	virtcache "kubevirt.io/kubevirt/pkg/virt-handler/cache"
 	cmdclient "kubevirt.io/kubevirt/pkg/virt-handler/cmd-client"
-	containerdisk "kubevirt.io/kubevirt/pkg/virt-handler/container-disk"
+	container_disk "kubevirt.io/kubevirt/pkg/virt-handler/container-disk"
 	hotplugvolume "kubevirt.io/kubevirt/pkg/virt-handler/hotplug-disk"
 	"kubevirt.io/kubevirt/pkg/virt-handler/isolation"
 	launcherclients "kubevirt.io/kubevirt/pkg/virt-handler/launcher-clients"
@@ -237,7 +238,7 @@ var _ = Describe("VirtualMachineInstance migration target", func() {
 			migrationTargetPasstRepairHandler,
 			nil,
 			nil,
-			containerdisk.NewMounter(mockIsolationDetector, GinkgoT().TempDir(), config),
+			container_disk.NewMounter(mockIsolationDetector, checkpoint.NewSimpleCheckpointManager(GinkgoT().TempDir()), config),
 			mockHotplugVolumeMounter,
 		)
 

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -136,7 +136,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 		vmiShareDir := GinkgoT().TempDir()
 		ghostCacheDir := GinkgoT().TempDir()
 
-		_ = virtcache.InitializeGhostRecordCache(virtcache.NewIterableCheckpointManager(ghostCacheDir))
+		_ = virtcache.InitializeGhostRecordCache(virtcache.NewIterableCheckpointManager(ghostCacheDir, GinkgoT().TempDir()))
 
 		Expect(os.MkdirAll(filepath.Join(vmiShareDir, "var", "run", "kubevirt"), 0755)).To(Succeed())
 
@@ -218,7 +218,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 			cbtHandler,
 			nil,
 			&noopNodeHookExecutor{},
-			container_disk.NewMounter(mockIsolationDetector, checkpoint.NewSimpleCheckpointManager(GinkgoT().TempDir()), config),
+			container_disk.NewMounter(mockIsolationDetector, checkpoint.NewSimpleCheckpointManager(GinkgoT().TempDir(), GinkgoT().TempDir()), config),
 			mockHotplugVolumeMounter,
 		)
 

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -54,6 +54,7 @@ import (
 	kubevirtfake "kubevirt.io/client-go/kubevirt/fake"
 
 	"kubevirt.io/kubevirt/pkg/certificates"
+	"kubevirt.io/kubevirt/pkg/checkpoint"
 	virtcontroller "kubevirt.io/kubevirt/pkg/controller"
 	controllertesting "kubevirt.io/kubevirt/pkg/controller/testing"
 	diskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
@@ -72,6 +73,7 @@ import (
 	virtcache "kubevirt.io/kubevirt/pkg/virt-handler/cache"
 	"kubevirt.io/kubevirt/pkg/virt-handler/cgroup"
 	cmdclient "kubevirt.io/kubevirt/pkg/virt-handler/cmd-client"
+	container_disk "kubevirt.io/kubevirt/pkg/virt-handler/container-disk"
 	containerdisk "kubevirt.io/kubevirt/pkg/virt-handler/container-disk"
 	hotplugvolume "kubevirt.io/kubevirt/pkg/virt-handler/hotplug-disk"
 	"kubevirt.io/kubevirt/pkg/virt-handler/isolation"
@@ -216,7 +218,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 			cbtHandler,
 			nil,
 			&noopNodeHookExecutor{},
-			containerdisk.NewMounter(mockIsolationDetector, GinkgoT().TempDir(), config),
+			container_disk.NewMounter(mockIsolationDetector, checkpoint.NewSimpleCheckpointManager(GinkgoT().TempDir()), config),
 			mockHotplugVolumeMounter,
 		)
 


### PR DESCRIPTION
### What this PR does
The current implementation is prone to losing data or producing corrupt records if the virt-handler would get restarted.
The PR implements atomic write in order to be resilient and be able to rely on the checkpoints.


Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->


### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bug fix: Ensuring that records (ghost records, mount records) are written atomically to disk
```

