### PR TITLE
Fix SSRF in port-forward via guest-agent IP poisoning

### DIFF
--- a/pkg/network/setup/BUILD.bazel
+++ b/pkg/network/setup/BUILD.bazel
@@ -26,7 +26,6 @@ go_library(
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
-        "//vendor/k8s.io/utils/net:go_default_library",
     ],
 )
 

--- a/pkg/network/setup/netstat.go
+++ b/pkg/network/setup/netstat.go
@@ -21,14 +21,11 @@ package network
 
 import (
 	"fmt"
-	"net"
-	"net/netip"
 	"slices"
 	"strings"
 	"sync"
 
 	"k8s.io/apimachinery/pkg/types"
-	netutils "k8s.io/utils/net"
 
 	v1 "kubevirt.io/api/core/v1"
 
@@ -114,7 +111,7 @@ func (c *NetStat) UpdateStatus(vmi *v1.VirtualMachineInstance, domain *api.Domai
 	}
 
 	// Guest Agent information will add and conditionally override data gathered from the cache.
-	interfacesStatus = ifacesStatusFromGuestAgent(interfacesStatus, domain.Status.Interfaces, vmiInterfacesSpecByName)
+	interfacesStatus = ifacesStatusFromGuestAgent(interfacesStatus, domain.Status.Interfaces)
 
 	if primaryNetwork := netvmispec.LookupPodNetwork(vmi.Spec.Networks); primaryNetwork != nil {
 		interfacesStatus = restorePrimaryIfaceStatus(interfacesStatus, vmi.Status.Interfaces, primaryNetwork.Name)
@@ -326,21 +323,12 @@ func sriovIfacesStatusFromDomainHostDevices(hostDevices []api.HostDevice, vmiIfa
 func ifacesStatusFromGuestAgent(
 	vmiIfacesStatus []v1.VirtualMachineInstanceNetworkInterface,
 	guestAgentInterfaces []api.InterfaceStatus,
-	vmiInterfacesSpecByName map[string]v1.Interface,
 ) []v1.VirtualMachineInstanceNetworkInterface {
 	const guestOnlyInterfaceLimit = 10
 	var guestOnlyInterfaceCount int
 
 	for _, guestAgentInterface := range guestAgentInterfaces {
 		if vmiIfaceStatus := netvmispec.LookupInterfaceStatusByMac(vmiIfacesStatus, guestAgentInterface.Mac); vmiIfaceStatus != nil {
-			vmiIfaceSpec := vmiInterfacesSpecByName[vmiIfaceStatus.Name]
-
-			// When using masquerade binding, guest-defined Link-Local Addresses (LLAs) are unreachable from the pod network.
-			// These addresses remain internal to the guest and are outside the scope of KubeVirt's NAT translation rules.
-			if vmiIfaceSpec.Masquerade != nil {
-				guestAgentInterface.IPs = filterOutLinkLocalAddresses(guestAgentInterface.IPs)
-			}
-
 			updateVMIIfaceStatusWithGuestAgentData(vmiIfaceStatus, guestAgentInterface)
 			if !isGuestAgentIfaceOriginatedFromOldVirtLauncher(guestAgentInterface) {
 				vmiIfaceStatus.InfoSource = netvmispec.InfoSourceDomainAndGA
@@ -370,37 +358,17 @@ func isGuestAgentIfaceOriginatedFromOldVirtLauncher(guestAgentInterface api.Inte
 
 func updateVMIIfaceStatusWithGuestAgentData(ifaceStatus *v1.VirtualMachineInstanceNetworkInterface, guestAgentIface api.InterfaceStatus) {
 	ifaceStatus.InterfaceName = guestAgentIface.InterfaceName
-	// IP data from the Guest Agent overrides previous iface status information in the following cases:
-	// - No status IPs existed before, i.e. GA data is adding new information.
-	// - Status IPs exist, however, GA information does not include any IP.
-	// In other words, if IP data already existed in the status, GA IP data will not override it.
-	// However, in case GA does not include IP data, it will clear IP status data (guest is not reachable by any IP).
-	ifaceStatusIPv4, ifaceStatusIPv6 := splitIPByFamiliy(ifaceStatus.IPs)
-	guestAgentIfaceIPv4, guestAgentIfaceIPv6 := splitIPByFamiliy(guestAgentIface.IPs)
-	if len(ifaceStatusIPv4) == 0 || len(guestAgentIfaceIPv4) == 0 {
-		ifaceStatusIPv4 = guestAgentIfaceIPv4
+
+	// Pod-cache IPs (set during network setup from the pod interface) are authoritative.
+	// Only use guest-agent IPs when no pod-cache IPs exist (e.g. guest-only interfaces).
+	if len(ifaceStatus.IPs) > 0 {
+		return
 	}
-	if len(ifaceStatusIPv6) == 0 || len(guestAgentIfaceIPv6) == 0 {
-		ifaceStatusIPv6 = guestAgentIfaceIPv6
-	}
-	ifaceStatus.IP = ""
-	ifaceStatus.IPs = nil
-	if len(ifaceStatusIPv4) > 0 {
-		ifaceStatus.IPs = append(ifaceStatus.IPs, ifaceStatusIPv4...)
-	}
-	if len(ifaceStatusIPv6) > 0 {
-		ifaceStatus.IPs = append(ifaceStatus.IPs, ifaceStatusIPv6...)
-	}
+
+	ifaceStatus.IPs = guestAgentIface.IPs
 	if len(ifaceStatus.IPs) > 0 {
 		ifaceStatus.IP = ifaceStatus.IPs[0]
 	}
-}
-
-func filterOutLinkLocalAddresses(ipv6Addresses []string) []string {
-	return slices.DeleteFunc(ipv6Addresses, func(s string) bool {
-		addr, err := netip.ParseAddr(s)
-		return err != nil || addr.IsLinkLocalUnicast()
-	})
 }
 
 func newVMIIfaceStatusFromGuestAgentData(guestAgentInterface api.InterfaceStatus) v1.VirtualMachineInstanceNetworkInterface {
@@ -421,22 +389,4 @@ func filterHostDevicesByAlias(hostDevices []api.HostDevice, prefix string) []api
 		}
 	}
 	return filteredHostDevices
-}
-
-func splitIPByFamiliy(ips []string) ([]string, []string) {
-	var IPv4Addresses []string
-	var IPv6Addresses []string
-
-	for _, ipRaw := range ips {
-		ip := net.ParseIP(ipRaw)
-		switch {
-		case ip == nil:
-			continue
-		case netutils.IsIPv4(ip):
-			IPv4Addresses = append(IPv4Addresses, ipRaw)
-		case netutils.IsIPv6(ip):
-			IPv6Addresses = append(IPv6Addresses, ipRaw)
-		}
-	}
-	return IPv4Addresses, IPv6Addresses
 }

--- a/pkg/network/setup/netstat_test.go
+++ b/pkg/network/setup/netstat_test.go
@@ -207,6 +207,8 @@ var _ = Describe("netstat", func() {
 				{
 					Name:          secondaryNetworkName,
 					InterfaceName: secondaryIfaceName,
+					IP:            secondaryPodIPv4,
+					IPs:           []string{secondaryPodIPv4, secondaryPodIPv6},
 					MAC:           secondaryMAC,
 					InfoSource:    netvmispec.InfoSourceDomainAndGA,
 					QueueCount:    netsetup.DefaultInterfaceQueueCount,
@@ -371,14 +373,14 @@ var _ = Describe("netstat", func() {
 				{
 					Name:          primaryNetworkName,
 					InterfaceName: primaryIfaceName,
-					IP:            primaryGaIPv6,
-					IPs:           []string{primaryGaIPv6},
+					IP:            primaryPodIPv4,
+					IPs:           []string{primaryPodIPv4},
 					MAC:           primaryMAC,
 					InfoSource:    netvmispec.InfoSourceDomainAndGA,
 					QueueCount:    netsetup.DefaultInterfaceQueueCount,
 					LinkState:     linkStateUp,
 				},
-			}), "the guest-agent IP/s should be reported in the status")
+			}), "the pod cache IP/s should be reported in the status, guest-agent IPs are not used when pod cache IPs exist")
 
 			Expect(setup.NetStat.PodInterfaceVolatileDataIsCached(setup.Vmi, primaryNetworkName)).To(BeTrue())
 		})
@@ -484,12 +486,14 @@ var _ = Describe("netstat", func() {
 			{
 				Name:          primaryNetworkName,
 				InterfaceName: primaryIfaceName,
+				IP:            origIPv4,
+				IPs:           []string{origIPv4, origIPv6},
 				MAC:           origMAC,
 				InfoSource:    netvmispec.InfoSourceDomainAndGA,
 				QueueCount:    netsetup.DefaultInterfaceQueueCount,
 				LinkState:     linkStateUp,
 			},
-		}), "the pod IP/s should be reported in the status")
+		}), "the pod IP/s should be reported in the status, guest-agent cannot clear pod cache IPs")
 	})
 
 	It("should report SR-IOV interface when guest-agent is inactive and no other interface exists", func() {
@@ -587,50 +591,6 @@ var _ = Describe("netstat", func() {
 				QueueCount:    netsetup.UnknownInterfaceQueueCount,
 			},
 		}), "the SR-IOV interface should be reported in the status, associated to the network")
