### PR TITLE
chore(gsutil); Migrate gsutil to gcloud storage 

### DIFF
--- a/automation/release.sh
+++ b/automation/release.sh
@@ -77,8 +77,8 @@ function update_github_release() {
 
 function upload_testing_manifests() {
     # replaces periodic-kubevirt-update-release-x.y-testing-manifests periodics
-    gsutil -m rm -r "gs://kubevirt-prow/devel/release/kubevirt/kubevirt/$DOCKER_TAG" || true
-    gsutil cp -r "_out/manifests/testing" "gs://kubevirt-prow/devel/release/kubevirt/kubevirt/$DOCKER_TAG/manifests/"
+    gcloud storage rm -r "gs://kubevirt-prow/devel/release/kubevirt/kubevirt/$DOCKER_TAG" || true
+    gcloud storage cp -r "_out/manifests/testing" "gs://kubevirt-prow/devel/release/kubevirt/kubevirt/$DOCKER_TAG/manifests/"
 }
 
 function generate_stable_version_file() {
@@ -91,8 +91,8 @@ function generate_stable_version_file() {
         head -1
     ) > _out/stable.txt
     # this place is deprecated. Combining "devel" and stable is not optimal
-    gsutil cp "_out/stable.txt" "gs://kubevirt-prow/devel/release/kubevirt/kubevirt/"
-    gsutil cp "_out/stable.txt" "gs://kubevirt-prow/release/kubevirt/kubevirt/"
+    gcloud storage cp "_out/stable.txt" "gs://kubevirt-prow/devel/release/kubevirt/kubevirt/"
+    gcloud storage cp "_out/stable.txt" "gs://kubevirt-prow/release/kubevirt/kubevirt/"
 }
 
 function main() {

--- a/automation/test.sh
+++ b/automation/test.sh
@@ -255,7 +255,7 @@ safe_download() (
     # Remote file includes only sha1 w/o filename suffix
     for i in $(seq 1 $retry);
     do
-      remote_sha1="$(gsutil cat ${remote_sha1_url})"
+      remote_sha1="$(gcloud storage cat ${remote_sha1_url})"
       if [[ "$remote_sha1" != "" ]]; then
         break
       fi
@@ -264,7 +264,7 @@ safe_download() (
     if [[ "$(cat "$local_sha1_file")" != "$remote_sha1" ]]; then
         echo "${download_to} is not up to date, corrupted or doesn't exist."
         echo "Downloading file from: ${remote_sha1_url}"
-        gsutil cp $download_from $download_to
+        gcloud storage cp $download_from $download_to
         sha1sum "$download_to" | cut -d " " -f1 > "$local_sha1_file"
         [[ "$(cat "$local_sha1_file")" == "$remote_sha1" ]] || {
             echo "${download_to} is corrupted"


### PR DESCRIPTION
### What this PR does
#### Before this PR:
Automation scripts use gsutils. 
#### After this PR:
- Migrate `gsutil` commands to `gcloud storage` ahead of gsutil deprecation
- `gcloud storage` is already available in the bootstrap image via the installed google-cloud-sdk, no image changes needed
- All commands are drop-in replacements
### References

### Why we need it and why it was done in this way
Migration [reference ](https://docs.cloud.google.com/storage/docs/gsutil-transition-to-gcloud)

### Special notes for your reviewer
/cc @dollierp @xpivarc 

