### PR TITLE
tests: Partial revert of 9e58ac0fa2 to fix y-1 upgrade test flake

### DIFF
--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -885,31 +885,6 @@ var _ = Describe("[sig-operator]Operator", Serial, decorators.SigOperator, func(
 			By("Verifying infrastructure Is Updated")
 			allKvInfraPodsAreReady(kv)
 
-			By("Verifying RBAC aggregate labels are preserved after upgrade")
-			verifyAggregateLabels(virtClient, "true")
-
-			By("Setting RoleAggregationStrategy to Manual after upgrade")
-			currentKV := libkubevirt.GetCurrentKv(virtClient)
-			savedConfig := currentKV.Spec.Configuration.DeepCopy()
-			if currentKV.Spec.Configuration.DeveloperConfiguration == nil {
-				currentKV.Spec.Configuration.DeveloperConfiguration = &v1.DeveloperConfiguration{}
-			}
-			currentKV.Spec.Configuration.DeveloperConfiguration.FeatureGates = append(
-				currentKV.Spec.Configuration.DeveloperConfiguration.FeatureGates,
-				featuregate.OptOutRoleAggregation,
-			)
-			currentKV.Spec.Configuration.RoleAggregationStrategy = pointer.P(v1.RoleAggregationStrategyManual)
-			kvconfig.UpdateKubeVirtConfigValueAndWait(currentKV.Spec.Configuration)
-
-			By("Verifying aggregate labels are set to false after upgrade with Manual strategy")
-			verifyAggregateLabels(virtClient, "false")
-
-			By("Restoring RoleAggregationStrategy to default after upgrade verification")
-			kvconfig.UpdateKubeVirtConfigValueAndWait(*savedConfig)
-
-			By("Verifying aggregate labels are restored after upgrade")
-			verifyAggregateLabels(virtClient, "true")
-
 			// Verify console connectivity to VMI still works and stop VM
 			for _, vmYaml := range vmYamls {
 				By(fmt.Sprintf("Ensuring vm %s is ready and latest API annotation is set", vmYaml.apiVersion))
@@ -1046,8 +1021,8 @@ var _ = Describe("[sig-operator]Operator", Serial, decorators.SigOperator, func(
 			By("Deleting KubeVirt object")
 			deleteAllKvAndWait(false, originalKv.Name)
 		},
-			Entry("[QUARANTINE]from previous y release by patching KubeVirt CR", decorators.Quarantine, fromY, false),
-			Entry("[QUARANTINE]from previous y release by updating virt-operator", decorators.Quarantine, fromY, true),
+			Entry("from previous y release by patching KubeVirt CR", fromY, false),
+			Entry("from previous y release by updating virt-operator", fromY, true),
 			Entry("from previous z release by patching KubeVirt CR", fromZ, false),
 			Entry("from previous z release by updating virt-operator", fromZ, true),
 		)


### PR DESCRIPTION
### What this PR does
#### Before this PR:

The y-1 upgrade test (`[test_id:3145]`) is quarantined due to a flake where workload update migrations race with virt-handler DaemonSet re-rolls, causing VMIs to transition to `Failed` state.

#### After this PR:

The RoleAggregation verification block introduced by 9e58ac0fa2 (PR #17540) is removed from the upgrade test path and the y-1 upgrade test entries are dequarantined.

### References

- Fixes #18490
- Fixes #18465
- Fixes #18396
- Fixes #18336


### Why we need it and why it was done in this way

The RoleAggregation verification block ([operator.go:L891-L908](https://github.com/kubevirt/kubevirt/blob/cbb640319e087d682642a1d95e2f6981d3dc9eba/tests/operator/operator.go#L891-L908)) modifies the KubeVirt CR spec mid-upgrade-test by enabling the `OptOutRoleAggregation` feature gate and setting `RoleAggregationStrategy=Manual`, then restoring the original config. Each modification changes the install strategy ID hash, triggering a full virt-operator reconciliation cycle including a virt-handler DaemonSet rollout.

This produces three sequential upgrade cycles instead of one:

1. Intended y-1 upgrade (e.g. v1.8 → v1.9)
2. Hash change from setting `OptOutRoleAggregation` + `Manual` → new install strategy ID
3. Hash change from restoring original config → back to previous install strategy ID

During cycles 2/3, virt-handler pods are recycled while workload update migrations are in flight. The VMI's domain gets undefined by the recycling virt-handler ~3s after a successful migration, causing it to transition to `Failed`. The test then fails when attempting to re-migrate the already-Failed VMI:

```
admission webhook "migration-create-validator.kubevirt.io" denied the request: Cannot migrate VMI in finalized state.
```

The following alternatives were considered:

- Waiting for all upgrade cycles to complete before attempting the final VMI migration. Rejected because the test should not need to account for unintended extra reconciliation cycles — the root cause is the unnecessary spec modifications, not insufficient waiting.

The `OptOutRoleAggregation` feature is still covered by its own dedicated test suite outside the upgrade path.

### Special notes for your reviewer

Root cause was identified by instrumenting the virt-operator with additional DEBUG logging and running a soak loop (2 failures in 13 runs) on the release-1.9 branch via PR #18699. See the [root cause update comment on #18396](https://github.com/kubevirt/kubevirt/issues/18396#issuecomment-5190249399) for the full timeline analysis.

### Checklist

- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Testing: This is a test-only change removing test code that caused flakes
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
NONE
```