### PR TITLE
Release the VMBackup finalizer when its BackupTracker is gone

### DIFF
--- a/pkg/storage/cbt/backup.go
+++ b/pkg/storage/cbt/backup.go
@@ -446,6 +446,11 @@ func (ctrl *VMBackupController) sync(backup *backupv1.VirtualMachineBackup) erro
 		return err
 	}
 	if backupTracker == nil && backup.Spec.Source.Kind == backupv1.VirtualMachineBackupTrackerGroupVersionKind.Kind {
+		if backupDeleting {
+			// The source VMI is only reachable through the tracker, so without it there is
+			// nothing left to clean up and blocking deletion would strand the finalizer.
+			return ctrl.removeBackupFinalizer(backup)
+		}
 		setInitializing(backup, fmt.Sprintf(backupTrackerNotFoundMsg, backup.Spec.Source.Name))
 		return nil
 	}

--- a/pkg/storage/cbt/backup_test.go
+++ b/pkg/storage/cbt/backup_test.go
@@ -429,6 +429,26 @@ var _ = Describe("Backup Controller", func() {
 		Expect(statusUpdated).To(BeTrue())
 	})
 
+	It("should remove the finalizer when a deleted backup's backupTracker no longer exists", func() {
+		backup := createBackupWithTracker(backupName, vmName, pvcName)
+		backup.DeletionTimestamp = &metav1.Time{Time: metav1.Now().Time}
+		backup.Finalizers = []string{vmBackupFinalizer}
+		addBackup(backup)
+		// Don't add backupTracker
+
+		patched := false
+		kubevirtClient.Fake.PrependReactor("patch", "virtualmachinebackups", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+			patched = true
+			updatedBackup := backup.DeepCopy()
+			updatedBackup.Finalizers = nil
+			return true, updatedBackup, nil
+		})
+
+		err := controller.execute(types.NamespacedName{Namespace: testNamespace, Name: backupName}.String())
+		Expect(err).ToNot(HaveOccurred())
+		Expect(patched).To(BeTrue())
+	})
+
 	It("should wait when backupTracker needs checkpoint redefinition", func() {
 		backupTracker := createBackupTracker(backupTrackerName, vmName, "existing-checkpoint")
 		backupTracker.Status.CheckpointRedefinitionRequired = pointer.P(true)


### PR DESCRIPTION
### What this PR does
#### Before this PR:

A `VirtualMachineBackup` sourced from a `VirtualMachineBackupTracker` could never finish deleting once that tracker was gone. `VMBackupController.sync()` returned early on a missing tracker:

```go
if backupTracker == nil && backup.Spec.Source.Kind == backupv1.VirtualMachineBackupTrackerGroupVersionKind.Kind {
	setInitializing(backup, fmt.Sprintf(backupTrackerNotFoundMsg, backup.Spec.Source.Name))
	return nil
}
```

Every call site of `removeBackupFinalizer()` (the terminal-state branch, `reconcileStart()`, `reconcileActive()`) sits downstream of that return, so a backup deleted while still non-terminal kept `backup.kubevirt.io/vmbackup-protection` forever. Since virt-controller is the only writer of that finalizer, the object never went away and its namespace stayed in `Terminating` until someone stripped the finalizer by hand.

#### After this PR:

Deletion is handled before the early return. When the backup is being deleted and its tracker is missing, the finalizer is released and the object is allowed to go away.

### References

- Fixes #18724
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/25

### Why we need it and why it was done in this way

Any interrupted or aborted backup whose namespace is cleaned up before the backup reaches a terminal state permanently poisons that namespace name — it hangs in `Terminating` indefinitely. That is a real hazard for CI, which reuses test namespace names, and for clusters that delete namespaces during or after a backup.

Releasing the finalizer unconditionally in this path is safe because the source VMI is resolved through `backupTracker.Spec.Source.Name` (`getSourceName`). With the tracker gone there is no way to locate the VMI, so `cleanupVMIState()` (detach the backup target PVC, clear `vmi.status.changedBlockTracking.backupStatus`) cannot run either way. Holding the finalizer buys nothing and blocks namespace teardown.

The following alternatives were considered:

- Keep blocking and requeue until the tracker returns. Rejected: the tracker is not coming back, so this is the current behavior — a permanent hang.
- Persist the resolved source VMI name into `backup.Status` at `startBackup()` time so cleanup can still run after the tracker is lost. This is worth doing for the narrower case where a user deletes only the tracker while the VMI keeps running (stale `backupStatus` on the VMI can block the next backup), but it is a larger API-touching change and orthogonal to unblocking namespace deletion. Happy to follow up separately if reviewers want it.

### Special notes for your reviewer

The reporter hit this on a downstream build whose condition names differ from upstream (`Initializing`/`Deleting` vs. `Progressing`/`Complete`/`Failed`), but the code path is identical in `main`.

The new unit test was verified to fail without the production change (`Expected <bool>: false to be true` on the finalizer patch assertion) and pass with it; the rest of the `pkg/storage/cbt` suite is green (210 specs).

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required — bug fix within VEP-25, no new design
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required — none; no API or storage change
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test — unit test added; happy to add an e2e case in `tests/storage/backup.go` if reviewers want one for this path
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required — not required
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered — not required
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md) — AI-assisted, disclosed via commit trailer, reviewed and tested by the author

### Release note
```release-note
Fixed a bug where a VirtualMachineBackup would never finish deleting if its VirtualMachineBackupTracker no longer existed, leaving the finalizer in place and blocking namespace deletion.
```
