### PR TITLE
[release-1.9]: Fix Running VMIs being marked Failed during virt-handler restart- #18453

### DIFF
--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -2323,33 +2323,24 @@ func (c *VirtualMachineController) calculateVmPhaseForStatusReason(domain *api.D
 			return vmi.Status.Phase, nil
 		}
 		switch {
-		case vmi.IsScheduled():
+		case vmi.IsScheduled() || vmi.IsRunning():
 			isUnresponsive, isInitialized, err := c.launcherClients.IsLauncherClientUnresponsive(vmi)
-
 			if err != nil {
 				return vmi.Status.Phase, err
 			}
 			if !isInitialized {
 				c.queue.AddAfter(controller.VirtualMachineInstanceKey(vmi), time.Second*1)
-				return vmi.Status.Phase, err
-			} else if isUnresponsive {
+				return vmi.Status.Phase, nil
+			}
+			if isUnresponsive {
 				if vmi.IsMigrationTarget() {
 					return v1.WaitingForSync, nil
 				}
-				// virt-launcher is gone and VirtualMachineInstance never transitioned
-				// from scheduled to Running.
 				return v1.Failed, nil
 			}
-			return v1.Scheduled, nil
-		case !vmi.IsRunning() && !vmi.IsFinal():
-			return v1.Scheduled, nil
+			return vmi.Status.Phase, nil
 		case !vmi.IsFinal():
-			if vmi.IsMigrationTarget() {
-				return v1.WaitingForSync, nil
-			}
-			// That is unexpected. We should not be able to delete a VirtualMachineInstance before we stop it.
-			// However, if someone directly interacts with libvirt it is possible
-			return v1.Failed, nil
+			return v1.Scheduled, nil
 		}
 	} else {
 		switch domain.Status.Status {

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -522,6 +522,95 @@ var _ = Describe("VirtualMachineInstance", func() {
 			Expect(updatedVMI.Status.Phase).To(Equal(v1.Failed))
 		})
 
+		Context("When a Running VMI has no domain", func() {
+			It("should re-enqueue if the launcher client is not yet initialized", func() {
+				vmi := NewRunningVMI(vmiTestUUID, podTestUUID, host)
+
+				createVMI(vmi)
+
+				controller.launcherClients = &launcherclients.MockLauncherClientManager{
+					Initialized: false,
+				}
+
+				sanityExecute()
+
+				Expect(mockQueue.GetAddAfterEnqueueCount()).To(BeNumerically(">", 0))
+				updatedVMI, err := virtfakeClient.KubevirtV1().VirtualMachineInstances(metav1.NamespaceDefault).Get(context.TODO(), vmi.Name, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(updatedVMI.Status.Phase).To(Equal(v1.Running))
+			})
+
+			It("should move to Failed if the launcher client is unresponsive", func() {
+				vmi := NewRunningVMI(vmiTestUUID, podTestUUID, host)
+
+				createVMI(vmi)
+
+				controller.launcherClients = &launcherclients.MockLauncherClientManager{
+					Initialized:  true,
+					UnResponsive: true,
+				}
+
+				sanityExecute()
+
+				testutils.ExpectEvent(recorder, VMICrashed)
+				Expect(mockQueue.GetAddAfterEnqueueCount()).To(Equal(0))
+				updatedVMI, err := virtfakeClient.KubevirtV1().VirtualMachineInstances(metav1.NamespaceDefault).Get(context.TODO(), vmi.Name, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(updatedVMI.Status.Phase).To(Equal(v1.Failed))
+			})
+
+			It("should stay Running if the launcher client is responsive", func() {
+				vmi := NewRunningVMI(vmiTestUUID, podTestUUID, host)
+
+				createVMI(vmi)
+
+				controller.launcherClients = &launcherclients.MockLauncherClientManager{
+					Initialized:  true,
+					UnResponsive: false,
+				}
+
+				sanityExecute()
+				testutils.ExpectEvent(recorder, v1.SyncFailed.String())
+
+				Expect(mockQueue.GetAddAfterEnqueueCount()).To(Equal(0))
+				updatedVMI, err := virtfakeClient.KubevirtV1().VirtualMachineInstances(metav1.NamespaceDefault).Get(context.TODO(), vmi.Name, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(updatedVMI.Status.Phase).To(Equal(v1.Running))
+			})
+
+			It("should move to WaitingForSync if the VMI is a migration target and launcher is unresponsive", func() {
+				vmi := NewRunningVMI(vmiTestUUID, podTestUUID, host)
+				vmi.Annotations = map[string]string{
+					v1.CreateMigrationTarget: "true",
+				}
+
+				controller.launcherClients = &launcherclients.MockLauncherClientManager{
+					Initialized:  true,
+					UnResponsive: true,
+				}
+
+				phase, err := controller.calculateVmPhaseForStatusReason(nil, vmi)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(phase).To(Equal(v1.WaitingForSync))
+			})
+
+			It("should propagate error from IsLauncherClientUnresponsive and keep the current phase", func() {
+				vmi := NewRunningVMI(vmiTestUUID, podTestUUID, host)
+
+				createVMI(vmi)
+
+				controller.launcherClients = &launcherclients.MockLauncherClientManager{
+					UnResponsiveError: fmt.Errorf("test error"),
+				}
+
+				sanityExecute()
+
+				updatedVMI, err := virtfakeClient.KubevirtV1().VirtualMachineInstances(metav1.NamespaceDefault).Get(context.TODO(), vmi.Name, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(updatedVMI.Status.Phase).To(Equal(v1.Running))
+			})
+		})
+
 		It("should cleanup if vmi is finalized and domain does not exist", func() {
 			vmi := api2.NewMinimalVMI("testvmi")
 			vmi.UID = vmiTestUUID
@@ -1159,6 +1248,10 @@ var _ = Describe("VirtualMachineInstance", func() {
 			vmi.Status.Phase = v1.Running
 
 			createVMI(vmi)
+			controller.launcherClients = &launcherclients.MockLauncherClientManager{
+				Initialized:  true,
+				UnResponsive: true,
+			}
 
 			sanityExecute()
 
@@ -3624,6 +3717,16 @@ func NewScheduledVMI(vmiUID types.UID, podUID types.UID, hostname string) *v1.Vi
 	vmi.UID = vmiUID
 	vmi.ObjectMeta.ResourceVersion = "1"
 	vmi.Status.Phase = v1.Scheduled
+
+	vmi = addActivePods(vmi, podUID, hostname)
+	return vmi
+}
+
+func NewRunningVMI(vmiUID types.UID, podUID types.UID, hostname string) *v1.VirtualMachineInstance {
+	vmi := api2.NewMinimalVMI("testvmi")
+	vmi.UID = vmiUID
+	vmi.ObjectMeta.ResourceVersion = "1"
+	vmi.Status.Phase = v1.Running
 
 	vmi = addActivePods(vmi, podUID, hostname)
 	return vmi


### PR DESCRIPTION
### What this PR does
#### Before this PR:

Running VMIs with `domain == nil` in `calculateVmPhaseForStatusReason` were immediately
transitioned to `Failed` on virt-handler restart. Only Scheduled VMIs had the
`IsLauncherClientUnresponsive` 3-minute grace period — Running VMIs fell through to a
bare `return v1.Failed, nil`, causing healthy VMs to be unnecessarily killed during
upgrades and DaemonSet rolls.

#### After this PR:

Running VMIs receive the same 3-minute grace period as Scheduled VMIs. A single-line
change extends the existing case:

```diff
-case vmi.IsScheduled():
+case vmi.IsScheduled() || vmi.IsRunning():
```

Within the grace period the launcher socket can reconnect and the domain cache can be
repopulated, preventing spurious Failed transitions for Running VMIs on handler restart.

### References

- Partially addresses #18763
- Partially addresses #18765
- Cherry-pick of #18453

### Why we need it and why it was done in this way
The following tradeoffs were made:

This is a minimal, targeted cherry-pick. The fix mirrors existing Scheduled VMI behaviour
exactly rather than introducing a new code path.

The following alternatives were considered:

An additional `MigrationState.Completed` guard was considered for the post-grace edge
case (annotation removed, launcher unresponsive for >3 min). Left as a follow-up in
#18763 given the 3-minute window is generous for normal restart scenarios.

Links to places where the discussion took place: #18396, #18763, #18765

### Special notes for your reviewer

Cherry-pick of #18453 (merged 2026-07-24) onto release-1.9. Applied cleanly with no
conflicts. The diff is identical to the main merge.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
Bug fix: Running VMIs are no longer immediately marked as Failed when virt-handler restarts and temporarily loses the launcher socket connection. A 3-minute grace period (matching the existing Scheduled VMI behavior) now allows the launcher client to reconnect before transitioning the VMI to Failed.
```