### PR TITLE
fix: propagate hotplug volume attachment errors to volumeStatus

### DIFF
--- a/pkg/virt-handler/controller.go
+++ b/pkg/virt-handler/controller.go
@@ -69,6 +69,8 @@ const (
 	VolumeMountedToPodReason = "VolumeMountedToPod"
 	//VolumeUnplugged is the reason set when the volume is completely unplugged from the VMI
 	VolumeUnplugged = "VolumeUnplugged"
+	//HotplugFailedReason is the reason set when a hotplug volume attachment fails at the hypervisor level
+	HotplugFailedReason = "HotplugFailed"
 	//VMIDefined is the reason set when a VMI is defined
 	VMIDefined = "VirtualMachineInstance defined."
 	//VMIStarted is the reason set when a VMI is started

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -476,7 +476,11 @@ func (c *VirtualMachineController) generateEventsForVolumeStatusChange(vmi *v1.V
 			continue
 		}
 		if newStatus.Phase != oldStatus.Phase {
-			c.recorder.Event(vmi, k8sv1.EventTypeNormal, newStatus.Reason, newStatus.Message)
+			eventType := k8sv1.EventTypeNormal
+			if newStatus.Phase == v1.HotplugVolumeFailed {
+				eventType = k8sv1.EventTypeWarning
+			}
+			c.recorder.Event(vmi, eventType, newStatus.Reason, newStatus.Message)
 		}
 		delete(newStatusMapCopy, newStatus.Name)
 	}
@@ -486,7 +490,7 @@ func (c *VirtualMachineController) generateEventsForVolumeStatusChange(vmi *v1.V
 	}
 }
 
