### PR TITLE
ImageVolume: Avoid Image volume for launcher binary to fix performance regression

### DIFF
--- a/pkg/container-disk/container-disk.go
+++ b/pkg/container-disk/container-disk.go
@@ -483,7 +483,7 @@ func CreateImageVolumeInitContainer(vmi *v1.VirtualMachineInstance, config *virt
 		Name:            fmt.Sprintf("volume%s", name),
 		Image:           image,
 		ImagePullPolicy: imagePullPolicy,
-		Command:         []string{filepath.Join(util.ContainerBinary, "/usr/bin/container-disk")},
+		Command:         []string{"/usr/bin/container-disk"},
 		Args:            []string{"--no-op"},
 		Resources:       resources,
 		SecurityContext: &kubev1.SecurityContext{
@@ -495,9 +495,8 @@ func CreateImageVolumeInitContainer(vmi *v1.VirtualMachineInstance, config *virt
 			},
 		},
 		VolumeMounts: []kubev1.VolumeMount{{
-			Name:      LauncherVolume,
-			MountPath: util.ContainerBinary,
-			ReadOnly:  true,
+			Name:      "virt-bin-share-dir",
+			MountPath: "/usr/bin",
 		}},
 	}
 }

--- a/pkg/virt-controller/services/rendervolumes.go
+++ b/pkg/virt-controller/services/rendervolumes.go
@@ -29,15 +29,9 @@ import (
 
 type VolumeRendererOption func(renderer *VolumeRenderer) error
 
-type imagePullPolicyGetter interface {
-	GetImagePullPolicy() k8sv1.PullPolicy
-}
-
 type VolumeRenderer struct {
 	useImageVolumes       bool
-	launcherImage         string
 	imageIDs              map[string]string
-	imagePullPolicyGetter imagePullPolicyGetter
 	containerDiskDir      string
 	ephemeralDiskDir      string
 	virtShareDir          string
@@ -48,16 +42,14 @@ type VolumeRenderer struct {
 	volumeDevices         []k8sv1.VolumeDevice
 }
 
-func NewVolumeRenderer(imagePullPolicyGetter imagePullPolicyGetter, imageVolumeFeatureGateEnabled bool, launcherImage string, imageIDs map[string]string, namespace string, ephemeralDisk string, containerDiskDir string, virtShareDir string, volumeOptions ...VolumeRendererOption) (*VolumeRenderer, error) {
+func NewVolumeRenderer(imageVolumeFeatureGateEnabled bool, imageIDs map[string]string, namespace string, ephemeralDisk string, containerDiskDir string, virtShareDir string, volumeOptions ...VolumeRendererOption) (*VolumeRenderer, error) {
 	volumeRenderer := &VolumeRenderer{
-		useImageVolumes:       imageVolumeFeatureGateEnabled,
-		launcherImage:         launcherImage,
-		imageIDs:              imageIDs,
-		imagePullPolicyGetter: imagePullPolicyGetter,
-		containerDiskDir:      containerDiskDir,
-		ephemeralDiskDir:      ephemeralDisk,
-		namespace:             namespace,
-		virtShareDir:          virtShareDir,
+		useImageVolumes:  imageVolumeFeatureGateEnabled,
+		imageIDs:         imageIDs,
+		containerDiskDir: containerDiskDir,
+		ephemeralDiskDir: ephemeralDisk,
+		namespace:        namespace,
+		virtShareDir:     virtShareDir,
 	}
 	for _, volumeOption := range volumeOptions {
 		if err := volumeOption(volumeRenderer); err != nil {
@@ -251,11 +243,6 @@ func withImageVolumes(vmi *v1.VirtualMachineInstance) VolumeRendererOption {
 			kbc := vmi.Spec.Domain.Firmware.KernelBoot.Container
 			renderer.addKernelBootVolume(kbc)
 			renderer.addKernelBootVolumeMount()
-		}
-
-		if vmi.Annotations[v1.ImageVolumeSkipDigestResolutionAnnotation] != "true" &&
-			shouldAddLauncherBinaryVolume(vmi, renderer.imageIDs) {
-			renderer.addLauncherBinaryVolume()
 		}
 
 		return nil
@@ -771,18 +758,6 @@ func (vr *VolumeRenderer) addKernelBootVolumeMount() {
 		Name:      containerdisk.KernelBootVolumeName,
 		MountPath: util.VirtKernelBootVolumeDir,
 		ReadOnly:  true,
-	})
-}
-
-func (vr *VolumeRenderer) addLauncherBinaryVolume() {
-	vr.podVolumes = append(vr.podVolumes, k8sv1.Volume{
-		Name: containerdisk.LauncherVolume,
-		VolumeSource: k8sv1.VolumeSource{
-			Image: &k8sv1.ImageVolumeSource{
-				Reference:  vr.launcherImage,
-				PullPolicy: vr.imagePullPolicyGetter.GetImagePullPolicy(),
-			},
-		},
 	})
 }
 

--- a/pkg/virt-controller/services/rendervolumes_test.go
+++ b/pkg/virt-controller/services/rendervolumes_test.go
@@ -12,7 +12,6 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 
-	containerdisk "kubevirt.io/kubevirt/pkg/container-disk"
 	"kubevirt.io/kubevirt/pkg/libvmi"
 	libvmistatus "kubevirt.io/kubevirt/pkg/libvmi/status"
 	"kubevirt.io/kubevirt/pkg/storage/cbt"
@@ -27,13 +26,12 @@ var _ = Describe("Container spec renderer", func() {
 		namespace         = "ns1"
 		virtShareDir      = "dir1"
 		backendStoragePVC = "vm-state-pvc"
-		launcherImage     = "test/virt-launcher:latest"
 	)
 
 	Context("without any options", func() {
 		BeforeEach(func() {
 			var err error
-			vsr, err = NewVolumeRenderer(stubImagePullPolicyGetter{}, false, launcherImage, make(map[string]string), namespace, ephemeralDisk, containerDisk, virtShareDir)
+			vsr, err = NewVolumeRenderer(false, make(map[string]string), namespace, ephemeralDisk, containerDisk, virtShareDir)
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -71,7 +69,7 @@ var _ = Describe("Container spec renderer", func() {
 			}
 
 			var err error
-			vsr, err = NewVolumeRenderer(stubImagePullPolicyGetter{}, false, launcherImage, make(map[string]string), namespace, ephemeralDisk, containerDisk, virtShareDir, withVMIVolumes(pvcStore, []v1.Volume{ephemeralVolumeOption}, nil))
+			vsr, err = NewVolumeRenderer(false, make(map[string]string), namespace, ephemeralDisk, containerDisk, virtShareDir, withVMIVolumes(pvcStore, []v1.Volume{ephemeralVolumeOption}, nil))
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -130,7 +128,7 @@ var _ = Describe("Container spec renderer", func() {
 			}
 
 			var err error
-			vsr, err = NewVolumeRenderer(stubImagePullPolicyGetter{}, false, launcherImage, make(map[string]string), namespace, ephemeralDisk, containerDisk, virtShareDir, withVMIVolumes(pvcStore, []v1.Volume{hostDisk}, nil))
+			vsr, err = NewVolumeRenderer(false, make(map[string]string), namespace, ephemeralDisk, containerDisk, virtShareDir, withVMIVolumes(pvcStore, []v1.Volume{hostDisk}, nil))
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -187,7 +185,7 @@ var _ = Describe("Container spec renderer", func() {
 			}
 
 			var err error
-			vsr, err = NewVolumeRenderer(stubImagePullPolicyGetter{}, false, launcherImage, make(map[string]string), namespace, ephemeralDisk, containerDisk, virtShareDir, withVMIVolumes(pvcStore, []v1.Volume{cloudInitConfig}, nil))
+			vsr, err = NewVolumeRenderer(false, make(map[string]string), namespace, ephemeralDisk, containerDisk, virtShareDir, withVMIVolumes(pvcStore, []v1.Volume{cloudInitConfig}, nil))
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -262,7 +260,7 @@ var _ = Describe("Container spec renderer", func() {
 			}
 
 			var err error
-			vsr, err = NewVolumeRenderer(stubImagePullPolicyGetter{}, false, launcherImage, make(map[string]string), namespace, ephemeralDisk, containerDisk, virtShareDir, withVMIVolumes(pvcStore, []v1.Volume{dataVolume}, nil))
+			vsr, err = NewVolumeRenderer(false, make(map[string]string), namespace, ephemeralDisk, containerDisk, virtShareDir, withVMIVolumes(pvcStore, []v1.Volume{dataVolume}, nil))
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -310,7 +308,7 @@ var _ = Describe("Container spec renderer", func() {
 			disk := v1.Disk{Name: downwardAPIVolumeName}
 
 			var err error
-			vsr, err = NewVolumeRenderer(stubImagePullPolicyGetter{}, false, launcherImage, make(map[string]string), namespace, ephemeralDisk, containerDisk, virtShareDir, withVMIConfigVolumes([]v1.Disk{disk}, []v1.Volume{downwardAPIVolume}))
+			vsr, err = NewVolumeRenderer(false, make(map[string]string), namespace, ephemeralDisk, containerDisk, virtShareDir, withVMIConfigVolumes([]v1.Disk{disk}, []v1.Volume{downwardAPIVolume}))
 			Expect(err).NotTo(HaveOccurred())
 		})
 
@@ -346,7 +344,7 @@ var _ = Describe("Container spec renderer", func() {
 			vmi := &v1.VirtualMachineInstance{}
 
 			var err error
-			vsr, err = NewVolumeRenderer(stubImagePullPolicyGetter{}, false, launcherImage, make(map[string]string), namespace, ephemeralDisk, containerDisk, virtShareDir, withBackendStorage(vmi, backendStoragePVC))
+			vsr, err = NewVolumeRenderer(false, make(map[string]string), namespace, ephemeralDisk, containerDisk, virtShareDir, withBackendStorage(vmi, backendStoragePVC))
 			Expect(err).NotTo(HaveOccurred())
 
 			expectedMount := k8sv1.VolumeMount{
@@ -367,7 +365,7 @@ var _ = Describe("Container spec renderer", func() {
 			)
 
 			var err error
-			vsr, err = NewVolumeRenderer(stubImagePullPolicyGetter{}, false, launcherImage, make(map[string]string), namespace, ephemeralDisk, containerDisk, virtShareDir, withBackendStorage(vmi, backendStoragePVC))
+			vsr, err = NewVolumeRenderer(false, make(map[string]string), namespace, ephemeralDisk, containerDisk, virtShareDir, withBackendStorage(vmi, backendStoragePVC))
 			Expect(err).NotTo(HaveOccurred())
 
 			expectedVolume := k8sv1.Volume{
@@ -389,70 +387,6 @@ var _ = Describe("Container spec renderer", func() {
 			}
 
 			Expect(vsr.Mounts()).To(ContainElement(expectedMount))
-		})
-	})
-
-	Context("image pull policy propagation", func() {
-		DescribeTable("should set the image pull policy from the getter", func(pullPolicy k8sv1.PullPolicy) {
-			const imageVolumeFeatureGateEnabled = true
-			vmi := libvmi.New(
-				libvmi.WithContainerDisk("test-disk", "registry/image:tag"),
-			)
-
-			var err error
-			vsr, err = NewVolumeRenderer(
-				stubImagePullPolicyGetter{imagePullPolicy: pullPolicy},
-				imageVolumeFeatureGateEnabled,
-				launcherImage,
-				make(map[string]string),
-				namespace,
-				ephemeralDisk,
-				containerDisk,
-				virtShareDir,
-				withImageVolumes(vmi),
-			)
-			Expect(err).NotTo(HaveOccurred())
-
-			Expect(vsr.Volumes()).To(ContainElement(k8sv1.Volume{
-				Name: containerdisk.LauncherVolume,
-				VolumeSource: k8sv1.VolumeSource{
-					Image: &k8sv1.ImageVolumeSource{
-						Reference:  launcherImage,
-						PullPolicy: pullPolicy,
-					},
-				},
-			}))
-		},
-			Entry("PullAlways", k8sv1.PullAlways),
-			Entry("PullNever", k8sv1.PullNever),
-			Entry("PullIfNotPresent", k8sv1.PullIfNotPresent),
-		)
-
-		It("should not add launcher binary volume when skip-digest-resolution annotation is set", func() {
-			const imageVolumeFeatureGateEnabled = true
-			vmi := libvmi.New(
-				libvmi.WithContainerDisk("test-disk", "registry/image:tag"),
-				libvmi.WithAnnotation(v1.ImageVolumeSkipDigestResolutionAnnotation, "true"),
-			)
-
-			var err error
-			vsr, err = NewVolumeRenderer(
-				stubImagePullPolicyGetter{imagePullPolicy: k8sv1.PullAlways},
-				imageVolumeFeatureGateEnabled,
-				launcherImage,
-				make(map[string]string),
-				namespace,
-				ephemeralDisk,
-				containerDisk,
-				virtShareDir,
-				withImageVolumes(vmi),
-			)
-			Expect(err).NotTo(HaveOccurred())
-
-			for _, vol := range vsr.Volumes() {
-				Expect(vol.Name).ToNot(Equal(containerdisk.LauncherVolume),
-					"should not create launcher binary volume when digest resolution is skipped")
-			}
 		})
 	})
 })
@@ -499,12 +433,4 @@ func defaultVolumeMounts() []k8sv1.VolumeMount {
 		{Name: "libvirt-runtime", MountPath: "/var/run/libvirt"},
 		{Name: "sockets", MountPath: "dir1/sockets"},
 	}
-}
-
-type stubImagePullPolicyGetter struct {
-	imagePullPolicy k8sv1.PullPolicy
-}
-
-func (s stubImagePullPolicyGetter) GetImagePullPolicy() k8sv1.PullPolicy {
-	return s.imagePullPolicy
 }

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -658,7 +658,25 @@ func (t *TemplateService) renderLaunchManifest(vmi *v1.VirtualMachineInstance, i
 		if kernelBootInitContainer != nil {
 			initContainers = append(initContainers, *kernelBootInitContainer)
 		}
-	} else if t.clusterConfig.ImageVolumeEnabled() && vmi.Annotations[v1.ImageVolumeSkipDigestResolutionAnnotation] != "true" {
+	} else if t.clusterConfig.ImageVolumeEnabled() && vmi.Annotations[v1.ImageVolumeSkipDigestResolutionAnnotation] != "true" &&
+		shouldAddLauncherBinaryVolume(vmi, imageIDs) {
+		// Copy the container-disk binary to the shared EmptyDir.
+		// Uses a distinct name from "container-disk-binary" to avoid triggering the
+		// old bind-mount path detection in virt-handler.
+		cpOpts := []Option{
+			WithVolumeMounts(initContainerVolumeMount()),
+			WithResourceRequirements(initContainerResourceRequirementsForVMI(vmi, v1.ContainerDisk, t.clusterConfig)),
+			WithNoCapabilities(),
+			WithCommand([]string{"/usr/bin/cp"}),
+			WithArgs([]string{"--preserve=all", "/usr/bin/container-disk", "/init/usr/bin/container-disk"}),
+		}
+		if vmitrait.IsNonRoot(vmi) {
+			cpOpts = append(cpOpts, WithNonRoot(userId))
+		}
+		initContainers = append(
+			initContainers,
+			NewContainerSpecRenderer("image-volume-binary", t.launcherImage, t.clusterConfig.GetImagePullPolicy(), cpOpts...).Render())
+
 		// TODO: Once the KEP https://github.com/kubernetes/enhancements/pull/5375 is fully implemented and stable
 		// in all Kubernetes versions supported by KubeVirt, this entire init containers logic should be removed,
 		// and the digest can be fetched directly from the Pod volume status.
@@ -1008,9 +1026,7 @@ func (t *TemplateService) newVolumeRenderer(vmi *v1.VirtualMachineInstance, imag
 	}
 
 	volumeRenderer, err := NewVolumeRenderer(
-		t.clusterConfig,
 		imageVolumeFeatureGateEnabled,
-		t.launcherImage,
 		imageIDs,
 		namespace,
 		t.ephemeralDiskDir,

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -4252,15 +4252,11 @@ var _ = Describe("Template", func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(pod).ToNot(BeNil())
 
-				Expect(pod.Spec.Volumes).To(ContainElement(k8sv1.Volume{
-					Name: containerdisk.LauncherVolume,
-					VolumeSource: k8sv1.VolumeSource{
-						Image: &k8sv1.ImageVolumeSource{
-							Reference:  "kubevirt/virt-launcher",
-							PullPolicy: config.GetImagePullPolicy(),
-						},
-					},
-				}), "should create launcher binary volume when ImageVolume is used")
+				Expect(pod.Spec.InitContainers).To(ContainElement(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+					"Name":    Equal("image-volume-binary"),
+					"Command": Equal([]string{"/usr/bin/cp"}),
+					"Args":    Equal([]string{"--preserve=all", "/usr/bin/container-disk", "/init/usr/bin/container-disk"}),
+				})))
 
 				// Find noop init containers
 				var initContainerNames []string
@@ -4269,14 +4265,11 @@ var _ = Describe("Template", func() {
 						continue
 					}
 					initContainerNames = append(initContainerNames, container.Name)
-					// Verify the noop command is used
-					Expect(container.Command).To(ContainElement("/container-disk-binary/usr/bin/container-disk"))
+					Expect(container.Command).To(ContainElement("/usr/bin/container-disk"))
 					Expect(container.Args).To(ContainElement("--no-op"))
-					// Verify volume mount for launcher binary
 					Expect(container.VolumeMounts).To(ContainElement(k8sv1.VolumeMount{
-						Name:      containerdisk.LauncherVolume,
-						MountPath: "/container-disk-binary",
-						ReadOnly:  true,
+						Name:      "virt-bin-share-dir",
+						MountPath: "/usr/bin",
 					}))
 				}
 				// Verify expected init containers are created


### PR DESCRIPTION
### Summary

Since enabling beta feature gates by default, the ImageVolume feature introduced a dedicated Image volume (LauncherVolume) to provide the container-disk binary to init containers that resolve container disk image tags to digests (needed for live migration correctness).

At density (100 VMIs), this causes an ~80% regression in VMI creation-to-running time (P50 ~30s vs ~17s). We suspect this is caused by CRI lock contention that occurs when mounting the same image layer on the same node for many pods concurrently.

This patch provides the launcher binary to the init containers by copying it to an EmptyDir volume through a preceding init container, which does not require an Image volume mount. This is the same method that was used before the ImageVolume feature was introduced.

Once [VEP-118](https://github.com/kubevirt/enhancements/pull/117) is complete, the digest will be available directly from the Pod volume status, eliminating the need for these init containers entirely.


### launcher pod yaml Before (current code)
```
spec:
  volumes:
    - name: containerdisk
      image:
        reference: registry/my-vm-disk:latest
    - name: launcher-binary   # <-- extra Image volume (causes performance regression)
      image:
        reference: registry/virt-launcher:latest
  initContainers:
    - name: volumecontainerdisk
      image: registry/my-vm-disk:latest
      command: ["/container-disk-binary/usr/bin/container-disk"]
      args: ["--no-op"]
      volumeMounts:
        - name: launcher-binary          # mounts the Image volume
          mountPath: /container-disk-binary
          readOnly: true
```      
          
### launcher pod yaml After (this patch)
```
spec:
  volumes:
    - name: containerdisk
      image:
        reference: registry/my-vm-disk:latest
    - name: virt-bin-share-dir   # EmptyDir, no Image volume needed
      emptyDir: {}
  initContainers:
    - name: image-volume-binary            # copies binary to EmptyDir
      image: registry/virt-launcher:latest
      command: ["/usr/bin/cp"]
      args: ["--preserve=all", "/usr/bin/container-disk", "/init/usr/bin/container-disk"]
      volumeMounts:
        - name: virt-bin-share-dir
          mountPath: /init/usr/bin
    - name: volumecontainerdisk
      image: registry/my-vm-disk:latest
      command: ["/usr/bin/container-disk"]
      args: ["--no-op"]
      volumeMounts:
        - name: virt-bin-share-dir         # reads binary from EmptyDir
          mountPath: /usr/bin
```



### References
Regression data (with ImageVolume enabled, k8s 1.36 periodic): https://storage.googleapis.com/kubevirt-prow/logs/periodic-kubevirt-e2e-k8s-1.36-sig-performance/2078027029990608896/artifacts/VMI-perf-audit-results.json

Removing the init containers confirms the regression is gone: [#18788](https://github.com/kubevirt/kubevirt/pull/18788) https://storage.googleapis.com/kubevirt-prow/pr-logs/pull/kubevirt_kubevirt/18788/pull-kubevirt-e2e-k8s-1.36-sig-performance/2087171124893847552/build-log.txt


### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

