### PR TITLE
virt-exportserver: gate readiness on backup tunnel establishment

### DIFF
--- a/pkg/storage/export/export/backup-source.go
+++ b/pkg/storage/export/export/backup-source.go
@@ -102,10 +102,6 @@ func (s *VMBackupSource) ReadyCondition() exportv1.Condition {
 	return exportv1.Condition{}
 }
 
-func (s *VMBackupSource) ServicePorts() []corev1.ServicePort {
-	return []corev1.ServicePort{exportPort()}
-}
-
 func (s *VMBackupSource) ConfigurePod(pod *corev1.Pod) {
 	for index, volume := range s.vmBackup.Status.IncludedVolumes {
 		pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env, corev1.EnvVar{

--- a/pkg/storage/export/export/backup-source_test.go
+++ b/pkg/storage/export/export/backup-source_test.go
@@ -409,6 +409,25 @@ var _ = Describe("Backup source", func() {
 		),
 	)
 
+	It("Should publish not ready addresses on the export service", func() {
+		testVMExport := createBackupVMExport()
+		source := NewVMBackupSource(nil, "", "")
+
+		var service *k8sv1.Service
+		k8sClient.Fake.PrependReactor("create", "services", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+			create, ok := action.(testing.CreateAction)
+			Expect(ok).To(BeTrue())
+			service, ok = create.GetObject().(*k8sv1.Service)
+			Expect(ok).To(BeTrue())
+			return true, service, nil
+		})
+
+		service, err := controller.getOrCreateExportService(testVMExport, source)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(service).ToNot(BeNil())
+		Expect(service.Spec.PublishNotReadyAddresses).To(BeTrue())
+	})
+
 	It("Should return error if VirtualMachineBackup is not found", func() {
 		testVMExport := createBackupVMExport()
 

--- a/pkg/storage/export/export/export.go
+++ b/pkg/storage/export/export/export.go
@@ -744,7 +744,7 @@ func (ctrl *VMExportController) updateVMExport(vmExport *exportv1.VirtualMachine
 }
 
 func (ctrl *VMExportController) handleSource(vmExport *exportv1.VirtualMachineExport, source exportSource) (time.Duration, error) {
-	service, err := ctrl.getOrCreateExportService(vmExport)
+	service, err := ctrl.getOrCreateExportService(vmExport, source)
 	if err != nil {
 		return 0, err
 	}
@@ -1028,12 +1028,12 @@ func (ctrl *VMExportController) getExportLabelValue(vmExport *exportv1.VirtualMa
 	return naming.GetName(exportPrefix, vmExport.Name, validation.DNS1035LabelMaxLength)
 }
 
-func (ctrl *VMExportController) getOrCreateExportService(vmExport *exportv1.VirtualMachineExport) (*corev1.Service, error) {
+func (ctrl *VMExportController) getOrCreateExportService(vmExport *exportv1.VirtualMachineExport, source exportSource) (*corev1.Service, error) {
 	key := controller.NamespacedKey(vmExport.Namespace, ctrl.getExportServiceName(vmExport))
 	if service, exists, err := ctrl.ServiceInformer.GetStore().GetByKey(key); err != nil {
 		return nil, err
 	} else if !exists {
-		service := ctrl.createServiceManifest(vmExport)
+		service := ctrl.createServiceManifest(vmExport, source)
 		log.Log.V(3).Infof("Creating new exporter service %s/%s", service.Namespace, service.Name)
 		service, err := ctrl.Client.CoreV1().Services(vmExport.Namespace).Create(context.Background(), service, metav1.CreateOptions{})
 		if err == nil {
@@ -1045,7 +1045,7 @@ func (ctrl *VMExportController) getOrCreateExportService(vmExport *exportv1.Virt
 	}
 }
 
-func (ctrl *VMExportController) createServiceManifest(vmExport *exportv1.VirtualMachineExport) *corev1.Service {
+func (ctrl *VMExportController) createServiceManifest(vmExport *exportv1.VirtualMachineExport, source exportSource) *corev1.Service {
 	labels := map[string]string{virtv1.AppLabel: exportv1.App}
 	for key, value := range vmExport.Labels {
 		labels[key] = value
@@ -1072,6 +1072,15 @@ func (ctrl *VMExportController) createServiceManifest(vmExport *exportv1.Virtual
 			},
 		},
 	}
+
+	// The backup tunnel is established by virt-launcher dialing this service,
+	// but the export server only reports ready once the tunnel is up. The
+	// endpoint must be routable while the pod is still unready, otherwise the
+	// tunnel can never connect and readiness deadlocks.
+	if _, isBackup := source.(*VMBackupSource); isBackup {
+		service.Spec.PublishNotReadyAddresses = true
+	}
+
 	return service
 }
 

--- a/pkg/storage/export/export/export.go
+++ b/pkg/storage/export/export/export.go
@@ -183,7 +183,6 @@ type exportSource interface {
 	HasContent() bool
 	SourceCondition() exportv1.Condition
 	ReadyCondition() exportv1.Condition
-	ServicePorts() []corev1.ServicePort
 	ConfigurePod(pod *corev1.Pod)
 	ConfigureExportLink(exportLink *exportv1.VirtualMachineExportLink, paths *ServerPaths, vmExport *exportv1.VirtualMachineExport, pod *corev1.Pod, hostAndBase, scheme string)
 	UpdateStatus(vmExport *exportv1.VirtualMachineExport, pod *corev1.Pod, svc *corev1.Service) (time.Duration, error)
@@ -745,7 +744,7 @@ func (ctrl *VMExportController) updateVMExport(vmExport *exportv1.VirtualMachine
 }
 
 func (ctrl *VMExportController) handleSource(vmExport *exportv1.VirtualMachineExport, source exportSource) (time.Duration, error) {
-	service, err := ctrl.getOrCreateExportService(vmExport, source.ServicePorts())
+	service, err := ctrl.getOrCreateExportService(vmExport)
 	if err != nil {
 		return 0, err
 	}
@@ -1029,12 +1028,12 @@ func (ctrl *VMExportController) getExportLabelValue(vmExport *exportv1.VirtualMa
 	return naming.GetName(exportPrefix, vmExport.Name, validation.DNS1035LabelMaxLength)
 }
 
-func (ctrl *VMExportController) getOrCreateExportService(vmExport *exportv1.VirtualMachineExport, ports []corev1.ServicePort) (*corev1.Service, error) {
+func (ctrl *VMExportController) getOrCreateExportService(vmExport *exportv1.VirtualMachineExport) (*corev1.Service, error) {
 	key := controller.NamespacedKey(vmExport.Namespace, ctrl.getExportServiceName(vmExport))
 	if service, exists, err := ctrl.ServiceInformer.GetStore().GetByKey(key); err != nil {
 		return nil, err
 	} else if !exists {
-		service := ctrl.createServiceManifest(vmExport, ports)
+		service := ctrl.createServiceManifest(vmExport)
 		log.Log.V(3).Infof("Creating new exporter service %s/%s", service.Namespace, service.Name)
 		service, err := ctrl.Client.CoreV1().Services(vmExport.Namespace).Create(context.Background(), service, metav1.CreateOptions{})
 		if err == nil {
@@ -1046,7 +1045,7 @@ func (ctrl *VMExportController) getOrCreateExportService(vmExport *exportv1.Virt
 	}
 }
 
-func (ctrl *VMExportController) createServiceManifest(vmExport *exportv1.VirtualMachineExport, ports []corev1.ServicePort) *corev1.Service {
+func (ctrl *VMExportController) createServiceManifest(vmExport *exportv1.VirtualMachineExport) *corev1.Service {
 	labels := map[string]string{virtv1.AppLabel: exportv1.App}
 	for key, value := range vmExport.Labels {
 		labels[key] = value
@@ -1067,7 +1066,7 @@ func (ctrl *VMExportController) createServiceManifest(vmExport *exportv1.Virtual
 			Annotations: vmExport.Annotations,
 		},
 		Spec: corev1.ServiceSpec{
-			Ports: ports,
+			Ports: []corev1.ServicePort{exportPort()},
 			Selector: map[string]string{
 				exportServiceLabel: ctrl.getExportLabelValue(vmExport),
 			},

--- a/pkg/storage/export/export/export_test.go
+++ b/pkg/storage/export/export/export_test.go
@@ -761,7 +761,7 @@ var _ = Describe("Export controller", func() {
 			return true, service, nil
 		})
 
-		service, err := controller.getOrCreateExportService(testVMExport)
+		service, err := controller.getOrCreateExportService(testVMExport, NewPVCSource(nil))
 		Expect(err).ToNot(HaveOccurred())
 		Expect(service).ToNot(BeNil())
 		Expect(service.Status.Conditions[0].Type).To(Equal("test"))
@@ -782,7 +782,7 @@ var _ = Describe("Export controller", func() {
 				},
 			}),
 		).To(Succeed())
-		service, err = controller.getOrCreateExportService(testVMExport)
+		service, err = controller.getOrCreateExportService(testVMExport, NewPVCSource(nil))
 		Expect(err).ToNot(HaveOccurred())
 		Expect(service).ToNot(BeNil())
 		Expect(service.Status.Conditions[0].Type).To(Equal("test2"))
@@ -884,7 +884,7 @@ var _ = Describe("Export controller", func() {
 			Expect(service.GetNamespace()).To(Equal(testNamespace))
 			return true, service, nil
 		})
-		service, err = controller.getOrCreateExportService(testVMExport)
+		service, err = controller.getOrCreateExportService(testVMExport, NewPVCSource(nil))
 		Expect(err).ToNot(HaveOccurred())
 		pod, err := controller.createExporterPod(testVMExport, service, source)
 		Expect(err).ToNot(HaveOccurred())
@@ -1198,7 +1198,7 @@ var _ = Describe("Export controller", func() {
 			Expect(service.GetNamespace()).To(Equal(testNamespace))
 			return true, service, nil
 		})
-		service, err = controller.getOrCreateExportService(testVMExport)
+		service, err = controller.getOrCreateExportService(testVMExport, NewPVCSource(nil))
 		Expect(err).ToNot(HaveOccurred())
 		pod, err := controller.createExporterPod(testVMExport, service, snapSource)
 		Expect(err).ToNot(HaveOccurred())
@@ -1278,7 +1278,7 @@ var _ = Describe("Export controller", func() {
 			return true, service, nil
 		})
 
-		service, err := controller.getOrCreateExportService(testVMExport)
+		service, err := controller.getOrCreateExportService(testVMExport, NewPVCSource(nil))
 		Expect(err).ToNot(HaveOccurred())
 		Expect(service).ToNot(BeNil())
 		Expect(service.Status.Conditions[0].Type).To(Equal("test"))

--- a/pkg/storage/export/export/export_test.go
+++ b/pkg/storage/export/export/export_test.go
@@ -761,7 +761,7 @@ var _ = Describe("Export controller", func() {
 			return true, service, nil
 		})
 
-		service, err := controller.getOrCreateExportService(testVMExport, []k8sv1.ServicePort{})
+		service, err := controller.getOrCreateExportService(testVMExport)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(service).ToNot(BeNil())
 		Expect(service.Status.Conditions[0].Type).To(Equal("test"))
@@ -782,7 +782,7 @@ var _ = Describe("Export controller", func() {
 				},
 			}),
 		).To(Succeed())
-		service, err = controller.getOrCreateExportService(testVMExport, []k8sv1.ServicePort{})
+		service, err = controller.getOrCreateExportService(testVMExport)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(service).ToNot(BeNil())
 		Expect(service.Status.Conditions[0].Type).To(Equal("test2"))
@@ -884,7 +884,7 @@ var _ = Describe("Export controller", func() {
 			Expect(service.GetNamespace()).To(Equal(testNamespace))
 			return true, service, nil
 		})
-		service, err = controller.getOrCreateExportService(testVMExport, source.ServicePorts())
+		service, err = controller.getOrCreateExportService(testVMExport)
 		Expect(err).ToNot(HaveOccurred())
 		pod, err := controller.createExporterPod(testVMExport, service, source)
 		Expect(err).ToNot(HaveOccurred())
@@ -1198,7 +1198,7 @@ var _ = Describe("Export controller", func() {
 			Expect(service.GetNamespace()).To(Equal(testNamespace))
 			return true, service, nil
 		})
-		service, err = controller.getOrCreateExportService(testVMExport, snapSource.ServicePorts())
+		service, err = controller.getOrCreateExportService(testVMExport)
 		Expect(err).ToNot(HaveOccurred())
 		pod, err := controller.createExporterPod(testVMExport, service, snapSource)
 		Expect(err).ToNot(HaveOccurred())
@@ -1278,7 +1278,7 @@ var _ = Describe("Export controller", func() {
 			return true, service, nil
 		})
 
-		service, err := controller.getOrCreateExportService(testVMExport, []k8sv1.ServicePort{})
+		service, err := controller.getOrCreateExportService(testVMExport)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(service).ToNot(BeNil())
 		Expect(service.Status.Conditions[0].Type).To(Equal("test"))

--- a/pkg/storage/export/export/pvc-source.go
+++ b/pkg/storage/export/export/pvc-source.go
@@ -62,10 +62,6 @@ func (s *PVCSource) ReadyCondition() exportv1.Condition {
 	return s.sourceVolumes.readyCondition
 }
 
-func (s *PVCSource) ServicePorts() []corev1.ServicePort {
-	return []corev1.ServicePort{exportPort()}
-}
-
 func (s *PVCSource) ConfigurePod(pod *corev1.Pod) {
 	s.sourceVolumes.configurePodVolumes(pod)
 }

--- a/pkg/storage/export/export/vm-source.go
+++ b/pkg/storage/export/export/vm-source.go
@@ -64,10 +64,6 @@ func (s *VMSource) ReadyCondition() exportv1.Condition {
 	return s.sourceVolumes.readyCondition
 }
 
-func (s *VMSource) ServicePorts() []corev1.ServicePort {
-	return []corev1.ServicePort{exportPort()}
-}
-
 func (s *VMSource) ConfigurePod(pod *corev1.Pod) {
 	pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env, corev1.EnvVar{
 		Name:  "EXPORT_VM_DEF_URI",

--- a/pkg/storage/export/export/vmsnapshot-source.go
+++ b/pkg/storage/export/export/vmsnapshot-source.go
@@ -74,10 +74,6 @@ func (s *VMSnapshotSource) ReadyCondition() exportv1.Condition {
 	return s.sourceVolumes.readyCondition
 }
 
-func (s *VMSnapshotSource) ServicePorts() []corev1.ServicePort {
-	return []corev1.ServicePort{exportPort()}
-}
-
 func (s *VMSnapshotSource) ConfigurePod(pod *corev1.Pod) {
 	pod.Spec.Containers[0].Env = append(pod.Spec.Containers[0].Env, corev1.EnvVar{
 		Name:  "EXPORT_VM_DEF_URI",

--- a/pkg/storage/export/export/vmtemplate-source.go
+++ b/pkg/storage/export/export/vmtemplate-source.go
@@ -78,10 +78,6 @@ func (s *VMTemplateSource) ReadyCondition() exportv1.Condition {
 	return s.sourceVolumes.readyCondition
 }
 
-func (s *VMTemplateSource) ServicePorts() []corev1.ServicePort {
-	return []corev1.ServicePort{exportPort()}
-}
-
 func (s *VMTemplateSource) ConfigurePod(pod *corev1.Pod) {
 	s.sourceVolumes.configurePodVolumes(pod)
 }

--- a/pkg/storage/export/virt-exportserver/exportserver.go
+++ b/pkg/storage/export/virt-exportserver/exportserver.go
@@ -133,13 +133,17 @@ type execReader struct {
 	stderr io.ReadCloser
 }
 
+type readinessGate func() (string, bool)
+
 type exportServer struct {
 	ExportServerConfig
-	handler http.Handler
+	handler        http.Handler
+	readinessGates []readinessGate
 
-	nbdClient  nbdv1.NBDClient
-	nbdMu      sync.RWMutex
-	ociBuilder *oci.Builder
+	nbdClient         nbdv1.NBDClient
+	tunnelEstablished bool
+	nbdMu             sync.RWMutex
+	ociBuilder        *oci.Builder
 }
 
 func (er *execReader) Read(p []byte) (int, error) {
@@ -184,9 +188,25 @@ func (s *exportServer) initHandler() {
 	}
 	if s.ociBuilder != nil && s.Paths.OCIURI != "" {
 		mux.Handle(s.Paths.OCIURI, tokenChecker(s.TokenGetter, s.OCIHandler(s.ociBuilder)))
+		s.readinessGates = append(s.readinessGates, func() (string, bool) {
+			if !s.ociBuilder.Ready() {
+				return "OCI digest computation in progress", false
+			}
+			return "", true
+		})
+	}
+	if len(s.Paths.Backups) > 0 {
+		s.readinessGates = append(s.readinessGates, func() (string, bool) {
+			s.nbdMu.RLock()
+			established := s.tunnelEstablished
+			s.nbdMu.RUnlock()
+			if !established {
+				return "Backup tunnel not yet established", false
+			}
+			return "", true
+		})
 	}
 
-	// Readiness probe
 	mux.HandleFunc(export.ReadinessPath, s.readyHandler)
 
 	s.handler = mux
@@ -915,9 +935,11 @@ func secretHandler(tokenGetter TokenGetterFunc) http.Handler {
 }
 
 func (s *exportServer) readyHandler(w http.ResponseWriter, r *http.Request) {
-	if s.ociBuilder != nil && !s.ociBuilder.Ready() {
-		http.Error(w, "OCI digest computation in progress", http.StatusServiceUnavailable)
-		return
+	for _, gate := range s.readinessGates {
+		if reason, ready := gate(); !ready {
+			http.Error(w, reason, http.StatusServiceUnavailable)
+			return
+		}
 	}
 	io.WriteString(w, "OK")
 }
@@ -979,6 +1001,7 @@ func (s *exportServer) handleTunnel(w http.ResponseWriter, r *http.Request) {
 	w.(http.Flusher).Flush()
 
 	s.nbdClient = nbdv1.NewNBDClient(clientConn)
+	s.tunnelEstablished = true
 	s.nbdMu.Unlock()
 
 	log.Log.Infof("Exclusive backup tunnel established for %s", s.BackupUID)

--- a/pkg/storage/export/virt-exportserver/exportserver_test.go
+++ b/pkg/storage/export/virt-exportserver/exportserver_test.go
@@ -1416,4 +1416,56 @@ var _ = Describe("exportserver", func() {
 
 		})
 	})
+
+	Context("readiness with backup paths", func() {
+		It("should return 503 when backup paths exist but tunnel is not established", func() {
+			es := newTestServer("token")
+			es.Paths = &export.ServerPaths{
+				Backups: []export.BackupInfo{
+					{Path: "vol1", DataURI: "/exports/vol1/data", MapURI: "/exports/vol1/map"},
+				},
+			}
+			es.initHandler()
+
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, export.ReadinessPath, http.NoBody)
+			es.handler.ServeHTTP(rec, req)
+			Expect(rec.Code).To(Equal(http.StatusServiceUnavailable))
+		})
+
+		It("should return 200 when backup paths exist and tunnel is established", func() {
+			ctrl := gomock.NewController(GinkgoT())
+			es := newTestServer("token")
+			es.Paths = &export.ServerPaths{
+				Backups: []export.BackupInfo{
+					{Path: "vol1", DataURI: "/exports/vol1/data", MapURI: "/exports/vol1/map"},
+				},
+			}
+			es.nbdClient = nbdv1.NewMockNBDClient(ctrl)
+			es.tunnelEstablished = true
+			es.initHandler()
+
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, export.ReadinessPath, http.NoBody)
+			es.handler.ServeHTTP(rec, req)
+			Expect(rec.Code).To(Equal(http.StatusOK))
+		})
+
+		It("should keep returning 200 after the tunnel disconnects", func() {
+			es := newTestServer("token")
+			es.Paths = &export.ServerPaths{
+				Backups: []export.BackupInfo{
+					{Path: "vol1", DataURI: "/exports/vol1/data", MapURI: "/exports/vol1/map"},
+				},
+			}
+			es.tunnelEstablished = true
+			es.nbdClient = nil
+			es.initHandler()
+
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, export.ReadinessPath, http.NoBody)
+			es.handler.ServeHTTP(rec, req)
+			Expect(rec.Code).To(Equal(http.StatusOK))
+		})
+	})
 })

--- a/pkg/storage/export/virt-exportserver/oci_test.go
+++ b/pkg/storage/export/virt-exportserver/oci_test.go
@@ -111,7 +111,7 @@ var _ = Describe("OCI export", func() {
 	It("should return 503 while OCI is not ready", func() {
 		es := newTestServer(testToken)
 		es.ociBuilder = &oci.Builder{}
-		es.Paths = &export.ServerPaths{}
+		es.Paths = &export.ServerPaths{OCIURI: testOCIURI}
 		es.initHandler()
 
 		rec := httptest.NewRecorder()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
The readiness probe at /exportready returned 200 immediately for backup exports even though the NBD tunnel wasn't established yet, causing the VMExport to become Ready before data was actually servable. 

#### After this PR:
A readinessGate pattern now lets each subsystem register its own readiness during init. VMExports with backup source will only become ready once the NBD tunnel is establishment.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```