### PR TITLE
Release adopted DataVolumes removed from VM DataVolumeTemplates

### DIFF
--- a/pkg/controller/controller_ref_manager.go
+++ b/pkg/controller/controller_ref_manager.go
@@ -335,13 +335,17 @@ func (m *VirtualMachineControllerRefManager) ReleaseDetachedVirtualMachines(vms 
 //
 // If the error is nil, either the reconciliation succeeded, or no
 // reconciliation was necessary. The list of DataVolumes that you now own is returned.
-func (m *VirtualMachineControllerRefManager) ClaimMatchedDataVolumes(dataVolumes []*cdiv1.DataVolume) ([]*cdiv1.DataVolume, error) {
+func (m *VirtualMachineControllerRefManager) ClaimMatchedDataVolumes(dataVolumes []*cdiv1.DataVolume, dvTemplates []virtv1.DataVolumeTemplateSpec) ([]*cdiv1.DataVolume, error) {
 	var claimed []*cdiv1.DataVolume
 	var errlist []error
 
 	match := func(obj metav1.Object) bool {
-		return true
-
+		for i := range dvTemplates {
+			if dvTemplates[i].Name == obj.GetName() {
+				return true
+			}
+		}
+		return false
 	}
 	adopt := func(obj metav1.Object) error {
 		return m.AdoptDataVolume(obj.(*cdiv1.DataVolume))

--- a/pkg/controller/controller_ref_manager_test.go
+++ b/pkg/controller/controller_ref_manager_test.go
@@ -203,8 +203,18 @@ func TestClaimDataVolume(t *testing.T) {
 		name        string
 		manager     *VirtualMachineControllerRefManager
 		datavolumes []*cdiv1.DataVolume
+		dvTemplates []virtv1.DataVolumeTemplateSpec
 		claimed     []*cdiv1.DataVolume
 		expectError bool
+	}
+	dvTemplatesFor := func(names ...string) []virtv1.DataVolumeTemplateSpec {
+		templates := make([]virtv1.DataVolumeTemplateSpec, len(names))
+		for i, name := range names {
+			templates[i] = virtv1.DataVolumeTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Name: name},
+			}
+		}
+		return templates
 	}
 	var tests = []test{
 		func() test {
@@ -220,6 +230,7 @@ func TestClaimDataVolume(t *testing.T) {
 					controllerKind,
 					func() error { return nil }),
 				datavolumes: []*cdiv1.DataVolume{newDataVolume("datavolume1", nil), newDataVolume("datavolume2", nil)},
+				dvTemplates: dvTemplatesFor("datavolume1", "datavolume2"),
 				claimed:     nil,
 			}
 		}(),
@@ -236,6 +247,7 @@ func TestClaimDataVolume(t *testing.T) {
 					controllerKind,
 					func() error { return nil }),
 				datavolumes: []*cdiv1.DataVolume{newDataVolume("datavolume1", &controller), newDataVolume("datavolume2", nil)},
+				dvTemplates: dvTemplatesFor("datavolume1", "datavolume2"),
 				claimed:     []*cdiv1.DataVolume{newDataVolume("datavolume1", &controller)},
 			}
 		}(),
@@ -252,6 +264,7 @@ func TestClaimDataVolume(t *testing.T) {
 					controllerKind,
 					func() error { return nil }),
 				datavolumes: []*cdiv1.DataVolume{newDataVolume("datavolume1", &controller), newDataVolume("datavolume2", &controller2)},
+				dvTemplates: dvTemplatesFor("datavolume1", "datavolume2"),
 				claimed:     []*cdiv1.DataVolume{newDataVolume("datavolume1", &controller)},
 			}
 		}(),
@@ -272,12 +285,28 @@ func TestClaimDataVolume(t *testing.T) {
 					controllerKind,
 					func() error { return nil }),
 				datavolumes: []*cdiv1.DataVolume{datavolumeToDelete1, datavolumeToDelete2},
+				dvTemplates: dvTemplatesFor("datavolume1", "datavolume2"),
 				claimed:     []*cdiv1.DataVolume{datavolumeToDelete1},
