### PR TITLE
tests: use RequiresTwoSchedulableNodes decorator

### DIFF
--- a/tests/compute/subresources/BUILD.bazel
+++ b/tests/compute/subresources/BUILD.bazel
@@ -26,7 +26,6 @@ go_library(
         "//tests/framework/kubevirt:go_default_library",
         "//tests/framework/matcher:go_default_library",
         "//tests/libinstancetype/builder:go_default_library",
-        "//tests/libnode:go_default_library",
         "//tests/libvmifact:go_default_library",
         "//tests/libvmops:go_default_library",
         "//tests/testsuite:go_default_library",

--- a/tests/compute/subresources/migrate.go
+++ b/tests/compute/subresources/migrate.go
@@ -34,9 +34,9 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/libvmi"
 	"kubevirt.io/kubevirt/tests/compute"
+	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/framework/matcher"
-	"kubevirt.io/kubevirt/tests/libnode"
 	"kubevirt.io/kubevirt/tests/libvmifact"
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
@@ -48,11 +48,7 @@ var _ = Describe(compute.SIG("Migrate subresource", func() {
 		virtClient = kubevirt.Client()
 	})
 
-	It("[test_id:4119]should migrate a running VM", func() {
-		nodes := libnode.GetAllSchedulableNodes(virtClient)
-
-		Expect(len(nodes.Items)).To(BeNumerically(">", 1), "Migration tests require at least 2 nodes")
-
+	It("[test_id:4119]should migrate a running VM", decorators.RequiresTwoSchedulableNodes, func() {
 		By("Creating a VM with RunStrategyAlways")
 		vm := libvmi.NewVirtualMachine(libvmifact.NewGuestless(
 			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),
@@ -77,11 +73,7 @@ var _ = Describe(compute.SIG("Migrate subresource", func() {
 		}, 240*time.Second, 1*time.Second).Should(Succeed())
 	})
 
-	It("[test_id:7743]should not migrate a running vm if dry-run option is passed", func() {
-		nodes := libnode.GetAllSchedulableNodes(virtClient)
-		if len(nodes.Items) < 2 {
-			Fail("Migration tests require at least 2 nodes")
-		}
+	It("[test_id:7743]should not migrate a running vm if dry-run option is passed", decorators.RequiresTwoSchedulableNodes, func() {
 		By("Creating a VM with RunStrategyAlways")
 		vm := libvmi.NewVirtualMachine(libvmifact.NewGuestless(
 			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding()),

--- a/tests/infrastructure/security.go
+++ b/tests/infrastructure/security.go
@@ -45,7 +45,6 @@ import (
 
 var _ = Describe(SIGSerial("Node Restriction", decorators.RequiresTwoSchedulableNodes, func() {
 	var virtClient kubecli.KubevirtClient
-	const minNodesWithVirtHandler = 2
 
 	BeforeEach(func() {
 		virtClient = kubevirt.Client()
@@ -54,9 +53,6 @@ var _ = Describe(SIGSerial("Node Restriction", decorators.RequiresTwoSchedulable
 
 	It("Should disallow to modify VMs on different node", func() {
 		nodes := libnode.GetAllSchedulableNodes(virtClient).Items
-		if len(nodes) < minNodesWithVirtHandler {
-			Fail("Requires multiple nodes with virt-handler running")
-		}
 
 		vmi := libvmifact.NewGuestless()
 		vmi = libvmops.RunVMIAndExpectLaunch(vmi, flags.StartupTimeoutSecondsSmall())

--- a/tests/network/nad_live_update.go
+++ b/tests/network/nad_live_update.go
@@ -100,8 +100,6 @@ var _ = Describe(SIG("NAD name live update", decorators.RequiresTwoSchedulableNo
 
 	BeforeEach(func() {
 		nodes := libnode.GetAllSchedulableNodes(kubevirt.Client())
-		const minNoOfNodesNeeded = 2
-		Expect(len(nodes.Items)).To(BeNumerically(">=", minNoOfNodesNeeded))
 		sourceNodeName = nodes.Items[0].Name
 
 		const (

--- a/tests/replicaset_test.go
+++ b/tests/replicaset_test.go
@@ -456,11 +456,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 	Context("replicaset with topology spread constraints", decorators.WgS390x, func() {
 		It("Replicas should be spread across nodes", decorators.RequiresTwoSchedulableNodes, func() {
 			nodes := libnode.GetAllSchedulableNodes(kubevirt.Client())
-			Expect(nodes.Items).ToNot(BeEmpty(), "There should be some schedulable nodes")
 			numNodes := len(nodes.Items)
-			if numNodes < 2 {
-				Fail("Test environment has less than two schedulable nodes")
-			}
 			vmLabelKey := "test" + rand.String(5)
 			vmLabelValue := "test" + rand.String(5)
 			vmi := libvmifact.NewGuestless()

--- a/tests/validatingadmissionpolicy/noderestrictions.go
+++ b/tests/validatingadmissionpolicy/noderestrictions.go
@@ -170,11 +170,9 @@ var _ = Describe("[sig-compute] virt-handler node restrictions via validatingAdm
 		}
 	})
 
-	Context("patching another node", func() {
+	Context("patching another node", decorators.RequiresTwoSchedulableNodes, func() {
 		BeforeEach(func() {
 			nodesList := libnode.GetAllSchedulableNodes(virtClient)
-			Expect(nodesList.Items).ToNot(BeEmpty())
-			Expect(len(nodesList.Items)).To(BeNumerically(">", 1))
 			for _, node := range nodesList.Items {
 				if nodeName != node.Name {
 					anotherNode = node.Name


### PR DESCRIPTION
Replace runtime GetAllSchedulableNodes checks with the RequiresTwoSchedulableNodes decorator label, so that the test framework can skip these tests early via label filtering instead of failing mid-test when fewer than two nodes are available.

```release-note
NONE
```

