### PR TITLE
storage, admitters: reject LUN disks with virtio bus at creation

### DIFF
--- a/pkg/storage/admitters/disks.go
+++ b/pkg/storage/admitters/disks.go
@@ -199,6 +199,15 @@ func validateBusSupport(field *k8sfield.Path, idx int, disk v1.Disk) []metav1.St
 				Field:   field.Index(idx).Child("cdrom", "bus").String(),
 			})
 		}
+		// special case. QEMU does not support SCSI passthrough (device=lun) on the virtio-blk bus.
+		// The hotplug path already rejects this combination.
+		if diskType == "lun" {
+			causes = append(causes, metav1.StatusCause{
+				Type:    metav1.CauseTypeFieldValueInvalid,
+				Message: fmt.Sprintf("Bus type %s is invalid for LUN device", bus),
+				Field:   field.Index(idx).Child("lun", "bus").String(),
+			})
+		}
 	case v1.DiskBusSATA:
 		// sata disks (in contrast to sata cdroms) don't support readOnly
 		if disk.Disk != nil && disk.Disk.ReadOnly {

--- a/pkg/storage/admitters/disks_test.go
+++ b/pkg/storage/admitters/disks_test.go
@@ -236,6 +236,22 @@ var _ = Describe("Disk Validation", func() {
 			Expect(causes).To(BeEmpty())
 		})
 
+		It("should reject LUN disks with virtio bus", func() {
+			vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
+				Name: "testdisk",
+				DiskDevice: v1.DiskDevice{
+					LUN: &v1.LunTarget{
+						Bus: v1.DiskBusVirtio,
+					},
+				},
+			})
+
+			causes := ValidateDisks(k8sfield.NewPath("fake"), vmi.Spec.Domain.Devices.Disks)
+			Expect(causes).To(HaveLen(1))
+			Expect(causes[0].Field).To(Equal("fake[0].lun.bus"))
+			Expect(causes[0].Message).To(ContainSubstring("invalid for LUN device"))
+		})
+
 		It("should reject disks with unsupported buses", func() {
 			vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
 				Name: "testdisk1",


### PR DESCRIPTION
### What this PR does

Before this PR: a VM/VMI with a LUN disk on the virtio bus was accepted at creation and only failed later at boot. QEMU does not support SCSI passthrough (device=lun) on the virtio-blk bus. The hotplug path (`ValidateHotplugDiskConfiguration`) and `virtctl addvolume` already reject this combination.

After this PR: `validateBusSupport` rejects `lun` + `virtio` at creation time, with the same error style as the existing CD-ROM check.

This picks up #17827, which was closed by the stale bot without ever getting a review. Scope is intentionally minimal: only `virtio` is rejected for now. Extending it to any non-`scsi` bus (full parity with the hotplug path) can follow up based on feedback, since that would also hit LUNs with no explicit bus — the webhook defaults them to `sata` on amd64 / `virtio` on arm64/s390x. See the discussion in #17826.

### Which issue(s) this PR fixes

Fixes #17826

### Special notes for your reviewer

Related: #18267 defaults LUN bus to `scsi` when persistent reservation is enabled.

### Release note

```release-note
LUN disks with virtio bus are now rejected at VM/VMI creation time; QEMU does not support SCSI passthrough on the virtio-blk bus.
```
