### PR TITLE
tests/migration: make stuck-migration test non-intrusive

### DIFF
--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -2014,34 +2014,17 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 				)
 			})
 
-			Context("when target pod cannot be scheduled and is stuck in Pending phase", Serial, func() {
-
-				var nodesSetUnschedulable []string
-
-				AfterEach(func() {
-					By("Restoring nodes to be schedulable")
-					for _, schedulableNodeName := range nodesSetUnschedulable {
-						libnode.SetNodeSchedulable(schedulableNodeName, virtClient)
-					}
-				})
+			Context("when target pod cannot be scheduled and is stuck in Pending phase", func() {
 
 				It("should be able to properly abort migration", func() {
-					By("Starting a VirtualMachineInstance")
+					By("Starting a VirtualMachineInstance pinned to a node by affinity")
+					nodes := libnode.GetAllSchedulableNodes(virtClient)
 					vmi := libvmifact.NewGuestless(
 						libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithMasqueradeBinding())),
 						libvmi.WithNetwork(v1.DefaultPodNetwork()),
+						libvmi.WithNodeAffinityFor(nodes.Items[0].Name),
 					)
 					vmi = libvmops.RunVMIAndExpectLaunch(vmi, flags.StartupTimeoutSecondsHuge())
-
-					By("Making all other nodes unschedulable so migration target cannot be placed")
-					schedulableNodes := libnode.GetAllSchedulableNodes(virtClient).Items
-					for _, schedulableNode := range schedulableNodes {
-						if schedulableNode.Name == vmi.Status.NodeName {
-							continue
-						}
-						libnode.SetNodeUnschedulable(schedulableNode.Name, virtClient)
-						nodesSetUnschedulable = append(nodesSetUnschedulable, schedulableNode.Name)
-					}
 
 					By("Trying to migrate VM and expect for the migration to get stuck")
 					migration := libmigration.New(vmi.Name, vmi.Namespace)


### PR DESCRIPTION
Instead of making all other nodes unschedulable (cluster-wide mutation requiring Serial), pin the VMI to a specific node using libvmi.WithNodeAffinityFor. The migration controller adds a required podAntiAffinity against the source pod's node, so the target pod needs to land on the pinned node but is blocked by the anti-affinity — leaving it stuck in Pending without touching any node's schedulability.

Using a specific node by its name is a bad practice for tests (in real life, nodes are inconsequential fungible resource) but it is far better than making the entire cluster unschedulable.

Assisted-By: Claude Sonnet 4.6

```release-note
NONE
```