+			}
+		}(),
+		func() test {
+			controller := v1.ReplicationController{}
+			controller.UID = types.UID(controllerUID)
+			return test{
+				name: "Controller releases owned datavolume not in template names",
+				manager: NewVirtualMachineControllerRefManager(&FakeVirtualMachineControl{},
+					&controller,
+					productionLabelSelector,
+					controllerKind,
+					func() error { return nil }),
+				datavolumes: []*cdiv1.DataVolume{newDataVolume("datavolume1", &controller), newDataVolume("datavolume2", &controller)},
+				dvTemplates: dvTemplatesFor("datavolume1"),
+				claimed:     []*cdiv1.DataVolume{newDataVolume("datavolume1", &controller)},
 			}
 		}(),
 	}
 	for _, test := range tests {
-		claimed, err := test.manager.ClaimMatchedDataVolumes(test.datavolumes)
+		claimed, err := test.manager.ClaimMatchedDataVolumes(test.datavolumes, test.dvTemplates)
 		if test.expectError && err == nil {
 			t.Errorf("Test case `%s`, expected error but got nil", test.name)
 		} else if !equality.Semantic.DeepEqual(test.claimed, claimed) {

--- a/pkg/storage/types/BUILD.bazel
+++ b/pkg/storage/types/BUILD.bazel
@@ -35,6 +35,7 @@ go_test(
     embed = [":go_default_library"],
     race = "on",
     deps = [
+        "//pkg/controller:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/containerizeddataimporter/fake:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
@@ -46,7 +47,9 @@ go_test(
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
+        "//vendor/k8s.io/utils/ptr:go_default_library",
         "//vendor/kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1:go_default_library",
     ],
 )

--- a/pkg/storage/types/dv.go
+++ b/pkg/storage/types/dv.go
@@ -360,3 +360,37 @@ func (e *DVNotFoundError) Error() string {
 func (e *DVNotFoundError) Unwrap() error {
 	return e.Err
 }
+
+// ListDataVolumeClaimCandidates returns DVs that need ownerRef reconciliation:
+// owned DVs (to release stale ones no longer in templates) and orphan template DVs (to adopt).
+func ListDataVolumeClaimCandidates(vm *virtv1.VirtualMachine, dataVolumeStore cache.Store) ([]*cdiv1.DataVolume, error) {
+	seen := make(map[string]struct{})
+	var dataVolumes []*cdiv1.DataVolume
+
+	for _, obj := range dataVolumeStore.List() {
+		dv, ok := obj.(*cdiv1.DataVolume)
+		if !ok || dv.Namespace != vm.Namespace {
+			continue
+		}
+		if metav1.IsControlledBy(dv, vm) {
+			dataVolumes = append(dataVolumes, dv)
+			seen[dv.Name] = struct{}{}
+		}
+	}
+
+	for _, template := range vm.Spec.DataVolumeTemplates {
+		if _, exists := seen[template.Name]; exists {
+			continue
+		}
+		dv, err := GetDataVolumeFromCache(vm.Namespace, template.Name, dataVolumeStore)
+		if err != nil {
+			return nil, err
+		}
+		if dv == nil {
+			continue
+		}
+		dataVolumes = append(dataVolumes, dv)
+	}
+
+	return dataVolumes, nil
+}

--- a/pkg/storage/types/dv_test.go
+++ b/pkg/storage/types/dv_test.go
@@ -28,11 +28,16 @@ import (
 	"go.uber.org/mock/gomock"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/utils/ptr"
 
 	virtv1 "kubevirt.io/api/core/v1"
 	cdifake "kubevirt.io/client-go/containerizeddataimporter/fake"
 	"kubevirt.io/client-go/kubecli"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
+
+	"kubevirt.io/kubevirt/pkg/controller"
 )
 
 var _ = Describe("DataVolume utils test", func() {
@@ -183,6 +188,158 @@ var _ = Describe("DataVolume utils test", func() {
 			Expect(cs).ToNot(BeNil())
 			Expect(cs.PVC.Namespace).To(Equal(vm.Namespace))
 			Expect(cs.PVC.Name).To(Equal(sourceName))
+		})
+	})
+
+	Context("ListDataVolumeClaimCandidates", func() {
+		var (
+			vm    *virtv1.VirtualMachine
+			store cache.Store
+		)
+
+		BeforeEach(func() {
+			vm = &virtv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test-ns",
+					Name:      "test-vm",
+					UID:       types.UID("vm-uid"),
+				},
+			}
+			store = cache.NewStore(controller.KeyFunc)
+		})
+
+		ownerRef := func(vm *virtv1.VirtualMachine) metav1.OwnerReference {
+			return metav1.OwnerReference{
+				APIVersion:         virtv1.VirtualMachineGroupVersionKind.GroupVersion().String(),
+				Kind:               virtv1.VirtualMachineGroupVersionKind.Kind,
+				Name:               vm.Name,
+				UID:                vm.UID,
+				Controller:         ptr.To(true),
+				BlockOwnerDeletion: ptr.To(true),
+			}
+		}
+
+		dvTemplatesFor := func(names ...string) []virtv1.DataVolumeTemplateSpec {
+			templates := make([]virtv1.DataVolumeTemplateSpec, len(names))
+			for i, name := range names {
+				templates[i] = virtv1.DataVolumeTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{Name: name},
+				}
+			}
+			return templates
+		}
+
+		It("should return owned DV that is still in templates", func() {
+			vm.Spec.DataVolumeTemplates = dvTemplatesFor("dv1")
+			dv := &cdiv1.DataVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "dv1",
+					Namespace:       vm.Namespace,
+					OwnerReferences: []metav1.OwnerReference{ownerRef(vm)},
+				},
+			}
+			Expect(store.Add(dv)).To(Succeed())
+
+			result, err := ListDataVolumeClaimCandidates(vm, store)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(ConsistOf(HaveField("Name", "dv1")))
+		})
+
+		It("should return owned DV removed from templates for release", func() {
+			vm.Spec.DataVolumeTemplates = nil
+			dv := &cdiv1.DataVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "stale-dv",
+					Namespace:       vm.Namespace,
+					OwnerReferences: []metav1.OwnerReference{ownerRef(vm)},
+				},
+			}
+			Expect(store.Add(dv)).To(Succeed())
+
+			result, err := ListDataVolumeClaimCandidates(vm, store)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(ConsistOf(HaveField("Name", "stale-dv")))
+		})
+
+		It("should return orphan DV matching a template for adoption", func() {
+			vm.Spec.DataVolumeTemplates = dvTemplatesFor("orphan-dv")
+			dv := &cdiv1.DataVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "orphan-dv",
+					Namespace: vm.Namespace,
+				},
+			}
+			Expect(store.Add(dv)).To(Succeed())
+
+			result, err := ListDataVolumeClaimCandidates(vm, store)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(ConsistOf(HaveField("Name", "orphan-dv")))
+		})
+
+		It("should not duplicate a DV that is both owned and in templates", func() {
+			vm.Spec.DataVolumeTemplates = dvTemplatesFor("dv1")
+			dv := &cdiv1.DataVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "dv1",
+					Namespace:       vm.Namespace,
+					OwnerReferences: []metav1.OwnerReference{ownerRef(vm)},
+				},
+			}
+			Expect(store.Add(dv)).To(Succeed())
+
+			result, err := ListDataVolumeClaimCandidates(vm, store)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(ConsistOf(HaveField("Name", "dv1")))
+		})
+
+		It("should exclude DVs from a different namespace", func() {
+			vm.Spec.DataVolumeTemplates = nil
+			dv := &cdiv1.DataVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "other-ns-dv",
+					Namespace:       "other-ns",
+					OwnerReferences: []metav1.OwnerReference{ownerRef(vm)},
+				},
+			}
+			Expect(store.Add(dv)).To(Succeed())
+
+			result, err := ListDataVolumeClaimCandidates(vm, store)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(BeEmpty())
+		})
+
+		It("should skip templates with no existing DV", func() {
+			vm.Spec.DataVolumeTemplates = dvTemplatesFor("missing-dv")
+
+			result, err := ListDataVolumeClaimCandidates(vm, store)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(BeEmpty())
+		})
+
+		It("should return both owned stale and orphan template DVs", func() {
+			vm.Spec.DataVolumeTemplates = dvTemplatesFor("new-dv")
+			staleDV := &cdiv1.DataVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:            "stale-dv",
+					Namespace:       vm.Namespace,
+					OwnerReferences: []metav1.OwnerReference{ownerRef(vm)},
+				},
+			}
+			orphanDV := &cdiv1.DataVolume{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "new-dv",
+					Namespace: vm.Namespace,
+				},
+			}
+			Expect(store.Add(staleDV)).To(Succeed())
+			Expect(store.Add(orphanDV)).To(Succeed())
+
+			result, err := ListDataVolumeClaimCandidates(vm, store)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).To(ConsistOf(
+				HaveField("Name", "stale-dv"),
+				HaveField("Name", "new-dv"),
+			))
 		})
 	})
 })

