### PR TITLE
[Draft] Move LiveUpdateNADRef featuregate to alpha for testing perf&scale

### DIFF
--- a/pkg/virt-config/featuregate/active.go
+++ b/pkg/virt-config/featuregate/active.go
@@ -292,6 +292,13 @@ const (
 	// PortRangesSpec enables the portRanges field, initially only on masquerade interfaces,
 	// allowing compact specification of contiguous port intervals to forward to the VM guest.
 	PortRangesSpec = "PortRangesSpec"
+
+	// Owner: sig-network
+	// Beta: v1.8.0
+	// GA: v1.9.0
+	//
+	// LiveUpdateNADRef enables dynamic modification of NAD references for secondary networks on running VMs.
+	LiveUpdateNADRef = "LiveUpdateNADRef"
 )
 
 func init() {
@@ -342,4 +349,5 @@ func init() {
 	RegisterFeatureGate(FeatureGate{Name: MigrationDowntimeTuning, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: CrossArchitectureVirtualization, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: PortRangesSpec, State: Alpha})
+	RegisterFeatureGate(FeatureGate{Name: LiveUpdateNADRef, State: Alpha})
 }

--- a/pkg/virt-config/featuregate/inactive.go
+++ b/pkg/virt-config/featuregate/inactive.go
@@ -152,13 +152,6 @@ const (
 	// PanicDevices allows defining panic devices for signaling crashes in the guest for a VirtualMachineInstance.
 	PanicDevicesGate = "PanicDevices"
 
-	// Owner: sig-network
-	// Beta: v1.8.0
-	// GA: v1.9.0
-	//
-	// LiveUpdateNADRef enables dynamic modification of NAD references for secondary networks on running VMs.
-	LiveUpdateNADRef = "LiveUpdateNADRef"
-
 	// Owner: sig-storage
 	// Alpha: v0.36.0
 	// Deprecated: v1.9.0
@@ -234,7 +227,6 @@ func init() {
 	RegisterFeatureGate(FeatureGate{Name: DisableMediatedDevicesHandling, State: Deprecated, Message: "DisableMDEVConfiguration has been deprecated since v1.8.0"})
 	RegisterFeatureGate(FeatureGate{Name: ExpandDisksGate, State: GA})
 	RegisterFeatureGate(FeatureGate{Name: PanicDevicesGate, State: GA})
-	RegisterFeatureGate(FeatureGate{Name: LiveUpdateNADRef, State: GA})
 	RegisterFeatureGate(FeatureGate{Name: HotplugVolumesGate, State: Deprecated, Message: "HotplugVolumes has been deprecated since v1.9.0 and has been replaced by DeclarativeHotplugVolumes"})
 	RegisterFeatureGate(FeatureGate{Name: VideoConfig, State: GA})
 	RegisterFeatureGate(FeatureGate{Name: SecureExecution, State: GA})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
Performance changes observed after enabling beta feature gates by default, trying to find out which feature is responsible for it by backporting to alpha and running perf tests.
### What this PR does
#### Before this PR:

#### After this PR:

### Release note
```release-note
NONE
```