### PR TITLE
docs: fix dead link to removed direct-pv-disks.md

### DIFF
--- a/docs/filesystem-pv-disks.md
+++ b/docs/filesystem-pv-disks.md
@@ -47,9 +47,10 @@ virtual disk.
 ## API
 
 The general API to use PersistentVolume claims as virtual disk backends was
-introduced with [direct PV proposal](direct-pv-disks.md).
+introduced with the direct PV proposal, which was later removed as the
+feature is not supported.
 
-The change suggested by this proposal, does not require any API change.
+The change suggested by this proposal does not require any API change.
 
 To use a PV as a virtual disk backend, a user needs to create a claim for the
 required PV, this claim is then used as a disk source for a virtual disk.


### PR DESCRIPTION
### What this PR does
#### Before this PR:
`docs/filesystem-pv-disks.md` linked to `direct-pv-disks.md`, a file that
was deleted in cfbdd78fd0 ("Remove dircet-pv-disks documentation") because
the feature is not supported. The link has been dead since then, and the
surrounding sentence gave no indication the linked proposal was gone.

#### After this PR:
The dead link is removed, and the sentence now clarifies that the proposal
was later removed because the feature is not supported, so readers aren't
left looking for a document that no longer exists. A nearby comma splice
in the adjacent sentence is also fixed.

### Why we need it and why it was done in this way
No tradeoffs or alternatives — this is a minimal docs fix restoring
correctness in an existing doc, with no functional or API impact.

### Checklist
- [x] Design: not required (docs-only fix)
- [x] PR: description included
- [ ] Code: N/A, docs only
- [ ] Refactor: N/A
- [ ] Upgrade: N/A, no code change
- [ ] Testing: N/A, no code change
- [x] Documentation: not required — this fixes an existing docs/ file, not a user-guide/user-facing change
- [ ] Community: not required for a trivial doc fix
- [x] AI Contributions: disclosed via `Assisted-by` trailer per the KubeVirt AI Contribution Policy

### Release note
```release-note
NONE
```