### PR TITLE
virt-controller: fix incorrect VMI restart for stopped RerunOnFailure VMs

### DIFF
--- a/pkg/virt-controller/watch/vm/vm.go
+++ b/pkg/virt-controller/watch/vm/vm.go
@@ -1066,8 +1066,7 @@ func (c *Controller) syncRunStrategy(vm *virtv1.VirtualMachine, vmi *virtv1.Virt
 			return vm, nil
 		}
 
-		// when coming here from a different RunStrategy we have to start the VM
-		if !hasStartRequest(vm) && vm.Status.RunStrategy == runStrategy {
+		if !shouldStartRerunOnFailure(vm, runStrategy) {
 			return vm, nil
 		}
 
@@ -1211,6 +1210,15 @@ func (c *Controller) isVMIStopExpected(vm *virtv1.VirtualMachine) bool {
 	return dels > 0
 }
 
+// shouldStartRerunOnFailure reports whether a VM using the RerunOnFailure
+// strategy should create a new VMI when no VMI currently exists
+// It returns true when there is an explicit StartRequest
+// or when the RunStrategy has just been switched to RerunOnFailure from
+// a different strategy (detected via vm.Status.RunStrategy)
+func shouldStartRerunOnFailure(vm *virtv1.VirtualMachine, runStrategy virtv1.VirtualMachineRunStrategy) bool {
+	return hasStartRequest(vm) || vm.Status.RunStrategy != runStrategy
+}
+
 // isSetToStart determines whether a VM is configured to be started (running).
 func isSetToStart(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance) bool {
 	runStrategy, err := vm.RunStrategy()
@@ -1233,7 +1241,7 @@ func isSetToStart(vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance)
 		if vmi != nil {
 			return vmi.Status.Phase != virtv1.Succeeded
 		}
-		return true
+		return shouldStartRerunOnFailure(vm, runStrategy)
 	case virtv1.RunStrategyOnce:
 		if vmi == nil {
 			return true

--- a/pkg/virt-controller/watch/vm/vm_test.go
+++ b/pkg/virt-controller/watch/vm/vm_test.go
@@ -7053,7 +7053,7 @@ var _ = Describe("VirtualMachine", func() {
 				Expect(err).To(MatchError(k8serrors.IsNotFound, "IsNotFound"))
 			})
 
-			PIt("The VM should get restarted when doing RerunOnFailure -> Halted -> RerunOnFailure", func() {
+			It("The VM should get restarted when doing RerunOnFailure -> Halted -> RerunOnFailure", func() {
 				vm, _ := watchtesting.DefaultVirtualMachine(true)
 				vm.Spec.Running = nil
 				vm.Spec.RunStrategy = pointer.P(v1.RunStrategyRerunOnFailure)
@@ -7063,6 +7063,7 @@ var _ = Describe("VirtualMachine", func() {
 
 				addVirtualMachine(vm)
 				sanityExecute(vm)
+				clearExpectations(vm)
 
 				controller.crIndexer.Add(createVMRevision(vm))
 
@@ -7076,6 +7077,7 @@ var _ = Describe("VirtualMachine", func() {
 				Expect(err).To(Not(HaveOccurred()))
 				controller.Queue.Add(key)
 				sanityExecute(vm)
+				clearExpectations(vm)
 
 				By("Change RunStrategy to Halted")
 				vm.Spec.RunStrategy = pointer.P(v1.RunStrategyHalted)
@@ -7085,13 +7087,18 @@ var _ = Describe("VirtualMachine", func() {
 
 				addVirtualMachine(vm)
 				sanityExecute(vm)
+				clearExpectations(vm)
 
-				controller.crIndexer.Delete(createVMRevision(vm))
+				cr := createVMRevision(vm)
+				controller.crIndexer.Delete(cr)
+				err = k8sClient.AppsV1().ControllerRevisions(vm.Namespace).Delete(context.TODO(), cr.Name, metav1.DeleteOptions{})
+				Expect(err).ToNot(HaveOccurred())
 
 				// let the controller pick up the deletion
 				controller.Queue.Add(key)
 				controller.vmiIndexer.Delete(vmi)
 				sanityExecute(vm)
+				clearExpectations(vm)
 
 				_, err = virtFakeClient.KubevirtV1().VirtualMachineInstances(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
 				Expect(err).To(MatchError(k8serrors.IsNotFound, "IsNotFound"))
@@ -7104,6 +7111,7 @@ var _ = Describe("VirtualMachine", func() {
 
 				addVirtualMachine(vm)
 				sanityExecute(vm)
+				clearExpectations(vm)
 
 				vmi, err = virtFakeClient.KubevirtV1().VirtualMachineInstances(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
 				Expect(err).ToNot(HaveOccurred())

--- a/pkg/virt-controller/watch/vm/vm_test.go
+++ b/pkg/virt-controller/watch/vm/vm_test.go
@@ -4410,6 +4410,45 @@ var _ = Describe("VirtualMachine", func() {
 					Entry("PersistentVolumeClaim is in Lost phase", k8sv1.ClaimLost),
 				)
 
+				It("Should NOT set WaitingForVolumeBinding when RerunOnFailure VM was stopped and PVC is unbound", func() {
+					err := virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Delete(context.TODO(), vm.Name, metav1.DeleteOptions{})
+					Expect(err).To(Succeed())
+
+					vm, _ = watchtesting.DefaultVirtualMachine(true)
+					vm.Spec.Running = nil
+					vm.Spec.RunStrategy = pointer.P(v1.RunStrategyRerunOnFailure)
+					vm.Status.RunStrategy = v1.RunStrategyRerunOnFailure
+					vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, v1.Volume{
+						Name: "test1",
+						VolumeSource: v1.VolumeSource{
+							PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
+								ClaimName: "pvc1",
+							}},
+						},
+					})
+
+					vm, err = virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Create(context.TODO(), vm, metav1.CreateOptions{})
+					Expect(err).To(Succeed())
+					addVirtualMachine(vm)
+
+					pvc := k8sv1.PersistentVolumeClaim{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "pvc1",
+							Namespace: vm.Namespace,
+						},
+						Status: k8sv1.PersistentVolumeClaimStatus{
+							Phase: k8sv1.ClaimPending,
+						},
+					}
+					Expect(controller.pvcStore.Add(&pvc)).To(Succeed())
+
+					sanityExecute(vm)
+
+					vm, err = virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
+					Expect(err).To(Succeed())
+					Expect(vm.Status.PrintableStatus).To(Equal(v1.VirtualMachineStatusStopped))
+				})
+
 			})
 
 			It("should set a Running status when VMI is running but not paused", func() {
@@ -6955,6 +6994,64 @@ var _ = Describe("VirtualMachine", func() {
 				Entry("Halted", v1.RunStrategyHalted),
 				Entry("Manual", v1.RunStrategyManual),
 			)
+
+			DescribeTable("shouldStartRerunOnFailure should", func(stateChangeRequests []v1.VirtualMachineStateChangeRequest, statusRunStrategy v1.VirtualMachineRunStrategy, expected bool) {
+				vm, _ := watchtesting.DefaultVirtualMachine(true)
+				vm.Spec.Running = nil
+				vm.Spec.RunStrategy = pointer.P(v1.RunStrategyRerunOnFailure)
+				vm.Status.StateChangeRequests = stateChangeRequests
+				vm.Status.RunStrategy = statusRunStrategy
+
+				result := shouldStartRerunOnFailure(vm, v1.RunStrategyRerunOnFailure)
+				Expect(result).To(Equal(expected))
+			},
+				Entry("return true when VM was never started (empty status RunStrategy)",
+					[]v1.VirtualMachineStateChangeRequest{},
+					v1.VirtualMachineRunStrategy(""),
+					true,
+				),
+				Entry("return false when VM was stopped and status matches spec",
+					[]v1.VirtualMachineStateChangeRequest{},
+					v1.RunStrategyRerunOnFailure,
+					false,
+				),
+				Entry("return true when a StartRequest is present after VMI failure",
+					[]v1.VirtualMachineStateChangeRequest{{Action: v1.StartRequest}},
+					v1.RunStrategyRerunOnFailure,
+					true,
+				),
+				Entry("return true when RunStrategy was changed from Always",
+					[]v1.VirtualMachineStateChangeRequest{},
+					v1.RunStrategyAlways,
+					true,
+				),
+				Entry("return true when RunStrategy was changed from Halted",
+					[]v1.VirtualMachineStateChangeRequest{},
+					v1.RunStrategyHalted,
+					true,
+				),
+				Entry("return true when StartRequest is present and RunStrategy was also changed",
+					[]v1.VirtualMachineStateChangeRequest{{Action: v1.StartRequest}},
+					v1.RunStrategyAlways,
+					true,
+				),
+			)
+
+			It("should not start a RerunOnFailure VM that was manually stopped", func() {
+				vm, _ := watchtesting.DefaultVirtualMachine(true)
+				vm.Spec.Running = nil
+				vm.Spec.RunStrategy = pointer.P(v1.RunStrategyRerunOnFailure)
+				vm.Status.RunStrategy = v1.RunStrategyRerunOnFailure
+
+				vm, err := virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Create(context.TODO(), vm, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				addVirtualMachine(vm)
+
+				sanityExecute(vm)
+
+				_, err = virtFakeClient.KubevirtV1().VirtualMachineInstances(vm.Namespace).Get(context.TODO(), vm.Name, metav1.GetOptions{})
+				Expect(err).To(MatchError(k8serrors.IsNotFound, "IsNotFound"))
+			})
 
 			PIt("The VM should get restarted when doing RerunOnFailure -> Halted -> RerunOnFailure", func() {
 				vm, _ := watchtesting.DefaultVirtualMachine(true)

--- a/tests/vm_test.go
+++ b/tests/vm_test.go
@@ -632,6 +632,45 @@ var _ = Describe("[rfe_id:1177][crit:medium][vendor:cnv-qe@redhat.com][level:com
 		})
 
 		Context("Using RunStrategyRerunOnFailure", func() {
+			It("should remain Stopped after PVC is deleted and recreated", func() {
+				sc, exists := libstorage.GetRWOFileSystemStorageClass()
+				Expect(exists).To(BeTrue())
+				ns := testsuite.GetTestNamespace(nil)
+				pvcName := "rerun-pvc-test"
+
+				By("Creating a PVC")
+				pvc := libstorage.NewPVC(pvcName, "1Gi", sc)
+				_, err := virtClient.CoreV1().PersistentVolumeClaims(ns).Create(context.Background(), pvc, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Creating a VM with RunStrategyRerunOnFailure and the PVC")
+				vm := libvmi.NewVirtualMachine(
+					libvmifact.NewGuestless(libvmi.WithPersistentVolumeClaim("testdisk", pvcName)),
+					libvmi.WithRunStrategy(v1.RunStrategyRerunOnFailure),
+				)
+				vm, err = virtClient.VirtualMachine(ns).Create(context.Background(), vm, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Waiting for VM to be running")
+				Eventually(ThisVM(vm), 360*time.Second, 1*time.Second).Should(HavePrintableStatus(v1.VirtualMachineStatusRunning))
+
+				By("Stopping the VM")
+				vm = libvmops.StopVirtualMachine(vm)
+				Eventually(ThisVM(vm), 60*time.Second, 1*time.Second).Should(HavePrintableStatus(v1.VirtualMachineStatusStopped))
+
+				By("Deleting the PVC")
+				err = virtClient.CoreV1().PersistentVolumeClaims(ns).Delete(context.Background(), pvcName, metav1.DeleteOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				Eventually(ThisPVCWith(ns, pvcName), 60*time.Second, 1*time.Second).Should(BeGone())
+
+				By("Recreating the PVC")
+				_, err = virtClient.CoreV1().PersistentVolumeClaims(ns).Create(context.Background(), libstorage.NewPVC(pvcName, "1Gi", sc), metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Verifying the VM remains Stopped")
+				Consistently(ThisVM(vm), 30*time.Second, 5*time.Second).Should(HavePrintableStatus(v1.VirtualMachineStatusStopped))
+			})
+
 			It("[test_id:2188] should remove a succeeded VMI", decorators.WgS390x, func() {
 				By("Creating a VM with RunStrategyRerunOnFailure")
 				vm := libvmi.NewVirtualMachine(libvmifact.NewAlpine(), libvmi.WithRunStrategy(v1.RunStrategyRerunOnFailure))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
The VM controller has a bug where `isSetToStart()` and `syncRunStrategy()` use different logic to decide whether a `RerunOnFailure` VM should start when no VMI exists. `isSetToStart()` always returns `true`, while `syncRunStrategy()` has an additional guard that checks for a `StartRequest` or a RunStrategy change. This divergence causes the status reporting path to believe the VM wants to start (and set `WaitingForVolumeBinding` when a PVC is Pending), while the sync path correctly prevents the VMI creation. The result is a stopped VM stuck in `WaitingForVolumeBinding` status.

#### After this PR:
The duplicated start-decision logic is extracted into a shared `shouldStartRerunOnFailure()` function used by both `isSetToStart()` and `syncRunStrategy()`. The function returns `true` only when:
- An explicit `StartRequest` exists, OR
- The RunStrategy was just switched to `RerunOnFailure` from a different strategy
A stopped RerunOnFailure VM now correctly reports `Stopped` status regardless of PVC state.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  -->
- Fixes #18424

<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:
- A small helper function was introduced rather than inlining the condition in two places, to ensure the start-decision logic stays consistent and is independently testable.

The following alternatives were considered:
- Patching only `isSetToStart()` to match the existing guard in `syncRunStrategy()` — rejected because it would preserve the code duplication that caused the bug in the first place.
- Adding a dedicated VM status field to track "manually stopped" — rejected as over-engineering, since the existing `Status.RunStrategy` comparison already encodes this information.

Links to places where the discussion took place: https://github.com/kubevirt/kubevirt/issues/18424

### Special notes for your reviewer
The `shouldStartRerunOnFailure` function is covered by a dedicated `DescribeTable` with all 4 boolean combinations of `hasStartRequest` and `Status.RunStrategy != runStrategy`.
A controller-level integration test verifies that `PrintableStatus` stays `Stopped` when a RerunOnFailure VM has an unbound PVC after being stopped.
A new e2e test covers the Halted → RerunOnFailure strategy switch, verifying that the VM correctly restarts in this scenario.

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [X] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [X] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [X] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed a bug where a VM with RunStrategyRerunOnFailure incorrectly showed WaitingForVolumeBinding status after being manually stopped when its PVC was unbound.
```

