### PR TITLE
tests: add ModifiesKubeVirtCR decorator to KV CR tests

### DIFF
--- a/tests/canary_upgrade_test.go
+++ b/tests/canary_upgrade_test.go
@@ -46,7 +46,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libkubevirt"
 )
 
-var _ = Describe("[sig-operator]virt-handler canary upgrade", Serial, decorators.SigOperator, func() {
+var _ = Describe("[sig-operator]virt-handler canary upgrade", Serial, decorators.ModifiesKubeVirtCR, decorators.SigOperator, func() {
 
 	var originalKV *v1.KubeVirt
 	var virtCli kubecli.KubevirtClient

--- a/tests/compute/cpu.go
+++ b/tests/compute/cpu.go
@@ -379,7 +379,7 @@ var _ = Describe(SIG("CPU", func() {
 			Expect(cpuRequest.String()).To(Equal("100m"))
 		})
 
-		It("[test_id:3129]should set CPU request from kubevirt-config", Serial, func() {
+		It("[test_id:3129]should set CPU request from kubevirt-config", Serial, decorators.ModifiesKubeVirtCR, func() {
 			kv := libkubevirt.GetCurrentKv(virtClient)
 
 			config := kv.Spec.Configuration
@@ -398,7 +398,7 @@ var _ = Describe(SIG("CPU", func() {
 		})
 	})
 
-	Context("with automatic CPU limit configured in the CR", Serial, func() {
+	Context("with automatic CPU limit configured in the CR", Serial, decorators.ModifiesKubeVirtCR, func() {
 		const autoCPULimitLabel = "autocpulimit"
 		BeforeEach(func() {
 			By("Adding a label selector to the CR for auto CPU limit")

--- a/tests/compute/guest_agent.go
+++ b/tests/compute/guest_agent.go
@@ -501,7 +501,7 @@ var _ = Describe(SIG("GuestAgent info", func() {
 		})
 	})
 
-	Context("with cluster config changes", Serial, func() {
+	Context("with cluster config changes", Serial, decorators.ModifiesKubeVirtCR, func() {
 		BeforeEach(func() {
 			kv := libkubevirt.GetCurrentKv(kubevirt.Client())
 

--- a/tests/compute/vmi_memory_overhead.go
+++ b/tests/compute/vmi_memory_overhead.go
@@ -47,7 +47,7 @@ import (
 )
 
 // TODO: remove the Serial once VmiMemoryOverheadReport is enabled by default
-var _ = Describe(SIG("VMI Memory Overhead Reporting", decorators.RequiresTwoSchedulableNodes, Serial, func() {
+var _ = Describe(SIG("VMI Memory Overhead Reporting", decorators.RequiresTwoSchedulableNodes, Serial, decorators.ModifiesKubeVirtCR, func() {
 	var virtClient kubecli.KubevirtClient
 
 	BeforeEach(func() {

--- a/tests/compute/vmidefaults.go
+++ b/tests/compute/vmidefaults.go
@@ -118,7 +118,7 @@ var _ = Describe(SIG("VMIDefaults", func() {
 			}
 		})
 
-		DescribeTable("Should override period in domain if present in virt-config ", Serial, func(period uint32) {
+		DescribeTable("Should override period in domain if present in virt-config ", Serial, decorators.ModifiesKubeVirtCR, func(period uint32) {
 			By("Adding period to virt-config")
 			kvConfigurationCopy := kvConfiguration.DeepCopy()
 			kvConfigurationCopy.MemBalloonStatsPeriod = &period

--- a/tests/container_disk_test.go
+++ b/tests/container_disk_test.go
@@ -98,7 +98,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 	})
 
 	Describe("[rfe_id:273][crit:medium][vendor:cnv-qe@redhat.com][level:component]Starting a VirtualMachineInstance", decorators.WgS390x, func() {
-		Context("should obey the disk verification limits in the KubeVirt CR", Serial, func() {
+		Context("should obey the disk verification limits in the KubeVirt CR", Serial, decorators.ModifiesKubeVirtCR, func() {
 			It("[test_id:7182]disk verification should fail when the memory limit is too low", func() {
 				By("Reducing the diskVerificaton memory usage limit")
 				kv := libkubevirt.GetCurrentKv(virtClient)
@@ -170,7 +170,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 
 	Describe("[rfe_id:4052][crit:high][vendor:cnv-qe@redhat.com][level:component]VMI disk permissions", decorators.WgS390x, decorators.WgArm64, func() {
 		Context("with ephemeral registry disk", func() {
-			It("[test_id:4299]should not have world write permissions", Serial, func() {
+			It("[test_id:4299]should not have world write permissions", Serial, decorators.ModifiesKubeVirtCR, func() {
 				if checks.HasFeature(featuregate.ImageVolume) {
 					config.DisableFeatureGate(featuregate.ImageVolume)
 					DeferCleanup(config.EnableFeatureGate, featuregate.ImageVolume)
@@ -251,7 +251,7 @@ var _ = Describe("[rfe_id:588][crit:medium][vendor:cnv-qe@redhat.com][level:comp
 		})
 	})
 
-	Describe("Simulate an upgrade from a version where ImageVolume was disabled to a version where it is enabled", Serial, decorators.ImageVolume, decorators.NoFlakeCheck, func() {
+	Describe("Simulate an upgrade from a version where ImageVolume was disabled to a version where it is enabled", Serial, decorators.ModifiesKubeVirtCR, decorators.ImageVolume, decorators.NoFlakeCheck, func() {
 		BeforeEach(func() {
 			v, err := checks.GetKubernetesVersion()
 			Expect(err).ToNot(HaveOccurred())

--- a/tests/cross_arch_emulation_test.go
+++ b/tests/cross_arch_emulation_test.go
@@ -42,7 +42,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libvmops"
 )
 
-var _ = Describe("[sig-compute]Cross-architecture software emulation", Serial, decorators.SigCompute, decorators.RequiresCrossArchEmulation, func() {
+var _ = Describe("[sig-compute]Cross-architecture software emulation", Serial, decorators.ModifiesKubeVirtCR, decorators.SigCompute, decorators.RequiresCrossArchEmulation, func() {
 
 	BeforeEach(func() {
 		config.EnableFeatureGate(featuregate.CrossArchitectureVirtualization)

--- a/tests/decorators/decorators.go
+++ b/tests/decorators/decorators.go
@@ -149,6 +149,11 @@ var (
 	// Disruptive indicates that the test may cause a disruption to the cluster's normal operation
 	Disruptive = Label("disruptive")
 
+	// ModifiesKubeVirtCR indicates that the test modifies the KubeVirt Custom Resource
+	// (configuration, feature gates, operator settings). Tests with this decorator
+	// cannot run in HCO-managed environments without a config adapter.
+	ModifiesKubeVirtCR = Label("modifies-kubevirt-cr")
+
 	// LargeStoragePoolRequired indicates that the test may fail in a cluster with a low storage pool capacity.
 	// This decorator can be used to skip the test as the failure might not indicate a functional problem.
 	LargeStoragePoolRequired = Label("large-storage-pool-required")

--- a/tests/dryrun_test.go
+++ b/tests/dryrun_test.go
@@ -530,7 +530,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", decorators.SigCompute, decorat
 		})
 	})
 
-	Context("VM Snapshots", func() {
+	Context("VM Snapshots", decorators.ModifiesKubeVirtCR, func() {
 		var snap *snapshotv1.VirtualMachineSnapshot
 
 		BeforeEach(func() {
@@ -609,7 +609,7 @@ var _ = Describe("[sig-compute]Dry-Run requests", decorators.SigCompute, decorat
 		})
 	})
 
-	Context("VM Restores", func() {
+	Context("VM Restores", decorators.ModifiesKubeVirtCR, func() {
 		var restore *snapshotv1.VirtualMachineRestore
 
 		BeforeEach(func() {

--- a/tests/hotplug/cpu.go
+++ b/tests/hotplug/cpu.go
@@ -37,7 +37,7 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = Describe("[sig-compute]CPU Hotplug", decorators.SigCompute, decorators.SigComputeMigrations, decorators.RequiresTwoSchedulableNodes, decorators.VMLiveUpdateRolloutStrategy, Serial, func() {
+var _ = Describe("[sig-compute]CPU Hotplug", decorators.SigCompute, decorators.SigComputeMigrations, decorators.RequiresTwoSchedulableNodes, decorators.VMLiveUpdateRolloutStrategy, Serial, decorators.ModifiesKubeVirtCR, func() {
 	var (
 		virtClient kubecli.KubevirtClient
 	)

--- a/tests/hotplug/instancetype.go
+++ b/tests/hotplug/instancetype.go
@@ -34,7 +34,7 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = Describe("[sig-compute]Instance Type and Preference Hotplug", decorators.SigCompute, decorators.SigComputeInstancetype, decorators.SigComputeMigrations, decorators.RequiresTwoSchedulableNodes, Serial, func() {
+var _ = Describe("[sig-compute]Instance Type and Preference Hotplug", decorators.SigCompute, decorators.SigComputeInstancetype, decorators.SigComputeMigrations, decorators.RequiresTwoSchedulableNodes, Serial, decorators.ModifiesKubeVirtCR, func() {
 	var (
 		virtClient kubecli.KubevirtClient
 	)

--- a/tests/hotplug/memory.go
+++ b/tests/hotplug/memory.go
@@ -33,7 +33,7 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = Describe("[sig-compute]Memory Hotplug", decorators.SigCompute, decorators.SigComputeMigrations, decorators.RequiresTwoSchedulableNodes, decorators.VMLiveUpdateRolloutStrategy, Serial, func() {
+var _ = Describe("[sig-compute]Memory Hotplug", decorators.SigCompute, decorators.SigComputeMigrations, decorators.RequiresTwoSchedulableNodes, decorators.VMLiveUpdateRolloutStrategy, Serial, decorators.ModifiesKubeVirtCR, func() {
 	var (
 		virtClient kubecli.KubevirtClient
 	)

--- a/tests/hotplug/rolloutstrategy.go
+++ b/tests/hotplug/rolloutstrategy.go
@@ -34,7 +34,7 @@ var _ = Describe("[sig-compute]VM Rollout Strategy", decorators.SigCompute, Seri
 		virtClient = kubevirt.Client()
 	})
 
-	Context("When using the Stage rollout strategy", func() {
+	Context("When using the Stage rollout strategy", decorators.ModifiesKubeVirtCR, func() {
 		BeforeEach(func() {
 			rolloutStrategy := pointer.P(v1.VMRolloutStrategyStage)
 			err := config.RegisterKubevirtConfigChange(

--- a/tests/infrastructure/cluster-profiler.go
+++ b/tests/infrastructure/cluster-profiler.go
@@ -31,7 +31,7 @@ import (
 	"kubevirt.io/client-go/kubecli"
 )
 
-var _ = Describe(SIGSerial("cluster profiler for pprof data aggregation", func() {
+var _ = Describe(SIGSerial("cluster profiler for pprof data aggregation", decorators.ModifiesKubeVirtCR, func() {
 	var virtClient kubecli.KubevirtClient
 	var kvConfig v1.KubeVirtConfiguration
 

--- a/tests/infrastructure/k8s-client-changes.go
+++ b/tests/infrastructure/k8s-client-changes.go
@@ -44,7 +44,7 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = Describe(SIGSerial("changes to the kubernetes client", func() {
+var _ = Describe(SIGSerial("changes to the kubernetes client", decorators.ModifiesKubeVirtCR, func() {
 	var (
 		virtClient kubecli.KubevirtClient
 		err        error

--- a/tests/infrastructure/node-labeller.go
+++ b/tests/infrastructure/node-labeller.go
@@ -50,7 +50,7 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = Describe(SIGSerial("Node-labeller", func() {
+var _ = Describe(SIGSerial("Node-labeller", decorators.ModifiesKubeVirtCR, func() {
 	const trueStr = "true"
 
 	var (

--- a/tests/infrastructure/security.go
+++ b/tests/infrastructure/security.go
@@ -43,7 +43,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libvmops"
 )
 
-var _ = Describe(SIGSerial("Node Restriction", decorators.RequiresTwoSchedulableNodes, func() {
+var _ = Describe(SIGSerial("Node Restriction", decorators.ModifiesKubeVirtCR, decorators.RequiresTwoSchedulableNodes, func() {
 	var virtClient kubecli.KubevirtClient
 	const minNodesWithVirtHandler = 2
 

--- a/tests/infrastructure/tls-configuration.go
+++ b/tests/infrastructure/tls-configuration.go
@@ -42,7 +42,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libpod"
 )
 
-var _ = Describe(SIGSerial("tls configuration", func() {
+var _ = Describe(SIGSerial("tls configuration", decorators.ModifiesKubeVirtCR, func() {
 	// FIPS-compliant so we can test on different platforms (otherwise won't revert properly)
 	cipher := &tls.CipherSuite{
 		ID:   tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,

--- a/tests/infrastructure/virt-handler.go
+++ b/tests/infrastructure/virt-handler.go
@@ -42,7 +42,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libnode"
 )
 
-var _ = Describe(SIGSerial("virt-handler", decorators.WgS390x, func() {
+var _ = Describe(SIGSerial("virt-handler", decorators.ModifiesKubeVirtCR, decorators.WgS390x, func() {
 	var (
 		virtClient       kubecli.KubevirtClient
 		originalKubeVirt *v1.KubeVirt

--- a/tests/instancetype/memory_overcommit.go
+++ b/tests/instancetype/memory_overcommit.go
@@ -33,7 +33,7 @@ var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-c
 		virtClient = kubevirt.Client()
 	})
 
-	It("should apply memory overcommit instancetype to VMI even with cluster overcommit set", Serial, func() {
+	It("should apply memory overcommit instancetype to VMI even with cluster overcommit set", Serial, decorators.ModifiesKubeVirtCR, func() {
 		kv := libkubevirt.GetCurrentKv(virtClient)
 
 		config := kv.Spec.Configuration

--- a/tests/instancetype/reference_policy.go
+++ b/tests/instancetype/reference_policy.go
@@ -27,7 +27,7 @@ import (
 )
 
 var _ = Describe("[crit:medium][vendor:cnv-qe@redhat.com][level:component][sig-compute] InstancetypeReferencePolicy",
-	decorators.SigCompute, decorators.SigComputeInstancetype, Serial, decorators.WgS390x, func() {
+	decorators.SigCompute, decorators.SigComputeInstancetype, Serial, decorators.ModifiesKubeVirtCR, decorators.WgS390x, func() {
 		var virtClient kubecli.KubevirtClient
 
 		BeforeEach(func() {

--- a/tests/launchsecurity/sev.go
+++ b/tests/launchsecurity/sev.go
@@ -259,7 +259,7 @@ var _ = Describe("[sig-compute]AMD Secure Encrypted Virtualization (SEV)", decor
 		}, tikBase64, tekBase64
 	}
 
-	Context("device management", Serial, func() {
+	Context("device management", Serial, decorators.ModifiesKubeVirtCR, func() {
 		const (
 			sevResourceName = "devices.kubevirt.io/sev"
 			sevDevicePath   = "/proc/1/root/dev/sev"

--- a/tests/mdev_configuration_allocation_test.go
+++ b/tests/mdev_configuration_allocation_test.go
@@ -45,7 +45,7 @@ const (
 	mdevSupportedTypesDirName = "mdev_supported_types"
 )
 
-var _ = Describe("[sig-compute]MediatedDevices", Serial, decorators.VGPU, decorators.SigCompute, func() {
+var _ = Describe("[sig-compute]MediatedDevices", Serial, decorators.ModifiesKubeVirtCR, decorators.VGPU, decorators.SigCompute, func() {
 	var err error
 	var testNodeName string
 	var virtClient kubecli.KubevirtClient

--- a/tests/migration/eviction_strategy.go
+++ b/tests/migration/eviction_strategy.go
@@ -207,7 +207,7 @@ var _ = Describe(SIG("Live Migration", decorators.RequiresTwoSchedulableNodes, f
 				}, 180*time.Second, 500*time.Millisecond).Should(Equal(v1.MigrationSucceeded))
 			})
 
-			Context(" with node tainted during node drain", Serial, func() {
+			Context(" with node tainted during node drain", Serial, decorators.ModifiesKubeVirtCR, func() {
 
 				var (
 					nodeAffinity     *k8sv1.NodeAffinity
@@ -520,7 +520,7 @@ var _ = Describe(SIG("Live Migration", decorators.RequiresTwoSchedulableNodes, f
 		})
 	})
 
-	Describe(" with a cluster-wide live-migrate eviction strategy set", Serial, decorators.WgS390x, func() {
+	Describe(" with a cluster-wide live-migrate eviction strategy set", Serial, decorators.ModifiesKubeVirtCR, decorators.WgS390x, func() {
 		var originalKV *v1.KubeVirt
 
 		BeforeEach(func() {

--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -760,7 +760,7 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 				Eventually(matcher.ThisMigration(migration)).WithPolling(5 * time.Second).WithTimeout(2 * time.Minute).Should(matcher.BeInPhase(v1.MigrationFailed))
 			})
 		})
-		Context(" with auto converge enabled", Serial, decorators.WgS390x, func() {
+		Context(" with auto converge enabled", Serial, decorators.ModifiesKubeVirtCR, decorators.WgS390x, func() {
 			BeforeEach(func() {
 
 				// set autoconverge flag
@@ -1114,7 +1114,7 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 			return dv
 		}
 
-		Context(" migration to nonroot", Serial, func() {
+		Context(" migration to nonroot", Serial, decorators.ModifiesKubeVirtCR, func() {
 			var dv *cdiv1.DataVolume
 			size := "256Mi"
 			var clusterIsRoot bool
@@ -1198,7 +1198,7 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 				}, console.LoginToAlpine),
 			)
 		})
-		Context(" migration to root", Serial, func() {
+		Context(" migration to root", Serial, decorators.ModifiesKubeVirtCR, func() {
 			var dv *cdiv1.DataVolume
 			var clusterIsRoot bool
 			size := "256Mi"
@@ -1286,7 +1286,7 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 			)
 		})
 		Context("migration security", func() {
-			Context(" with TLS disabled", Serial, func() {
+			Context(" with TLS disabled", Serial, decorators.ModifiesKubeVirtCR, func() {
 				It("[test_id:6976] should be successfully migrated", decorators.WgS390x, func() {
 					cfg := getCurrentKvConfig(virtClient)
 					cfg.MigrationConfiguration.DisableTLS = pointer.P(true)
@@ -1466,7 +1466,7 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 			})
 		})
 
-		Context(" migration monitor", Serial, func() {
+		Context(" migration monitor", Serial, decorators.ModifiesKubeVirtCR, func() {
 			var createdPods []string
 			AfterEach(func() {
 				for _, podName := range createdPods {
@@ -2090,7 +2090,7 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 
 		})
 
-		Context(" with migration policies", Serial, func() {
+		Context(" with migration policies", Serial, decorators.ModifiesKubeVirtCR, func() {
 			confirmMigrationPolicyName := func(vmi *v1.VirtualMachineInstance, expectedName *string) {
 				By("Verifying the VMI's configuration source")
 				if expectedName == nil {
@@ -2147,7 +2147,7 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 
 		})
 
-		Context("with downtime tuning", Serial, func() {
+		Context("with downtime tuning", Serial, decorators.ModifiesKubeVirtCR, func() {
 			BeforeEach(func() {
 				kvconfig.EnableFeatureGate(featuregate.MigrationDowntimeTuning)
 			})
@@ -2306,7 +2306,7 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 			})
 		})
 
-		Context(" with freePageReporting", Serial, decorators.WgS390x, func() {
+		Context(" with freePageReporting", Serial, decorators.ModifiesKubeVirtCR, decorators.WgS390x, func() {
 
 			BeforeEach(func() {
 				kv := libkubevirt.GetCurrentKv(virtClient)
@@ -2725,7 +2725,7 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 		})
 	})
 
-	Context("with a dedicated migration network", Serial, func() {
+	Context("with a dedicated migration network", Serial, decorators.ModifiesKubeVirtCR, func() {
 		var nadName string
 
 		BeforeEach(func() {

--- a/tests/migration/namespace.go
+++ b/tests/migration/namespace.go
@@ -448,7 +448,7 @@ var _ = Describe(SIG("Live Migration across namespaces", decorators.RequiresDece
 			Expect(console.RunCommand(targetVMI, "cat /home/alpine/test/data.txt", 30*time.Second)).To(Succeed())
 		})
 
-		Context("with RWOFs backend storage class", func() {
+		Context("with RWOFs backend storage class", decorators.ModifiesKubeVirtCR, func() {
 			checkTPM := func(vmi *v1.VirtualMachineInstance) {
 				By("Ensuring the TPM is still functional and its state carried over")
 				ExpectWithOffset(1, console.SafeExpectBatch(vmi, []expect.Batcher{

--- a/tests/migration/paused.go
+++ b/tests/migration/paused.go
@@ -148,7 +148,7 @@ var _ = Describe(SIG("Live Migrate A Paused VMI", decorators.RequiresTwoSchedula
 
 					},
 						Entry("migrate successfully (migration policy)", expectSuccess, "10Mi", applyWithMigrationPolicy),
-						Entry("migrate successfully (CR change)", decorators.WgS390x, Serial, expectSuccess, "10Mi", applyWithKubevirtCR),
+						Entry("migrate successfully (CR change)", decorators.WgS390x, Serial, decorators.ModifiesKubeVirtCR, expectSuccess, "10Mi", applyWithKubevirtCR),
 					)
 				})
 			})

--- a/tests/migration/postcopy.go
+++ b/tests/migration/postcopy.go
@@ -163,7 +163,7 @@ var _ = Describe(SIG("VM Post Copy Live Migration", decorators.RequiresTwoSchedu
 			libmigration.ConfirmMigrationMode(virtClient, vmi, v1.MigrationPostCopy)
 		},
 			Entry("a migration policy", applyWithMigrationPolicy),
-			Entry("the Kubevirt CR", Serial, applyWithKubevirtCR),
+			Entry("the Kubevirt CR", Serial, decorators.ModifiesKubeVirtCR, applyWithKubevirtCR),
 		)
 
 		Context("with a guest-agent-ping liveness probe", func() {
@@ -208,7 +208,7 @@ var _ = Describe(SIG("VM Post Copy Live Migration", decorators.RequiresTwoSchedu
 			})
 		})
 
-		Context("and fail", Serial, func() {
+		Context("and fail", Serial, decorators.ModifiesKubeVirtCR, func() {
 			var killerPod string
 
 			runVirtHandlerKillerPod := func(nodeName string) {

--- a/tests/migration/priority.go
+++ b/tests/migration/priority.go
@@ -51,7 +51,7 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = Describe(SIG("Live Migrations with priority", decorators.RequiresTwoSchedulableNodes, decorators.WgS390x, Serial, func() {
+var _ = Describe(SIG("Live Migrations with priority", decorators.RequiresTwoSchedulableNodes, decorators.WgS390x, Serial, decorators.ModifiesKubeVirtCR, func() {
 	var virtClient kubecli.KubevirtClient
 
 	BeforeEach(func() {

--- a/tests/migration/recovery.go
+++ b/tests/migration/recovery.go
@@ -150,8 +150,8 @@ var _ = Describe("[sig-compute]Migration recovery", decorators.SigCompute, decor
 	},
 		Entry("failure", decorators.NoFlakeCheck, false, false),
 		Entry("success", decorators.NoFlakeCheck, true, false),
-		Entry("failure [Serial]", decorators.FlakeCheck, Serial, false, true),
-		Entry("success [Serial]", decorators.FlakeCheck, Serial, true, true),
+		Entry("failure [Serial]", decorators.FlakeCheck, Serial, decorators.ModifiesKubeVirtCR, false, true),
+		Entry("success [Serial]", decorators.FlakeCheck, Serial, decorators.ModifiesKubeVirtCR, true, true),
 	)
 })
 

--- a/tests/monitoring/component_monitoring.go
+++ b/tests/monitoring/component_monitoring.go
@@ -95,7 +95,7 @@ var (
 	}
 )
 
-var _ = Describe("[sig-monitoring]Component Monitoring", Serial, Ordered, decorators.SigMonitoring, func() {
+var _ = Describe("[sig-monitoring]Component Monitoring", Serial, Ordered, decorators.ModifiesKubeVirtCR, decorators.SigMonitoring, func() {
 	var err error
 	var virtClient kubecli.KubevirtClient
 	var scales *libmonitoring.Scaling

--- a/tests/monitoring/metrics.go
+++ b/tests/monitoring/metrics.go
@@ -261,7 +261,7 @@ var _ = Describe("[sig-monitoring]Metrics", decorators.SigMonitoring, func() {
 		})
 	})
 
-	Context("Configuration metrics", Serial, func() {
+	Context("Configuration metrics", Serial, decorators.ModifiesKubeVirtCR, func() {
 		It("kubevirt_configuration_emulation_enabled is 1 when useEmulation=true", func() {
 			updateUseEmulationAndWaitForMetric(virtClient, true)
 		})

--- a/tests/network/bindingplugin.go
+++ b/tests/network/bindingplugin.go
@@ -48,7 +48,7 @@ const (
 	vmiReadyTimeoutManagedTap = 30
 )
 
-var _ = Describe(SIG("network binding plugin", Serial, decorators.NetCustomBindingPlugins, func() {
+var _ = Describe(SIG("network binding plugin", Serial, decorators.ModifiesKubeVirtCR, decorators.NetCustomBindingPlugins, func() {
 	Context("with CNI and Sidecar", func() {
 		const passtNetAttDefName = "netbindingpasst"
 

--- a/tests/network/bindingplugin_macvtap.go
+++ b/tests/network/bindingplugin_macvtap.go
@@ -46,7 +46,7 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = Describe(SIG("VirtualMachineInstance with macvtap network binding plugin", decorators.Macvtap, decorators.NetCustomBindingPlugins, Serial, func() {
+var _ = Describe(SIG("VirtualMachineInstance with macvtap network binding plugin", decorators.Macvtap, decorators.NetCustomBindingPlugins, Serial, decorators.ModifiesKubeVirtCR, func() {
 	const (
 		macvtapLowerDevice = "eth0"
 		macvtapNetworkName = "net1"

--- a/tests/network/hotplug_bridge.go
+++ b/tests/network/hotplug_bridge.go
@@ -59,7 +59,7 @@ const (
 	inPlace        hotplugMethod = "inPlace"
 )
 
-var _ = Describe(SIG("bridge nic-hotplug", Serial, func() {
+var _ = Describe(SIG("bridge nic-hotplug", Serial, decorators.ModifiesKubeVirtCR, func() {
 	BeforeEach(func() {
 		virtClient := kubevirt.Client()
 		updateStrategy := &v1.KubeVirtWorkloadUpdateStrategy{
@@ -262,7 +262,7 @@ var _ = Describe(SIG("bridge nic-hotplug", Serial, func() {
 	})
 }))
 
-var _ = Describe(SIG("bridge nic-hotunplug", Serial, func() {
+var _ = Describe(SIG("bridge nic-hotunplug", Serial, decorators.ModifiesKubeVirtCR, func() {
 	BeforeEach(func() {
 		virtClient := kubevirt.Client()
 		updateStrategy := &v1.KubeVirtWorkloadUpdateStrategy{

--- a/tests/network/hotplug_sriov.go
+++ b/tests/network/hotplug_sriov.go
@@ -46,7 +46,7 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = Describe(SIG(" SRIOV nic-hotplug", Serial, decorators.SRIOV, func() {
+var _ = Describe(SIG(" SRIOV nic-hotplug", Serial, decorators.ModifiesKubeVirtCR, decorators.SRIOV, func() {
 	sriovResourceName := readSRIOVResourceName()
 
 	BeforeEach(func() {

--- a/tests/network/nad_live_update.go
+++ b/tests/network/nad_live_update.go
@@ -49,7 +49,7 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = Describe(SIG("NAD name live update", decorators.RequiresTwoSchedulableNodes, Serial, func() {
+var _ = Describe(SIG("NAD name live update", decorators.RequiresTwoSchedulableNodes, Serial, decorators.ModifiesKubeVirtCR, func() {
 	const (
 		vmName          = "migrating-vm"
 		vmIP            = "10.1.1.100"

--- a/tests/network/sriov.go
+++ b/tests/network/sriov.go
@@ -325,7 +325,7 @@ var _ = Describe(SIG("SRIOV", Serial, decorators.SRIOV, func() {
 			})
 		})
 
-		Context("memory hotplug", Serial, decorators.RequiresTwoSchedulableNodes, func() {
+		Context("memory hotplug", Serial, decorators.ModifiesKubeVirtCR, decorators.RequiresTwoSchedulableNodes, func() {
 			BeforeEach(func() {
 				virtClient := kubevirt.Client()
 				updateStrategy := &v1.KubeVirtWorkloadUpdateStrategy{

--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -131,7 +131,7 @@ const (
 	secondaryNetworkName          = "secondarynet"
 )
 
-var _ = Describe("[sig-operator]Operator", Serial, decorators.SigOperator, func() {
+var _ = Describe("[sig-operator]Operator", Serial, decorators.ModifiesKubeVirtCR, decorators.SigOperator, func() {
 
 	var originalKv *v1.KubeVirt
 	var originalOperatorVersion string

--- a/tests/security_features_test.go
+++ b/tests/security_features_test.go
@@ -59,7 +59,7 @@ var _ = Describe("[sig-compute]SecurityFeatures", decorators.SigCompute, func() 
 		virtClient = kubevirt.Client()
 	})
 
-	Context("Check virt-launcher securityContext", Serial, func() {
+	Context("Check virt-launcher securityContext", Serial, decorators.ModifiesKubeVirtCR, func() {
 		var kubevirtConfiguration *v1.KubeVirtConfiguration
 
 		BeforeEach(func() {

--- a/tests/storage/export.go
+++ b/tests/storage/export.go
@@ -1700,7 +1700,7 @@ var _ = Describe(SIG("Export", func() {
 		waitForExportCondition(export, expectedVMRunningCondition(vm.Name, vm.Namespace), "export should report VM running")
 	})
 
-	Context("with limit range", func() {
+	Context("with limit range", decorators.ModifiesKubeVirtCR, func() {
 		var (
 			lr             *k8sv1.LimitRange
 			originalConfig v1.KubeVirtConfiguration
@@ -2290,7 +2290,7 @@ var _ = Describe(SIG("Export", func() {
 		}
 	})
 
-	Context(" with potential KubeVirt CR update", Serial, func() {
+	Context(" with potential KubeVirt CR update", Serial, decorators.ModifiesKubeVirtCR, func() {
 		var beforeCertParams *v1.KubeVirtCertificateRotateStrategy
 
 		BeforeEach(func() {
@@ -2360,7 +2360,7 @@ var _ = Describe(SIG("Export", func() {
 		})
 	})
 
-	Context("OCI export", Serial, Ordered, decorators.OncePerOrderedCleanup, func() {
+	Context("OCI export", Serial, Ordered, decorators.ModifiesKubeVirtCR, decorators.OncePerOrderedCleanup, func() {
 		const (
 			reasonDigestsComputed = "DigestsComputed"
 		)

--- a/tests/storage/hotplug.go
+++ b/tests/storage/hotplug.go
@@ -886,7 +886,7 @@ var _ = Describe(SIG("Hotplug", func() {
 				return sc
 			}
 
-			Context("with legacy hotplug", Serial, func() {
+			Context("with legacy hotplug", Serial, decorators.ModifiesKubeVirtCR, func() {
 				BeforeEach(func() {
 					kvconfig.DisableFeatureGate(featuregate.DeclarativeHotplugVolumesGate)
 					kvconfig.EnableFeatureGate(featuregate.HotplugVolumesGate)
@@ -1509,7 +1509,7 @@ var _ = Describe(SIG("Hotplug", func() {
 		)
 	})
 
-	Context("with limit range in namespace", decorators.RequiresRWXBlock, func() {
+	Context("with limit range in namespace", decorators.ModifiesKubeVirtCR, decorators.RequiresRWXBlock, func() {
 		var (
 			sc                         string
 			lr                         *k8sv1.LimitRange
@@ -2083,7 +2083,7 @@ var _ = Describe(SIG("Hotplug", func() {
 	})
 
 	// Regression test for https://github.com/kubevirt/kubevirt/issues/17124
-	Context("with PCI HostDevices", Serial, func() {
+	Context("with PCI HostDevices", Serial, decorators.ModifiesKubeVirtCR, func() {
 		const deviceName = "example.org/soundcard"
 
 		BeforeEach(func() {

--- a/tests/storage/migration.go
+++ b/tests/storage/migration.go
@@ -76,7 +76,7 @@ import (
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
 
-var _ = Describe(SIG("Volumes update with migration", decorators.RequiresTwoSchedulableNodes, decorators.VMLiveUpdateRolloutStrategy, func() {
+var _ = Describe(SIG("Volumes update with migration", decorators.RequiresTwoSchedulableNodes, decorators.VMLiveUpdateRolloutStrategy, decorators.ModifiesKubeVirtCR, func() {
 	var virtClient kubecli.KubevirtClient
 	var testSc string
 	createBlankDV := func(virtClient kubecli.KubevirtClient, ns, size string) *cdiv1.DataVolume {

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -807,7 +807,7 @@ var _ = Describe(SIG("Storage", func() {
 				}
 
 				// Not a candidate for NFS test due to usage of host disk
-				It("[test_id:3108]Should not initialize an empty PVC with a disk.img when disk is too small even with toleration", Serial, func() {
+				It("[test_id:3108]Should not initialize an empty PVC with a disk.img when disk is too small even with toleration", Serial, decorators.ModifiesKubeVirtCR, func() {
 
 					configureToleration(10)
 
@@ -834,7 +834,7 @@ var _ = Describe(SIG("Storage", func() {
 				})
 
 				// Not a candidate for NFS test due to usage of host disk
-				It("[test_id:3109]Should initialize an empty PVC with a disk.img when disk is too small but within toleration", Serial, func() {
+				It("[test_id:3109]Should initialize an empty PVC with a disk.img when disk is too small but within toleration", Serial, decorators.ModifiesKubeVirtCR, func() {
 
 					configureToleration(30)
 

--- a/tests/usb/usb.go
+++ b/tests/usb/usb.go
@@ -32,7 +32,7 @@ const (
 	cmdNumberUSBs   = "dmesg | grep -c idVendor=46f4"
 )
 
-var _ = Describe("[sig-compute][USB] [QUARANTINE] host USB Passthrough", Serial,
+var _ = Describe("[sig-compute][USB] [QUARANTINE] host USB Passthrough", Serial, decorators.ModifiesKubeVirtCR,
 	decorators.Quarantine, decorators.SigCompute, decorators.USB, func() {
 		var virtClient kubecli.KubevirtClient
 		var config v1.KubeVirtConfiguration

--- a/tests/virt_control_plane_test.go
+++ b/tests/virt_control_plane_test.go
@@ -217,7 +217,7 @@ var _ = Describe("[ref_id:2717][sig-compute]KubeVirt control plane resilience", 
 
 		})
 
-		When("Control plane pods temporarily lose connection to Kubernetes API", func() {
+		When("Control plane pods temporarily lose connection to Kubernetes API", decorators.ModifiesKubeVirtCR, func() {
 			// virt-handler is the only component that has the tools to add blackhole routes for testing healthz. Ideally we would test all component healthz endpoints.
 			componentName := "virt-handler"
 

--- a/tests/virtiofs/datavolume.go
+++ b/tests/virtiofs/datavolume.go
@@ -145,7 +145,7 @@ var _ = Describe("[sig-storage] virtiofs", decorators.SigStorage, decorators.Sto
 		})
 	})
 
-	Context("VirtIO-FS with an empty PVC", func() {
+	Context("VirtIO-FS with an empty PVC", decorators.ModifiesKubeVirtCR, func() {
 		var (
 			pvc            = "empty-pvc1"
 			originalConfig v1.KubeVirtConfiguration

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -507,7 +507,7 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 			),
 		)
 
-		It("[test_id:6869]should report an error status when image pull error occurs", Serial, decorators.Conformance, decorators.WgS390x, func() {
+		It("[test_id:6869]should report an error status when image pull error occurs", Serial, decorators.ModifiesKubeVirtCR, decorators.Conformance, decorators.WgS390x, func() {
 			if checks.HasFeature(featuregate.ImageVolume) {
 				config.DisableFeatureGate(featuregate.ImageVolume)
 				DeferCleanup(config.EnableFeatureGate, featuregate.ImageVolume)

--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -324,7 +324,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 		},
 			Entry("[test_id:1668]should use EFI without secure boot", Serial, false, "SecureBoot disabled", false),
 			Entry("[test_id:4437]should enable EFI secure boot", Serial, true, "SecureBoot enabled", false),
-			Entry("should enable EFI secure boot with firmware auto-selection", Serial, true, "SecureBoot enabled", true),
+			Entry("should enable EFI secure boot with firmware auto-selection", Serial, decorators.ModifiesKubeVirtCR, true, "SecureBoot enabled", true),
 		)
 
 		Context("[rfe_id:609][crit:medium][vendor:cnv-qe@redhat.com][level:component]Support memory over commitment test", func() {
@@ -726,7 +726,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 			})
 		})
 
-		Context("using defaultRuntimeClass configuration", Serial, func() {
+		Context("using defaultRuntimeClass configuration", Serial, decorators.ModifiesKubeVirtCR, func() {
 			var runtimeClassName string
 
 			BeforeEach(func() {
@@ -775,7 +775,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 			Expect(pod.Spec.RuntimeClassName).To(BeNil())
 		})
 
-		Context("with guest-to-request memory ", Serial, decorators.WgS390x, func() {
+		Context("with guest-to-request memory ", Serial, decorators.ModifiesKubeVirtCR, decorators.WgS390x, func() {
 			setHeadroom := func(ratioStr string) {
 				kv := libkubevirt.GetCurrentKv(virtClient)
 
@@ -839,7 +839,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 		})
 	})
 
-	Context("[rfe_id:2869][crit:medium][vendor:cnv-qe@redhat.com][level:component]with machine type settings", decorators.WgS390x, Serial, func() {
+	Context("[rfe_id:2869][crit:medium][vendor:cnv-qe@redhat.com][level:component]with machine type settings", decorators.WgS390x, Serial, decorators.ModifiesKubeVirtCR, func() {
 		testEmulatedMachines := []string{"q35*", "pc-q35*", "pc*"}
 		testEmulatedMachinesS390x := []string{"s390-ccw-virtio*"}
 

--- a/tests/vmi_hook_sidecar_test.go
+++ b/tests/vmi_hook_sidecar_test.go
@@ -87,7 +87,7 @@ var _ = Describe("[sig-compute]HookSidecars", decorators.SigCompute, func() {
 	})
 
 	Describe("[rfe_id:2667][crit:medium][vendor:cnv-qe@redhat.com][level:component] VMI definition", func() {
-		Context("set sidecar resources", func() {
+		Context("set sidecar resources", decorators.ModifiesKubeVirtCR, func() {
 			var originalConfig v1.KubeVirtConfiguration
 			BeforeEach(func() {
 				originalConfig = *libkubevirt.GetCurrentKv(virtClient).Spec.Configuration.DeepCopy()

--- a/tests/vmi_hostdev_test.go
+++ b/tests/vmi_hostdev_test.go
@@ -34,7 +34,7 @@ const (
 	failedDeleteVMI = "Failed to delete VMI"
 )
 
-var _ = Describe("[sig-compute]HostDevices", Serial, decorators.SigCompute, func() {
+var _ = Describe("[sig-compute]HostDevices", Serial, decorators.ModifiesKubeVirtCR, decorators.SigCompute, func() {
 	var (
 		virtClient kubecli.KubevirtClient
 		config     v1.KubeVirtConfiguration

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -599,7 +599,7 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			})
 		})
 
-		Context("when virt-handler is not responsive", Serial, func() {
+		Context("when virt-handler is not responsive", Serial, decorators.ModifiesKubeVirtCR, func() {
 
 			var vmi *v1.VirtualMachineInstance
 			var nodeName string
@@ -716,7 +716,7 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			})
 		})
 
-		Context("with default cpu model", Serial, decorators.WgS390x, decorators.CPUModel, func() {
+		Context("with default cpu model", Serial, decorators.ModifiesKubeVirtCR, decorators.WgS390x, decorators.CPUModel, func() {
 			var originalConfig v1.KubeVirtConfiguration
 			var supportedCpuModels []string
 			var defaultCPUModel string

--- a/tests/vmi_vsock_test.go
+++ b/tests/vmi_vsock_test.go
@@ -53,7 +53,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libvmops"
 )
 
-var _ = Describe("[sig-compute]VSOCK", Serial, decorators.SigCompute, decorators.VSOCK, func() {
+var _ = Describe("[sig-compute]VSOCK", Serial, decorators.ModifiesKubeVirtCR, decorators.SigCompute, decorators.VSOCK, func() {
 	var virtClient kubecli.KubevirtClient
 	var err error
 


### PR DESCRIPTION
### What this PR does
Add a new `ModifiesKubeVirtCR` Ginkgo label decorator for tests that modify the KubeVirt Custom Resource (configuration, feature gates, operator settings). On platforms that manage the KubeVirt resource externally (e.g. HCO), these tests conflict with the managing operator because direct CR modifications get reconciled back. The decorator allows filtering these tests out precisely rather than skipping the entire Serial set.

#### Before this PR:
- There is no way to distinguish tests that modify the KubeVirt CR from other Serial tests
- Filtering by the Serial label would skip ~410 tests, but only ~139 actually modify the KV CR - losing ~270 unrelated tests unnecessarily

#### After this PR:
- A dedicated `modifies-kubevirt-cr` label is applied to all 139 tests across ~53 files that modify the KubeVirt CR
- Platforms managing the KubeVirt resource can filter precisely with `--label-filter='!modifies-kubevirt-cr'` to skip only conflicting tests
- No test logic changes - purely additive decorator placement

### References
https://github.com/kubevirt/kubevirt/issues/18548

### Release note
```release-note
NONE
```