-	})
-
-	It("should not report link local addresses for masquerade binding when reported by guest-agent", func() {
-		const (
-			primaryNetworkName = "primary"
-
-			primaryGaIPv4    = "1.1.1.1"
-			primaryGaIPv6    = "fd20:244::8c4c"
-			primaryGaLLAIPv6 = "fe80::a00:27ff:fe8f:5d42"
-
-			primaryMAC     = "1C:CE:C0:01:BE:E7"
-			primaryPodIPv4 = "1.1.1.1"
-		)
-
-		Expect(
-			setup.addNetworkInterface(
-				newVMISpecIfaceWithMasqueradeBinding(primaryNetworkName),
-				newVMISpecPodNetwork(primaryNetworkName),
-				newDomainSpecIface(primaryNetworkName, primaryMAC),
-				primaryPodIPv4,
-			)).To(Succeed())
-
-		setup.addGuestAgentInterfaces(
-			newDomainStatusIface(
-				[]string{primaryGaIPv4, primaryGaIPv6, primaryGaLLAIPv6},
-				primaryMAC,
-				"eth0",
-			),
-		)
-
-		Expect(setup.NetStat.UpdateStatus(setup.Vmi, setup.Domain)).To(Succeed())
-
-		Expect(setup.Vmi.Status.Interfaces).To(Equal([]v1.VirtualMachineInstanceNetworkInterface{
-			{
-				Name:          primaryNetworkName,
-				InterfaceName: "eth0",
-				IP:            primaryPodIPv4,
-				IPs:           []string{primaryPodIPv4, primaryGaIPv6},
-				MAC:           primaryMAC,
-				InfoSource:    netvmispec.InfoSourceDomainAndGA,
-				QueueCount:    netsetup.DefaultInterfaceQueueCount,
-				LinkState:     linkStateUp,
-			},
-		}))
 	})
 
 	It("should report link local addresses for secondary iface using bridge binding w/o IPAM when reported by guest-agent", func() {
@@ -937,6 +897,8 @@ var _ = Describe("netstat", func() {
 			Expect(setup.Vmi.Status.Interfaces).To(Equal([]v1.VirtualMachineInstanceNetworkInterface{
 				{
 					Name:       primaryNetworkName,
+					IP:         primaryPodIPv4,
+					IPs:        []string{primaryPodIPv4},
 					MAC:        primaryMAC,
 					InfoSource: netvmispec.InfoSourceDomain,
 					QueueCount: netsetup.DefaultInterfaceQueueCount,

--- a/pkg/virt-api/rest/BUILD.bazel
+++ b/pkg/virt-api/rest/BUILD.bazel
@@ -31,6 +31,7 @@ go_library(
         "//pkg/instancetype/find:go_default_library",
         "//pkg/instancetype/preference/find:go_default_library",
         "//pkg/monitoring/metrics/virt-api:go_default_library",
+        "//pkg/network/vmispec:go_default_library",
         "//pkg/storage/types:go_default_library",
         "//pkg/storage/utils:go_default_library",
         "//pkg/util:go_default_library",

--- a/pkg/virt-api/rest/dialers.go
+++ b/pkg/virt-api/rest/dialers.go
@@ -34,6 +34,7 @@ import (
 	kvcorev1 "kubevirt.io/client-go/kubevirt/typed/core/v1"
 	"kubevirt.io/client-go/log"
 
+	netvmispec "kubevirt.io/kubevirt/pkg/network/vmispec"
 	"kubevirt.io/kubevirt/pkg/virt-api/definitions"
 )
 
@@ -130,12 +131,14 @@ func (app *SubresourceAPIApp) getVirtHandlerConnForVMI(vmi *v1.VirtualMachineIns
 	return kubecli.NewVirtHandlerClient(app.virtCli, app.handlerHttpClient).Port(app.consoleServerPort).ForNode(vmi.Status.NodeName), nil
 }
 
-// get the first available interface IP
-// if no interface is present, return error
 func getTargetInterfaceIP(vmi *v1.VirtualMachineInstance) (string, error) {
-	interfaces := vmi.Status.Interfaces
-	if len(interfaces) < 1 {
-		return "", fmt.Errorf("no network interfaces are present")
+	podNetwork := netvmispec.LookupPodNetwork(vmi.Spec.Networks)
+	if podNetwork == nil {
+		return "", fmt.Errorf("vmi has no pod network")
 	}
-	return interfaces[0].IP, nil
+	ifaceStatus := netvmispec.LookupInterfaceStatusByName(vmi.Status.Interfaces, podNetwork.Name)
+	if ifaceStatus == nil || ifaceStatus.IP == "" {
+		return "", fmt.Errorf("pod network interface has no IP")
+	}
+	return ifaceStatus.IP, nil
 }

--- a/pkg/virt-api/rest/dialers.go
+++ b/pkg/virt-api/rest/dialers.go
@@ -22,6 +22,7 @@ package rest
 import (
 	"fmt"
 	"net"
+	"net/netip"
 
 	"github.com/gorilla/websocket"
 
@@ -89,6 +90,9 @@ func (n netDial) DialUnderlying(vmi *v1.VirtualMachineInstance) (net.Conn, *k8se
 	if protocolParam := n.request.PathParameter(definitions.ProtocolParamName); len(protocolParam) > 0 {
 		protocol = protocolParam
 	}
+	if protocol != "tcp" && protocol != "udp" {
+		return nil, k8serrors.NewBadRequest(fmt.Sprintf("unsupported protocol %q", protocol))
+	}
 
 	addr := fmt.Sprintf("%s:%s", targetIP, port)
 	if netutils.IsIPv6String(targetIP) {
@@ -140,5 +144,23 @@ func getTargetInterfaceIP(vmi *v1.VirtualMachineInstance) (string, error) {
 	if ifaceStatus == nil || ifaceStatus.IP == "" {
 		return "", fmt.Errorf("pod network interface has no IP")
 	}
-	return ifaceStatus.IP, nil
+	return validateTargetIP(ifaceStatus.IP)
+}
+
+func validateTargetIP(ip string) (string, error) {
+	addr, err := netip.ParseAddr(ip)
+	if err != nil {
+		return "", fmt.Errorf("invalid target IP %q: %w", ip, err)
+	}
+	switch {
+	case addr.IsLoopback():
+		return "", fmt.Errorf("target IP %s is a loopback address", ip)
+	case addr.IsLinkLocalUnicast():
+		return "", fmt.Errorf("target IP %s is a link-local address", ip)
+	case addr.IsMulticast():
+		return "", fmt.Errorf("target IP %s is a multicast address", ip)
+	case addr.IsUnspecified():
+		return "", fmt.Errorf("target IP %s is an unspecified address", ip)
+	}
+	return ip, nil
 }

--- a/pkg/virt-api/rest/dialers_test.go
+++ b/pkg/virt-api/rest/dialers_test.go
@@ -31,7 +31,6 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"go.uber.org/mock/gomock"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
@@ -56,38 +55,44 @@ var _ = Describe("NetDialer", func() {
 		request = restful.NewRequest(httpReq)
 	})
 
-	makeVMIWithInterfaceStatus := func(interfaces []v1.VirtualMachineInstanceNetworkInterface) *v1.VirtualMachineInstance {
-		return &v1.VirtualMachineInstance{
-			TypeMeta: metav1.TypeMeta{},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      vmName,
-				Namespace: vmNamespace,
-			},
-			Spec: v1.VirtualMachineInstanceSpec{},
-			Status: v1.VirtualMachineInstanceStatus{
-				Interfaces: interfaces,
-			},
-		}
+	newVMIWithPodNetwork := func(ip string) *v1.VirtualMachineInstance {
+		return libvmi.New(
+			libvmi.WithNamespace(vmNamespace),
+			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
+			libvmi.WithNetwork(v1.DefaultPodNetwork()),
+			libvmistatus.WithStatus(libvmistatus.New(
+				libvmistatus.WithInterfaceStatus(v1.VirtualMachineInstanceNetworkInterface{
+					Name: v1.DefaultPodNetwork().Name,
+					IP:   ip,
+				}),
+			)),
+		)
 	}
 
-	It("Should fail if vmi has no network interfaces", func() {
-		dialer := netDial{
-			request: request,
-		}
-		_, statusErr := dialer.DialUnderlying(makeVMIWithInterfaceStatus(nil))
-		Expect(statusErr.Status().Message).To(Equal("no network interfaces are present"))
+	It("Should fail if VMI has no pod network", func() {
+		vmi := libvmi.New(
+			libvmi.WithNamespace(vmNamespace),
+			libvmistatus.WithStatus(libvmistatus.New(
+				libvmistatus.WithInterfaceStatus(v1.VirtualMachineInstanceNetworkInterface{
+					IP: "10.0.0.1",
+				}),
+			)),
+		)
+		dialer := netDial{request: request}
+		_, statusErr := dialer.DialUnderlying(vmi)
+		Expect(statusErr.Status().Message).To(ContainSubstring("no pod network"))
+	})
+
+	It("Should fail if pod network interface has no IP", func() {
+		dialer := netDial{request: request}
+		_, statusErr := dialer.DialUnderlying(newVMIWithPodNetwork(""))
+		Expect(statusErr.Status().Message).To(ContainSubstring("no IP"))
 	})
 
 	It("Should fail if request has no port", func() {
 		request.PathParameters()["port"] = ""
-		dialer := netDial{
-			request: request,
-		}
-		_, statusErr := dialer.DialUnderlying(makeVMIWithInterfaceStatus([]v1.VirtualMachineInstanceNetworkInterface{
-			{
-				IP: "192.168.0.1",
-			},
-		}))
+		dialer := netDial{request: request}
+		_, statusErr := dialer.DialUnderlying(newVMIWithPodNetwork("192.168.0.1"))
 		Expect(statusErr.Status().Message).To(Equal("port must not be empty"))
 	})
 
@@ -136,14 +141,8 @@ var _ = Describe("NetDialer", func() {
 		tcpAddr := ln.Addr().(*net.TCPAddr)
 
 		request.PathParameters()["port"] = strconv.FormatInt(int64(tcpAddr.Port), 10)
-		dialer := netDial{
-			request: request,
-		}
-		conn, statusErr := dialer.DialUnderlying(makeVMIWithInterfaceStatus([]v1.VirtualMachineInstanceNetworkInterface{
-			{
-				IP: tcpAddr.IP.String(),
-			},
-		}))
+		dialer := netDial{request: request}
+		conn, statusErr := dialer.DialUnderlying(newVMIWithPodNetwork(tcpAddr.IP.String()))
 		Expect(statusErr).NotTo(HaveOccurred())
 		Expect(conn).NotTo(BeNil())
 	},

--- a/pkg/virt-api/rest/dialers_test.go
+++ b/pkg/virt-api/rest/dialers_test.go
@@ -21,7 +21,6 @@ package rest
 
 import (
 	"fmt"
-	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -96,6 +95,29 @@ var _ = Describe("NetDialer", func() {
 		Expect(statusErr.Status().Message).To(Equal("port must not be empty"))
 	})
 
+	It("Should fail with unsupported protocol", func() {
+		request.PathParameters()["port"] = "22"
+		request.PathParameters()["protocol"] = "unix"
+		dialer := netDial{request: request}
+		_, statusErr := dialer.DialUnderlying(newVMIWithPodNetwork("192.168.0.1"))
+		Expect(statusErr.Status().Message).To(ContainSubstring("unsupported protocol"))
+	})
+
+	DescribeTable("Should reject dangerous target IPs", func(ip, expectedMsg string) {
+		dialer := netDial{request: request}
+		_, statusErr := dialer.DialUnderlying(newVMIWithPodNetwork(ip))
+		Expect(statusErr.Status().Message).To(ContainSubstring(expectedMsg))
+	},
+		Entry("loopback IPv4", "127.0.0.1", "loopback"),
+		Entry("loopback IPv6", "::1", "loopback"),
+		Entry("link-local IPv4", "169.254.1.1", "link-local"),
+		Entry("link-local IPv6", "fe80::1", "link-local"),
+		Entry("multicast IPv4", "224.0.0.1", "multicast"),
+		Entry("multicast IPv6", "ff02::1", "multicast"),
+		Entry("unspecified IPv4", "0.0.0.0", "unspecified"),
+		Entry("unspecified IPv6", "::", "unspecified"),
+	)
+
 	It("Should forward error from Request's Body", func() {
 		const errMsg = "foo bar from the App handler!"
 		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
@@ -133,20 +155,4 @@ var _ = Describe("NetDialer", func() {
 		Expect(statusErr).To(MatchError(ContainSubstring(errMsg)))
 		Expect(conn).To(BeNil())
 	})
-
-	DescribeTable("Should dial vmi", func(ipAddr string) {
-		ln, err := net.Listen("tcp", fmt.Sprintf("%s:0", ipAddr))
-		Expect(err).NotTo(HaveOccurred())
-		defer ln.Close()
-		tcpAddr := ln.Addr().(*net.TCPAddr)
-
-		request.PathParameters()["port"] = strconv.FormatInt(int64(tcpAddr.Port), 10)
-		dialer := netDial{request: request}
-		conn, statusErr := dialer.DialUnderlying(newVMIWithPodNetwork(tcpAddr.IP.String()))
-		Expect(statusErr).NotTo(HaveOccurred())
-		Expect(conn).NotTo(BeNil())
-	},
-		Entry("with ipv4 ip address", "127.0.0.1"),
-		Entry("with ipv6 ip address", "[::1]"),
-	)
 })


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
The QEMU guest agent could poison VMI interface status IPs, which virt-api's port-forward handler then passed to `net.Dial()` without validation. This allowed a malicious guest to tunnel arbitrary TCP traffic through virt-api to any endpoint it could reach (SSRF).

The per-family IP merge logic in `updateVMIIfaceStatusWithGuestAgentData` used an OR condition that allowed two attack patterns:
  - Clear one IP family and inject an arbitrary address of the other.
  - On IPv6-only clusters, inject a malicious IPv4 that becomes the primary IP.
 
All pod-network binding types are affected on single-stack clusters (bridge, masquerade, passt, binding plugins).
                                       
Fix with three layers:

1. **virt-handler**: Pod-cache IPs (set during network setup from the actual pod interface) are authoritative. Guest-agent IPs are only used for interfaces with no pod-cache entry (guest-only interfaces).
                                          
2. **virt-api**: Port-forward resolves the target IP by looking up the pod network by name instead of trusting `vmi.status.interfaces[0]`. VMIs without a pod network are rejected.

3. **virt-api**: Target IP is validated before dialing — loopback, link-local (including the metadata service), multicast, and   
unspecified addresses are rejected. Protocol is restricted to TCP / UDP.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix SSRF vulnerability (CVE-2026-13318) in virt-api port-forward that allowed a malicious QEMU guest agent to redirect traffic to arbitrary network endpoints. vmi.status.interfaces[].IPs for pod-network interfaces now only contains pod IPs assigned by the CNI; guest-agent-reported IPs of the other address family no longer appear in status.IPs before dialing.
```