-func (c *VirtualMachineController) updateHotplugVolumeStatus(vmi *v1.VirtualMachineInstance, volumeStatus v1.VolumeStatus, specVolumeMap map[string]struct{}) (v1.VolumeStatus, bool) {
+func (c *VirtualMachineController) updateHotplugVolumeStatus(vmi *v1.VirtualMachineInstance, volumeStatus v1.VolumeStatus, specVolumeMap map[string]struct{}, syncErr error) (v1.VolumeStatus, bool) {
 	needsRefresh := false
 	if volumeStatus.Target == "" {
 		needsRefresh = true
@@ -495,18 +499,20 @@ func (c *VirtualMachineController) updateHotplugVolumeStatus(vmi *v1.VirtualMach
 			c.logger.Object(vmi).Errorf("error occurred while checking if volume is mounted: %v", err)
 		}
 		if mounted {
-			if _, ok := specVolumeMap[volumeStatus.Name]; ok && canUpdateToMounted(volumeStatus.Phase) {
+			if syncErr != nil && volumeStatus.Phase == v1.HotplugVolumeMounted {
+				log.DefaultLogger().Infof("Hotplug attachment of volume %s failed: %v", volumeStatus.Name, syncErr)
+				volumeStatus.Phase = v1.HotplugVolumeFailed
+				volumeStatus.Message = syncErr.Error()
+				volumeStatus.Reason = HotplugFailedReason
+			} else if _, ok := specVolumeMap[volumeStatus.Name]; ok && canUpdateToMounted(volumeStatus.Phase) {
 				log.DefaultLogger().Infof("Marking volume %s as mounted in pod, it can now be attached", volumeStatus.Name)
-				// mounted, and still in spec, and in phase we can change, update status to mounted.
 				volumeStatus.Phase = v1.HotplugVolumeMounted
 				volumeStatus.Message = fmt.Sprintf("Volume %s has been mounted in virt-launcher pod", volumeStatus.Name)
 				volumeStatus.Reason = VolumeMountedToPodReason
 			}
 		} else {
-			// Not mounted, check if the volume is in the spec, if not update status
 			if _, ok := specVolumeMap[volumeStatus.Name]; !ok && canUpdateToUnmounted(volumeStatus.Phase) {
 				log.DefaultLogger().Infof("Marking volume %s as unmounted from pod, it can now be detached", volumeStatus.Name)
-				// Not mounted.
 				volumeStatus.Phase = v1.HotplugVolumeUnMounted
 				volumeStatus.Message = fmt.Sprintf("Volume %s has been unmounted from virt-launcher pod", volumeStatus.Name)
 				volumeStatus.Reason = VolumeUnMountedFromPodReason
@@ -521,7 +527,7 @@ func (c *VirtualMachineController) updateHotplugVolumeStatus(vmi *v1.VirtualMach
 	return volumeStatus, needsRefresh
 }
 
-func (c *VirtualMachineController) updateVolumeStatusesFromDomain(vmi *v1.VirtualMachineInstance, domain *api.Domain) bool {
+func (c *VirtualMachineController) updateVolumeStatusesFromDomain(vmi *v1.VirtualMachineInstance, domain *api.Domain, syncErr error) bool {
 	// The return value is only used by unit tests
 	hasHotplug := false
 
@@ -555,7 +561,7 @@ func (c *VirtualMachineController) updateVolumeStatusesFromDomain(vmi *v1.Virtua
 		volumeStatus.Target = diskDeviceMap[volumeStatus.Name]
 		if volumeStatus.HotplugVolume != nil {
 			hasHotplug = true
-			volumeStatus, tmpNeedsRefresh = c.updateHotplugVolumeStatus(vmi, volumeStatus, specVolumeMap)
+			volumeStatus, tmpNeedsRefresh = c.updateHotplugVolumeStatus(vmi, volumeStatus, specVolumeMap, syncErr)
 			needsRefresh = needsRefresh || tmpNeedsRefresh
 		}
 		if volumeStatus.MemoryDumpVolume != nil {
@@ -952,14 +958,14 @@ func (c *VirtualMachineController) updateMemoryInfo(vmi *v1.VirtualMachineInstan
 	return nil
 }
 
-func (c *VirtualMachineController) updateVMIStatusFromDomain(vmi *v1.VirtualMachineInstance, domain *api.Domain) error {
+func (c *VirtualMachineController) updateVMIStatusFromDomain(vmi *v1.VirtualMachineInstance, domain *api.Domain, syncErr error) error {
 	c.updateIsoSizeStatus(vmi)
 	err := c.updateSELinuxContext(vmi)
 	if err != nil {
 		c.logger.Reason(err).Errorf("couldn't find the SELinux context for %s", vmi.Name)
 	}
 	c.updateGuestInfoFromDomain(vmi, domain)
-	c.updateVolumeStatusesFromDomain(vmi, domain)
+	c.updateVolumeStatusesFromDomain(vmi, domain, syncErr)
 	c.updateFSFreezeStatus(vmi, domain)
 	c.updateBackupStatus(vmi, domain)
 	c.updateMachineType(vmi, domain)
@@ -995,7 +1001,7 @@ func (c *VirtualMachineController) updateVMIStatus(oldStatus *v1.VirtualMachineI
 	}
 
 	// Update VMI status fields based on what is reported on the domain
-	err = c.updateVMIStatusFromDomain(vmi, domain)
+	err = c.updateVMIStatusFromDomain(vmi, domain, syncError)
 	if err != nil {
 		return err
 	}

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -1708,7 +1708,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 				domain := api.NewMinimalDomainWithUUID("testvmi", vmiTestUUID)
 				domain.Status.Status = api.Running
 				addVMI(vmi, domain)
-				hasHotplug := controller.updateVolumeStatusesFromDomain(vmi, domain)
+				hasHotplug := controller.updateVolumeStatusesFromDomain(vmi, domain, nil)
 				Expect(hasHotplug).To(BeFalse())
 			})
 
@@ -1736,7 +1736,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 					},
 				})
 				addVMI(vmi, domain)
-				hasHotplug := controller.updateVolumeStatusesFromDomain(vmi, domain)
+				hasHotplug := controller.updateVolumeStatusesFromDomain(vmi, domain, nil)
 				testutils.ExpectEvent(recorder, VolumeReadyReason)
 				Expect(hasHotplug).To(BeTrue())
 			})
@@ -1762,13 +1762,13 @@ var _ = Describe("VirtualMachineInstance", func() {
 				domain.Status.Status = api.Running
 				addVMI(vmi, domain)
 				mockHotplugVolumeMounter.EXPECT().IsMounted(vmi, "test", gomock.Any()).Return(true, nil)
-				hasHotplug := controller.updateVolumeStatusesFromDomain(vmi, domain)
+				hasHotplug := controller.updateVolumeStatusesFromDomain(vmi, domain, nil)
 				Expect(hasHotplug).To(BeTrue())
 				Expect(vmi.Status.VolumeStatus[0].Phase).To(Equal(v1.HotplugVolumeMounted))
 				testutils.ExpectEvent(recorder, "Volume test has been mounted in virt-launcher pod")
 				By("Calling it again with updated status, no new events are generated")
 				mockHotplugVolumeMounter.EXPECT().IsMounted(vmi, "test", gomock.Any()).Return(true, nil)
-				controller.updateVolumeStatusesFromDomain(vmi, domain)
+				controller.updateVolumeStatusesFromDomain(vmi, domain, nil)
 			},
 				Entry("When current phase is bound", v1.VolumeBound),
 				Entry("When current phase is pending", v1.VolumePending),
@@ -1793,13 +1793,13 @@ var _ = Describe("VirtualMachineInstance", func() {
 				domain.Status.Status = api.Running
 				addVMI(vmi, domain)
 				mockHotplugVolumeMounter.EXPECT().IsMounted(vmi, "test", gomock.Any()).Return(false, nil)
-				hasHotplug := controller.updateVolumeStatusesFromDomain(vmi, domain)
+				hasHotplug := controller.updateVolumeStatusesFromDomain(vmi, domain, nil)
 				Expect(hasHotplug).To(BeTrue())
 				Expect(vmi.Status.VolumeStatus[0].Phase).To(Equal(v1.HotplugVolumeUnMounted))
 				testutils.ExpectEvent(recorder, "Volume test has been unmounted from virt-launcher pod")
 				By("Calling it again with updated status, no new events are generated")
 				mockHotplugVolumeMounter.EXPECT().IsMounted(vmi, "test", gomock.Any()).Return(false, nil)
-				controller.updateVolumeStatusesFromDomain(vmi, domain)
+				controller.updateVolumeStatusesFromDomain(vmi, domain, nil)
 			},
 				Entry("When current phase is bound", v1.VolumeReady),
 				Entry("When current phase is pending", v1.HotplugVolumeMounted),
@@ -1827,7 +1827,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 				addVMI(vmi, domain)
 				// IsMounted returns true — block device still exists on host
 				mockHotplugVolumeMounter.EXPECT().IsMounted(vmi, "test", gomock.Any()).Return(true, nil)
-				hasHotplug := controller.updateVolumeStatusesFromDomain(vmi, domain)
+				hasHotplug := controller.updateVolumeStatusesFromDomain(vmi, domain, nil)
 				Expect(hasHotplug).To(BeTrue())
 				// Phase should NOT change — we wait for Unmount() to clean up the
 				// block device before advancing to avoid breaking the safety invariant
@@ -1837,6 +1837,61 @@ var _ = Describe("VirtualMachineInstance", func() {
 				Entry("When current phase is HotplugVolumeMounted", v1.HotplugVolumeMounted),
 				Entry("When current phase is HotplugVolumeAttachedToNode", v1.HotplugVolumeAttachedToNode),
 			)
+
+			It("should set HotplugVolumeFailed when volume is mounted but attachment fails with syncErr", func() {
+				vmi := api2.NewMinimalVMI("testvmi")
+				vmi.UID = vmiTestUUID
+				vmi.Status.Phase = v1.Running
+				vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
+					Name: "test",
+				})
+				vmi.Status.VolumeStatus = append(vmi.Status.VolumeStatus, v1.VolumeStatus{
+					Name:  "test",
+					Phase: v1.HotplugVolumeMounted,
+					HotplugVolume: &v1.HotplugVolumeStatus{
+						AttachPodName: "testpod",
+						AttachPodUID:  "1234",
+					},
+				})
+				domain := api.NewMinimalDomainWithUUID("testvmi", vmiTestUUID)
+				domain.Status.Status = api.Running
+				addVMI(vmi, domain)
+				syncErr := fmt.Errorf("server error. command SyncVMI failed: \"virError(Code=1, Domain=10, Message='internal error: unable to execute QEMU command 'device_add': The serial number can't be longer than 36 characters')\"")
+				mockHotplugVolumeMounter.EXPECT().IsMounted(vmi, "test", gomock.Any()).Return(true, nil)
+				hasHotplug := controller.updateVolumeStatusesFromDomain(vmi, domain, syncErr)
+				Expect(hasHotplug).To(BeTrue())
+				Expect(vmi.Status.VolumeStatus[0].Phase).To(Equal(v1.HotplugVolumeFailed))
+				Expect(vmi.Status.VolumeStatus[0].Reason).To(Equal(HotplugFailedReason))
+				Expect(vmi.Status.VolumeStatus[0].Message).To(ContainSubstring("serial number"))
+				testutils.ExpectEvent(recorder, HotplugFailedReason)
+			})
+
+			It("should not overwrite HotplugVolumeFailed on subsequent syncs", func() {
+				vmi := api2.NewMinimalVMI("testvmi")
+				vmi.UID = vmiTestUUID
+				vmi.Status.Phase = v1.Running
+				vmi.Spec.Volumes = append(vmi.Spec.Volumes, v1.Volume{
+					Name: "test",
+				})
+				vmi.Status.VolumeStatus = append(vmi.Status.VolumeStatus, v1.VolumeStatus{
+					Name:    "test",
+					Phase:   v1.HotplugVolumeFailed,
+					Reason:  HotplugFailedReason,
+					Message: "previous error",
+					HotplugVolume: &v1.HotplugVolumeStatus{
+						AttachPodName: "testpod",
+						AttachPodUID:  "1234",
+					},
+				})
+				domain := api.NewMinimalDomainWithUUID("testvmi", vmiTestUUID)
+				domain.Status.Status = api.Running
+				addVMI(vmi, domain)
+				mockHotplugVolumeMounter.EXPECT().IsMounted(vmi, "test", gomock.Any()).Return(true, nil)
+				hasHotplug := controller.updateVolumeStatusesFromDomain(vmi, domain, nil)
+				Expect(hasHotplug).To(BeTrue())
+				Expect(vmi.Status.VolumeStatus[0].Phase).To(Equal(v1.HotplugVolumeFailed))
+				Expect(vmi.Status.VolumeStatus[0].Message).To(Equal("previous error"))
+			})
 
 			DescribeTable("should generate an unmount event for cdrom when appropriate", func(source string) {
 				vmi := api2.NewMinimalVMI("testvmi")
@@ -1869,14 +1924,14 @@ var _ = Describe("VirtualMachineInstance", func() {
 					mockHotplugVolumeMounter.EXPECT().IsMounted(vmi, "test", gomock.Any()).Return(false, nil)
 					expectedPhase = v1.HotplugVolumeUnMounted
 				}
-				hasHotplug := controller.updateVolumeStatusesFromDomain(vmi, domain)
+				hasHotplug := controller.updateVolumeStatusesFromDomain(vmi, domain, nil)
 				Expect(hasHotplug).To(BeTrue())
 				Expect(vmi.Status.VolumeStatus[0].Phase).To(Equal(expectedPhase))
 				if source == "" {
 					testutils.ExpectEvent(recorder, "Volume test has been unmounted from virt-launcher pod")
 					By("Calling it again with updated status, no new events are generated")
 					mockHotplugVolumeMounter.EXPECT().IsMounted(vmi, "test", gomock.Any()).Return(false, nil)
-					controller.updateVolumeStatusesFromDomain(vmi, domain)
+					controller.updateVolumeStatusesFromDomain(vmi, domain, nil)
 				}
 			},
 				Entry("When target is set", "test"),
@@ -1912,13 +1967,13 @@ var _ = Describe("VirtualMachineInstance", func() {
 					},
 				})
 				addVMI(vmi, domain)
-				hasHotplug := controller.updateVolumeStatusesFromDomain(vmi, domain)
+				hasHotplug := controller.updateVolumeStatusesFromDomain(vmi, domain, nil)
 				Expect(hasHotplug).To(BeTrue())
 				Expect(vmi.Status.VolumeStatus[0].Phase).To(Equal(v1.VolumeReady))
 				Expect(vmi.Status.VolumeStatus[0].Target).To(Equal("vdbbb"))
 				testutils.ExpectEvent(recorder, "Successfully attach hotplugged volume test to VM")
 				By("Calling it again with updated status, no new events are generated")
-				controller.updateVolumeStatusesFromDomain(vmi, domain)
+				controller.updateVolumeStatusesFromDomain(vmi, domain, nil)
 			})
 
 			It("generateEventsForVolumeStatusChange should not modify arguments", func() {
@@ -1979,7 +2034,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 				updatedVolumeStatus := *volumeStatus.DeepCopy()
 				updatedVolumeStatus.MemoryDumpVolume.TargetFileName = dumpTargetFile(vmi.Name, volumeStatus.Name)
 				mockHotplugVolumeMounter.EXPECT().IsMounted(vmi, "test", gomock.Any()).Return(true, nil)
-				hasHotplug := controller.updateVolumeStatusesFromDomain(vmi, domain)
+				hasHotplug := controller.updateVolumeStatusesFromDomain(vmi, domain, nil)
 				Expect(hasHotplug).To(BeTrue())
 
 				Expect(vmi.Status.VolumeStatus[0].Phase).To(Equal(v1.MemoryDumpVolumeInProgress))
@@ -1987,7 +2042,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 				testutils.ExpectEvent(recorder, "Memory dump Volume test is attached, getting memory dump")
 				By("Calling it again with updated status, no new events are generated as long as memory dump not completed")
 				mockHotplugVolumeMounter.EXPECT().IsMounted(vmi, "test", gomock.Any()).Return(true, nil)
-				controller.updateVolumeStatusesFromDomain(vmi, domain)
+				controller.updateVolumeStatusesFromDomain(vmi, domain, nil)
 			})
 
 			It("Should generate memory dump completed event once memory dump completed", func() {
@@ -2024,7 +2079,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 				addVMI(vmi, domain)
 
 				mockHotplugVolumeMounter.EXPECT().IsMounted(vmi, "test", gomock.Any()).Return(true, nil)
-				hasHotplug := controller.updateVolumeStatusesFromDomain(vmi, domain)
+				hasHotplug := controller.updateVolumeStatusesFromDomain(vmi, domain, nil)
 				Expect(hasHotplug).To(BeTrue())
 
 				Expect(vmi.Status.VolumeStatus[0].Phase).To(Equal(v1.MemoryDumpVolumeCompleted))
@@ -2033,7 +2088,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 				testutils.ExpectEvent(recorder, "Memory dump to Volume test has completed successfully")
 				By("Calling it again with updated status, no new events are generated as long as memory dump not completed")
 				mockHotplugVolumeMounter.EXPECT().IsMounted(vmi, "test", gomock.Any()).Return(true, nil)
-				controller.updateVolumeStatusesFromDomain(vmi, domain)
+				controller.updateVolumeStatusesFromDomain(vmi, domain, nil)
 			})
 
 			It("Should generate memory dump failed event if memory dump failed", func() {
@@ -2072,7 +2127,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 				addVMI(vmi, domain)
 
 				mockHotplugVolumeMounter.EXPECT().IsMounted(vmi, "test", gomock.Any()).Return(true, nil)
-				hasHotplug := controller.updateVolumeStatusesFromDomain(vmi, domain)
+				hasHotplug := controller.updateVolumeStatusesFromDomain(vmi, domain, nil)
 				Expect(hasHotplug).To(BeTrue())
 
 				Expect(vmi.Status.VolumeStatus[0].Phase).To(Equal(v1.MemoryDumpVolumeFailed))
@@ -2081,7 +2136,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 				testutils.ExpectEvent(recorder, fmt.Sprintf("Memory dump to pvc %s failed: %s", volumeStatus.Name, failureReason))
 				By("Calling it again with updated status, no new events are generated as long as memory dump not completed")
 				mockHotplugVolumeMounter.EXPECT().IsMounted(vmi, "test", gomock.Any()).Return(true, nil)
-				controller.updateVolumeStatusesFromDomain(vmi, domain)
+				controller.updateVolumeStatusesFromDomain(vmi, domain, nil)
 			})
 
 		})

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -515,6 +515,8 @@ const (
 	MemoryDumpVolumeInProgress VolumePhase = "MemoryDumpInProgress"
 	// MemoryDumpVolumeInProgress means that the volume for the memory dump was attached, and now the command is being triggered
 	MemoryDumpVolumeFailed VolumePhase = "MemoryDumpFailed"
+	// HotplugVolumeFailed means the hotplug volume attachment to the VM failed at the hypervisor level.
+	HotplugVolumeFailed VolumePhase = "HotplugFailed"
 )
 
 func (v *VirtualMachineInstance) IsScheduling() bool {


### PR DESCRIPTION
**What does this PR do?**

When a hotplug volume fails to attach at the hypervisor level (e.g. QEMU rejects a serial number longer than 36 characters), the error was not surfaced to the user. The VMI stayed Running, the volume stayed stuck at MountedToPod, and virt-handler entered an infinite retry loop with no user-visible indication of the failure.

This PR defines a new `HotplugVolumeFailed` volume phase and `HotplugFailed` reason. When virt-handler detects a sync error for a mounted hotplug volume that has no target device in the domain, it transitions the volume to `HotplugVolumeFailed`, sets the libvirt error as the `volumeStatus.Message`, and emits a Warning event.

**Why is this needed?**

Today, hotplugging a PVC with a name longer than 36 characters (without explicitly setting `--serial`) causes an infinite retry loop in virt-launcher with no feedback to the user. The only way to discover the error is to dig through virt-launcher logs.

**How was this tested?**

- Unit tests for `HotplugVolumeFailed` phase transition and stickiness
- Reproduced the original bug on a CNV 5.0.0 s390x cluster (44-char PVC name)

**Release note**

```release-note
Hotplug volume attachment failures at the hypervisor level are now surfaced to the user via volumeStatus.Phase=HotplugFailed with the error in volumeStatus.Message, instead of silently retrying indefinitely.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a distinct failed status for hotplugged volumes when attachment synchronization fails.
  - Failure details are surfaced in volume status updates.
  - Warning events are emitted when hotplug volume attachment fails.

- **Bug Fixes**
  - Prevented failed hotplug volumes from being incorrectly reported as successfully mounted during subsequent status updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->