### PR TITLE
export, backup-source: fix affinity to use correct selector

### DIFF
--- a/pkg/storage/export/export/BUILD.bazel
+++ b/pkg/storage/export/export/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/pkg/storage/export/export",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/apimachinery:go_default_library",
         "//pkg/certificates/bootstrap:go_default_library",
         "//pkg/certificates/triple:go_default_library",
         "//pkg/certificates/triple/cert:go_default_library",
@@ -27,7 +28,6 @@ go_library(
         "//pkg/storage/types:go_default_library",
         "//pkg/storage/utils:go_default_library",
         "//pkg/util:go_default_library",
-        "//pkg/util/net/dns:go_default_library",
         "//pkg/util/tls:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//pkg/virt-controller/watch/util:go_default_library",

--- a/pkg/storage/export/export/backup-source.go
+++ b/pkg/storage/export/export/backup-source.go
@@ -37,8 +37,8 @@ import (
 	backupv1 "kubevirt.io/api/backup/v1alpha1"
 	virtv1 "kubevirt.io/api/core/v1"
 
+	"kubevirt.io/kubevirt/pkg/apimachinery"
 	"kubevirt.io/kubevirt/pkg/controller"
-	"kubevirt.io/kubevirt/pkg/util/net/dns"
 	"kubevirt.io/kubevirt/pkg/virt-operator/resource/generate/components"
 )
 
@@ -52,16 +52,16 @@ const (
 )
 
 type VMBackupSource struct {
-	vmBackup        *backupv1.VirtualMachineBackup
-	caCert          string
-	sanitizedVMName string
+	vmBackup *backupv1.VirtualMachineBackup
+	caCert   string
+	vmiID    string
 }
 
-func NewVMBackupSource(vmBackup *backupv1.VirtualMachineBackup, caCert string, sanitizedVMName string) *VMBackupSource {
+func NewVMBackupSource(vmBackup *backupv1.VirtualMachineBackup, caCert string, vmiID string) *VMBackupSource {
 	return &VMBackupSource{
-		vmBackup:        vmBackup,
-		caCert:          caCert,
-		sanitizedVMName: sanitizedVMName,
+		vmBackup: vmBackup,
+		caCert:   caCert,
+		vmiID:    vmiID,
 	}
 }
 
@@ -153,8 +153,8 @@ func (s *VMBackupSource) ConfigurePod(pod *corev1.Pod) {
 					PodAffinityTerm: corev1.PodAffinityTerm{
 						LabelSelector: &metav1.LabelSelector{
 							MatchLabels: map[string]string{
-								virtv1.AppLabel:                          "virt-launcher",
-								virtv1.DeprecatedVirtualMachineNameLabel: s.sanitizedVMName,
+								virtv1.AppLabel:                      "virt-launcher",
+								virtv1.VirtualMachineInstanceIDLabel: s.vmiID,
 							},
 						},
 						TopologyKey: "kubernetes.io/hostname",
@@ -294,10 +294,9 @@ func (ctrl *VMExportController) getBackupTracker(namespace, name string) (*backu
 	return obj.(*backupv1.VirtualMachineBackupTracker).DeepCopy(), true, nil
 }
 
-// getBackupSourceName resolves the actual VM name from the backup's source,
+// getBackupSourceVMIID resolves the actual VM name from the backup's source,
 // handling both direct VM sources and VirtualMachineBackupTracker sources.
-// The returned name is sanitized to match how virt-launcher pod labels are set.
-func (ctrl *VMExportController) getBackupSourceName(vmBackup *backupv1.VirtualMachineBackup) (string, error) {
+func (ctrl *VMExportController) getBackupSourceVMIID(vmBackup *backupv1.VirtualMachineBackup) (string, error) {
 	var vmName string
 
 	if vmBackup.Spec.Source.Kind == backupv1.VirtualMachineBackupTrackerGroupVersionKind.Kind {
@@ -313,12 +312,5 @@ func (ctrl *VMExportController) getBackupSourceName(vmBackup *backupv1.VirtualMa
 		vmName = vmBackup.Spec.Source.Name
 	}
 
-	vmi, exists, err := ctrl.getVmi(vmBackup.Namespace, vmName)
-	if err != nil {
-		return "", fmt.Errorf("error fetching VMI %s/%s: %w", vmBackup.Namespace, vmName, err)
-	}
-	if !exists {
-		return "", fmt.Errorf("VMI not found: %s/%s", vmBackup.Namespace, vmName)
-	}
-	return dns.SanitizeHostname(vmi), nil
+	return apimachinery.CalculateVirtualMachineInstanceID(vmName), nil
 }

--- a/pkg/storage/export/export/backup-source_test.go
+++ b/pkg/storage/export/export/backup-source_test.go
@@ -560,7 +560,7 @@ var _ = Describe("Backup source", func() {
 		Expect(affinityTerm.PodAffinityTerm.TopologyKey).To(Equal("kubernetes.io/hostname"))
 		Expect(affinityTerm.PodAffinityTerm.LabelSelector).ToNot(BeNil())
 		Expect(affinityTerm.PodAffinityTerm.LabelSelector.MatchLabels).To(HaveKeyWithValue(virtv1.AppLabel, "virt-launcher"))
-		Expect(affinityTerm.PodAffinityTerm.LabelSelector.MatchLabels).To(HaveKeyWithValue(virtv1.DeprecatedVirtualMachineNameLabel, "test-vm"))
+		Expect(affinityTerm.PodAffinityTerm.LabelSelector.MatchLabels).To(HaveKeyWithValue(virtv1.VirtualMachineInstanceIDLabel, "test-vm"))
 	})
 
 	It("Should NOT add pod affinity when CBT is disabled (CheckpointName is nil)", func() {
@@ -611,7 +611,7 @@ var _ = Describe("Backup source", func() {
 		Expect(pod.Spec.Affinity).To(BeNil())
 	})
 
-	Context("getBackupSourceName", func() {
+	Context("getBackupSourceVMIID", func() {
 		It("Should return error when VirtualMachineBackupTracker not found", func() {
 			vmBackup := &backupv1.VirtualMachineBackup{
 				ObjectMeta: metav1.ObjectMeta{
@@ -627,13 +627,13 @@ var _ = Describe("Backup source", func() {
 				},
 			}
 
-			_, err := controller.getBackupSourceName(vmBackup)
+			_, err := controller.getBackupSourceVMIID(vmBackup)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("VirtualMachineBackupTracker not found"))
 			Expect(err.Error()).To(ContainSubstring("missing-tracker"))
 		})
 
-		It("Should return error when VMI not found", func() {
+		It("Should return the VMI ID for a direct VM source", func() {
 			vmBackup := &backupv1.VirtualMachineBackup{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-backup",
@@ -648,10 +648,9 @@ var _ = Describe("Backup source", func() {
 				},
 			}
 
-			_, err := controller.getBackupSourceName(vmBackup)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("VMI not found"))
-			Expect(err.Error()).To(ContainSubstring("test-vm"))
+			vmiID, err := controller.getBackupSourceVMIID(vmBackup)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(vmiID).To(Equal("test-vm"))
 		})
 	})
 })

--- a/pkg/storage/export/export/export.go
+++ b/pkg/storage/export/export/export.go
@@ -734,11 +734,11 @@ func (ctrl *VMExportController) updateVMExport(vmExport *exportv1.VirtualMachine
 		if err != nil || !exists {
 			return 0, fmt.Errorf("could not obtain VirtualMachineBackup tunnel CA: %w", err)
 		}
-		sanitizedVMName, err := ctrl.getBackupSourceName(vmBackup)
+		vmiID, err := ctrl.getBackupSourceVMIID(vmBackup)
 		if err != nil {
 			return 0, err
 		}
-		return ctrl.handleSource(vmExport, NewVMBackupSource(vmBackup, caCert, sanitizedVMName))
+		return ctrl.handleSource(vmExport, NewVMBackupSource(vmBackup, caCert, vmiID))
 	}
 
 	return 0, nil

--- a/tests/storage/BUILD.bazel
+++ b/tests/storage/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
     importpath = "kubevirt.io/kubevirt/tests/storage",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/apimachinery:go_default_library",
         "//pkg/apimachinery/patch:go_default_library",
         "//pkg/certificates/triple/cert:go_default_library",
         "//pkg/controller:go_default_library",
@@ -40,7 +41,6 @@ go_library(
         "//pkg/storage/types:go_default_library",
         "//pkg/storage/velero:go_default_library",
         "//pkg/util:go_default_library",
-        "//pkg/util/net/dns:go_default_library",
         "//pkg/virt-config/featuregate:go_default_library",
         "//pkg/virt-operator/resource/generate/components:go_default_library",
         "//staging/src/kubevirt.io/api/backup:go_default_library",

--- a/tests/storage/backup.go
+++ b/tests/storage/backup.go
@@ -48,6 +48,7 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/kubecli"
 
+	"kubevirt.io/kubevirt/pkg/apimachinery"
 	"kubevirt.io/kubevirt/pkg/libdv"
 	"kubevirt.io/kubevirt/pkg/libvmi"
 	"kubevirt.io/kubevirt/pkg/pointer"
@@ -56,7 +57,6 @@ import (
 	cbt "kubevirt.io/kubevirt/pkg/storage/cbt"
 	exportServer "kubevirt.io/kubevirt/pkg/storage/export/virt-exportserver"
 	"kubevirt.io/kubevirt/pkg/storage/velero"
-	"kubevirt.io/kubevirt/pkg/util/net/dns"
 
 	"kubevirt.io/kubevirt/tests/console"
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
@@ -1925,7 +1925,11 @@ func verifyExportPodAffinity(virtClient kubecli.KubevirtClient, vmbackup *backup
 		"Should match virt-launcher pods",
 	)
 
-	// Get the sanitized VM name (what virt-launcher pod uses)
+	Expect(affinityTerm.LabelSelector.MatchLabels).To(
+		HaveKeyWithValue(v1.VirtualMachineInstanceIDLabel, apimachinery.CalculateVirtualMachineInstanceID(vm.Name)),
+	)
+
+	By("Verifying export pod is scheduled on the same node as virt-launcher")
 	vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(
 		context.Background(),
 		vm.Name,
@@ -1933,16 +1937,6 @@ func verifyExportPodAffinity(virtClient kubecli.KubevirtClient, vmbackup *backup
 	)
 	Expect(err).ToNot(HaveOccurred())
 
-	// The virt-launcher pod label uses dns.SanitizeHostname logic
-	expectedVMName := dns.SanitizeHostname(vmi)
-
-	Expect(affinityTerm.LabelSelector.MatchLabels).To(
-		HaveKeyWithValue(v1.DeprecatedVirtualMachineNameLabel, expectedVMName),
-		"Should match the sanitized VM name",
-	)
-
-	// Verify the pods are actually on the same node
-	By("Verifying export pod is scheduled on the same node as virt-launcher")
 	// Find the virt-launcher pod using label selector
 	vmiPods, err := virtClient.CoreV1().Pods(vmi.Namespace).List(
 		context.Background(),


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
The backup export pod affinity selector used the deprecated vm.kubevirt.io/name label to co-locate with virt-launcher pods. 

#### After this PR:
Replace the deprecated vm.kubevirt.io/name label with vmi.kubevirt.io/id in the backup export pod affinity selector. This also removes the VMI lookup since the ID can be computed directly from the VM name.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

