### PR TITLE
virt-handler/cache: bound domain-watcher event sends to ctx

### DIFF
--- a/pkg/virt-handler/cache/domain-watcher.go
+++ b/pkg/virt-handler/cache/domain-watcher.go
@@ -93,23 +93,35 @@ func (d *domainWatcher) worker(ctx context.Context, runServer runServerFunc, res
 	for {
 		select {
 		case <-resyncTicker.C:
-			d.handleResync()
+			d.handleResync(ctx)
 		case <-expiredWatchdogTicker.C:
-			d.handleStaleSocketConnections(watchdogTimeout)
+			d.handleStaleSocketConnections(ctx, watchdogTimeout)
 		case err := <-srvErr:
 			if err != nil {
 				log.Log.Reason(err).Errorf("Domain notify server exited unexpectedly")
 				d.panicOnConsecutiveFailures(err, startedAt)
-				d.result <- watch.Event{
+				d.send(ctx, watch.Event{
 					Type: watch.Error,
 					Object: &metav1.Status{
 						Status:  metav1.StatusFailure,
 						Message: fmt.Sprintf("domain notify server error: %v", err),
 					},
-				}
+				})
 			}
 			return
 		}
+	}
+}
+
+// send delivers event on d.result, but gives up once ctx is done. Without
+// this, a worker shutting down after the informer has already stopped
+// reading ResultChan() would block on this send forever, hanging Stop().
+func (d *domainWatcher) send(ctx context.Context, event watch.Event) bool {
+	select {
+	case d.result <- event:
+		return true
+	case <-ctx.Done():
+		return false
 	}
 }
 
@@ -139,7 +151,7 @@ func (d *domainWatcher) recordNotifyServerFailureEvent(err error) {
 		"Domain notify server exited unexpectedly: %v", err)
 }
 
