### PR TITLE
net, netbinding: Add resource claim to NBP sidecar for DRA ifaces

### DIFF
--- a/pkg/hooks/hooks.go
+++ b/pkg/hooks/hooks.go
@@ -56,6 +56,7 @@ type HookSidecar struct {
 	PVC                      *PVC                             `json:"pvc,omitempty"`
 	DownwardAPI              v1.NetworkBindingDownwardAPIType `json:"-"`
 	NetworkBindingPluginName string                           `json:"-"`
+	ResourceClaims           []k8sv1.ResourceClaim            `json:"-"`
 }
 
 func UnmarshalHookSidecarList(vmiObject *v1.VirtualMachineInstance) (HookSidecarList, error) {

--- a/pkg/network/netbinding/BUILD.bazel
+++ b/pkg/network/netbinding/BUILD.bazel
@@ -7,7 +7,9 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/hooks:go_default_library",
+        "//pkg/network/vmispec:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
     ],
 )
 
@@ -26,5 +28,6 @@ go_test(
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
     ],
 )

--- a/pkg/network/netbinding/netbinding.go
+++ b/pkg/network/netbinding/netbinding.go
@@ -22,9 +22,12 @@ package netbinding
 import (
 	"fmt"
 
+	k8sv1 "k8s.io/api/core/v1"
+
 	v1 "kubevirt.io/api/core/v1"
 
 	"kubevirt.io/kubevirt/pkg/hooks"
+	"kubevirt.io/kubevirt/pkg/network/vmispec"
 )
 
 func NetBindingPluginSidecarList(vmi *v1.VirtualMachineInstance, config *v1.KubeVirtConfiguration) (hooks.HookSidecarList, error) {
@@ -33,6 +36,7 @@ func NetBindingPluginSidecarList(vmi *v1.VirtualMachineInstance, config *v1.Kube
 		registeredBindings = config.NetworkConfiguration.Binding
 	}
 
+	networkByName := vmispec.IndexNetworkSpecByName(vmi.Spec.Networks)
 	sidecars := map[string]*hooks.HookSidecar{}
 
 	for _, iface := range vmi.Spec.Domain.Devices.Interfaces {
@@ -56,6 +60,14 @@ func NetBindingPluginSidecarList(vmi *v1.VirtualMachineInstance, config *v1.Kube
 				DownwardAPI:              pluginInfo.DownwardAPI,
 				NetworkBindingPluginName: iface.Binding.Name,
 			}
+		}
+
+		if net, ok := networkByName[iface.Name]; ok && vmispec.IsDRANetwork(net) {
+			sidecars[iface.Binding.Name].ResourceClaims = append(sidecars[iface.Binding.Name].ResourceClaims,
+				k8sv1.ResourceClaim{
+					Name:    net.ResourceClaim.ClaimName,
+					Request: net.ResourceClaim.RequestName,
+				})
 		}
 	}
 

