### PR TITLE
[release-1.4] virt-launcher: suppress GuestAgentPing probe for migration and healthy paused states

### DIFF
--- a/pkg/libvmi/vmi.go
+++ b/pkg/libvmi/vmi.go
@@ -262,6 +262,19 @@ func WithStartStrategy(startStrategy v1.StartStrategy) Option {
 	}
 }
 
+func WithGuestAgentPingLivenessProbe(initialDelaySeconds, periodSeconds, failureThreshold int32) Option {
+	return func(vmi *v1.VirtualMachineInstance) {
+		vmi.Spec.LivenessProbe = &v1.Probe{
+			Handler: v1.Handler{
+				GuestAgentPing: &v1.GuestAgentPing{},
+			},
+			InitialDelaySeconds: initialDelaySeconds,
+			PeriodSeconds:       periodSeconds,
+			FailureThreshold:    failureThreshold,
+		}
+	}
+}
+
 func WithoutSerialConsole() Option {
 	return func(vmi *v1.VirtualMachineInstance) {
 		enabled := false

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -609,7 +609,33 @@ func (l *LibvirtDomainManager) Exec(domainName, command string, args []string, t
 func (l *LibvirtDomainManager) GuestPing(domainName string) error {
 	pingCmd := `{"execute":"guest-ping"}`
 	_, err := l.virConn.QemuAgentCommand(pingCmd, domainName)
+	if err == nil {
+		return nil
+	}
+	if isGuestAgentUnavailableError(err) && l.migrationInProgress() {
+		log.Log.V(4).Infof("GuestPing for %s failed with %v but the VM is healthy although paused on this pod; suppressing probe error", domainName, err)
+		return nil
+	}
 	return err
+}
+
+// isGuestAgentUnavailableError returns true when the error from QemuAgentCommand
+// indicates that the guest agent is unreachable rather than a libvirt or
+// connection issue unrelated to the guest state.
+func isGuestAgentUnavailableError(err error) bool {
+	var libvirtErr libvirt.Error
+	if !errors.As(err, &libvirtErr) {
+		return false
+	}
+	switch libvirtErr.Code {
+	case libvirt.ERR_AGENT_UNRESPONSIVE, libvirt.ERR_NO_DOMAIN:
+		// ERR_AGENT_UNRESPONSIVE: guest agent not responding (pre-copy target,
+		// post-copy source).
+		// ERR_NO_DOMAIN: domain not yet present on the target before pages start
+		// flowing (prepareMigrationTarget has run but migration has not begun).
+		return true
+	}
+	return false
 }
 
 func getVMIEphemeralDisksTotalSize(ephemeralDiskDir string) *resource.Quantity {

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -2416,6 +2416,98 @@ var _ = Describe("Manager", func() {
 		Expect(err).To(MatchError(ContainSubstring("failed to find the status of volume test1")))
 	})
 
+	Context("on GuestPing", func() {
+		const pingCmd = `{"execute":"guest-ping"}`
+
+		It("should succeed when guest-ping returns successfully", func() {
+			manager, _ := NewLibvirtDomainManager(mockConn, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock, metadataCache, nil)
+			mockConn.EXPECT().QemuAgentCommand(pingCmd, testDomainName).Return("", nil)
+			Expect(manager.GuestPing(testDomainName)).To(Succeed())
+		})
+
+		It("should return error when guest-ping fails and no migration is in progress", func() {
+			pingErr := fmt.Errorf("guest agent not responding")
+			manager, _ := NewLibvirtDomainManager(mockConn, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock, metadataCache, nil)
+			mockConn.EXPECT().QemuAgentCommand(pingCmd, testDomainName).Return("", pingErr)
+			Expect(manager.GuestPing(testDomainName)).To(MatchError(pingErr))
+		})
+
+		Context("in pre-copy migration phase", func() {
+			BeforeEach(func() {
+				now := metav1.Now()
+				metadataCache.Migration.Store(api.MigrationMetadata{
+					UID:            "test-migration-uid",
+					StartTimestamp: &now,
+					Mode:           v1.MigrationPreCopy,
+				})
+			})
+
+			It("should not suppress a passing probe on the source pod (VM is running and reachable)", func() {
+				manager, _ := NewLibvirtDomainManager(mockConn, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock, metadataCache, nil)
+				mockConn.EXPECT().QemuAgentCommand(pingCmd, testDomainName).Return("", nil)
+				Expect(manager.GuestPing(testDomainName)).To(Succeed())
+			})
+
+			It("should suppress ERR_AGENT_UNRESPONSIVE on the target pod (VM paused, receiving memory pages)", func() {
+				agentErr := libvirt.Error{Code: libvirt.ERR_AGENT_UNRESPONSIVE}
+				manager, _ := NewLibvirtDomainManager(mockConn, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock, metadataCache, nil)
+				mockConn.EXPECT().QemuAgentCommand(pingCmd, testDomainName).Return("", agentErr)
+				Expect(manager.GuestPing(testDomainName)).To(Succeed())
+			})
+
+			It("should suppress ERR_NO_DOMAIN on the target pod (domain not yet present)", func() {
+				manager, _ := NewLibvirtDomainManager(mockConn, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock, metadataCache, nil)
+				mockConn.EXPECT().QemuAgentCommand(pingCmd, testDomainName).Return("", libvirt.Error{Code: libvirt.ERR_NO_DOMAIN})
+				Expect(manager.GuestPing(testDomainName)).To(Succeed())
+			})
+
+			It("should still surface unrelated libvirt errors during migration", func() {
+				connErr := libvirt.Error{Code: libvirt.ERR_INTERNAL_ERROR}
+				manager, _ := NewLibvirtDomainManager(mockConn, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock, metadataCache, nil)
+				mockConn.EXPECT().QemuAgentCommand(pingCmd, testDomainName).Return("", connErr)
+				Expect(manager.GuestPing(testDomainName)).To(MatchError(connErr))
+			})
+		})
+
+		Context("in post-copy migration phase", func() {
+			BeforeEach(func() {
+				now := metav1.Now()
+				metadataCache.Migration.Store(api.MigrationMetadata{
+					UID:            "test-migration-uid",
+					StartTimestamp: &now,
+					Mode:           v1.MigrationPostCopy,
+				})
+			})
+
+			It("should not suppress a passing probe on the target pod (VM is running and reachable)", func() {
+				manager, _ := NewLibvirtDomainManager(mockConn, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock, metadataCache, nil)
+				mockConn.EXPECT().QemuAgentCommand(pingCmd, testDomainName).Return("", nil)
+				Expect(manager.GuestPing(testDomainName)).To(Succeed())
+			})
+
+			It("should suppress ERR_AGENT_UNRESPONSIVE on the source pod (VM handed off, no longer accessible)", func() {
+				agentErr := libvirt.Error{Code: libvirt.ERR_AGENT_UNRESPONSIVE}
+				manager, _ := NewLibvirtDomainManager(mockConn, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock, metadataCache, nil)
+				mockConn.EXPECT().QemuAgentCommand(pingCmd, testDomainName).Return("", agentErr)
+				Expect(manager.GuestPing(testDomainName)).To(Succeed())
+			})
+		})
+
+		It("should not suppress agent errors once the migration has completed", func() {
+			now := metav1.Now()
+			later := metav1.NewTime(now.Add(time.Second))
+			metadataCache.Migration.Store(api.MigrationMetadata{
+				UID:            "test-migration-uid",
+				StartTimestamp: &now,
+				EndTimestamp:   &later,
+			})
+			agentErr := libvirt.Error{Code: libvirt.ERR_AGENT_UNRESPONSIVE}
+			manager, _ := NewLibvirtDomainManager(mockConn, testVirtShareDir, testEphemeralDiskDir, nil, "/usr/share/OVMF", ephemeralDiskCreatorMock, metadataCache, nil)
+			mockConn.EXPECT().QemuAgentCommand(pingCmd, testDomainName).Return("", agentErr)
+			Expect(manager.GuestPing(testDomainName)).To(MatchError(agentErr))
+		})
+	})
+
 	// TODO: test error reporting on non successful VirtualMachineInstance syncs and kill attempts
 })
 

--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -3404,6 +3404,30 @@ var _ = SIGMigrationDescribe("VM Live Migration", func() {
 			}, 60*time.Second, 1*time.Second).Should(HaveConditionTrue(v1.VirtualMachineInstanceMigrationRejectedByResourceQuota))
 		})
 	})