-func (d *domainWatcher) handleResync() {
+func (d *domainWatcher) handleResync(ctx context.Context) {
 	socketFiles, err := listSockets(GhostRecordGlobalStore.list())
 	if err != nil {
 		log.Log.Reason(err).Error("failed to list sockets")
@@ -169,11 +181,13 @@ func (d *domainWatcher) handleResync() {
 			continue
 		}
 
-		d.result <- watch.Event{Type: watch.Modified, Object: domain}
+		if !d.send(ctx, watch.Event{Type: watch.Modified, Object: domain}) {
+			return
+		}
 	}
 }
 
-func (d *domainWatcher) handleStaleSocketConnections(watchdogTimeout int) error {
+func (d *domainWatcher) handleStaleSocketConnections(ctx context.Context, watchdogTimeout int) error {
 	var unresponsive []string
 
 	socketFiles, err := listSockets(GhostRecordGlobalStore.list())
@@ -234,7 +248,9 @@ func (d *domainWatcher) handleStaleSocketConnections(watchdogTimeout int) error 
 				now := metav1.Now()
 				domain.ObjectMeta.DeletionTimestamp = &now
 				log.Log.Object(domain).Warningf("detected unresponsive virt-launcher command socket (%s) for domain", key)
-				d.result <- watch.Event{Type: watch.Modified, Object: domain}
+				if !d.send(ctx, watch.Event{Type: watch.Modified, Object: domain}) {
+					return ctx.Err()
+				}
 
 				err := cmdclient.MarkSocketUnresponsive(key)
 				if err != nil {

--- a/pkg/virt-handler/cache/domain-watcher_test.go
+++ b/pkg/virt-handler/cache/domain-watcher_test.go
@@ -83,6 +83,28 @@ var _ = Describe("Domain Watcher", func() {
 		})
 	})
 
+	Context("send", func() {
+		It("should deliver the event when the result channel is read", func() {
+			d := &domainWatcher{result: make(chan watch.Event, 1)}
+
+			Expect(d.send(context.Background(), watch.Event{Type: watch.Modified})).To(BeTrue())
+			Expect(<-d.result).To(Equal(watch.Event{Type: watch.Modified}))
+		})
+
+		It("should give up instead of blocking forever once ctx is done", func() {
+			d := &domainWatcher{result: make(chan watch.Event)}
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+
+			sent := make(chan bool, 1)
+			go func() {
+				sent <- d.send(ctx, watch.Event{Type: watch.Modified})
+			}()
+
+			Eventually(sent, 500*time.Millisecond).Should(Receive(BeFalse()))
+		})
+	})
+
 	Context("Stop() idempotency", func() {
 		It("should not panic when Stop is called twice", func() {
 			d := newDomainWatcher(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:

`handleResync` and `handleStaleSocketConnections` in `pkg/virt-handler/cache/domain-watcher.go` send events on the worker's result channel with a bare, unconditional channel send (`d.result <- watch.Event{...}`). That channel is consumed by client-go's reflector (wired up via `WatchFuncWithContext`/`ListWatch` in `NewSharedInformer`). The vendored reflector stops reading `ResultChan()` as soon as its `ctx` is done, and only afterwards calls `Stop()` on the watcher. `domainWatcher.Stop()` is `cancel()` followed by `wg.Wait()` on the same worker goroutine that owns the blocking sends. Because our internal `ctx` is a child of the reflector's `ctx`, both sides observe cancellation together: if the worker is in the middle of a send to the (100-slot buffered) result channel right as/after the reflector stops consuming it, that send can block forever, so `worker()` never returns and `Stop()`/`wg.Wait()` hangs forever.

This is the "secondary issue" called out in the linked report (`handleResync` sending without listening on `stopChan`). The report's primary issue — `handleStaleSocketConnections` holding a `watchDogLock` mutex across the same blocking send — no longer applies: that mutex was already removed on `main` by an unrelated refactor, since `unresponsiveSockets` is only ever touched by the single worker goroutine. This PR only addresses the still-present shutdown hang; it is not a repeat of the original "all VMI reconciliation freezes" claim, which no longer applies now that the lock is gone.

#### After this PR:

A small `domainWatcher.send(ctx, event)` helper selects between the channel send and `ctx.Done()`, and is used at every `d.result` send site (`handleResync`, `handleStaleSocketConnections`, and the `srvErr` error path in `worker()`), bailing out early instead of blocking forever once `ctx` is already done.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
- Fixes #17183

### Why we need it and why it was done in this way
The following tradeoffs were made:

`handleStaleSocketConnections` returns early (skipping the remaining `unresponsiveSockets` map iteration and the `cmdclient.MarkSocketUnresponsive` call for the current entry) once `send` reports `ctx` is done. This only happens while the watcher is shutting down, and a fresh `unresponsiveSockets` map is built the next time a `domainWatcher` starts, so skipping the rest of that pass is inconsequential relative to the alternative of hanging shutdown indefinitely.

The following alternatives were considered:

Passing `ctx` through as an additional parameter (as done here) versus storing it on the `domainWatcher` struct — the struct was recently trimmed to remove fields only used inside the worker goroutine (see the `watchDogLock` removal), so keeping `ctx` as a parameter matches that direction.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

I could not run `go test ./pkg/virt-handler/cache/...` (or `golangci-lint` on that package) in my sandbox: a sibling test file already in the package, `cache_test.go`, imports `kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap`, which requires real libvirt cgo bindings not installed in my environment, and my sandbox has no docker/podman/bazel available either (the mechanism this repo's own `make test` normally uses to provide that dependency). I confirmed with `git stash` that the identical compile failure happens on unmodified `main`, so this is a pre-existing environment limitation unrelated to this change, not something it introduces.

What I did validate:
- `GOOS=linux go build ./pkg/virt-handler/...` passes.
- `gofmt -l` on both changed files is clean.
- Added two Ginkgo tests exercising the new `send()` helper directly: one proving it still delivers the event when the channel has a reader, one proving it returns `false` within 2s instead of hanging when `ctx` is already canceled and nobody reads `d.result`. These could not be executed inside the real package test binary here for the reason above, but the same select/ctx-cancellation logic was checked against an isolated scratch reproduction outside the repo (since removed) confirming a bare channel send hangs indefinitely with no reader while the ctx-aware `select` returns promptly.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required (none — internal-only behavior, no API/state changes)
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is not required (internal-only change, no user-facing API)
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

---
AI assistance: this change was drafted with Claude Code.