### PR TITLE
fix: use ACPI power button for graceful shutdown when domain has ACPI

### DIFF
--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -2182,7 +2182,24 @@ func (l *LibvirtDomainManager) SignalShutdownVMI(vmi *v1.VirtualMachineInstance)
 	}
 
 	if domState == libvirt.DOMAIN_RUNNING || domState == libvirt.DOMAIN_PAUSED {
-		err = dom.ShutdownFlags(libvirt.DOMAIN_SHUTDOWN_DEFAULT)
+		// Since v1.5.0 (commit d555b25e26, "Fix graceful shutdown on IBM Z"),
+		// DOMAIN_SHUTDOWN_DEFAULT is used for graceful shutdown. With this flag,
+		// libvirt prefers shutting down via the QEMU guest agent when an agent
+		// channel is present. If the guest does not run qemu-guest-agent, the
+		// agent shutdown attempt blocks for the agent command timeout (60s),
+		// which exceeds the default terminationGracePeriodSeconds (30s) of the
+		// VMI. As a result virt-handler forcibly destroys the domain before the
+		// ACPI fallback inside libvirt can take effect, leaving the VMI in the
+		// Failed phase and triggering an automatic restart with
+		// runStrategy=RerunOnFailure.
+		// Restore the pre-v1.5.0 behavior: use an explicit ACPI power button
+		// when the domain actually enables ACPI, and keep DOMAIN_SHUTDOWN_DEFAULT
+		// for domains without ACPI (e.g. s390x) to preserve the original fix.
+		shutdownFlag := libvirt.DOMAIN_SHUTDOWN_DEFAULT
+		if domainHasACPI(dom) {
+			shutdownFlag = libvirt.DOMAIN_SHUTDOWN_ACPI_POWER_BTN
+		}
+		err = dom.ShutdownFlags(shutdownFlag)
 		if err != nil {
 			log.Log.Object(vmi).Reason(err).Error("Signalling graceful shutdown failed.")
 			return err
@@ -2199,6 +2216,45 @@ func (l *LibvirtDomainManager) SignalShutdownVMI(vmi *v1.VirtualMachineInstance)
 	}
 
 	return nil
+}
+
+// acpiFeaturesXML mirrors only the <features><acpi> subtree of the domain XML.
+// api.Features does not carry the enabled attribute, so we read it directly
+// from the XML to correctly handle <acpi enabled='no'/>.
+type acpiFeaturesXML struct {
+	Features *featuresXML `xml:"features"`
+}
+
+type featuresXML struct {
+	ACPI *acpiXML `xml:"acpi"`
+}
+
+type acpiXML struct {
+	// libvirt boolean attribute: "yes"/"no"
+	Enabled string `xml:"enabled,attr"`
+}
+
+// domainHasACPI reports whether the domain actually enables the ACPI feature
+// by inspecting the live libvirt XML. It intentionally does not rely on the VMI
+// spec alone: when the VMI does not explicitly set domain features, QEMU
+// (x86_64/aarch64) still enables ACPI by default, so checking only the VMI spec
+// would miss that and wrongly fall back to the guest-agent shutdown path.
+func domainHasACPI(dom cli.VirDomain) bool {
+	xmlDesc, err := dom.GetXMLDesc(0)
+	if err != nil {
+		log.Log.Reason(err).Warning("Failed to get domain XML to detect ACPI feature, assuming ACPI disabled")
+		return false
+	}
+	var domainSpec acpiFeaturesXML
+	if err := xml.Unmarshal([]byte(xmlDesc), &domainSpec); err != nil {
+		log.Log.Reason(err).Warning("Failed to parse domain XML to detect ACPI feature, assuming ACPI disabled")
+		return false
+	}
+	if domainSpec.Features == nil || domainSpec.Features.ACPI == nil {
+		return false
+	}
+	// An explicitly disabled <acpi enabled='no'/> means ACPI is off.
+	return !strings.EqualFold(domainSpec.Features.ACPI.Enabled, "no")
 }
 
 func (l *LibvirtDomainManager) KillVMI(vmi *v1.VirtualMachineInstance) error {

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -83,6 +83,19 @@ const (
 var (
 	clusterConfig *virtconfig.ClusterConfig
 
+	// domain XML samples used by the graceful shutdown tests: domainHasACPI
+	// decides the shutdown signal based on the ACPI feature in the live XML.
+	domainXMLWithACPI    = `<domain type="kvm"><features><acpi/></features></domain>`
+	domainXMLACPIEnabled = `<domain type="kvm"><features><acpi enabled="yes"/></features></domain>`
+	// Typical arm64 virt machine configuration: ACPI coexists with other
+	// features (e.g. GIC); sibling elements must not affect ACPI detection.
+	domainXMLWithACPIAndGIC  = `<domain type="kvm"><features><acpi/><gic version='3'/></features></domain>`
+	domainXMLWithoutACPI     = `<domain type="kvm"><features></features></domain>`
+	domainXMLACPIDisabled    = `<domain type="kvm"><features><acpi enabled="no"/></features></domain>`
+	domainXMLWithoutFeatures = `<domain type="kvm"></domain>`
+	// 属性顺序、空格和多余属性变化不应影响 enabled 属性的解析
+	domainXMLACPIDisabledSpaced = `<domain type="kvm"><features><acpi foo="bar" enabled = "no" /></features></domain>`
+
 	//go:embed testdata/migration_domain.xml
 	embedMigrationDomain string
 
@@ -1882,6 +1895,147 @@ var _ = Describe("Manager", func() {
 		It("Should signal graceful shutdown after marked for shutdown", func() {
 			mockLibvirt.DomainEXPECT().GetState().AnyTimes().Return(libvirt.DOMAIN_RUNNING, 1, nil)
 			mockLibvirt.ConnectionEXPECT().LookupDomainByName(testDomainName).AnyTimes().DoAndReturn(mockDomainWithFreeExpectation)
+			// domainHasACPI inspects the live XML: with ACPI enabled the domain
+			// must be shut down via the explicit ACPI power button signal
+			// (pre-v1.5.0 behavior), avoiding the guest-agent shutdown path
+			// that can time out on guests without qemu-guest-agent.
+			mockLibvirt.DomainEXPECT().GetXMLDesc(0).Return(domainXMLWithACPI, nil)
+			mockLibvirt.DomainEXPECT().ShutdownFlags(libvirt.DOMAIN_SHUTDOWN_ACPI_POWER_BTN).Return(nil)
+
+			manager, _ := newLibvirtDomainManagerDefault()
+
+			vmi := newVMI(testNamespace, testVmName)
+			manager.SignalShutdownVMI(vmi)
+
+			gracePeriod, _ := metadataCache.GracePeriod.Load()
+			Expect(gracePeriod.DeletionTimestamp).NotTo(BeNil())
+		})
+
+		It("Should signal graceful shutdown with the ACPI power button when ACPI is explicitly enabled", func() {
+			mockLibvirt.DomainEXPECT().GetState().AnyTimes().Return(libvirt.DOMAIN_RUNNING, 1, nil)
+			mockLibvirt.ConnectionEXPECT().LookupDomainByName(testDomainName).AnyTimes().DoAndReturn(mockDomainWithFreeExpectation)
+			// `<acpi enabled='yes'/>` explicitly enables ACPI and must use the
+			// ACPI power button signal like the default-enabled case.
+			mockLibvirt.DomainEXPECT().GetXMLDesc(0).Return(domainXMLACPIEnabled, nil)
+			mockLibvirt.DomainEXPECT().ShutdownFlags(libvirt.DOMAIN_SHUTDOWN_ACPI_POWER_BTN).Return(nil)
+
+			manager, _ := newLibvirtDomainManagerDefault()
+
+			vmi := newVMI(testNamespace, testVmName)
+			manager.SignalShutdownVMI(vmi)
+
+			gracePeriod, _ := metadataCache.GracePeriod.Load()
+			Expect(gracePeriod.DeletionTimestamp).NotTo(BeNil())
+		})
+
+		It("Should signal graceful shutdown with the ACPI power button when ACPI coexists with other features", func() {
+			mockLibvirt.DomainEXPECT().GetState().AnyTimes().Return(libvirt.DOMAIN_RUNNING, 1, nil)
+			mockLibvirt.ConnectionEXPECT().LookupDomainByName(testDomainName).AnyTimes().DoAndReturn(mockDomainWithFreeExpectation)
+			// Sibling feature elements (e.g. <gic/> on arm64) must not affect
+			// the ACPI detection.
+			mockLibvirt.DomainEXPECT().GetXMLDesc(0).Return(domainXMLWithACPIAndGIC, nil)
+			mockLibvirt.DomainEXPECT().ShutdownFlags(libvirt.DOMAIN_SHUTDOWN_ACPI_POWER_BTN).Return(nil)
+
+			manager, _ := newLibvirtDomainManagerDefault()
+
+			vmi := newVMI(testNamespace, testVmName)
+			manager.SignalShutdownVMI(vmi)
+
+			gracePeriod, _ := metadataCache.GracePeriod.Load()
+			Expect(gracePeriod.DeletionTimestamp).NotTo(BeNil())
+		})
+
+		It("Should signal graceful shutdown with the default flag when the domain has no ACPI", func() {
+			mockLibvirt.DomainEXPECT().GetState().AnyTimes().Return(libvirt.DOMAIN_RUNNING, 1, nil)
+			mockLibvirt.ConnectionEXPECT().LookupDomainByName(testDomainName).AnyTimes().DoAndReturn(mockDomainWithFreeExpectation)
+			// Domains without ACPI (e.g. s390x) keep DOMAIN_SHUTDOWN_DEFAULT to
+			// preserve the graceful shutdown fix from v1.5.0 (commit d555b25e26).
+			mockLibvirt.DomainEXPECT().GetXMLDesc(0).Return(domainXMLWithoutACPI, nil)
+			mockLibvirt.DomainEXPECT().ShutdownFlags(libvirt.DOMAIN_SHUTDOWN_DEFAULT).Return(nil)
+
+			manager, _ := newLibvirtDomainManagerDefault()
+
+			vmi := newVMI(testNamespace, testVmName)
+			manager.SignalShutdownVMI(vmi)
+
+			gracePeriod, _ := metadataCache.GracePeriod.Load()
+			Expect(gracePeriod.DeletionTimestamp).NotTo(BeNil())
+		})
+
+		It("Should signal graceful shutdown with the default flag when ACPI is explicitly disabled", func() {
+			mockLibvirt.DomainEXPECT().GetState().AnyTimes().Return(libvirt.DOMAIN_RUNNING, 1, nil)
+			mockLibvirt.ConnectionEXPECT().LookupDomainByName(testDomainName).AnyTimes().DoAndReturn(mockDomainWithFreeExpectation)
+			// `<acpi enabled='no'/>` explicitly disables ACPI and must not be
+			// treated as ACPI enabled by domainHasACPI.
+			mockLibvirt.DomainEXPECT().GetXMLDesc(0).Return(domainXMLACPIDisabled, nil)
+			mockLibvirt.DomainEXPECT().ShutdownFlags(libvirt.DOMAIN_SHUTDOWN_DEFAULT).Return(nil)
+
+			manager, _ := newLibvirtDomainManagerDefault()
+
+			vmi := newVMI(testNamespace, testVmName)
+			manager.SignalShutdownVMI(vmi)
+
+			gracePeriod, _ := metadataCache.GracePeriod.Load()
+			Expect(gracePeriod.DeletionTimestamp).NotTo(BeNil())
+		})
+
+		It("Should signal graceful shutdown with the default flag when ACPI is disabled with varying attribute formatting", func() {
+			mockLibvirt.DomainEXPECT().GetState().AnyTimes().Return(libvirt.DOMAIN_RUNNING, 1, nil)
+			mockLibvirt.ConnectionEXPECT().LookupDomainByName(testDomainName).AnyTimes().DoAndReturn(mockDomainWithFreeExpectation)
+			// Attribute order, whitespace and extra attributes must not affect
+			// the enabled attribute parsing.
+			mockLibvirt.DomainEXPECT().GetXMLDesc(0).Return(domainXMLACPIDisabledSpaced, nil)
+			mockLibvirt.DomainEXPECT().ShutdownFlags(libvirt.DOMAIN_SHUTDOWN_DEFAULT).Return(nil)
+
+			manager, _ := newLibvirtDomainManagerDefault()
+
+			vmi := newVMI(testNamespace, testVmName)
+			manager.SignalShutdownVMI(vmi)
+
+			gracePeriod, _ := metadataCache.GracePeriod.Load()
+			Expect(gracePeriod.DeletionTimestamp).NotTo(BeNil())
+		})
+
+		It("Should signal graceful shutdown with the default flag when the domain has no features element", func() {
+			mockLibvirt.DomainEXPECT().GetState().AnyTimes().Return(libvirt.DOMAIN_RUNNING, 1, nil)
+			mockLibvirt.ConnectionEXPECT().LookupDomainByName(testDomainName).AnyTimes().DoAndReturn(mockDomainWithFreeExpectation)
+			// A domain without any <features> element unmarshals to a nil
+			// Features pointer, which must be treated as ACPI disabled.
+			mockLibvirt.DomainEXPECT().GetXMLDesc(0).Return(domainXMLWithoutFeatures, nil)
+			mockLibvirt.DomainEXPECT().ShutdownFlags(libvirt.DOMAIN_SHUTDOWN_DEFAULT).Return(nil)
+
+			manager, _ := newLibvirtDomainManagerDefault()
+
+			vmi := newVMI(testNamespace, testVmName)
+			manager.SignalShutdownVMI(vmi)
+
+			gracePeriod, _ := metadataCache.GracePeriod.Load()
+			Expect(gracePeriod.DeletionTimestamp).NotTo(BeNil())
+		})
+
+		It("Should signal graceful shutdown with the default flag when reading the domain XML fails", func() {
+			mockLibvirt.DomainEXPECT().GetState().AnyTimes().Return(libvirt.DOMAIN_RUNNING, 1, nil)
+			mockLibvirt.ConnectionEXPECT().LookupDomainByName(testDomainName).AnyTimes().DoAndReturn(mockDomainWithFreeExpectation)
+			// If the live XML cannot be fetched, assume ACPI is disabled and
+			// fall back to the default shutdown flag.
+			mockLibvirt.DomainEXPECT().GetXMLDesc(0).Return("", fmt.Errorf("failed to get domain XML"))
+			mockLibvirt.DomainEXPECT().ShutdownFlags(libvirt.DOMAIN_SHUTDOWN_DEFAULT).Return(nil)
+
+			manager, _ := newLibvirtDomainManagerDefault()
+
+			vmi := newVMI(testNamespace, testVmName)
+			manager.SignalShutdownVMI(vmi)
+
+			gracePeriod, _ := metadataCache.GracePeriod.Load()
+			Expect(gracePeriod.DeletionTimestamp).NotTo(BeNil())
+		})
+
+		It("Should signal graceful shutdown with the default flag when the domain XML cannot be parsed", func() {
+			mockLibvirt.DomainEXPECT().GetState().AnyTimes().Return(libvirt.DOMAIN_RUNNING, 1, nil)
+			mockLibvirt.ConnectionEXPECT().LookupDomainByName(testDomainName).AnyTimes().DoAndReturn(mockDomainWithFreeExpectation)
+			// Malformed XML must not fail the graceful shutdown; fall back to
+			// the default shutdown flag.
+			mockLibvirt.DomainEXPECT().GetXMLDesc(0).Return("<invalid", nil)
 			mockLibvirt.DomainEXPECT().ShutdownFlags(libvirt.DOMAIN_SHUTDOWN_DEFAULT).Return(nil)
 
 			manager, _ := newLibvirtDomainManagerDefault()

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -1421,6 +1421,51 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 
 				Eventually(matcher.ThisVMI(vmi)).WithTimeout(15 * time.Second).WithPolling(time.Second).Should(matcher.BeGone())
 			})
+
+			It("[test_id:1657]should gracefully shut down via ACPI when the guest agent is not available", decorators.Conformance, func() {
+				// This test relies on the kubevirt default termination grace
+				// period (30s) being shorter than libvirt's agent shutdown
+				// timeout (60s): the guest-agent path would otherwise win the
+				// race even without this fix and the test could silently invert
+				// its semantics. Guard against such config drift.
+				if v1.DefaultGracePeriodSeconds >= 60 {
+					Skip(fmt.Sprintf("DefaultGracePeriodSeconds (%ds) must be less than libvirt's agent shutdown timeout (60s) for this test", v1.DefaultGracePeriodSeconds))
+				}
+
+				By("Creating a VirtualMachineInstance with the default grace period")
+				vmi := libvmifact.NewAlpineWithTestTooling()
+
+				By("Creating the VirtualMachineInstance")
+				vmi = libvmops.RunVMIAndExpectLaunch(vmi, startupTimeout)
+
+				By("Logging into the VirtualMachineInstance")
+				Expect(console.LoginToAlpine(vmi)).To(Succeed())
+
+				By("Waiting for the guest agent to connect")
+				Eventually(matcher.ThisVMI(vmi), 60*time.Second, 2*time.Second).Should(
+					matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
+
+				By("Stopping the guest agent to force the ACPI shutdown path")
+				Expect(console.RunCommand(vmi, "rc-service qemu-guest-agent stop", 10*time.Second)).To(Succeed())
+
+				By("Verifying the guest agent is no longer connected")
+				Eventually(matcher.ThisVMI(vmi), 60*time.Second, 2*time.Second).Should(
+					matcher.HaveConditionMissingOrFalse(v1.VirtualMachineInstanceAgentConnected))
+
+				By("Deleting the VirtualMachineInstance")
+				Expect(kubevirt.Client().VirtualMachineInstance(vmi.Namespace).Delete(context.Background(), vmi.Name, metav1.DeleteOptions{})).To(Succeed(), "Should delete VMI gracefully")
+
+				// With the default grace period (30s) being shorter than
+				// libvirt's agent command timeout (60s), graceful shutdown used
+				// to block on the guest agent channel and the domain was
+				// force-destroyed once the grace period expired, leaving the
+				// VMI in the Failed phase. With the explicit ACPI power button
+				// signal the guest shuts down promptly, so the VMI must
+				// transition to Succeeded instead.
+				By("Verifying the VirtualMachineInstance transitions to Succeeded (graceful shutdown)")
+				Eventually(matcher.ThisVMI(vmi)).WithTimeout(time.Duration(v1.DefaultGracePeriodSeconds) * time.Second).WithPolling(time.Second).Should(
+					matcher.BeInPhase(v1.Succeeded))
+			})
 		})
 	})
 


### PR DESCRIPTION
### What this PR does

Restores the pre-v1.5.0 graceful shutdown behavior: `SignalShutdownVMI` now sends an explicit `DOMAIN_SHUTDOWN_ACPI_POWER_BTN` signal when the domain enables ACPI, and keeps `DOMAIN_SHUTDOWN_DEFAULT` for domains without ACPI (e.g. s390x).

### Why it's needed

Since v1.5.0 (commit `d555b25e26`, PR #12820, "Fix graceful shutdown on IBM Z"), virt-launcher sends `DOMAIN_SHUTDOWN_DEFAULT` for graceful shutdown. With this flag libvirt prefers shutting down via the QEMU guest agent whenever an agent channel is present.

KubeVirt always configures the `org.qemu.guest_agent.0` channel on every domain. On guests that do **not** run `qemu-guest-agent`, the agent shutdown attempt blocks for libvirt's agent command timeout (`VIR_DOMAIN_QEMU_AGENT_COMMAND_SHUTDOWN = 60s`), which exceeds the VMI's default `terminationGracePeriodSeconds` (30s). As a result, `virt-handler` forcibly destroys the domain before libvirt's ACPI fallback can take effect, leaving the VMI in the `Failed` phase and triggering an automatic restart when `runStrategy: RerunOnFailure` is used:

```
Stop → VMI deleted (30s grace period starts)
     → graceful shutdown → libvirt DEFAULT → agent path (guest has no qga)
     → agent command blocks up to 60s ...
30s  → virt-handler grace period expires → domain destroyed → VMI=Failed
     → RerunOnFailure → automatic restart
```

`DOMAIN_SHUTDOWN_ACPI_POWER_BTN` bypasses the agent path entirely and issues `system_powerdown` immediately, which is what pre-v1.5.0 releases did and which works reliably on guests with ACPI enabled.

### How the fix decides

`domainHasACPI()` inspects the **live libvirt XML** rather than the VMI spec: when the VMI does not explicitly set `domain.features`, QEMU (x86_64/aarch64) still enables ACPI by default, so checking only the VMI spec would miss that and wrongly keep the guest-agent path.

- Domain has ACPI → `DOMAIN_SHUTDOWN_ACPI_POWER_BTN` (pre-v1.5.0 behavior)
- Domain has no ACPI (e.g. s390x) → `DOMAIN_SHUTDOWN_DEFAULT` (preserves #12820)

### Which issue(s) this PR fixes

Fixes the regression introduced by #12820 for ACPI-capable guests without qemu-guest-agent. Related context: #18160 (graceful shutdown test flakes on arm64 caused by libvirt silently using the guest agent channel) and #18504 (flaky graceful shutdown e2e test removed).

### Release note

```release-note
Graceful shutdown now uses an explicit ACPI power button signal when the domain enables ACPI, avoiding guest-agent shutdown timeouts on guests without qemu-guest-agent that previously caused the VMI to be marked Failed and restarted under runStrategy=RerunOnFailure.
```

### Test coverage

- Unit tests in `pkg/virt-launcher/virtwrap/manager_test.go` covering: ACPI enabled → `ACPI_POWER_BTN`, no ACPI / ACPI explicitly disabled → `DEFAULT`.
- New e2e test `[test_id:1657]` in `tests/vmi_lifecycle_test.go`: stops `qemu-guest-agent` before deleting the VMI, forcing the ACPI shutdown path. With the default grace period (30s) shorter than libvirt's agent command timeout (60s), this test fails before the fix (VMI ends in `Failed`) and passes after it (VMI transitions to `Succeeded`). Existing `test_id:1655` uses an image that ships qemu-guest-agent, so it exercises the agent path only (see #18160).
