### PR TITLE
[release-1.8] Bug fix: Skip domain stats collection during live migration

### DIFF
--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -2190,7 +2190,7 @@ func (l *LibvirtDomainManager) GetDomainDirtyRateStats(calculationDuration time.
 
 func (l *LibvirtDomainManager) getDomainStats() ([]*stats.DomainStats, error) {
 	statsTypes := libvirt.DOMAIN_STATS_BALLOON | libvirt.DOMAIN_STATS_CPU_TOTAL | libvirt.DOMAIN_STATS_VCPU | libvirt.DOMAIN_STATS_INTERFACE | libvirt.DOMAIN_STATS_BLOCK | libvirt.DOMAIN_STATS_DIRTYRATE
-	flags := libvirt.CONNECT_GET_ALL_DOMAINS_STATS_RUNNING | libvirt.CONNECT_GET_ALL_DOMAINS_STATS_PAUSED
+	flags := libvirt.CONNECT_GET_ALL_DOMAINS_STATS_RUNNING | libvirt.CONNECT_GET_ALL_DOMAINS_STATS_PAUSED | libvirt.CONNECT_GET_ALL_DOMAINS_STATS_NOWAIT
 
 	domstats, err := l.virConn.GetDomainStats(statsTypes, l.domainInfoStats, flags)
 	if err != nil {

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -2376,12 +2376,40 @@ var _ = Describe("Manager", func() {
 					libvirt.DOMAIN_STATS_INTERFACE |
 					libvirt.DOMAIN_STATS_BLOCK |
 					libvirt.DOMAIN_STATS_DIRTYRATE
-				flags = libvirt.CONNECT_GET_ALL_DOMAINS_STATS_RUNNING | libvirt.CONNECT_GET_ALL_DOMAINS_STATS_PAUSED
+				flags = libvirt.CONNECT_GET_ALL_DOMAINS_STATS_RUNNING | libvirt.CONNECT_GET_ALL_DOMAINS_STATS_PAUSED | libvirt.CONNECT_GET_ALL_DOMAINS_STATS_NOWAIT
 			)
 			fakeDomainStats := []*stats.DomainStats{
 				{},
 			}
 
+			mockLibvirt.ConnectionEXPECT().GetDomainStats(domainStats, gomock.Any(), flags).Return(fakeDomainStats, nil)
+
+			manager, _ := newLibvirtDomainManagerDefault()
+			domStats, err := manager.GetDomainStats()
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(domStats).ToNot(BeNil())
+		})
+	})
+
+	Context("when live migration is in progress", func() {
+		It("should still collect stats using NOWAIT flag", func() {
+			const (
+				domainStats = libvirt.DOMAIN_STATS_BALLOON |
+					libvirt.DOMAIN_STATS_CPU_TOTAL |
+					libvirt.DOMAIN_STATS_VCPU |
+					libvirt.DOMAIN_STATS_INTERFACE |
+					libvirt.DOMAIN_STATS_BLOCK |
+					libvirt.DOMAIN_STATS_DIRTYRATE
+				flags = libvirt.CONNECT_GET_ALL_DOMAINS_STATS_RUNNING | libvirt.CONNECT_GET_ALL_DOMAINS_STATS_PAUSED | libvirt.CONNECT_GET_ALL_DOMAINS_STATS_NOWAIT
+			)
+
+			now := metav1.Now()
+			migrationMetadata, _ := metadataCache.Migration.Load()
+			migrationMetadata.StartTimestamp = &now
+			metadataCache.Migration.Store(migrationMetadata)
+
+			fakeDomainStats := []*stats.DomainStats{{}}
 			mockLibvirt.ConnectionEXPECT().GetDomainStats(domainStats, gomock.Any(), flags).Return(fakeDomainStats, nil)
 
 			manager, _ := newLibvirtDomainManagerDefault()

--- a/tests/infrastructure/prometheus.go
+++ b/tests/infrastructure/prometheus.go
@@ -406,19 +406,19 @@ var _ = Describe(SIGSerial("[rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com]
 			}
 		}
 	},
-		Entry("[test_id:4142] storage flush requests metric",
+		Entry("[QUARANTINE][test_id:4142] storage flush requests metric", decorators.Quarantine,
 			"kubevirt_vmi_storage_flush_requests_total", ">="),
-		Entry("[test_id:4142] time spent on cache flushing metric",
+		Entry("[QUARANTINE][test_id:4142] time spent on cache flushing metric", decorators.Quarantine,
 			"kubevirt_vmi_storage_flush_times_seconds_total", ">="),
-		Entry("[test_id:4142] I/O read operations metric", "kubevirt_vmi_storage_iops_read_total", ">="),
-		Entry("[test_id:4142] I/O write operations metric", "kubevirt_vmi_storage_iops_write_total", ">="),
-		Entry("[test_id:4142] storage read operation time metric",
+		Entry("[QUARANTINE][test_id:4142] I/O read operations metric", decorators.Quarantine, "kubevirt_vmi_storage_iops_read_total", ">="),
+		Entry("[QUARANTINE][test_id:4142] I/O write operations metric", decorators.Quarantine, "kubevirt_vmi_storage_iops_write_total", ">="),
+		Entry("[QUARANTINE][test_id:4142] storage read operation time metric", decorators.Quarantine,
 			"kubevirt_vmi_storage_read_times_seconds_total", ">="),
-		Entry("[test_id:4142] storage read traffic in bytes metric",
+		Entry("[QUARANTINE][test_id:4142] storage read traffic in bytes metric", decorators.Quarantine,
 			"kubevirt_vmi_storage_read_traffic_bytes_total", ">="),
-		Entry("[test_id:4142] storage write operation time metric",
+		Entry("[QUARANTINE][test_id:4142] storage write operation time metric", decorators.Quarantine,
 			"kubevirt_vmi_storage_write_times_seconds_total", ">="),
-		Entry("[test_id:4142] storage write traffic in bytes metric",
+		Entry("[QUARANTINE][test_id:4142] storage write traffic in bytes metric", decorators.Quarantine,
 			"kubevirt_vmi_storage_write_traffic_bytes_total", ">="),
 	)
 


### PR DESCRIPTION
### What this PR does
Manual cherry-pick of #18362 to release-1.8. The automatic backport from #18663 (release-1.9) failed due to a merge conflict in `pkg/virt-launcher/virtwrap/manager_test.go`.

Also quarantines four storage Prometheus metric tests that are affected by the NOWAIT flag change (second commit).

#### Why the automatic cherry-pick failed:
- The original commit on main modified flags in 3 test contexts and added 1 new test
- Two of those test contexts - "device alias injection in getDomainStats" and "on failed GetAllDomainStats" - do not exist on release-1.8 (they were introduced in a separate PR that only landed on main/release-1.9)
- Git could not find the target lines for those hunks, causing a conflict between the "on successful GetAllDomainStats" block and the "on failed GetDomainSpecWithRuntimeInfo" block

#### Resolution:
- Dropped the two hunks that modify test blocks not present on release-1.8
- Kept the flags change in "on successful GetAllDomainStats" and the new "when live migration is in progress" test - these are the actual changes from #18362

#### Why the quarantine:
The NOWAIT flag can cause libvirt to skip a domain when its job lock is momentarily held by routine internal operations (QEMU monitor queries, block job status checks), not just during migration. This was discussed in the original PR (#18362) and results in ~5% flake rate on storage metric tests. The same four tests have already been quarantined on main via PRs #18689, #18752, #18772, and #18779.

#### Before this PR:
- `getDomainStats()` blocks for up to 30 seconds during live migration waiting on the libvirt job lock
- This produces error logs and disrupts OCP upgrade flows

#### After this PR:
- The `NOWAIT` flag is added to `GetAllDomainStats` so libvirt skips locked domains instead of blocking
- Stats collection proceeds normally; the `TimeDefinedCache` serves previously cached values when a domain is skipped
- Affected storage metric tests are quarantined to match main

### References
- Original PR: #18362
- release-1.9 backport (merged): #18663
- Supersedes automatic backport attempt: #18697
- Quarantined on main: #18689, #18752, #18772, #18779

### Release note
```release-note
Bug fix: During live migration, domain stats collection no longer blocks on the libvirt job lock for up to 30 seconds. The NOWAIT flag is used to skip locked domains instead of waiting, avoiding lock contention and disruptive error logs.
```