### PR TITLE
[Draft] Move KubevirtSeccompProfile featuregate to alpha for testing perf&scale

### DIFF
--- a/pkg/virt-config/featuregate/active.go
+++ b/pkg/virt-config/featuregate/active.go
@@ -309,7 +309,7 @@ func init() {
 	RegisterFeatureGate(FeatureGate{Name: WorkloadEncryptionSEV, State: Beta})
 	RegisterFeatureGate(FeatureGate{Name: WorkloadEncryptionTDX, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: VSOCKGate, State: Alpha})
-	RegisterFeatureGate(FeatureGate{Name: KubevirtSeccompProfile, State: Beta})
+	RegisterFeatureGate(FeatureGate{Name: KubevirtSeccompProfile, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: AlignCPUsGate, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: NodeRestrictionGate, State: Beta})
 	RegisterFeatureGate(FeatureGate{Name: VirtIOFSStorageVolumeGate, State: Alpha})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
Performance changes observed after enabling beta feature gates by default, trying to find out which feature is responsible for it by backporting to alpha and running perf tests.
### What this PR does
#### Before this PR:

#### After this PR:

### Release note
```release-note
NONE
```