--- a/pkg/virt-controller/watch/vm/vm.go
+++ b/pkg/virt-controller/watch/vm/vm.go
@@ -424,15 +424,13 @@ func (c *Controller) execute(key string) error {
 		}
 	}
 
-	dataVolumes, err := storagetypes.ListDataVolumesFromTemplates(vm.Namespace, vm.Spec.DataVolumeTemplates, c.dataVolumeStore)
+	dvClaimCandidates, err := storagetypes.ListDataVolumeClaimCandidates(vm, c.dataVolumeStore)
 	if err != nil {
 		logger.Reason(err).Error("Failed to fetch dataVolumes for namespace from cache.")
 		return err
 	}
-
-	if len(dataVolumes) != 0 {
-		dataVolumes, err = cm.ClaimMatchedDataVolumes(dataVolumes)
-		if err != nil {
+	if len(dvClaimCandidates) != 0 {
+		if _, err = cm.ClaimMatchedDataVolumes(dvClaimCandidates, vm.Spec.DataVolumeTemplates); err != nil {
 			return err
 		}
 	}

--- a/pkg/virt-controller/watch/vm/vm_test.go
+++ b/pkg/virt-controller/watch/vm/vm_test.go
@@ -2820,6 +2820,56 @@ var _ = Describe("VirtualMachine", func() {
 			sanityExecute(vm)
 		})
 
+		It("should release an owned DataVolume that is no longer in DataVolumeTemplates", func() {
+			vm, _ := watchtesting.DefaultVirtualMachine(false)
+			vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, v1.Volume{
+				Name: "test1",
+				VolumeSource: v1.VolumeSource{
+					DataVolume: &v1.DataVolumeSource{
+						Name: "dv1",
+					},
+				},
+			})
+			vm.Spec.DataVolumeTemplates = append(vm.Spec.DataVolumeTemplates, v1.DataVolumeTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "dv1",
+					Namespace: vm.Namespace,
+				},
+			})
+
+			vm, err := virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Create(context.TODO(), vm, metav1.CreateOptions{})
+			Expect(err).To(Succeed())
+
+			dv, _ := watchutil.CreateDataVolumeManifest(virtClient, vm.Spec.DataVolumeTemplates[0], vm)
+			Expect(dv.OwnerReferences).ToNot(BeEmpty())
+			Expect(controller.dataVolumeStore.Add(dv)).To(Succeed())
+
+			// Simulate removing the DataVolumeTemplate from the VM
+			vm.Spec.DataVolumeTemplates = nil
+			addVirtualMachine(vm)
+
+			releasedDV := &cdiv1.DataVolume{}
+			released := false
+			cdiClient.Fake.PrependReactor("patch", "datavolumes", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+				patchAction, ok := action.(testing.PatchAction)
+				Expect(ok).To(BeTrue())
+				Expect(patchAction.GetName()).To(Equal(dv.Name))
+
+				original, err := json.Marshal(dv)
+				Expect(err).ToNot(HaveOccurred())
+				modified, err := jsonpatch.MergePatch(original, patchAction.GetPatch())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(json.Unmarshal(modified, releasedDV)).To(Succeed())
+
+				released = true
+				return true, releasedDV, nil
+			})
+
+			sanityExecute(vm)
+			Expect(released).To(BeTrue())
+			Expect(releasedDV.OwnerReferences).To(BeEmpty())
+		})
+
 		It("should detect that it has nothing to do beside updating the status", func() {
 			vm, vmi := watchtesting.DefaultVirtualMachine(true)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
When a DataVolume is removed from a VM's DataVolumeTemplates, its
ownerReference to the VM was not cleaned up. This caused the DV to be
garbage collected when the VM was deleted, leading to potential data loss.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: prevent released dvtemplates from being garbage collected when their old owner vm gets deleted
```

