### PR TITLE
emulated-igb: Explicit set KUBEVIRT_NUM_NUMA_NODES

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -92,6 +92,7 @@ case "$TARGET" in
     export KUBEVIRT_PROVIDER=${TARGET/-emulated-igb*/}
     export KUBEVIRT_FUNC_TEST_SUITE_ARGS="${KUBEVIRT_FUNC_TEST_SUITE_ARGS} -emulated-sriov=true"
     export KUBEVIRT_WITH_SRIOV=true
+    export KUBEVIRT_NUM_NUMA_NODES=2
     export KUBEVIRT_NUM_NODES=3
     export KUBEVIRT_DEPLOY_CDI=false
     export KUBEVIRT_DEPLOY_NETWORK_RESOURCES_INJECTOR=true


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

`automation/test.sh` for the emulated-igb lane currently relies on kubevirtci's provider.sh to set `KUBEVIRT_NUM_NUMA_NODES=2` when `KUBEVIRT_WITH_SRIOV=true`.
An upcoming kubevirtci change ([2]) removes that implicit default (to allow NUMA=1 to be used by other lanes).
Without this PR, the emulated-igb lane would silently inherit NUMA=1, breaking its CPU placement test.

That test requires 2 NUMA nodes to verify that allocated CPUs align with the same NUMA node as the SR-IOV interface. With only 1 NUMA node, the alignment is trivially true.

This PR makes the emulated-igb lane's NUMA requirement explicit and self-contained, independent of kubevirtci's defaults.

Note: This is a temporary bridge — once the emulated-igb tests are folded into the sig-network lane ([1]), this explicit setting will be dropped alongside the
emulated-igb lane itself.

[1] https://github.com/kubevirt/kubevirt/pull/18595
[2] https://github.com/kubevirt/kubevirtci/pull/1804

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
Context https://github.com/kubevirt/kubevirtci/pull/1804
which is required for https://github.com/kubevirt/kubevirt/pull/18595

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