--- a/pkg/network/netbinding/netbinding.go
+++ b/pkg/network/netbinding/netbinding.go
@@ -28,45 +28,41 @@ import (
 )
 
 func NetBindingPluginSidecarList(vmi *v1.VirtualMachineInstance, config *v1.KubeVirtConfiguration) (hooks.HookSidecarList, error) {
-	var pluginSidecars hooks.HookSidecarList
-
-	netbindingPluginSidecars, err := netBindingPluginSidecar(vmi, config)
-	if err != nil {
-		return nil, err
+	var registeredBindings map[string]v1.InterfaceBindingPlugin
+	if config.NetworkConfiguration != nil && config.NetworkConfiguration.Binding != nil {
+		registeredBindings = config.NetworkConfiguration.Binding
 	}
-	pluginSidecars = append(pluginSidecars, netbindingPluginSidecars...)
 
-	return pluginSidecars, nil
-}
+	sidecars := map[string]*hooks.HookSidecar{}
 
-func netBindingPluginSidecar(vmi *v1.VirtualMachineInstance, config *v1.KubeVirtConfiguration) (hooks.HookSidecarList, error) {
-	var pluginSidecars hooks.HookSidecarList
-	bindingByName := map[string]v1.InterfaceBindingPlugin{}
 	for _, iface := range vmi.Spec.Domain.Devices.Interfaces {
-		if iface.Binding != nil {
-			var exist bool
-			var pluginInfo v1.InterfaceBindingPlugin
-			if config.NetworkConfiguration != nil && config.NetworkConfiguration.Binding != nil {
-				pluginInfo, exist = config.NetworkConfiguration.Binding[iface.Binding.Name]
-				bindingByName[iface.Binding.Name] = pluginInfo
-			}
-
-			if !exist {
-				return nil, fmt.Errorf("couldn't find configuration for network binding: %s", iface.Binding.Name)
-			}
+		if iface.Binding == nil {
+			continue
 		}
-	}
 
-	for bindingName, pluginInfo := range bindingByName {
-		if pluginInfo.SidecarImage != "" {
-			pluginSidecars = append(pluginSidecars, hooks.HookSidecar{
+		pluginInfo, exist := registeredBindings[iface.Binding.Name]
+		if !exist {
+			return nil, fmt.Errorf("couldn't find configuration for network binding: %s", iface.Binding.Name)
+		}
+
+		if pluginInfo.SidecarImage == "" {
+			continue
+		}
+
+		if _, seen := sidecars[iface.Binding.Name]; !seen {
+			sidecars[iface.Binding.Name] = &hooks.HookSidecar{
 				Image:                    pluginInfo.SidecarImage,
 				ImagePullPolicy:          config.ImagePullPolicy,
 				DownwardAPI:              pluginInfo.DownwardAPI,
-				NetworkBindingPluginName: bindingName,
-			})
+				NetworkBindingPluginName: iface.Binding.Name,
+			}
 		}
 	}
 
-	return pluginSidecars, nil
+	result := make(hooks.HookSidecarList, 0, len(sidecars))
+	for _, sc := range sidecars {
+		result = append(result, *sc)
+	}
+
+	return result, nil
 }

--- a/pkg/network/netbinding/netbinding_test.go
+++ b/pkg/network/netbinding/netbinding_test.go
@@ -23,6 +23,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	k8sv1 "k8s.io/api/core/v1"
+
 	v1 "kubevirt.io/api/core/v1"
 
 	"kubevirt.io/kubevirt/pkg/hooks"
@@ -101,6 +103,48 @@ var _ = Describe("Network Binding", func() {
 				),
 				map[string]v1.InterfaceBindingPlugin{testBindingName1: {SidecarImage: testSidecarImage1}},
 				hooks.HookSidecarList{{Image: testSidecarImage1, NetworkBindingPluginName: testBindingName1}}),
+			Entry("VMI has multiple DRA networks on same binding plugin including shared claim with different requests",
+				libvmi.New(
+					libvmi.WithInterface(v1.Interface{Name: testNetworkName1, Binding: &v1.PluginBinding{Name: testBindingName1}}),
+					libvmi.WithNetwork(libvmi.DRANetwork(testNetworkName1, "claim1", "req1")),
+					libvmi.WithInterface(v1.Interface{Name: testNetworkName2, Binding: &v1.PluginBinding{Name: testBindingName1}}),
+					libvmi.WithNetwork(libvmi.DRANetwork(testNetworkName2, "claim2", "req2")),
+					libvmi.WithInterface(v1.Interface{Name: testNetworkName3, Binding: &v1.PluginBinding{Name: testBindingName1}}),
+					libvmi.WithNetwork(libvmi.DRANetwork(testNetworkName3, "claim1", "req3")),
+				),
+				map[string]v1.InterfaceBindingPlugin{testBindingName1: {SidecarImage: testSidecarImage1}},
+				hooks.HookSidecarList{{
+					Image:                    testSidecarImage1,
+					NetworkBindingPluginName: testBindingName1,
+					ResourceClaims: []k8sv1.ResourceClaim{
+						{Name: "claim1", Request: "req1"},
+						{Name: "claim2", Request: "req2"},
+						{Name: "claim1", Request: "req3"},
+					},
+				}}),
+			Entry("VMI has binding plugin with DRA networks on different binding plugins",
+				libvmi.New(
+					libvmi.WithInterface(v1.Interface{Name: testNetworkName1, Binding: &v1.PluginBinding{Name: testBindingName1}}),
+					libvmi.WithNetwork(libvmi.DRANetwork(testNetworkName1, "claim1", "req1")),
+					libvmi.WithInterface(v1.Interface{Name: testNetworkName2, Binding: &v1.PluginBinding{Name: testBindingName2}}),
+					libvmi.WithNetwork(libvmi.DRANetwork(testNetworkName2, "claim2", "req2")),
+				),
+				map[string]v1.InterfaceBindingPlugin{
+					testBindingName1: {SidecarImage: testSidecarImage1},
+					testBindingName2: {SidecarImage: testSidecarImage2},
+				},
+				hooks.HookSidecarList{
+					{
+						Image:                    testSidecarImage1,
+						NetworkBindingPluginName: testBindingName1,
+						ResourceClaims:           []k8sv1.ResourceClaim{{Name: "claim1", Request: "req1"}},
+					},
+					{
+						Image:                    testSidecarImage2,
+						NetworkBindingPluginName: testBindingName2,
+						ResourceClaims:           []k8sv1.ResourceClaim{{Name: "claim2", Request: "req2"}},
+					},
+				}),
 		)
 
 		It("should retrun an error when VMI has binding plugin but config doesn't exist", func() {

--- a/pkg/network/netbinding/netbinding_test.go
+++ b/pkg/network/netbinding/netbinding_test.go
@@ -38,7 +38,7 @@ var _ = Describe("Network Binding", func() {
 		testNetworkName2  = "net2"
 		testBindingName2  = "binding2"
 		testSidecarImage2 = "image2"
-		testNetworkName3  = "net1"
+		testNetworkName3  = "net3"
 	)
 
 	Context("binding plugin sidecar list", func() {

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -887,6 +887,9 @@ func newSidecarContainerRenderer(sidecarName string, vmiSpec *v1.VirtualMachineI
 		})
 	}
 
+	// resources already contains the CPU and memory spec of the sidecar container
+	// add the DRA ResourceClaims as well
+	resources.Claims = requestedHookSidecar.ResourceClaims
 	sidecarOpts := []Option{
 		WithCommand(requestedHookSidecar.Command),
 		WithResourceRequirements(resources),

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -69,7 +69,11 @@ import (
 	"kubevirt.io/kubevirt/tools/vms-generator/utils"
 )
 
-var testHookSidecar = hooks.HookSidecar{Image: "test-image", ImagePullPolicy: "test-policy"}
+var testHookSidecar = hooks.HookSidecar{
+	Image:           "test-image",
+	ImagePullPolicy: "test-policy",
+	ResourceClaims:  []k8sv1.ResourceClaim{{Name: "test-claim", Request: "test-req"}},
+}
 
 var _ = Describe("Template", func() {
 	const expectedNetworkResource = "amazing-network-resource.com"
@@ -3254,6 +3258,8 @@ var _ = Describe("Template", func() {
 				Name:  hooks.ContainerNameEnvVar,
 				Value: "hook-sidecar-0",
 			}))
+
+			Expect(pod.Spec.Containers[1].Resources.Claims).To(Equal(testHookSidecar.ResourceClaims))
 		})
 
 		Context("with pod networking", func() {


### PR DESCRIPTION


### What this PR does
VEP-183 Beta adds binding plugin support for DRA-backed network devices
This requires the binding plugin sidecar to access DRA device metadata
to configure the domain XML.
Without the resource claim in the sidecar container's resources,
Kubernetes does not mount the metadata files and the plugin cannot
discover the allocated device.

This PR propagates DRA resource claims from the VMI network spec to
the HookSidecar struct so virt-controller renders them in the
sidecar container's resources.claims[].

Since the same function renders the target pod after migration, the
claim persists across migrations.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->

- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/183


### Special notes for your reviewer
Tested using https://github.com/kubevirt/kubevirt/pull/18489

VMI with specs:
```
spec:
..
          interfaces:
          - name: dra-net
            binding:
              name: passt
..
      networks:
      - name: dra-net
        resourceClaim:
          claimName: passt-net-claim
          requestName: passt-net-device
      resourceClaims:
      - name: passt-net-claim
        resourceClaimTemplateName: passt-net-claim-template
```

generates VL pod with:
```
kubectl get pod virt-launcher-vmi-dra-nbp-hdhpp -o json | jq '.spec.containers[] | select(.name=="hook-sidecar-0") | {image, imagePullPolicy, name, resources}'
{
  "image": "registry:5000/kubevirt/network-passt-binding:devel",
  "imagePullPolicy": "Always",
  "name": "hook-sidecar-0",
  "resources": {
    "claims": [
      {
        "name": "passt-net-claim",
        "request": "passt-net-device"
      }
    ]
  }
}

```
and after migration the new pod has the claim as well
```
kubectl get pod virt-launcher-vmi-dra-nbp-wxndr -o json | jq '.spec.containers[] | select(.name=="hook-sidecar-0") | {image, imagePullPolicy, name, resources}'
{
  "image": "registry:5000/kubevirt/network-passt-binding:devel",
  "imagePullPolicy": "Always",
  "name": "hook-sidecar-0",
  "resources": {
    "claims": [
      {
        "name": "passt-net-claim",
        "request": "passt-net-device"
      }
    ]
  }

```

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Network Binding Plugins sidecars receive DRA resource claims for device metadata access
```

