### PR TITLE
network: fix masquerade interface IP corruption by guest-agent

### DIFF
--- a/pkg/network/setup/netstat.go
+++ b/pkg/network/setup/netstat.go
@@ -335,13 +335,14 @@ func ifacesStatusFromGuestAgent(
 		if vmiIfaceStatus := netvmispec.LookupInterfaceStatusByMac(vmiIfacesStatus, guestAgentInterface.Mac); vmiIfaceStatus != nil {
 			vmiIfaceSpec := vmiInterfacesSpecByName[vmiIfaceStatus.Name]
 
+			isMasquerade := vmiIfaceSpec.Masquerade != nil
 			// When using masquerade binding, guest-defined Link-Local Addresses (LLAs) are unreachable from the pod network.
 			// These addresses remain internal to the guest and are outside the scope of KubeVirt's NAT translation rules.
-			if vmiIfaceSpec.Masquerade != nil {
+			if isMasquerade {
 				guestAgentInterface.IPs = filterOutLinkLocalAddresses(guestAgentInterface.IPs)
 			}
 
-			updateVMIIfaceStatusWithGuestAgentData(vmiIfaceStatus, guestAgentInterface)
+			updateVMIIfaceStatusWithGuestAgentData(vmiIfaceStatus, guestAgentInterface, isMasquerade)
 			if !isGuestAgentIfaceOriginatedFromOldVirtLauncher(guestAgentInterface) {
 				vmiIfaceStatus.InfoSource = netvmispec.InfoSourceDomainAndGA
 			}
@@ -368,7 +369,7 @@ func isGuestAgentIfaceOriginatedFromOldVirtLauncher(guestAgentInterface api.Inte
 	return guestAgentInterface.InterfaceName == ""
 }
 
-func updateVMIIfaceStatusWithGuestAgentData(ifaceStatus *v1.VirtualMachineInstanceNetworkInterface, guestAgentIface api.InterfaceStatus) {
+func updateVMIIfaceStatusWithGuestAgentData(ifaceStatus *v1.VirtualMachineInstanceNetworkInterface, guestAgentIface api.InterfaceStatus, isMasquerade bool) {
 	ifaceStatus.InterfaceName = guestAgentIface.InterfaceName
 	// IP data from the Guest Agent overrides previous iface status information in the following cases:
 	// - No status IPs existed before, i.e. GA data is adding new information.
@@ -377,8 +378,10 @@ func updateVMIIfaceStatusWithGuestAgentData(ifaceStatus *v1.VirtualMachineInstan
 	// However, in case GA does not include IP data, it will clear IP status data (guest is not reachable by any IP).
 	ifaceStatusIPv4, ifaceStatusIPv6 := splitIPByFamiliy(ifaceStatus.IPs)
 	guestAgentIfaceIPv4, guestAgentIfaceIPv6 := splitIPByFamiliy(guestAgentIface.IPs)
-	if len(ifaceStatusIPv4) == 0 || len(guestAgentIfaceIPv4) == 0 {
-		ifaceStatusIPv4 = guestAgentIfaceIPv4
+	if !isMasquerade {
+		if len(ifaceStatusIPv4) == 0 || len(guestAgentIfaceIPv4) == 0 {
+			ifaceStatusIPv4 = guestAgentIfaceIPv4
+		}
 	}
 	if len(ifaceStatusIPv6) == 0 || len(guestAgentIfaceIPv6) == 0 {
 		ifaceStatusIPv6 = guestAgentIfaceIPv6

--- a/pkg/network/setup/netstat_test.go
+++ b/pkg/network/setup/netstat_test.go
@@ -50,6 +50,128 @@ var _ = Describe("netstat", func() {
 		Expect(setup.NetStat.UpdateStatus(setup.Vmi, nil)).To(Succeed())
 	})
 
+	// Regression test for: masquerade interface gets wrong IP (guest-side NAT address)
+	// after Guest Agent connects, specifically when the pod interface cache is not yet
+	// populated (race with GPU passthrough / many guest interfaces causing virt-handler
+	// to process domain status before the pod cache is written).
+	//
+	// Conditions that expose the bug:
+	//   - masquerade binding on the pod network
+	//   - QEMU Guest Agent active, reporting the guest-side masquerade IP (e.g. 10.0.2.2)
+	//   - pod interface cache empty (PodIP / PodIPs not yet populated)
+	//   - more than 10 guest interfaces (GPU passthrough + Cilium adds extra interfaces
+	//     that exhaust the guest-only interface limit and alter interface enumeration order)
+	//
+	// Expected: status.interfaces[0].ipAddress must remain the reachable pod IP (10.244.1.120),
+	// NOT the internal masquerade guest address (10.0.2.2).
+	It("regression: masquerade interface keeps pod IP when guest-agent reports internal NAT address and pod cache is empty", func() {
+		const (
+			primaryNetworkName = "primary"
+			primaryMAC         = "52:54:00:00:BE:EF"
+			primaryIfaceName   = "eth0"
+
+			// The virt-launcher pod IP — the only reachable address from the cluster.
+			podIP = "10.244.1.120"
+
+			// The guest-side masquerade address — internal to the NAT, NOT reachable from outside.
+			masqueradeGuestIP = "10.0.2.2"
+		)
+
+		// Add the masquerade interface to VMI spec and domain spec, but intentionally
+		// do NOT populate the pod interface cache (no podIPs argument to addNetworkInterface).
+		// This simulates the race where virt-handler processes the guest-agent report before
+		// the cache file has been written (observed with GPU passthrough + many interfaces).
+		Expect(
+			setup.addNetworkInterface(
+				newVMISpecIfaceWithMasqueradeBinding(primaryNetworkName),
+				newVMISpecPodNetwork(primaryNetworkName),
+				newDomainSpecIface(primaryNetworkName, primaryMAC),
+				// No pod IPs: the cache is intentionally empty to simulate the race.
+			),
+		).To(Succeed())
+
+		// Simulate >10 guest interfaces: the primary masquerade NIC plus many guest-only
+		// interfaces (GPU passthrough + Cilium veth pairs appear as extra NICs in the guest).
+		// These exhaust the guest-only interface limit and reproduce the ordering conditions.
+		guestAgentIfaces := []api.InterfaceStatus{
+			// The masquerade NIC as seen from inside the guest: it reports the NAT address.
+			newDomainStatusIface([]string{masqueradeGuestIP}, primaryMAC, primaryIfaceName),
+		}
+		const extraGuestInterfaces = 12 // > guestOnlyInterfaceLimit (10)
+		for i := 1; i <= extraGuestInterfaces; i++ {
+			guestAgentIfaces = append(guestAgentIfaces, newDomainStatusIface(
+				nil,
+				fmt.Sprintf("00:00:00:00:00:%02X", i),
+				fmt.Sprintf("eth%d", i),
+			))
+		}
+		setup.addGuestAgentInterfaces(guestAgentIfaces...)
+
+		Expect(setup.NetStat.UpdateStatus(setup.Vmi, setup.Domain)).To(Succeed())
+
+		// The primary interface must have an empty IP (not the masquerade guest address).
+		// When the pod cache is empty, there is no routable IP to report yet;
+		// the internal 10.0.2.2 must NEVER appear in the VMI status.
+		Expect(setup.Vmi.Status.Interfaces).To(HaveLen(1 + 10)) // primary + 10 guest-only (limit)
+		primaryStatus := setup.Vmi.Status.Interfaces[0]
+		Expect(primaryStatus.Name).To(Equal(primaryNetworkName))
+		Expect(primaryStatus.IP).NotTo(Equal(masqueradeGuestIP),
+			"masquerade guest-side address must not appear as the interface IP")
+		Expect(primaryStatus.IPs).NotTo(ContainElement(masqueradeGuestIP),
+			"masquerade guest-side address must not appear in the IPs list")
+	})
+
+	// Companion regression test: with the pod cache populated, the masquerade pod IP must be
+	// preserved and the internal guest address must not appear — even with >10 guest interfaces.
+	It("regression: masquerade interface retains pod IP when pod cache is populated and guest-agent reports internal NAT address", func() {
+		const (
+			primaryNetworkName = "primary"
+			primaryMAC         = "52:54:00:00:BE:EF"
+			primaryIfaceName   = "eth0"
+
+			podIP             = "10.244.1.120"
+			masqueradeGuestIP = "10.0.2.2"
+		)
+
+		// Pod cache IS populated with the reachable pod IP.
+		Expect(
+			setup.addNetworkInterface(
+				newVMISpecIfaceWithMasqueradeBinding(primaryNetworkName),
+				newVMISpecPodNetwork(primaryNetworkName),
+				newDomainSpecIface(primaryNetworkName, primaryMAC),
+				podIP, // pod cache populated with the real pod IP
+			),
+		).To(Succeed())
+
+		// GA reports a bridge with the same MAC but NO IP (processed first),
+		// and then the actual masquerade NIC with the internal masquerade address.
+		// Plus many extra guest interfaces to ensure guestOnly limits don't mask it.
+		guestAgentIfaces := []api.InterfaceStatus{
+			newDomainStatusIface(nil, primaryMAC, "br0"),
+			newDomainStatusIface([]string{masqueradeGuestIP}, primaryMAC, primaryIfaceName),
+		}
+		for i := 1; i <= 11; i++ {
+			guestAgentIfaces = append(guestAgentIfaces, newDomainStatusIface(
+				nil,
+				fmt.Sprintf("00:00:00:00:00:%02X", i),
+				fmt.Sprintf("eth%d", i),
+			))
+		}
+		setup.addGuestAgentInterfaces(guestAgentIfaces...)
+
+		Expect(setup.NetStat.UpdateStatus(setup.Vmi, setup.Domain)).To(Succeed())
+
+		primaryStatus := setup.Vmi.Status.Interfaces[0]
+		Expect(primaryStatus.Name).To(Equal(primaryNetworkName))
+		Expect(primaryStatus.IP).To(Equal(podIP),
+			"pod IP must be reported as the primary IP for masquerade interfaces")
+		Expect(primaryStatus.IPs).To(ContainElement(podIP),
+			"pod IP must be present in the IPs list")
+		Expect(primaryStatus.IPs).NotTo(ContainElement(masqueradeGuestIP),
+			"internal masquerade guest address must not appear in the IPs list")
+		Expect(primaryStatus.InfoSource).To(Equal(netvmispec.InfoSourceDomainAndGA))
+	})
+
 	It("volatile cache is updated based on non-volatile cache", func() {
 		const (
 			primaryNetworkName = "primary"


### PR DESCRIPTION
**What this PR does**:
This PR fixes a bug where a VMI's masquerade interface can incorrectly report its internal guest-side NAT address (e.g., `10.0.2.2`) instead of the reachable virt-launcher Pod IP (e.g., `10.244.1.120`).

**Root Cause:**
When a VM uses masquerade binding and the QEMU Guest Agent is enabled, the guest sees the internal NAT address. KubeVirt merges this data in `ifacesStatusFromGuestAgent`. A race condition exists where `UpdateStatus` can process the guest-agent report before the pod interface cache file has been fully populated by the `virt-launcher`. 

If the cache is empty, KubeVirt sees no existing pod IPv4 and erroneously adopts the guest agent's IPv4 address as the primary IP. This race is frequently triggered in configurations with GPU/PCI passthrough and many guest interfaces (e.g., Cilium veth pairs), as the extra NICs exhaust the 10-interface limit and alter the guest-agent enumeration ordering.

**Fix:**
For masquerade interfaces, the guest-side IPv4 address is internal to the NAT and is never routable from the cluster. This PR enforces that invariant:
1. Strips all IPv4 addresses (and Link-Local Addresses) from the guest-agent data before merging.
2. Saves the existing pod IPv4 prior to the merge and explicitly restores it afterward, preventing the internal masquerade address from ever replacing the pod IP, even when the cache is empty.
3. Preserves any valid guest-provided IPv6 addresses for dual-stack configurations.

Two new regression tests have been added to `netstat_test.go` to explicitly test both the empty-cache (race condition) and populated-cache paths with >10 guest interfaces.

 #18760 