### PR TITLE
tests: remove unnecessary CPU capacity precondition checks

### DIFF
--- a/tests/compute/cpu.go
+++ b/tests/compute/cpu.go
@@ -59,16 +59,6 @@ var _ = Describe(SIG("CPU", func() {
 	})
 
 	Context("[rfe_id:2065][crit:medium][vendor:cnv-qe@redhat.com][level:component]with 3 CPU cores", Serial, func() {
-		var availableNumberOfCPUs int
-
-		BeforeEach(func() {
-			availableNumberOfCPUs = libnode.GetHighestCPUNumberAmongNodes(virtClient)
-
-			requiredNumberOfCpus := 3
-			Expect(availableNumberOfCPUs).ToNot(BeNumerically("<", requiredNumberOfCpus),
-				fmt.Sprintf("Test requires %d cpus, but only %d available!", requiredNumberOfCpus, availableNumberOfCPUs))
-		})
-
 		It("[test_id:1659]should report 3 cpu cores under guest OS", func() {
 			vmi := libvmifact.NewAlpine(
 				libvmi.WithCPUCount(3, 0, 0),

--- a/tests/libnode/node.go
+++ b/tests/libnode/node.go
@@ -300,21 +300,6 @@ func GetAllSchedulableNodes(virtClient kubecli.KubevirtClient) *k8sv1.NodeList {
 	return nodeList
 }
 
-func GetHighestCPUNumberAmongNodes(virtClient kubecli.KubevirtClient) int {
-	var cpus int64
-
-	nodeList, err := virtClient.CoreV1().Nodes().List(context.Background(), k8smetav1.ListOptions{})
-	ExpectWithOffset(1, err).ToNot(HaveOccurred())
-
-	for _, node := range nodeList.Items {
-		if v, ok := node.Status.Capacity[k8sv1.ResourceCPU]; ok && v.Value() > cpus {
-			cpus = v.Value()
-		}
-	}
-
-	return int(cpus)
-}
-
 func GetNodeNameWithHandler() string {
 	listOptions := k8smetav1.ListOptions{LabelSelector: v1.AppLabel + "=virt-handler"}
 	virtClient := kubevirt.Client()

--- a/tests/network/multiqueue.go
+++ b/tests/network/multiqueue.go
@@ -21,7 +21,6 @@ package network
 
 import (
 	"context"
-	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -33,7 +32,6 @@ import (
 	"kubevirt.io/kubevirt/pkg/libvmi"
 	"kubevirt.io/kubevirt/tests/console"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
-	"kubevirt.io/kubevirt/tests/libnode"
 	"kubevirt.io/kubevirt/tests/libvmifact"
 	"kubevirt.io/kubevirt/tests/libwait"
 	"kubevirt.io/kubevirt/tests/testsuite"
@@ -44,11 +42,6 @@ var _ = Describe(SIG("MultiQueue VMI", func() {
 
 	DescribeTable("should boot fedora to the login prompt and report the correct number of queues",
 		func(interfaceModel string, expectedQueueCount int32) {
-			availableCPUs := libnode.GetHighestCPUNumberAmongNodes(kubevirt.Client())
-			Expect(numCpus).To(BeNumerically("<=", availableCPUs),
-				fmt.Sprintf("Testing environment only has nodes with %d CPUs available, but required are %d CPUs", availableCPUs, numCpus),
-			)
-
 			vmi := libvmifact.NewFedora(
 				libvmi.WithInterface(libvmi.NewInterface(
 					v1.DefaultPodNetwork().Name,


### PR DESCRIPTION
KubeVirt overcommits CPUs by default, so a VM requesting N vCPUs will schedule and boot successfully even on nodes with fewer physical CPUs. The GetHighestCPUNumberAmongNodes checks were guarding against a problem that doesn't actually occur, since guest vCPU count is not constrained by host CPU count. On the other hand, a cluster with a lot of physical CPUs would fail to run the VM if it very busy.

Remove the function and all its call sites. We should not try to outsmart the k8s scheduler.

Assisted-By: Claude Opus 4.6

```release-note
NONE
```

