### PR TITLE
Limit concurrent virt-launcher socket scrapes in ConcurrentCollector

### DIFF
--- a/pkg/monitoring/metrics/virt-handler/collector/collector.go
+++ b/pkg/monitoring/metrics/virt-handler/collector/collector.go
@@ -20,6 +20,8 @@
 package collector
 
 import (
+	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -35,6 +37,11 @@ const (
 	// "a bit more" than timeout, heuristic again
 	StatsMaxAge = CollectionTimeout + 2*time.Second
 
+	// DefaultMaxConcurrentSources caps how many virt-launcher sockets may be
+	// scraped in parallel. Unbounded fan-out starves virt-handler (including
+	// /healthz) when many VMIs share a node.
+	DefaultMaxConcurrentSources = 10
+
 	logVerbosityInfo  = 3
 	logVerbosityDebug = 4
 )
@@ -46,10 +53,12 @@ type Collector interface {
 }
 
 type ConcurrentCollector struct {
-	lock             sync.Mutex
-	clientsPerKey    map[string]int
-	maxClientsPerKey int
-	socketMapper     func(vmis []*k6tv1.VirtualMachineInstance) vmiSocketMap
+	lock                 sync.Mutex
+	clientsPerKey        map[string]int
+	maxClientsPerKey     int
+	maxConcurrentSources int
+	scrapeSlots          chan struct{}
+	socketMapper         func(vmis []*k6tv1.VirtualMachineInstance) vmiSocketMap
 }
 
 func NewConcurrentCollector(maxRequestsPerKey int) Collector {
@@ -57,10 +66,28 @@ func NewConcurrentCollector(maxRequestsPerKey int) Collector {
 }
 
 func NewConcurrentCollectorWithMapper(maxRequestsPerKey int, mapper func(vmis []*k6tv1.VirtualMachineInstance) vmiSocketMap) Collector {
+	return NewConcurrentCollectorWithLimits(maxRequestsPerKey, DefaultMaxConcurrentSources, mapper)
+}
+
+// NewConcurrentCollectorWithLimits creates a collector that:
+//   - skips a socket key already at maxRequestsPerKey in-flight scrapes
+//   - never runs more than maxConcurrentSources scrapes at once
+func NewConcurrentCollectorWithLimits(
+	maxRequestsPerKey, maxConcurrentSources int,
+	mapper func(vmis []*k6tv1.VirtualMachineInstance) vmiSocketMap,
+) Collector {
+	if maxRequestsPerKey < 1 {
+		panic(fmt.Sprintf("maxRequestsPerKey must be >= 1, got %d", maxRequestsPerKey))
+	}
+	if maxConcurrentSources < 1 {
+		panic(fmt.Sprintf("maxConcurrentSources must be >= 1, got %d", maxConcurrentSources))
+	}
 	return &ConcurrentCollector{
-		clientsPerKey:    make(map[string]int),
-		maxClientsPerKey: maxRequestsPerKey,
-		socketMapper:     mapper,
+		clientsPerKey:        make(map[string]int),
+		maxClientsPerKey:     maxRequestsPerKey,
+		maxConcurrentSources: maxConcurrentSources,
+		scrapeSlots:          make(chan struct{}, maxConcurrentSources),
+		socketMapper:         mapper,
 	}
 }
 
@@ -68,7 +95,12 @@ func (cc *ConcurrentCollector) Collect(
 	vmis []*k6tv1.VirtualMachineInstance, scraper MetricsScraper, timeout time.Duration,
 ) ([]string, bool) {
 	socketToVMIs := cc.socketMapper(vmis)
-	log.Log.V(logVerbosityInfo).Infof("Collecting VM metrics from %d sources", len(socketToVMIs))
+	log.Log.V(logVerbosityInfo).Infof("Collecting VM metrics from %d sources (max concurrent %d)",
+		len(socketToVMIs), cc.maxConcurrentSources)
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
 	var busyScrapers sync.WaitGroup
 
 	var skipped []string
@@ -82,7 +114,7 @@ func (cc *ConcurrentCollector) Collect(
 
 		log.Log.V(logVerbosityDebug).Infof("Source %s responsive, scraping", key)
 		busyScrapers.Add(1)
-		go cc.collectFromSource(scraper, &busyScrapers, key, vmi)
+		go cc.collectFromSource(ctx, scraper, &busyScrapers, key, vmi)
 	}
 
 	completed := true
@@ -94,7 +126,7 @@ func (cc *ConcurrentCollector) Collect(
 	select {
 	case <-c:
 		log.Log.V(logVerbosityInfo).Infof("Collection successful")
-	case <-time.After(timeout):
+	case <-ctx.Done():
 		log.Log.Warning("Collection timeout")
 		completed = false
 	}
@@ -106,10 +138,21 @@ func (cc *ConcurrentCollector) Collect(
 }
 
 func (cc *ConcurrentCollector) collectFromSource(
+	ctx context.Context,
 	scraper MetricsScraper, wg *sync.WaitGroup, socket string, vmi *k6tv1.VirtualMachineInstance,
 ) {
 	defer wg.Done()
 	defer cc.releaseKey(socket)
+
+	// Bounded acquire: if Collect timed out (or previous hung scrapes still
+	// hold every scrapeSlots slot), skip instead of blocking forever.
+	select {
+	case cc.scrapeSlots <- struct{}{}:
+		defer func() { <-cc.scrapeSlots }()
+	case <-ctx.Done():
+		log.Log.Warningf("Timed out waiting for scrape slot for source %s, skipped", socket)
+		return
+	}
 
 	log.Log.V(logVerbosityDebug).Infof("Getting stats from source %s", socket)
 	scraper.Scrape(socket, vmi)

--- a/pkg/monitoring/metrics/virt-handler/collector/collector_test.go
+++ b/pkg/monitoring/metrics/virt-handler/collector/collector_test.go
@@ -20,6 +20,7 @@
 package collector
 
 import (
+	"sync/atomic"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -130,7 +131,122 @@ var _ = Describe("Collector", func() {
 			Expect(completed).To(BeTrue())
 		})
 	})
+
+	Context("concurrent scrape limit", func() {
+		fakeMapper := func(vmiList []*k6tv1.VirtualMachineInstance) vmiSocketMap {
+			m := vmiSocketMap{}
+			for _, vmi := range vmiList {
+				m[vmi.Name] = vmi
+			}
+			return m
+		}
+
+		It("should not scrape more sources than maxConcurrentSources", func() {
+			const (
+				maxConcurrent = 2
+				numSources    = 8
+				scrapeDelay   = 50 * time.Millisecond
+			)
+
+			many := make([]*k6tv1.VirtualMachineInstance, numSources)
+			for i := 0; i < numSources; i++ {
+				many[i] = &k6tv1.VirtualMachineInstance{
+					ObjectMeta: metav1.ObjectMeta{Name: string(rune('a' + i))},
+				}
+			}
+
+			var (
+				inFlight    atomic.Int32
+				maxInFlight atomic.Int32
+			)
+			scraper := &concurrencyTrackingScraper{
+				delay: scrapeDelay,
+				onStart: func() {
+					current := inFlight.Add(1)
+					for {
+						max := maxInFlight.Load()
+						if current <= max || maxInFlight.CompareAndSwap(max, current) {
+							break
+						}
+					}
+				},
+				onDone: func() {
+					inFlight.Add(-1)
+				},
+			}
+
+			cc := NewConcurrentCollectorWithLimits(1, maxConcurrent, fakeMapper)
+			skipped, completed := cc.Collect(many, scraper, 5*time.Second)
+
+			Expect(skipped).To(BeEmpty())
+			Expect(completed).To(BeTrue())
+			Expect(maxInFlight.Load()).To(BeNumerically("<=", maxConcurrent))
+			Expect(maxInFlight.Load()).To(BeNumerically(">", 0))
+		})
+
+		It("should not block forever when hung scrapes hold all scrape slots", func() {
+			const maxConcurrent = 1
+
+			blocked := []*k6tv1.VirtualMachineInstance{
+				{ObjectMeta: metav1.ObjectMeta{Name: "stuck"}},
+			}
+			next := []*k6tv1.VirtualMachineInstance{
+				{ObjectMeta: metav1.ObjectMeta{Name: "next"}},
+			}
+
+			fs := newFakeScraper()
+			fs.Block("stuck")
+			cc := NewConcurrentCollectorWithLimits(2, maxConcurrent, fakeMapper)
+
+			By("Starting a collection that leaves a hung scrape holding the only slot")
+			skipped, completed := cc.Collect(blocked, fs, 200*time.Millisecond)
+			Expect(skipped).To(BeEmpty())
+			Expect(completed).To(BeFalse())
+
+			By("A later collection must return instead of blocking forever on scrapeSlots")
+			done := make(chan struct{})
+			var nextSkipped []string
+			var nextCompleted bool
+			go func() {
+				defer close(done)
+				nextSkipped, nextCompleted = cc.Collect(next, newFakeScraper(), 200*time.Millisecond)
+			}()
+
+			Eventually(done, 2*time.Second).Should(BeClosed())
+			// "stuck" is still reserved from the hung scrape, and/or we timed out
+			// waiting for a scrape slot — either way Collect must not hang.
+			_ = nextSkipped
+			Expect(nextCompleted).To(BeFalse())
+
+			ready := fs.Wakeup("stuck")
+			<-ready
+			fs.Unblock("stuck")
+		})
+
+		DescribeTable("should panic on invalid limits", func(maxRequestsPerKey, maxConcurrentSources int) {
+			Expect(func() {
+				NewConcurrentCollectorWithLimits(maxRequestsPerKey, maxConcurrentSources, fakeMapper)
+			}).To(Panic())
+		},
+			Entry("maxRequestsPerKey < 1", 0, 1),
+			Entry("maxConcurrentSources < 1", 1, 0),
+		)
+	})
 })
+
+type concurrencyTrackingScraper struct {
+	delay   time.Duration
+	onStart func()
+	onDone  func()
+}
+
+func (s *concurrencyTrackingScraper) Scrape(_ string, _ *k6tv1.VirtualMachineInstance) {
+	s.onStart()
+	defer s.onDone()
+	time.Sleep(s.delay)
+}
+
+func (s *concurrencyTrackingScraper) Complete() {}
 
 type fakeScraper struct {
 	ready   map[string]chan bool

--- a/pkg/monitoring/metrics/virt-handler/domainstats/collector.go
+++ b/pkg/monitoring/metrics/virt-handler/domainstats/collector.go
@@ -58,14 +58,16 @@ type resourceMetrics interface {
 }
 
 type collectorSettings struct {
-	maxRequestsInFlight int
-	vmiInformer         cache.SharedIndexInformer
+	vmiInformer cache.SharedIndexInformer
+	// Shared across domain-stats and dirty-rate scrapes so concurrent socket
+	// dials stay bounded process-wide for Prometheus collection.
+	concCollector collector.Collector
 }
 
 func SetupDomainStatsCollector(maxRequestsInFlight int, vmiInformer cache.SharedIndexInformer) {
 	settings = &collectorSettings{
-		maxRequestsInFlight: maxRequestsInFlight,
-		vmiInformer:         vmiInformer,
+		vmiInformer:   vmiInformer,
+		concCollector: collector.NewConcurrentCollector(maxRequestsInFlight),
 	}
 }
 
@@ -92,8 +94,7 @@ func domainStatsCollectorCallback() []operatormetrics.CollectorResult {
 		vmis[i] = obj.(*k6tv1.VirtualMachineInstance)
 	}
 
-	concCollector := collector.NewConcurrentCollector(settings.maxRequestsInFlight)
-	return execDomainStatsCollector(concCollector, vmis)
+	return execDomainStatsCollector(settings.concCollector, vmis)
 }
 
 func execDomainStatsCollector(concCollector collector.Collector, vmis []*k6tv1.VirtualMachineInstance) []operatormetrics.CollectorResult {

--- a/pkg/monitoring/metrics/virt-handler/domainstats/dirty_rate_collector.go
+++ b/pkg/monitoring/metrics/virt-handler/domainstats/dirty_rate_collector.go
@@ -44,8 +44,7 @@ func domainDirtyRateStatsCollectorCallback() []operatormetrics.CollectorResult {
 		vmis[i] = obj.(*k6tv1.VirtualMachineInstance)
 	}
 
-	concCollector := collector.NewConcurrentCollector(settings.maxRequestsInFlight)
-	return execDomainDirtyRateStatsCollector(concCollector, vmis)
+	return execDomainDirtyRateStatsCollector(settings.concCollector, vmis)
 }
 
 func execDomainDirtyRateStatsCollector(

--- a/tests/libmonitoring/metrics.go
+++ b/tests/libmonitoring/metrics.go
@@ -30,7 +30,8 @@ func RegisterAllMetrics() error {
 		return err
 	}
 
-	if err := virthandler.SetupMetrics("", 0, nil, nil); err != nil {
+	// maxRequestsInFlight must be >= 1; doc/metrics registration does not scrape.
+	if err := virthandler.SetupMetrics("", 1, nil, nil); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
`ConcurrentCollector` spawned one scrape goroutine per VMI socket with no global concurrency limit. At 200+ VMs/node under load, hundreds of blocked virt-launcher dials could saturate virt-handler and cause /healthz liveness probe timeouts (kubelet restarts). Domain-stats and dirty-rate also created a new collector on every scrape, so scrape pressure was not shared.

#### After this PR:
Socket scrapes are capped at `DefaultMaxConcurrentSources (10)` via a semaphore in Collect(). Domain-stats and dirty-rate reuse one shared collector so both stay under the same bound. Adds a unit test that asserts the concurrency limit.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://redhat.atlassian.net/browse/CNV-89810
```

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Limit concurrent virt-launcher socket scrapes in ConcurrentCollector
```