+
+	Describe("with a guest-agent-ping liveness probe", func() {
+		It("should complete migration without the liveness probe killing the target pod", func() {
+			By("Creating a Fedora VMI with a GuestAgentPing liveness probe")
+			vmi := libvmifact.NewFedora(
+				libnet.WithMasqueradeNetworking(),
+				libvmi.WithResourceMemory(fedoraVMSize),
+				libvmi.WithGuestAgentPingLivenessProbe(120, 5, 2),
+			)
+
+			By("Starting the VirtualMachineInstance")
+			vmi = libvmops.RunVMIAndExpectLaunch(vmi, 240)
+
+			By("Waiting for the guest agent to connect")
+			Eventually(matcher.ThisVMI(vmi), 5*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
+
+			By("Starting a migration")
+			migration := libmigration.New(vmi.Name, vmi.Namespace)
+			migration = libmigration.RunMigrationAndExpectToCompleteWithDefaultTimeout(virtClient, migration)
+
+			By("Confirming the VMI migrated successfully and is still running")
+			libmigration.ConfirmVMIPostMigration(virtClient, vmi, migration)
+		})
+	})
 })
 
 func createResourceQuota(resourceQuota *k8sv1.ResourceQuota) *k8sv1.ResourceQuota {

--- a/tests/migration/postcopy.go
+++ b/tests/migration/postcopy.go
@@ -101,6 +101,49 @@ var _ = SIGMigrationDescribe("VM Post Copy Live Migration", func() {
 				migrationPolicy.Spec.BandwidthPerMigration = kvpointer.P(resource.MustParse("5Mi"))
 			})
 
+			Context("with a guest-agent-ping liveness probe", func() {
+				// Regression test for probe suppression on the migration source pod
+				// during post-copy. Once post-copy starts the source VM is handed off
+				// to the target and enters a ghost/paused state, making it unreachable
+				// via the QEMU guest agent. Because virt-launcher pods use
+				// restartPolicy: Never, the failed probe kills the compute container
+				// and the pod enters Failed phase, aborting the migration.
+				It("should complete post-copy migration without the liveness probe killing the source pod", func() {
+					By("Creating a Fedora VMI with a GuestAgentPing liveness probe")
+					vmi := libvmifact.NewFedora(
+						libnet.WithMasqueradeNetworking(),
+						libvmi.WithResourceMemory("512Mi"),
+						libvmi.WithRng(),
+						libvmi.WithNamespace(testsuite.NamespacePrivileged),
+						libvmi.WithGuestAgentPingLivenessProbe(120, 5, 2),
+					)
+
+					By("Applying the post-copy migration policy")
+					AlignPolicyAndVmi(vmi, migrationPolicy)
+					migrationPolicy = CreateMigrationPolicy(virtClient, migrationPolicy)
+
+					By("Starting the VirtualMachineInstance")
+					vmi = libvmops.RunVMIAndExpectLaunch(vmi, 240)
+
+					By("Waiting for the guest agent to connect")
+					Eventually(matcher.ThisVMI(vmi), 5*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
+
+					By("Logging into the VMI")
+					Expect(console.LoginToFedora(vmi)).To(Succeed())
+
+					By("Running a stress test to dirty pages and trigger post-copy")
+					runStressTest(vmi, "350M", stressDefaultSleepDuration)
+
+					By("Starting the migration")
+					migration := libmigration.New(vmi.Name, vmi.Namespace)
+					migration = libmigration.RunMigrationAndExpectToCompleteWithDefaultTimeout(virtClient, migration)
+
+					By("Confirming the VMI migrated successfully via post-copy and is still running")
+					vmi = libmigration.ConfirmVMIPostMigration(virtClient, vmi, migration)
+					libmigration.ConfirmMigrationMode(virtClient, vmi, v1.MigrationPostCopy)
+				})
+			})
+
 			Context("with datavolume", func() {
 				var dv *cdiv1.DataVolume
 


### PR DESCRIPTION
###What this PR does
This is an manual cherry-pick of the first commit of https://github.com/kubevirt/kubevirt/pull/17235
Original credit goes to @tiraboschi

####Before this PR:
During live migration the QEMU guest agent is temporarily unreachable on two different pods depending on the migration phase:

Pre-copy: the target pod has the guest paused while receiving memory pages — a GuestAgentPing probe there produces false negatives, causing Kubernetes to restart the target pod and abort the migration.
Post-copy: the source VM is handed off to the target and enters a ghost/paused state — the same probe on the source pod produces false negatives, again risking a pod restart.
Because GuestAgentPing is implemented as a Kubernetes exec probe running inside each pod's compute container, kubelet executes it on both pods simultaneously throughout the migration. Both failure modes could abort an in-progress migration.

####After this PR:
LibvirtDomainManager.GuestPing suppresses probe errors for the duration of an in-progress migration on any pod where they occur. The check is intentionally simple: if migration metadata has StartTimestamp set and no EndTimestamp, a migration is in progress and any probe failure is returned as a synthetic success. No attempt is made to distinguish source from target, the suppression path is only reached when the probe has already failed, which only happens when the guest is genuinely unreachable. The suppression window closes as soon as EndTimestamp is set, after which the real guest-agent ping resumes normally.

Other probe types (exec, httpGet, tcpSocket) are intentionally left unchanged — their semantics during migration are consistent with regular Kubernetes pods and are tuneable via initialDelaySeconds/failureThreshold.

### References
- Fixes [CNV-86285](https://redhat.atlassian.net/browse/CNV-86285)

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
Fix: GuestAgentPing liveness/readiness probes no longer cause Kubernetes to restart the virt-launcher pod when the guest agent is temporarily unreachable during live migration (both pre-copy target and post-copy source phases).
```

