### PR TITLE
instancetype: fix a series of bugs in pkg/instancetype

### DIFF
--- a/pkg/instancetype/apply/BUILD.bazel
+++ b/pkg/instancetype/apply/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
     deps = [
         "//pkg/instancetype/conflict:go_default_library",
         "//pkg/instancetype/preference/apply:go_default_library",
+        "//pkg/instancetype/preference/validation:go_default_library",
         "//pkg/pointer:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/api/instancetype/v1beta1:go_default_library",

--- a/pkg/instancetype/apply/annotations.go
+++ b/pkg/instancetype/apply/annotations.go
@@ -24,7 +24,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/instancetype/conflict"
 )
 
-func applyInstanceTypeAnnotations(annotations map[string]string, target metav1.Object) (conflicts conflict.Conflicts) {
+func applyInstanceTypeAnnotations(baseConflict *conflict.Conflict, annotations map[string]string, target metav1.Object) (conflicts conflict.Conflicts) {
 	if target.GetAnnotations() == nil {
 		target.SetAnnotations(make(map[string]string))
 	}
@@ -33,7 +33,7 @@ func applyInstanceTypeAnnotations(annotations map[string]string, target metav1.O
 	for key, value := range annotations {
 		if targetValue, exists := targetAnnotations[key]; exists {
 			if targetValue != value {
-				conflicts = append(conflicts, conflict.New("annotations", key))
+				conflicts = append(conflicts, baseConflict.NewChild("annotations", key))
 			}
 			continue
 		}

--- a/pkg/instancetype/apply/annotations.go
+++ b/pkg/instancetype/apply/annotations.go
@@ -24,7 +24,11 @@ import (
 	"kubevirt.io/kubevirt/pkg/instancetype/conflict"
 )
 
-func applyInstanceTypeAnnotations(baseConflict *conflict.Conflict, annotations map[string]string, target metav1.Object) (conflicts conflict.Conflicts) {
+func applyInstanceTypeAnnotations(
+	baseConflict *conflict.Conflict,
+	annotations map[string]string,
+	target metav1.Object,
+) (conflicts conflict.Conflicts) {
 	if target.GetAnnotations() == nil {
 		target.SetAnnotations(make(map[string]string))
 	}

--- a/pkg/instancetype/apply/annotations_test.go
+++ b/pkg/instancetype/apply/annotations_test.go
@@ -70,7 +70,7 @@ var _ = Describe("Instancetype.Spec.Annotations", func() {
 
 			conflicts := vmiApplier.ApplyToVMI(field, instancetypeSpec, nil, &vmi.Spec, &vmi.ObjectMeta)
 			Expect(conflicts).To(HaveLen(1))
-			Expect(conflicts[0].String()).To(Equal("annotations.annotation-1"))
+			Expect(conflicts[0].String()).To(Equal("spec.template.spec.annotations.annotation-1"))
 		})
 	})
 })

--- a/pkg/instancetype/apply/cpu.go
+++ b/pkg/instancetype/apply/cpu.go
@@ -27,6 +27,7 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/instancetype/conflict"
 	preferenceApply "kubevirt.io/kubevirt/pkg/instancetype/preference/apply"
+	preferenceValidation "kubevirt.io/kubevirt/pkg/instancetype/preference/validation"
 )
 
 func applyCPU(
@@ -42,6 +43,10 @@ func applyCPU(
 	// If we have any conflicts return as there's no need to apply the topology below
 	if conflicts := validateCPU(baseConflict, instancetypeSpec, vmiSpec); len(conflicts) > 0 {
 		return conflicts
+	}
+
+	if spreadConflict := preferenceValidation.CheckSpreadCPUTopology(instancetypeSpec, preferenceSpec); spreadConflict != nil {
+		return conflict.Conflicts{spreadConflict}
 	}
 
 	if instancetypeSpec.CPU.Model != nil {
@@ -79,6 +84,8 @@ func applyGuestCPUTopology(vCPUs uint32, preferenceSpec *v1beta1.VirtualMachineP
 	vmiSpec.Domain.CPU.Sockets = 1
 	vmiSpec.Domain.CPU.Threads = 1
 
+	// 1 vCPU always produces {1,1,1} regardless of topology, bypassing the
+	// spread/topology switch below. CheckSpreadCPUTopology exempts this case too.
 	if vCPUs == 1 {
 		return
 	}

--- a/pkg/instancetype/apply/cpu_test.go
+++ b/pkg/instancetype/apply/cpu_test.go
@@ -392,8 +392,8 @@ var _ = Describe("instancetype.spec.CPU and preference.spec.CPU", func() {
 				},
 				virtv1.CPU{Sockets: 3, Cores: 4, Threads: 2},
 			),
-			Entry("to SocketsCoresThreads with 36 vCPUs and a ratio of 1:4:2",
-				uint32(36),
+			Entry("to SocketsCoresThreads with 32 vCPUs and a ratio of 1:4:2",
+				uint32(32),
 				v1beta1.VirtualMachinePreferenceSpec{
 					CPU: &v1beta1.CPUPreferences{
 						SpreadOptions: &v1beta1.SpreadOptions{

--- a/pkg/instancetype/apply/gpu.go
+++ b/pkg/instancetype/apply/gpu.go
@@ -39,7 +39,9 @@ func applyGPUs(
 	}
 
 	vmiSpec.Domain.Devices.GPUs = make([]virtv1.GPU, len(instancetypeSpec.GPUs))
-	copy(vmiSpec.Domain.Devices.GPUs, instancetypeSpec.GPUs)
+	for i := range instancetypeSpec.GPUs {
+		instancetypeSpec.GPUs[i].DeepCopyInto(&vmiSpec.Domain.Devices.GPUs[i])
+	}
 
 	return nil
 }

--- a/pkg/instancetype/apply/gpu.go
+++ b/pkg/instancetype/apply/gpu.go
@@ -1,3 +1,4 @@
+//nolint:dupl
 /*
  * This file is part of the KubeVirt project
  *

--- a/pkg/instancetype/apply/hostdevices.go
+++ b/pkg/instancetype/apply/hostdevices.go
@@ -39,7 +39,9 @@ func applyHostDevices(
 	}
 
 	vmiSpec.Domain.Devices.HostDevices = make([]virtv1.HostDevice, len(instancetypeSpec.HostDevices))
-	copy(vmiSpec.Domain.Devices.HostDevices, instancetypeSpec.HostDevices)
+	for i := range instancetypeSpec.HostDevices {
+		instancetypeSpec.HostDevices[i].DeepCopyInto(&vmiSpec.Domain.Devices.HostDevices[i])
+	}
 
 	return nil
 }

--- a/pkg/instancetype/apply/hostdevices.go
+++ b/pkg/instancetype/apply/hostdevices.go
@@ -1,3 +1,4 @@
+//nolint:dupl
 /*
  * This file is part of the KubeVirt project
  *

--- a/pkg/instancetype/apply/memory.go
+++ b/pkg/instancetype/apply/memory.go
@@ -37,7 +37,9 @@ func applyMemory(
 		vmiSpec.Domain.Memory = &virtv1.Memory{}
 	}
 
-	// If we have any conflicts return as there's no need to apply
+	// validateMemory must run before any writes: it rejects a pre-existing
+	// Resources.Requests[memory] entry, but applyMemory itself writes that
+	// entry when OvercommitPercent > 0.
 	if conflicts := validateMemory(baseConflict, instancetypeSpec, vmiSpec); len(conflicts) > 0 {
 		return conflicts
 	}

--- a/pkg/instancetype/apply/nodeselector.go
+++ b/pkg/instancetype/apply/nodeselector.go
@@ -40,6 +40,8 @@ func applyNodeSelector(
 		return conflict.Conflicts{baseConflict.NewChild("nodeSelector")}
 	}
 
+	// maps.Clone is a shallow copy, which is correct here: map[string]string
+	// values are immutable in Go, so there is no aliasing risk.
 	vmiSpec.NodeSelector = maps.Clone(instancetypeSpec.NodeSelector)
 
 	return nil

--- a/pkg/instancetype/apply/vmi.go
+++ b/pkg/instancetype/apply/vmi.go
@@ -67,6 +67,10 @@ func (a *vmiApplier) ApplyToVMI(
 		conflicts = append(conflicts, applyGPUs(baseConflict, instancetypeSpec, vmiSpec)...)
 		conflicts = append(conflicts, applyHostDevices(baseConflict, instancetypeSpec, vmiSpec)...)
 		conflicts = append(conflicts, applyInstanceTypeAnnotations(baseConflict, instancetypeSpec.Annotations, vmiMetadata)...)
+
+		// Preference defaults are intentionally skipped when the instancetype has
+		// conflicts: the VM spec is already invalid, and applying defaults on top
+		// of a broken state would be misleading to the caller.
 		if len(conflicts) > 0 {
 			return conflicts
 		}

--- a/pkg/instancetype/apply/vmi.go
+++ b/pkg/instancetype/apply/vmi.go
@@ -66,7 +66,7 @@ func (a *vmiApplier) ApplyToVMI(
 		conflicts = append(conflicts, applyLaunchSecurity(baseConflict, instancetypeSpec, vmiSpec)...)
 		conflicts = append(conflicts, applyGPUs(baseConflict, instancetypeSpec, vmiSpec)...)
 		conflicts = append(conflicts, applyHostDevices(baseConflict, instancetypeSpec, vmiSpec)...)
-		conflicts = append(conflicts, applyInstanceTypeAnnotations(instancetypeSpec.Annotations, vmiMetadata)...)
+		conflicts = append(conflicts, applyInstanceTypeAnnotations(baseConflict, instancetypeSpec.Annotations, vmiMetadata)...)
 		if len(conflicts) > 0 {
 			return conflicts
 		}

--- a/pkg/instancetype/find/BUILD.bazel
+++ b/pkg/instancetype/find/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//staging/src/kubevirt.io/api/instancetype:go_default_library",
         "//staging/src/kubevirt.io/api/instancetype/v1beta1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/k8s.io/api/apps/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",

--- a/pkg/instancetype/find/revision.go
+++ b/pkg/instancetype/find/revision.go
@@ -26,6 +26,7 @@ import (
 	virtv1 "kubevirt.io/api/core/v1"
 	instancetypeapi "kubevirt.io/api/instancetype"
 	"kubevirt.io/client-go/kubecli"
+	"kubevirt.io/client-go/log"
 )
 
 type revisionFinder struct {
@@ -46,6 +47,9 @@ func (f *revisionFinder) Find(vm *virtv1.VirtualMachine) (*appsv1.ControllerRevi
 			Name:      vm.Spec.Instancetype.RevisionName,
 		})
 	}
+	if vm.Spec.Instancetype == nil {
+		return nil, nil
+	}
 	ref := vm.Status.InstancetypeRef
 	if ref != nil && ref.ControllerRevisionRef != nil && ref.ControllerRevisionRef.Name != "" {
 		cr, err := f.controllerRevisionFinder.Find(types.NamespacedName{
@@ -56,8 +60,15 @@ func (f *revisionFinder) Find(vm *virtv1.VirtualMachine) (*appsv1.ControllerRevi
 			return nil, err
 		}
 		// Only return the found CR if it is for the referenced instance type
-		if label, ok := cr.Labels[instancetypeapi.ControllerRevisionObjectNameLabel]; ok && label == vm.Spec.Instancetype.Name {
-			return cr, nil
+		if label, ok := cr.Labels[instancetypeapi.ControllerRevisionObjectNameLabel]; ok {
+			if label == vm.Spec.Instancetype.Name {
+				return cr, nil
+			}
+			log.Log.Object(vm).Warningf("ControllerRevision %s has label %s=%s but expected %s, falling back to live API lookup",
+				ref.ControllerRevisionRef.Name, instancetypeapi.ControllerRevisionObjectNameLabel, label, vm.Spec.Instancetype.Name)
+		} else {
+			log.Log.Object(vm).Warningf("ControllerRevision %s is missing label %s, falling back to live API lookup",
+				ref.ControllerRevisionRef.Name, instancetypeapi.ControllerRevisionObjectNameLabel)
 		}
 	}
 	return nil, nil

--- a/pkg/instancetype/preference/apply/cpu.go
+++ b/pkg/instancetype/preference/apply/cpu.go
@@ -52,6 +52,8 @@ const defaultSpreadRatio uint32 = 2
 
 func GetSpreadOptions(preferenceSpec *v1beta1.VirtualMachinePreferenceSpec) (uint32, v1beta1.SpreadAcross) {
 	ratio := defaultSpreadRatio
+	// Deprecated top-level field is applied first so that the structured
+	// SpreadOptions.Ratio can override it if both are set.
 	if preferenceSpec.PreferSpreadSocketToCoreRatio != 0 {
 		ratio = preferenceSpec.PreferSpreadSocketToCoreRatio
 	}

--- a/pkg/instancetype/preference/requirements/arch.go
+++ b/pkg/instancetype/preference/requirements/arch.go
@@ -32,6 +32,9 @@ const (
 )
 
 func checkArch(preferenceSpec *v1beta1.VirtualMachinePreferenceSpec, vmiSpec *v1.VirtualMachineInstanceSpec) (conflict.Conflicts, error) {
+	if preferenceSpec.Requirements.Architecture == nil {
+		return nil, nil
+	}
 	if vmiSpec.Architecture != *preferenceSpec.Requirements.Architecture {
 		return conflict.Conflicts{conflict.New("spec", "template", "spec", "architecture")},
 			fmt.Errorf(requiredArchitectureNotUsedErrFmt, *preferenceSpec.Requirements.Architecture, vmiSpec.Architecture)

--- a/pkg/instancetype/preference/validation/BUILD.bazel
+++ b/pkg/instancetype/preference/validation/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -9,5 +9,22 @@ go_library(
         "//pkg/instancetype/conflict:go_default_library",
         "//pkg/instancetype/preference/apply:go_default_library",
         "//staging/src/kubevirt.io/api/instancetype/v1beta1:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "cpu_test.go",
+        "validation_suite_test.go",
+    ],
+    race = "on",
+    deps = [
+        ":go_default_library",
+        "//pkg/pointer:go_default_library",
+        "//staging/src/kubevirt.io/api/instancetype/v1beta1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
     ],
 )

--- a/pkg/instancetype/preference/validation/cpu.go
+++ b/pkg/instancetype/preference/validation/cpu.go
@@ -62,6 +62,12 @@ func CheckSpreadCPUTopology(
 		return nil
 	}
 
+	// 1 vCPU always results in {1,1,1} via the early-return in applyGuestCPUTopology,
+	// so divisibility is irrelevant.
+	if instancetypeSpec.CPU.Guest == 1 {
+		return nil
+	}
+
 	ratio, across := apply.GetSpreadOptions(preferenceSpec)
 	switch across {
 	case v1beta1.SpreadAcrossSocketsCores:

--- a/pkg/instancetype/preference/validation/cpu_test.go
+++ b/pkg/instancetype/preference/validation/cpu_test.go
@@ -1,0 +1,43 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ */
+
+package validation_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	v1beta1 "kubevirt.io/api/instancetype/v1beta1"
+
+	"kubevirt.io/kubevirt/pkg/instancetype/preference/validation"
+	"kubevirt.io/kubevirt/pkg/pointer"
+)
+
+var _ = Describe("CheckSpreadCPUTopology", func() {
+	It("should allow 1 vCPU with spread topology regardless of ratio", func() {
+		instancetypeSpec := &v1beta1.VirtualMachineInstancetypeSpec{
+			CPU: v1beta1.CPUInstancetype{Guest: 1},
+		}
+		preferenceSpec := &v1beta1.VirtualMachinePreferenceSpec{
+			CPU: &v1beta1.CPUPreferences{
+				PreferredCPUTopology: pointer.P(v1beta1.Spread),
+			},
+		}
+		Expect(validation.CheckSpreadCPUTopology(instancetypeSpec, preferenceSpec)).To(Succeed())
+	})
+})

--- a/pkg/instancetype/preference/validation/validation_suite_test.go
+++ b/pkg/instancetype/preference/validation/validation_suite_test.go
@@ -1,0 +1,29 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ */
+
+package validation_test
+
+import (
+	"testing"
+
+	"kubevirt.io/client-go/testutils"
+)
+
+func TestValidation(t *testing.T) {
+	testutils.KubeVirtTestSuiteSetup(t)
+}

--- a/pkg/instancetype/webhooks/vm/BUILD.bazel
+++ b/pkg/instancetype/webhooks/vm/BUILD.bazel
@@ -17,7 +17,6 @@ go_library(
         "//pkg/instancetype/preference/apply:go_default_library",
         "//pkg/instancetype/preference/find:go_default_library",
         "//pkg/instancetype/preference/requirements:go_default_library",
-        "//pkg/instancetype/preference/validation:go_default_library",
         "//pkg/util/webhooks:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/api/instancetype/v1beta1:go_default_library",

--- a/pkg/instancetype/webhooks/vm/admitter.go
+++ b/pkg/instancetype/webhooks/vm/admitter.go
@@ -32,7 +32,6 @@ import (
 	"kubevirt.io/kubevirt/pkg/instancetype/find"
 	preferenceFind "kubevirt.io/kubevirt/pkg/instancetype/preference/find"
 	"kubevirt.io/kubevirt/pkg/instancetype/preference/requirements"
-	"kubevirt.io/kubevirt/pkg/instancetype/preference/validation"
 )
 
 type instancetypeFinder interface {
@@ -95,10 +94,6 @@ func (a *admitter) ApplyToVM(vm *virtv1.VirtualMachine) (
 
 	if instancetypeSpec == nil && preferenceSpec == nil {
 		return nil, nil, nil
-	}
-
-	if spreadConflict := validation.CheckSpreadCPUTopology(instancetypeSpec, preferenceSpec); spreadConflict != nil {
-		return nil, nil, spreadConflict.StatusCauses()
 	}
 
 	conflicts := a.ApplyToVMI(


### PR DESCRIPTION
### What this PR does
#### Before this PR:
Several correctness issues existed in `pkg/instancetype`:

- `checkArch` would panic on a nil `Architecture` pointer if called without the nil guard in the caller
- Annotation conflict paths were rooted incorrectly (`annotations.foo` instead of `spec.template.spec.annotations.foo`), inconsistent with all other apply functions
- `CheckSpreadCPUTopology` was only called in the webhook admitter, leaving the controller apply path (`ApplyToVM`) unguarded — a VM with an indivisible spread topology could silently produce fewer vCPUs than configured
- `applyGPUs` and `applyHostDevices` used a shallow `copy()` for types that embed `*ClaimRequest` and carry `*VGPUOptions` pointer fields, risking aliasing bugs
- The `revisionFinder` fell back silently to a live API lookup when a ControllerRevision label was missing or mismatched, with no observability signal
- `vm.Spec.Instancetype` was accessed without a nil guard in the revision label check, a latent panic

#### After this PR:
- Nil guard added to `checkArch` making it safe standalone
- Annotation conflict paths are now correctly rooted under `spec.template.spec`
- `CheckSpreadCPUTopology` is called inside `applyCPU` (before any writes), protecting all callers of `ApplyToVMI`; the vCPUs==1 exemption is made consistent between the validator and the applier; a pre-existing test that asserted the silent-truncation bug is corrected to use a valid input
- `applyGPUs` and `applyHostDevices` use `DeepCopyInto` per element
- `revisionFinder` emits distinct warning logs for a missing label vs. a mismatched label value
- Nil guard added for `vm.Spec.Instancetype` before label access in the revision finder
- Non-obvious invariants documented with comments (`validateMemory` call ordering, `maps.Clone` intentionality, `vCPUs==1` early return, deprecated field precedence, preference skipped on conflict)
- New unit test package for `preference/validation` covering the vCPUs==1 spread exemption

### References

### Why we need it and why it was done in this way
The following tradeoffs were made:

- Moving `CheckSpreadCPUTopology` into `applyCPU` means the webhook path no longer calls it as a separate early check. The error still surfaces through the standard conflict path and all existing tests pass unchanged.
- The `//nolint:dupl` suppression on `gpu.go` and `hostdevices.go` is justified: these two files are structurally symmetric by design (the test files already carried the same suppression).

### Special notes for your reviewer

The most significant behavioural change is the `CheckSpreadCPUTopology` move (commit `ccec1d8`). The spread validation is now enforced on all paths through `ApplyToVMI`, not only through the webhook. The existing admitter tests cover the error-path behaviour and continue to pass.

### Checklist

- [ ] Design: VEP not required (bug fixes)
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [ ] Upgrade: No upgrade impact
- [x] Testing: New unit tests added for `preference/validation`; corrected a pre-existing test asserting wrong behaviour
- [ ] Documentation: No user-facing API change
- [ ] Community: Not required for bug fixes
- [x] AI Contributions: The PR abides by the KubeVirt AI Contribution Policy

### Release note
```release-note
NONE
```