### PR TITLE
selinux: verify SELinux capability before enabling context switching

### DIFF
--- a/pkg/virt-handler/selinux/context_executor.go
+++ b/pkg/virt-handler/selinux/context_executor.go
@@ -106,7 +106,24 @@ func (ce *ContextExecutor) resetContext() error {
 
 func (ce *ContextExecutor) isSELinuxEnabled() bool {
 	_, selinuxEnabled, err := ce.executor.NewSELinux()
-	return err == nil && selinuxEnabled
+	if err != nil || !selinuxEnabled {
+		return false
+	}
+	// SELinux capability check to avoid false positives on partially-enabled systems.
+	// Some custom kernels may mount selinuxfs (so /sys/fs/selinux/enforce exists and
+	// virt-chroot getenforce reports enforcing/permissive) while the SELinux LSM is
+	// not actually enabled in the kernel cmdline. In that case getxattr on
+	// /proc/<pid>/attr/current returns EOPNOTSUPP, and proceeding with SELinux context
+	// switching would make getLabelForPID fail fatally, breaking VMI network setup and
+	// leaving virt-handler unable to complete its task.
+	// Generic fix: verify that the SELinux label of our own process can be read.
+	// If it cannot, SELinux is considered not functional and we degrade to no context
+	// switching, matching the behavior of the go-selinux non-SELinux stub.
+	if _, err := ce.getLabelForPID(os.Getpid()); err != nil {
+		log.Log.Warningf("SELinux detected but not functional, disabling SELinux context switching: %v", err)
+		return false
+	}
+	return true
 }
 
 func (ce *ContextExecutor) getLabelForPID(pid int) (string, error) {

--- a/pkg/virt-handler/selinux/context_executor_test.go
+++ b/pkg/virt-handler/selinux/context_executor_test.go
@@ -90,10 +90,16 @@ var _ = Describe("SELinux context executor", func() {
 				EXPECT().
 				FileLabel(fmt.Sprintf("/proc/%d/attr/current", pid)).
 				Return(desiredLabel, nil)
+			// isSELinuxEnabled() now additionally verifies that our own process
+			// label can be read, so FileLabel(os.Getpid()) is called 3 times:
+			//  1) capability check inside newContextExecutor's isSELinuxEnabled()
+			//  2) originalLabel read inside newContextExecutor
+			//  3) capability check inside Execute()'s isSELinuxEnabled()
 			executor.
 				EXPECT().
 				FileLabel(fmt.Sprintf("/proc/%d/attr/current", os.Getpid())).
-				Return(originalLabel, nil)
+				Return(originalLabel, nil).
+				Times(3)
 			executor.
 				EXPECT().
 				LockOSThread()
@@ -116,6 +122,35 @@ var _ = Describe("SELinux context executor", func() {
 			Expect(ce.desiredLabel).To(Equal(desiredLabel))
 			Expect(ce.originalLabel).To(Equal(originalLabel))
 			Expect(ce.pid).To(Equal(pid))
+			err = ce.Execute()
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Context("with SELinux detected but not functional", func() {
+		// Simulate a partially-enabled custom kernel: selinuxfs is mounted and
+		// virt-chroot getenforce reports SELinux enabled, but the SELinux LSM is
+		// not actually active, so reading /proc/<pid>/attr/current returns
+		// EOPNOTSUPP. isSELinuxEnabled() must then degrade to false and skip
+		// context switching, avoiding the fatal getLabelForPID error on boot.
+		BeforeEach(func() {
+			executor.
+				EXPECT().
+				NewSELinux().
+				Return(&SELinuxImpl{}, true, nil).
+				Times(2)
+			executor.
+				EXPECT().
+				FileLabel(gomock.Any()).
+				Return("", fmt.Errorf("operation not supported")).
+				AnyTimes()
+		})
+
+		It("should degrade to non-SELinux execution", func() {
+			ce, err := newContextExecutor(pid, &exec.Cmd{}, executor)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ce.desiredLabel).To(BeEmpty())
+			Expect(ce.originalLabel).To(BeEmpty())
 			err = ce.Execute()
 			Expect(err).ToNot(HaveOccurred())
 		})

--- a/pkg/virt-handler/selinux/executor.go
+++ b/pkg/virt-handler/selinux/executor.go
@@ -23,12 +23,23 @@ package selinux
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"runtime"
 	"syscall"
 
 	"github.com/opencontainers/selinux/go-selinux"
 )
+
+// SELinux capability check to avoid false positives on partially-enabled systems.
+// Some custom kernels may mount selinuxfs while the SELinux LSM is not actually
+// enabled in the kernel cmdline, so reading /proc/<pid>/attr/current returns
+// EOPNOTSUPP. A successful read of our own process label is treated as proof that
+// SELinux is functional, consistent with ContextExecutor.isSELinuxEnabled.
+func IsSELinuxFunctional() bool {
+	_, err := selinux.FileLabel(fmt.Sprintf("/proc/%d/attr/current", os.Getpid()))
+	return err == nil
+}
 
 type Executor interface {
 	NewSELinux() (SELinux, bool, error)

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -1037,6 +1037,16 @@ func (c *VirtualMachineController) updateSELinuxContext(vmi *v1.VirtualMachineIn
 		return err
 	}
 	if present {
+		// SELinux capability check to avoid false positives on partially-enabled systems.
+		// Consistent with ContextExecutor.isSELinuxEnabled: some custom kernels mount
+		// selinuxfs while the SELinux LSM is not actually enabled, so go-selinux reports
+		// SELinux as present and every reconcile would hit GetVirtLauncherContext and fail
+		// (No command socket found / EOPNOTSUPP). If our own process label cannot be read,
+		// SELinux is considered not functional: set "none" and return early.
+		if !selinux.IsSELinuxFunctional() {
+			vmi.Status.SelinuxContext = "none"
+			return nil
+		}
 		context, err := selinux.GetVirtLauncherContext(vmi)
 		if err != nil {
 			return err


### PR DESCRIPTION
<!-- 提交到 kubevirt/kubevirt 的 PR 描述（英文，隐去公司信息） -->

**What this PR does / why we need it:**

On kernels with a **partially-enabled SELinux** (selinuxfs is mounted, so `/sys/fs/selinux/enforce` exists and `virt-chroot getenforce` reports enforcing/permissive, but the SELinux LSM is **not actually enabled** in the kernel cmdline), go-selinux reports SELinux as present. This causes two failure modes:

1. `ContextExecutor.isSELinuxEnabled()` returns `true` and the executor proceeds with SELinux context switching. `getLabelForPID` then fails fatally with `EOPNOTSUPP` (getxattr on `/proc/<pid>/attr/current`), breaking VMI network setup and leaving virt-handler unable to complete its task.
2. `updateSELinuxContext()` also treats SELinux as present and calls `GetVirtLauncherContext()` on every reconcile, logging a spurious `couldn't find the SELinux context` error (`No command socket found` / `EOPNOTSUPP`).

**What changed:**

Verify that the SELinux label of our own process (`/proc/<pid>/attr/current` of `os.Getpid()`) can actually be read before treating SELinux as functional:

- `pkg/virt-handler/selinux/context_executor.go`: `isSELinuxEnabled()` now additionally reads the label of `os.Getpid()`. If it fails (e.g. `EOPNOTSUPP`), SELinux is considered not functional and context switching is skipped — matching the behavior of the old go-selinux non-SELinux stub.
- `pkg/virt-handler/selinux/executor.go`: add package-level `IsSELinuxFunctional()` sharing the same capability check.
- `pkg/virt-handler/vm.go`: `updateSELinuxContext()` uses `IsSELinuxFunctional()` and sets the status to `"none"` early when SELinux is not functional, avoiding the spurious per-reconcile error.

No behavior change on real SELinux systems, where reading our own label always succeeds.

**Which issue(s) this PR fixes:**

Fixes # (none — reported from production upgrade testing)

**Special notes for your reviewer:**

The generic capability check is a single `getxattr` syscall on our own process — negligible overhead.

**Release note:**

```release-note
selinux: verify SELinux capability before enabling context switching, fixing fatal EOPNOTSUPP errors on kernels with selinuxfs mounted but SELinux LSM not enabled
```
