### PR TITLE
tests, migration: fix ResourceQuota rejection test flakiness

### DIFF
--- a/tests/migration/migration.go
+++ b/tests/migration/migration.go
@@ -2889,28 +2889,30 @@ var _ = Describe(SIG("VM Live Migration", decorators.RequiresTwoSchedulableNodes
 			By("Creating ResourceQuota with enough memory for the vmi but not enough for migration")
 			resourceQuota := newResourceQuota(resourcesToLimit, testsuite.GetTestNamespace(vmi))
 			resourceQuota = createResourceQuota(resourceQuota)
+
+			By("Starting the VirtualMachineInstance")
+			vmi = libvmops.RunVMIAndExpectLaunch(vmi, flags.StartupTimeoutSecondsHuge())
+
+			By("Waiting for the ResourceQuota status to reflect the VMI's resource consumption")
 			Eventually(func() error {
 				quota, err := virtClient.CoreV1().ResourceQuotas(resourceQuota.Namespace).Get(context.TODO(), resourceQuota.Name, metav1.GetOptions{})
 				if err != nil {
 					return err
 				}
-				for key := range resourcesToLimit {
-					if _, ok := quota.Status.Hard[key]; !ok {
-						return fmt.Errorf("Missing %s in status", key)
+				if quota.Status.Used == nil {
+					return fmt.Errorf("resource quota status.used not yet populated")
+				}
+				for k := range resourcesToLimit {
+					actualValue, found := quota.Status.Used[k]
+					if !found {
+						return fmt.Errorf("resource %s not yet in status.used", k)
 					}
-					value := quota.Status.Hard[key]
-					if value.Cmp(resourcesToLimit[key]) != 0 {
-						return fmt.Errorf("%v should equal %v", value, resourcesToLimit[key])
-					}
-					if _, ok := quota.Status.Used[key]; !ok {
-						return fmt.Errorf("Missing %s in status.used", key)
+					if actualValue.IsZero() {
+						return fmt.Errorf("resource %s status.used is still zero, waiting for quota controller to account for the running VMI", k)
 					}
 				}
 				return err
 			}).WithTimeout(time.Minute).WithPolling(time.Second).Should(Succeed())
-
-			By("Starting the VirtualMachineInstance")
-			vmi = libvmops.RunVMIAndExpectLaunch(vmi, flags.StartupTimeoutSecondsHuge())
 
 			By("Trying to migrate the VirtualMachineInstance")
 			migration := libmigration.New(vmi.Name, testsuite.GetTestNamespace(vmi))


### PR DESCRIPTION
## Summary

- Fix a race condition in the ResourceQuota migration rejection test that caused intermittent failures
- The test now waits for the quota controller to account for the running VMI's resources before attempting migration, following the pattern used by Kubernetes' own `waitForResourceQuota` helper

## Root Cause

The test polled the ResourceQuota status only to verify that `Status.Used` *existed* for each tracked resource, but did not verify the value was non-zero. Between starting the VMI and triggering migration, the quota controller may not have reconciled the pod's actual resource consumption yet. When `Status.Used` still reported zero memory usage, the migration was not rejected by quota as expected.

## Fix

Reorder the test to:
1. Create the ResourceQuota
2. Start the VMI
3. Poll until `Status.Used` reflects non-zero consumption (confirming the quota controller has accounted for the virt-launcher pod)
4. Then trigger migration
This matches the approach used by upstream Kubernetes e2e tests:
https://github.com/kubernetes/kubernetes/blob/566f939b19fa0be3d3f5d11b13c38884887eb915/test/e2e/apimachinery/resource_quota.go#L2218


### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

