### PR TITLE
snapshot: capture instancetype/preference CRs from Status for offline snapshots

### DIFF
--- a/pkg/instancetype/apply/BUILD.bazel
+++ b/pkg/instancetype/apply/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
     deps = [
         "//pkg/instancetype/conflict:go_default_library",
         "//pkg/instancetype/preference/apply:go_default_library",
+        "//pkg/instancetype/preference/validation:go_default_library",
         "//pkg/pointer:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/api/instancetype/v1beta1:go_default_library",

--- a/pkg/instancetype/apply/annotations.go
+++ b/pkg/instancetype/apply/annotations.go
@@ -24,7 +24,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/instancetype/conflict"
 )
 
-func applyInstanceTypeAnnotations(annotations map[string]string, target metav1.Object) (conflicts conflict.Conflicts) {
+func applyInstanceTypeAnnotations(baseConflict *conflict.Conflict, annotations map[string]string, target metav1.Object) (conflicts conflict.Conflicts) {
 	if target.GetAnnotations() == nil {
 		target.SetAnnotations(make(map[string]string))
 	}
@@ -33,7 +33,7 @@ func applyInstanceTypeAnnotations(annotations map[string]string, target metav1.O
 	for key, value := range annotations {
 		if targetValue, exists := targetAnnotations[key]; exists {
 			if targetValue != value {
-				conflicts = append(conflicts, conflict.New("annotations", key))
+				conflicts = append(conflicts, baseConflict.NewChild("annotations", key))
 			}
 			continue
 		}

--- a/pkg/instancetype/apply/annotations.go
+++ b/pkg/instancetype/apply/annotations.go
@@ -24,7 +24,11 @@ import (
 	"kubevirt.io/kubevirt/pkg/instancetype/conflict"
 )
 
-func applyInstanceTypeAnnotations(baseConflict *conflict.Conflict, annotations map[string]string, target metav1.Object) (conflicts conflict.Conflicts) {
+func applyInstanceTypeAnnotations(
+	baseConflict *conflict.Conflict,
+	annotations map[string]string,
+	target metav1.Object,
+) (conflicts conflict.Conflicts) {
 	if target.GetAnnotations() == nil {
 		target.SetAnnotations(make(map[string]string))
 	}

--- a/pkg/instancetype/apply/annotations_test.go
+++ b/pkg/instancetype/apply/annotations_test.go
@@ -70,7 +70,7 @@ var _ = Describe("Instancetype.Spec.Annotations", func() {
 
 			conflicts := vmiApplier.ApplyToVMI(field, instancetypeSpec, nil, &vmi.Spec, &vmi.ObjectMeta)
 			Expect(conflicts).To(HaveLen(1))
-			Expect(conflicts[0].String()).To(Equal("annotations.annotation-1"))
+			Expect(conflicts[0].String()).To(Equal("spec.template.spec.annotations.annotation-1"))
 		})
 	})
 })

--- a/pkg/instancetype/apply/cpu.go
+++ b/pkg/instancetype/apply/cpu.go
@@ -27,6 +27,7 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/instancetype/conflict"
 	preferenceApply "kubevirt.io/kubevirt/pkg/instancetype/preference/apply"
+	preferenceValidation "kubevirt.io/kubevirt/pkg/instancetype/preference/validation"
 )
 
 func applyCPU(
@@ -66,6 +67,10 @@ func applyCPU(
 
 	if instancetypeSpec.CPU.MaxSockets != nil {
 		vmiSpec.Domain.CPU.MaxSockets = *instancetypeSpec.CPU.MaxSockets
+	}
+
+	if spreadConflict := preferenceValidation.CheckSpreadCPUTopology(instancetypeSpec, preferenceSpec); spreadConflict != nil {
+		return conflict.Conflicts{spreadConflict}
 	}
 
 	applyGuestCPUTopology(instancetypeSpec.CPU.Guest, preferenceSpec, vmiSpec)

--- a/pkg/instancetype/apply/cpu.go
+++ b/pkg/instancetype/apply/cpu.go
@@ -84,6 +84,8 @@ func applyGuestCPUTopology(vCPUs uint32, preferenceSpec *v1beta1.VirtualMachineP
 	vmiSpec.Domain.CPU.Sockets = 1
 	vmiSpec.Domain.CPU.Threads = 1
 
+	// 1 vCPU always produces {1,1,1} regardless of topology, bypassing the
+	// spread/topology switch below. CheckSpreadCPUTopology exempts this case too.
 	if vCPUs == 1 {
 		return
 	}

--- a/pkg/instancetype/apply/cpu_test.go
+++ b/pkg/instancetype/apply/cpu_test.go
@@ -392,8 +392,8 @@ var _ = Describe("instancetype.spec.CPU and preference.spec.CPU", func() {
 				},
 				virtv1.CPU{Sockets: 3, Cores: 4, Threads: 2},
 			),
-			Entry("to SocketsCoresThreads with 36 vCPUs and a ratio of 1:4:2",
-				uint32(36),
+			Entry("to SocketsCoresThreads with 32 vCPUs and a ratio of 1:4:2",
+				uint32(32),
 				v1beta1.VirtualMachinePreferenceSpec{
 					CPU: &v1beta1.CPUPreferences{
 						SpreadOptions: &v1beta1.SpreadOptions{

--- a/pkg/instancetype/apply/gpu.go
+++ b/pkg/instancetype/apply/gpu.go
@@ -39,7 +39,9 @@ func applyGPUs(
 	}
 
 	vmiSpec.Domain.Devices.GPUs = make([]virtv1.GPU, len(instancetypeSpec.GPUs))
-	copy(vmiSpec.Domain.Devices.GPUs, instancetypeSpec.GPUs)
+	for i := range instancetypeSpec.GPUs {
+		instancetypeSpec.GPUs[i].DeepCopyInto(&vmiSpec.Domain.Devices.GPUs[i])
+	}
 
 	return nil
 }

--- a/pkg/instancetype/apply/gpu.go
+++ b/pkg/instancetype/apply/gpu.go
@@ -1,3 +1,4 @@
+//nolint:dupl
 /*
  * This file is part of the KubeVirt project
  *

--- a/pkg/instancetype/apply/hostdevices.go
+++ b/pkg/instancetype/apply/hostdevices.go
@@ -39,7 +39,9 @@ func applyHostDevices(
 	}
 
 	vmiSpec.Domain.Devices.HostDevices = make([]virtv1.HostDevice, len(instancetypeSpec.HostDevices))
-	copy(vmiSpec.Domain.Devices.HostDevices, instancetypeSpec.HostDevices)
+	for i := range instancetypeSpec.HostDevices {
+		instancetypeSpec.HostDevices[i].DeepCopyInto(&vmiSpec.Domain.Devices.HostDevices[i])
+	}
 
 	return nil
 }

--- a/pkg/instancetype/apply/hostdevices.go
+++ b/pkg/instancetype/apply/hostdevices.go
@@ -1,3 +1,4 @@
+//nolint:dupl
 /*
  * This file is part of the KubeVirt project
  *

--- a/pkg/instancetype/apply/memory.go
+++ b/pkg/instancetype/apply/memory.go
@@ -37,7 +37,9 @@ func applyMemory(
 		vmiSpec.Domain.Memory = &virtv1.Memory{}
 	}
 
-	// If we have any conflicts return as there's no need to apply
+	// validateMemory must run before any writes: it rejects a pre-existing
+	// Resources.Requests[memory] entry, but applyMemory itself writes that
+	// entry when OvercommitPercent > 0.
 	if conflicts := validateMemory(baseConflict, instancetypeSpec, vmiSpec); len(conflicts) > 0 {
 		return conflicts
 	}

--- a/pkg/instancetype/apply/nodeselector.go
+++ b/pkg/instancetype/apply/nodeselector.go
@@ -40,6 +40,8 @@ func applyNodeSelector(
 		return conflict.Conflicts{baseConflict.NewChild("nodeSelector")}
 	}
 
+	// maps.Clone is a shallow copy, which is correct here: map[string]string
+	// values are immutable in Go, so there is no aliasing risk.
 	vmiSpec.NodeSelector = maps.Clone(instancetypeSpec.NodeSelector)
 
 	return nil

--- a/pkg/instancetype/apply/vmi.go
+++ b/pkg/instancetype/apply/vmi.go
@@ -66,7 +66,7 @@ func (a *vmiApplier) ApplyToVMI(
 		conflicts = append(conflicts, applyLaunchSecurity(baseConflict, instancetypeSpec, vmiSpec)...)
 		conflicts = append(conflicts, applyGPUs(baseConflict, instancetypeSpec, vmiSpec)...)
 		conflicts = append(conflicts, applyHostDevices(baseConflict, instancetypeSpec, vmiSpec)...)
-		conflicts = append(conflicts, applyInstanceTypeAnnotations(instancetypeSpec.Annotations, vmiMetadata)...)
+		conflicts = append(conflicts, applyInstanceTypeAnnotations(baseConflict, instancetypeSpec.Annotations, vmiMetadata)...)
 		if len(conflicts) > 0 {
 			return conflicts
 		}

--- a/pkg/instancetype/apply/vmi.go
+++ b/pkg/instancetype/apply/vmi.go
@@ -67,6 +67,9 @@ func (a *vmiApplier) ApplyToVMI(
 		conflicts = append(conflicts, applyGPUs(baseConflict, instancetypeSpec, vmiSpec)...)
 		conflicts = append(conflicts, applyHostDevices(baseConflict, instancetypeSpec, vmiSpec)...)
 		conflicts = append(conflicts, applyInstanceTypeAnnotations(baseConflict, instancetypeSpec.Annotations, vmiMetadata)...)
+		// Preference defaults are intentionally skipped when the instancetype
+		// has conflicts: the VM spec is already invalid, and applying defaults
+		// on top of a broken state would be misleading to the caller.
 		if len(conflicts) > 0 {
 			return conflicts
 		}

--- a/pkg/instancetype/find/BUILD.bazel
+++ b/pkg/instancetype/find/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//staging/src/kubevirt.io/api/instancetype:go_default_library",
         "//staging/src/kubevirt.io/api/instancetype/v1beta1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/k8s.io/api/apps/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",

--- a/pkg/instancetype/find/revision.go
+++ b/pkg/instancetype/find/revision.go
@@ -26,6 +26,7 @@ import (
 	virtv1 "kubevirt.io/api/core/v1"
 	instancetypeapi "kubevirt.io/api/instancetype"
 	"kubevirt.io/client-go/kubecli"
+	"kubevirt.io/client-go/log"
 )
 
 type revisionFinder struct {
@@ -59,6 +60,8 @@ func (f *revisionFinder) Find(vm *virtv1.VirtualMachine) (*appsv1.ControllerRevi
 		if label, ok := cr.Labels[instancetypeapi.ControllerRevisionObjectNameLabel]; ok && label == vm.Spec.Instancetype.Name {
 			return cr, nil
 		}
+		log.Log.Object(vm).Warningf("ControllerRevision %s is missing or has an unexpected %s label, falling back to live API lookup",
+			ref.ControllerRevisionRef.Name, instancetypeapi.ControllerRevisionObjectNameLabel)
 	}
 	return nil, nil
 }

--- a/pkg/instancetype/preference/apply/cpu.go
+++ b/pkg/instancetype/preference/apply/cpu.go
@@ -52,6 +52,8 @@ const defaultSpreadRatio uint32 = 2
 
 func GetSpreadOptions(preferenceSpec *v1beta1.VirtualMachinePreferenceSpec) (uint32, v1beta1.SpreadAcross) {
 	ratio := defaultSpreadRatio
+	// Deprecated top-level field is applied first so that the structured
+	// SpreadOptions.Ratio can override it if both are set.
 	if preferenceSpec.PreferSpreadSocketToCoreRatio != 0 {
 		ratio = preferenceSpec.PreferSpreadSocketToCoreRatio
 	}

--- a/pkg/instancetype/preference/requirements/arch.go
+++ b/pkg/instancetype/preference/requirements/arch.go
@@ -32,6 +32,9 @@ const (
 )
 
 func checkArch(preferenceSpec *v1beta1.VirtualMachinePreferenceSpec, vmiSpec *v1.VirtualMachineInstanceSpec) (conflict.Conflicts, error) {
+	if preferenceSpec.Requirements.Architecture == nil {
+		return nil, nil
+	}
 	if vmiSpec.Architecture != *preferenceSpec.Requirements.Architecture {
 		return conflict.Conflicts{conflict.New("spec", "template", "spec", "architecture")},
 			fmt.Errorf(requiredArchitectureNotUsedErrFmt, *preferenceSpec.Requirements.Architecture, vmiSpec.Architecture)

--- a/pkg/instancetype/preference/validation/cpu.go
+++ b/pkg/instancetype/preference/validation/cpu.go
@@ -62,6 +62,12 @@ func CheckSpreadCPUTopology(
 		return nil
 	}
 
+	// 1 vCPU always results in {1,1,1} via the early-return in applyGuestCPUTopology,
+	// so divisibility is irrelevant.
+	if instancetypeSpec.CPU.Guest == 1 {
+		return nil
+	}
+
 	ratio, across := apply.GetSpreadOptions(preferenceSpec)
 	switch across {
 	case v1beta1.SpreadAcrossSocketsCores:

--- a/pkg/instancetype/webhooks/vm/BUILD.bazel
+++ b/pkg/instancetype/webhooks/vm/BUILD.bazel
@@ -17,7 +17,6 @@ go_library(
         "//pkg/instancetype/preference/apply:go_default_library",
         "//pkg/instancetype/preference/find:go_default_library",
         "//pkg/instancetype/preference/requirements:go_default_library",
-        "//pkg/instancetype/preference/validation:go_default_library",
         "//pkg/util/webhooks:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/api/instancetype/v1beta1:go_default_library",

--- a/pkg/instancetype/webhooks/vm/admitter.go
+++ b/pkg/instancetype/webhooks/vm/admitter.go
@@ -32,7 +32,6 @@ import (
 	"kubevirt.io/kubevirt/pkg/instancetype/find"
 	preferenceFind "kubevirt.io/kubevirt/pkg/instancetype/preference/find"
 	"kubevirt.io/kubevirt/pkg/instancetype/preference/requirements"
-	"kubevirt.io/kubevirt/pkg/instancetype/preference/validation"
 )
 
 type instancetypeFinder interface {
@@ -95,10 +94,6 @@ func (a *admitter) ApplyToVM(vm *virtv1.VirtualMachine) (
 
 	if instancetypeSpec == nil && preferenceSpec == nil {
 		return nil, nil, nil
-	}
-
-	if spreadConflict := validation.CheckSpreadCPUTopology(instancetypeSpec, preferenceSpec); spreadConflict != nil {
-		return nil, nil, spreadConflict.StatusCauses()
 	}
 
 	conflicts := a.ApplyToVMI(

--- a/pkg/storage/snapshot/snapshot_test.go
+++ b/pkg/storage/snapshot/snapshot_test.go
@@ -2803,6 +2803,113 @@ var _ = Describe("Snapshot controlleer", func() {
 					),
 				)
 
+				DescribeTable("should capture ControllerRevision from Status when Spec.RevisionName is empty",
+					func(
+						getInstancetypeMatcher func() *v1.InstancetypeMatcher,
+						getInstancetypeStatus func() *v1.InstancetypeStatusRef,
+						getPreferenceMatcher func() *v1.PreferenceMatcher,
+						getPreferenceStatus func() *v1.InstancetypeStatusRef,
+						expectedCRCreates int,
+						getExpectedSnapshotContentVM func() *v1.VirtualMachine,
+					) {
+						vm.Spec.Instancetype = getInstancetypeMatcher()
+						vm.Status.InstancetypeRef = getInstancetypeStatus()
+						vm.Spec.Preference = getPreferenceMatcher()
+						vm.Status.PreferenceRef = getPreferenceStatus()
+
+						crCreates := 0
+						k8sClient.Fake.PrependReactor("create", "controllerrevisions", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+							crCreates++
+							return true, action.(testing.CreateAction).GetObject(), nil
+						})
+
+						createCalls := expectVMSnapshotContentCreate(vmSnapshotClient, createVirtualMachineSnapshotContent(vmSnapshot, getExpectedSnapshotContentVM(), nil))
+
+						vmSource.Add(vm)
+						vmSnapshotSource.Add(vmSnapshot)
+
+						addVirtualMachineSnapshot(vmSnapshot)
+						controller.processVMSnapshotWorkItem()
+						testutils.ExpectEvent(recorder, "SuccessfulVirtualMachineSnapshotContentCreate")
+						Expect(*updateStatusCalls).To(Equal(1))
+						Expect(*createCalls).To(Equal(1))
+						Expect(crCreates).To(Equal(expectedCRCreates))
+					},
+					Entry("for a referenced instancetype",
+						func() *v1.InstancetypeMatcher {
+							return &v1.InstancetypeMatcher{
+								Name: instancetypeObj.Name,
+								Kind: instancetypeapi.SingularResourceName,
+							}
+						},
+						func() *v1.InstancetypeStatusRef {
+							return &v1.InstancetypeStatusRef{
+								ControllerRevisionRef: &v1.ControllerRevisionRef{Name: instancetypeCR.Name},
+							}
+						},
+						func() *v1.PreferenceMatcher { return nil },
+						func() *v1.InstancetypeStatusRef { return nil },
+						1,
+						func() *v1.VirtualMachine {
+							expectedVM := vm.DeepCopy()
+							expectedVM.Spec.Instancetype.RevisionName = strings.Replace(instancetypeCR.Name, vm.Name, vmSnapshotName, 1)
+							return expectedVM
+						},
+					),
+					Entry("for a referenced preference",
+						func() *v1.InstancetypeMatcher { return nil },
+						func() *v1.InstancetypeStatusRef { return nil },
+						func() *v1.PreferenceMatcher {
+							return &v1.PreferenceMatcher{
+								Name: preferenceObj.Name,
+								Kind: instancetypeapi.SingularPreferenceResourceName,
+							}
+						},
+						func() *v1.InstancetypeStatusRef {
+							return &v1.InstancetypeStatusRef{
+								ControllerRevisionRef: &v1.ControllerRevisionRef{Name: preferenceCR.Name},
+							}
+						},
+						1,
+						func() *v1.VirtualMachine {
+							expectedVM := vm.DeepCopy()
+							expectedVM.Spec.Preference.RevisionName = strings.Replace(preferenceCR.Name, vm.Name, vmSnapshotName, 1)
+							return expectedVM
+						},
+					),
+					Entry("for a referenced instancetype and preference",
+						func() *v1.InstancetypeMatcher {
+							return &v1.InstancetypeMatcher{
+								Name: instancetypeObj.Name,
+								Kind: instancetypeapi.SingularResourceName,
+							}
+						},
+						func() *v1.InstancetypeStatusRef {
+							return &v1.InstancetypeStatusRef{
+								ControllerRevisionRef: &v1.ControllerRevisionRef{Name: instancetypeCR.Name},
+							}
+						},
+						func() *v1.PreferenceMatcher {
+							return &v1.PreferenceMatcher{
+								Name: preferenceObj.Name,
+								Kind: instancetypeapi.SingularPreferenceResourceName,
+							}
+						},
+						func() *v1.InstancetypeStatusRef {
+							return &v1.InstancetypeStatusRef{
+								ControllerRevisionRef: &v1.ControllerRevisionRef{Name: preferenceCR.Name},
+							}
+						},
+						2,
+						func() *v1.VirtualMachine {
+							expectedVM := vm.DeepCopy()
+							expectedVM.Spec.Instancetype.RevisionName = strings.Replace(instancetypeCR.Name, vm.Name, vmSnapshotName, 1)
+							expectedVM.Spec.Preference.RevisionName = strings.Replace(preferenceCR.Name, vm.Name, vmSnapshotName, 1)
+							return expectedVM
+						},
+					),
+				)
+
 			})
 		})
 

--- a/pkg/storage/snapshot/source.go
+++ b/pkg/storage/snapshot/source.go
@@ -368,21 +368,38 @@ func (s *vmSnapshotSource) captureInstancetypeControllerRevision(namespace, revi
 	return snapshotCR.Name, nil
 }
 
+func instancetypeRevisionName(specRevisionName string, statusRef *kubevirtv1.InstancetypeStatusRef) string {
+	if specRevisionName != "" {
+		return specRevisionName
+	}
+	if statusRef != nil && statusRef.ControllerRevisionRef != nil {
+		return statusRef.ControllerRevisionRef.Name
+	}
+	return ""
+}
+
+// captureInstancetypeControllerRevisions captures the instancetype and preference ControllerRevisions
+// for the snapshot. The vm parameter is a copy used to build the snapshot content (with Status zeroed
+// for offline snapshots), so s.vm.Status.*Ref is consulted directly for the revision name fallback.
 func (s *vmSnapshotSource) captureInstancetypeControllerRevisions(vm *snapshotv1.VirtualMachine) error {
-	if vm.Spec.Instancetype != nil && vm.Spec.Instancetype.RevisionName != "" {
-		snapshotCRName, err := s.captureInstancetypeControllerRevision(vm.Namespace, vm.Spec.Instancetype.RevisionName)
-		if err != nil {
-			return err
+	if vm.Spec.Instancetype != nil {
+		if revisionName := instancetypeRevisionName(vm.Spec.Instancetype.RevisionName, s.vm.Status.InstancetypeRef); revisionName != "" {
+			snapshotCRName, err := s.captureInstancetypeControllerRevision(vm.Namespace, revisionName)
+			if err != nil {
+				return err
+			}
+			vm.Spec.Instancetype.RevisionName = snapshotCRName
 		}
-		vm.Spec.Instancetype.RevisionName = snapshotCRName
 	}
 
-	if vm.Spec.Preference != nil && vm.Spec.Preference.RevisionName != "" {
-		snapshotCRName, err := s.captureInstancetypeControllerRevision(vm.Namespace, vm.Spec.Preference.RevisionName)
-		if err != nil {
-			return err
+	if vm.Spec.Preference != nil {
+		if revisionName := instancetypeRevisionName(vm.Spec.Preference.RevisionName, s.vm.Status.PreferenceRef); revisionName != "" {
+			snapshotCRName, err := s.captureInstancetypeControllerRevision(vm.Namespace, revisionName)
+			if err != nil {
+				return err
+			}
+			vm.Spec.Preference.RevisionName = snapshotCRName
 		}
-		vm.Spec.Preference.RevisionName = snapshotCRName
 	}
 
 	return nil

--- a/tests/storage/restore.go
+++ b/tests/storage/restore.go
@@ -695,6 +695,48 @@ var _ = Describe(SIG("VirtualMachineRestore Tests", func() {
 				Entry("with a running VM", v1.RunStrategyAlways),
 				Entry("with a stopped VM", v1.RunStrategyHalted),
 			)
+
+			It("should restore instancetype and preference ControllerRevisions captured from an offline snapshot", decorators.StorageCritical, Label("instancetype", "preference", "restore"), func() {
+				libvmi.WithRunStrategy(v1.RunStrategyHalted)(vm)
+				vm, err := virtClient.VirtualMachine(testsuite.GetTestNamespace(vm)).Create(context.Background(), vm, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Waiting until the VM has instancetype and preference ControllerRevision refs")
+				Eventually(matcher.ThisVM(vm)).WithTimeout(300 * time.Second).WithPolling(time.Second).Should(matcher.HaveControllerRevisionRefs())
+
+				for _, dvt := range vm.Spec.DataVolumeTemplates {
+					libstorage.EventuallyDVWith(vm.Namespace, dvt.Name, 180, HaveSucceeded())
+				}
+
+				By("Creating an offline VirtualMachineSnapshot")
+				snapshot = createSnapshot(vm)
+
+				By("Asserting that the snapshot content captured instancetype and preference ControllerRevision names")
+				content, err := virtClient.VirtualMachineSnapshotContent(vm.Namespace).Get(context.Background(), *snapshot.Status.VirtualMachineSnapshotContentName, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(content.Spec.Source.VirtualMachine).ToNot(BeNil())
+				Expect(content.Spec.Source.VirtualMachine.Spec.Instancetype).ToNot(BeNil())
+				Expect(content.Spec.Source.VirtualMachine.Spec.Instancetype.RevisionName).ToNot(BeEmpty())
+				Expect(content.Spec.Source.VirtualMachine.Spec.Preference).ToNot(BeNil())
+				Expect(content.Spec.Source.VirtualMachine.Spec.Preference.RevisionName).ToNot(BeEmpty())
+
+				By("Deleting the instancetype and preference to prevent controller re-reconciliation from masking a missing CR capture")
+				err = virtClient.VirtualMachineInstancetype(vm.Namespace).Delete(context.Background(), vm.Spec.Instancetype.Name, metav1.DeleteOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				err = virtClient.VirtualMachinePreference(vm.Namespace).Delete(context.Background(), vm.Spec.Preference.Name, metav1.DeleteOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Creating a VirtualMachineRestore")
+				restore = createRestoreDef(vm.Name, snapshot.Name)
+				restore, err = virtClient.VirtualMachineRestore(vm.Namespace).Create(context.Background(), restore, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Waiting until the restore completes")
+				restore = waitRestoreComplete(restore, vm.Name, &vm.UID)
+
+				By("Asserting that the restored VM has instancetype and preference ControllerRevisions sourced from the snapshot")
+				Eventually(matcher.ThisVM(vm)).WithTimeout(300 * time.Second).WithPolling(time.Second).Should(matcher.HaveControllerRevisionRefs())
+			})
 		})
 	})
 


### PR DESCRIPTION
/cc @0xFelix
/cc @ksimon1
/area instancetype
/area snapshot

### What this PR does

#### Before this PR:

Offline snapshots (stopped VMs) silently skip capturing the instancetype and preference `ControllerRevision` objects. Since #13916 moved the `ControllerRevisionRef` from `Spec` into `Status`, the offline branch of `captureVMSnapshotSpec` deep-copies the live VM `Spec` (which no longer contains `Spec.Instancetype.RevisionName`) and zeroes `Status`, causing `captureInstancetypeControllerRevisions` to find an empty revision name and skip capture entirely.

The online snapshot path is unaffected: it reads from the VMI revision `ControllerRevision` written by `patchVMRevision`, which backfills `Spec.Instancetype.RevisionName` from `Status` before serialization.

#### After this PR:

`captureInstancetypeControllerRevisions` falls back to `s.vm.Status.InstancetypeRef.ControllerRevisionRef` and `s.vm.Status.PreferenceRef.ControllerRevisionRef` when the spec `RevisionName` is empty. The captured snapshot CR name is still written back into `Spec.Instancetype.RevisionName` in the snapshot content, so the restore path requires no changes.

### References

- Fixes #18738
- Introduced by #13916

### Why we need it and why it was done in this way

The fix is minimal and contained to the capture path. Since `captureInstancetypeControllerRevisions` is a method on `vmSnapshotSource`, it has direct access to `s.vm` (the live VM with populated `Status`), making the fallback straightforward without restructuring.

The restore path (`restoreInstancetypeControllerRevisions`) does not need changes: once capture correctly stores the snapshot CR name in `Spec.Instancetype.RevisionName` within the snapshot content, the existing restore logic finds it there as before.

### Special notes for your reviewer

The existing functional tests in `tests/storage/restore.go` do not catch this regression because they never delete the instancetype/preference before restoring — the instancetype controller simply re-reconciles after restore and populates `Status` from the still-existing live objects, masking the missing CR capture. A follow-up e2e test that deletes the instancetype before restoring would provide proper coverage.

### Checklist

- [x] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note

```release-note
snapshot: offline snapshots of VMs using instancetypes or preferences now correctly capture the associated ControllerRevision objects, ensuring restores produce the exact configuration at snapshot time even if the original instancetype or preference is later deleted or modified.
```