### PR TITLE
[Draft] Move ImageVolume featuregate to alpha for testing perf&scale

### DIFF
--- a/pkg/virt-config/featuregate/active.go
+++ b/pkg/virt-config/featuregate/active.go
@@ -296,7 +296,7 @@ const (
 
 func init() {
 	RegisterFeatureGate(FeatureGate{Name: LibvirtHooksServerAndClient, State: Beta})
-	RegisterFeatureGate(FeatureGate{Name: ImageVolume, State: Beta})
+	RegisterFeatureGate(FeatureGate{Name: ImageVolume, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: CPUManager, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: IgnitionGate, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: HypervStrictCheckGate, State: Alpha})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
Performance changes observed after enabling beta feature gates by default, trying to find out which feature is responsible for it by backporting to alpha and running perf tests.
### What this PR does
#### Before this PR:

#### After this PR:

### Release note
```release-note
NONE
```