### PR TITLE
tests: drop kind-sriov handling from automation/test.sh

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -195,13 +195,7 @@ if [ ! -d "kubevirtci/cluster-up/cluster/$KUBEVIRT_PROVIDER" ]; then
   exit 1
 fi
 
-if [[ $TARGET =~ sriov.* ]]; then
-  if [[ $TARGET =~ kind.* ]]; then
-    export KUBEVIRT_NUM_NODES=3
-  fi
-  export KUBEVIRT_DEPLOY_CDI="false"
-  export KUBEVIRT_VERBOSITY=${KUBEVIRT_VERBOSITY:-"virtLauncher:3,virtHandler:3"}
-elif [[ $TARGET =~ vgpu.* ]]; then
+if [[ $TARGET =~ vgpu.* ]]; then
   export KUBEVIRT_NUM_NODES=1
 else
   export KUBEVIRT_NUM_NODES=${KUBEVIRT_NUM_NODES:-2}
@@ -557,7 +551,7 @@ if [[ -z ${KUBEVIRT_E2E_FOCUS} && -z ${KUBEVIRT_E2E_SKIP} && -z ${label_filter} 
     label_filter='(sig-network && conformance)'
   elif [[ $TARGET =~ sig-network ]]; then
     label_filter='(sig-network,netCustomBindingPlugins)'
-    # SR-IOV tests runs on dedicated lane (matching the pattern: *kind-sriov*)
+    # SR-IOV tests runs on dedicated lane
     add_to_label_filter "(!SRIOV)" "&&"
     if [[ $KUBEVIRT_WITH_DYN_NET_CTRL == "true" ]]; then
       add_to_label_filter "(!migration-based-hotplug-NICs)" "&&"
@@ -602,8 +596,6 @@ if [[ -z ${KUBEVIRT_E2E_FOCUS} && -z ${KUBEVIRT_E2E_SKIP} && -z ${label_filter} 
     else
       label_filter='(sig-operator)'
     fi
-  elif [[ $TARGET =~ sriov.* ]]; then
-    label_filter='(SRIOV)'
   elif [[ $TARGET =~ emulated-igb ]]; then
     label_filter='(SRIOV)'
   elif [[ $TARGET =~ gpu.* ]]; then


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Remove the dedicated sriov lane setup from automation/test.sh now that kind-sriov is being retired. This keeps the test harness from carrying provider-specific defaults that no longer apply.


### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

