### PR TITLE
Domain watcher: simplify

### DIFF
--- a/pkg/virt-handler/cache/cache.go
+++ b/pkg/virt-handler/cache/cache.go
@@ -267,10 +267,9 @@ func listAllKnownDomains() []*api.Domain {
 		}
 
 		if !exists {
-			domain := api.NewMinimalDomainWithNS(record.Namespace, record.Name)
-			domain.ObjectMeta.UID = record.UID
+			domain := newDomainFromGhostRecord(record, api.DomainStatus{})
 			now := metav1.Now()
-			domain.ObjectMeta.DeletionTimestamp = &now
+			domain.DeletionTimestamp = &now
 			log.Log.Object(domain).Warning("detected stale domain from ghost record")
 			domains = append(domains, domain)
 			continue
@@ -280,10 +279,7 @@ func listAllKnownDomains() []*api.Domain {
 		client, err := cmdclient.NewClient(socketFile)
 		if err != nil {
 			log.Log.Reason(err).Warningf("failed to connect to cmd client socket %s, preserving domain with Unknown status", socketFile)
-			domain := api.NewMinimalDomainWithNS(record.Namespace, record.Name)
-			domain.ObjectMeta.UID = record.UID
-			domain.Spec.Metadata.KubeVirt.UID = record.UID
-			domain.Status.Status = api.Unknown
+			domain := newDomainFromGhostRecord(record, api.DomainStatus{Status: api.Unknown})
 			domains = append(domains, domain)
 			continue
 		}
@@ -292,10 +288,7 @@ func listAllKnownDomains() []*api.Domain {
 		domain, exists, err := client.GetDomain()
 		if err != nil {
 			log.Log.Reason(err).Warningf("failed to list domains on cmd client socket %s, preserving domain with Unknown status", socketFile)
-			domain := api.NewMinimalDomainWithNS(record.Namespace, record.Name)
-			domain.ObjectMeta.UID = record.UID
-			domain.Spec.Metadata.KubeVirt.UID = record.UID
-			domain.Status.Status = api.Unknown
+			domain := newDomainFromGhostRecord(record, api.DomainStatus{Status: api.Unknown})
 			domains = append(domains, domain)
 			continue
 		}
@@ -304,4 +297,13 @@ func listAllKnownDomains() []*api.Domain {
 		}
 	}
 	return domains
+}
+
+func newDomainFromGhostRecord(record ghostRecord, status api.DomainStatus) *api.Domain {
+	domain := api.NewMinimalDomainWithNS(record.Namespace, record.Name)
+	domain.ObjectMeta.UID = record.UID
+	domain.Spec.Metadata.KubeVirt.UID = record.UID
+	domain.Status = status
+
+	return domain
 }

--- a/pkg/virt-handler/cache/cache.go
+++ b/pkg/virt-handler/cache/cache.go
@@ -243,10 +243,7 @@ func NewSharedInformer(virtShareDir string, watchdogTimeout int, recorder record
 
 func List(_ context.Context, _ metav1.ListOptions) (runtime.Object, error) {
 	log.Log.V(3).Info("Synchronizing domains")
-	domains, err := listAllKnownDomains()
-	if err != nil {
-		return nil, err
-	}
+	domains := listAllKnownDomains()
 	list := api.DomainList{
 		Items: []api.Domain{},
 	}
@@ -256,7 +253,7 @@ func List(_ context.Context, _ metav1.ListOptions) (runtime.Object, error) {
 	return &list, nil
 }
 
-func listAllKnownDomains() ([]*api.Domain, error) {
+func listAllKnownDomains() []*api.Domain {
 	var domains []*api.Domain
 
 	ghostRecords := (GhostRecordGlobalStore.list())
@@ -306,5 +303,5 @@ func listAllKnownDomains() ([]*api.Domain, error) {
 			domains = append(domains, domain)
 		}
 	}
-	return domains, nil
+	return domains
 }

--- a/pkg/virt-handler/cache/cache.go
+++ b/pkg/virt-handler/cache/cache.go
@@ -38,8 +38,10 @@ import (
 	"kubevirt.io/client-go/log"
 
 	"kubevirt.io/kubevirt/pkg/checkpoint"
+	diskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 
+	cmdclient "kubevirt.io/kubevirt/pkg/virt-handler/cmd-client"
 	notifyserver "kubevirt.io/kubevirt/pkg/virt-handler/notify-server"
 )
 
@@ -250,4 +252,57 @@ func NewSharedInformer(virtShareDir string, watchdogTimeout int, recorder record
 		},
 	}
 	return cache.NewSharedInformer(lw, &api.Domain{}, 0)
+}
+
+func listAllKnownDomains() ([]*api.Domain, error) {
+	var domains []*api.Domain
+
+	ghostRecords := (GhostRecordGlobalStore.list())
+	for _, record := range ghostRecords {
+		socketFile := record.SocketFile
+
+		exists, err := diskutils.FileExists(socketFile)
+		if err != nil {
+			log.Log.Reason(err).Error("failed access cmd client socket")
+			continue
+		}
+
+		if !exists {
+			domain := api.NewMinimalDomainWithNS(record.Namespace, record.Name)
+			domain.ObjectMeta.UID = record.UID
+			now := metav1.Now()
+			domain.ObjectMeta.DeletionTimestamp = &now
+			log.Log.Object(domain).Warning("detected stale domain from ghost record")
+			domains = append(domains, domain)
+			continue
+		}
+
+		log.Log.V(3).Infof("List domains from sock %s", socketFile)
+		client, err := cmdclient.NewClient(socketFile)
+		if err != nil {
+			log.Log.Reason(err).Warningf("failed to connect to cmd client socket %s, preserving domain with Unknown status", socketFile)
+			domain := api.NewMinimalDomainWithNS(record.Namespace, record.Name)
+			domain.ObjectMeta.UID = record.UID
+			domain.Spec.Metadata.KubeVirt.UID = record.UID
+			domain.Status.Status = api.Unknown
+			domains = append(domains, domain)
+			continue
+		}
+		defer client.Close()
+
+		domain, exists, err := client.GetDomain()
+		if err != nil {
+			log.Log.Reason(err).Warningf("failed to list domains on cmd client socket %s, preserving domain with Unknown status", socketFile)
+			domain := api.NewMinimalDomainWithNS(record.Namespace, record.Name)
+			domain.ObjectMeta.UID = record.UID
+			domain.Spec.Metadata.KubeVirt.UID = record.UID
+			domain.Status.Status = api.Unknown
+			domains = append(domains, domain)
+			continue
+		}
+		if exists {
+			domains = append(domains, domain)
+		}
+	}
+	return domains, nil
 }

--- a/pkg/virt-handler/cache/cache.go
+++ b/pkg/virt-handler/cache/cache.go
@@ -258,41 +258,7 @@ func listAllKnownDomains() []*api.Domain {
 
 	ghostRecords := (GhostRecordGlobalStore.list())
 	for _, record := range ghostRecords {
-		socketFile := record.SocketFile
-
-		exists, err := diskutils.FileExists(socketFile)
-		if err != nil {
-			log.Log.Reason(err).Error("failed access cmd client socket")
-			continue
-		}
-
-		if !exists {
-			domain := newDomainFromGhostRecord(record, api.DomainStatus{})
-			now := metav1.Now()
-			domain.DeletionTimestamp = &now
-			log.Log.Object(domain).Warning("detected stale domain from ghost record")
-			domains = append(domains, domain)
-			continue
-		}
-
-		log.Log.V(3).Infof("List domains from sock %s", socketFile)
-		client, err := cmdclient.NewClient(socketFile)
-		if err != nil {
-			log.Log.Reason(err).Warningf("failed to connect to cmd client socket %s, preserving domain with Unknown status", socketFile)
-			domain := newDomainFromGhostRecord(record, api.DomainStatus{Status: api.Unknown})
-			domains = append(domains, domain)
-			continue
-		}
-		defer client.Close()
-
-		domain, exists, err := client.GetDomain()
-		if err != nil {
-			log.Log.Reason(err).Warningf("failed to list domains on cmd client socket %s, preserving domain with Unknown status", socketFile)
-			domain := newDomainFromGhostRecord(record, api.DomainStatus{Status: api.Unknown})
-			domains = append(domains, domain)
-			continue
-		}
-		if exists {
+		if domain := getDomainFromRecord(record); domain != nil {
 			domains = append(domains, domain)
 		}
 	}
@@ -305,5 +271,41 @@ func newDomainFromGhostRecord(record ghostRecord, status api.DomainStatus) *api.
 	domain.Spec.Metadata.KubeVirt.UID = record.UID
 	domain.Status = status
 
+	return domain
+}
+
+func getDomainFromRecord(record ghostRecord) *api.Domain {
+	socketFile := record.SocketFile
+
+	exists, err := diskutils.FileExists(socketFile)
+	if err != nil {
+		log.Log.Reason(err).Error("failed access cmd client socket")
+		return nil
+	}
+
+	if !exists {
+		domain := newDomainFromGhostRecord(record, api.DomainStatus{})
+		now := metav1.Now()
+		domain.DeletionTimestamp = &now
+		log.Log.Object(domain).Warning("detected stale domain from ghost record")
+		return domain
+	}
+
+	log.Log.V(3).Infof("List domains from sock %s", socketFile)
+	client, err := cmdclient.NewClient(socketFile)
+	if err != nil {
+		log.Log.Reason(err).Warningf("failed to connect to cmd client socket %s, preserving domain with Unknown status", socketFile)
+		return newDomainFromGhostRecord(record, api.DomainStatus{Status: api.Unknown})
+	}
+	defer client.Close()
+
+	domain, exists, err := client.GetDomain()
+	if err != nil {
+		log.Log.Reason(err).Warningf("failed to list domains on cmd client socket %s, preserving domain with Unknown status", socketFile)
+		return newDomainFromGhostRecord(record, api.DomainStatus{Status: api.Unknown})
+	}
+	if !exists {
+		return nil
+	}
 	return domain
 }

--- a/pkg/virt-handler/cache/cache.go
+++ b/pkg/virt-handler/cache/cache.go
@@ -233,25 +233,27 @@ func NewSharedInformer(virtShareDir string, watchdogTimeout int, recorder record
 		return notifyserver.RunServer(virtShareDir, ctx.Done(), c, recorder, vmiStore)
 	}
 	lw := &cache.ListWatch{
-		ListWithContextFunc: func(_ context.Context, _ metav1.ListOptions) (runtime.Object, error) {
-			log.Log.V(3).Info("Synchronizing domains")
-			domains, err := listAllKnownDomains()
-			if err != nil {
-				return nil, err
-			}
-			list := api.DomainList{
-				Items: []api.Domain{},
-			}
-			for _, domain := range domains {
-				list.Items = append(list.Items, *domain)
-			}
-			return &list, nil
-		},
+		ListWithContextFunc: List,
 		WatchFuncWithContext: func(ctx context.Context, _ metav1.ListOptions) (watch.Interface, error) {
 			return newDomainWatcher(ctx, runServer, watchdogTimeout, resyncPeriod, recorder, consecutiveFails), nil
 		},
 	}
 	return cache.NewSharedInformer(lw, &api.Domain{}, 0)
+}
+
+func List(_ context.Context, _ metav1.ListOptions) (runtime.Object, error) {
+	log.Log.V(3).Info("Synchronizing domains")
+	domains, err := listAllKnownDomains()
+	if err != nil {
+		return nil, err
+	}
+	list := api.DomainList{
+		Items: []api.Domain{},
+	}
+	for _, domain := range domains {
+		list.Items = append(list.Items, *domain)
+	}
+	return &list, nil
 }
 
 func listAllKnownDomains() ([]*api.Domain, error) {

--- a/pkg/virt-handler/cache/cache_test.go
+++ b/pkg/virt-handler/cache/cache_test.go
@@ -504,6 +504,90 @@ var _ = Describe("Iterable checkpoint manager", func() {
 	})
 })
 
+var _ = Describe("List", func() {
+	var ghostCacheDir string
+
+	BeforeEach(func() {
+		ghostCacheDir = GinkgoT().TempDir()
+		InitializeGhostRecordCache(NewIterableCheckpointManager(ghostCacheDir))
+	})
+
+	It("should return domain with Unknown status when socket exists but connection fails", func() {
+		socketDir := GinkgoT().TempDir()
+		socketPath := filepath.Join(socketDir, "cmd.sock")
+
+		err := os.WriteFile(socketPath, []byte{}, 0600)
+		Expect(err).ToNot(HaveOccurred())
+
+		err = GhostRecordGlobalStore.Add("test-ns", "test-vmi", socketPath, "uid-1234")
+		Expect(err).ToNot(HaveOccurred())
+
+		list, err := List(context.TODO(), metav1.ListOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		domains := list.(*api.DomainList).Items
+		Expect(domains).To(HaveLen(1))
+		Expect(domains[0].ObjectMeta.Namespace).To(Equal("test-ns"))
+		Expect(domains[0].ObjectMeta.Name).To(Equal("test-vmi"))
+		Expect(domains[0].ObjectMeta.UID).To(BeEquivalentTo("uid-1234"))
+		Expect(domains[0].Status.Status).To(Equal(api.Unknown))
+		Expect(domains[0].ObjectMeta.DeletionTimestamp).To(BeNil())
+	})
+
+	It("should return domain with DeletionTimestamp when socket file does not exist", func() {
+		socketPath := "/nonexistent/path/cmd.sock"
+
+		err := GhostRecordGlobalStore.Add("test-ns", "test-vmi", socketPath, "uid-1234")
+		Expect(err).ToNot(HaveOccurred())
+
+		list, err := List(context.TODO(), metav1.ListOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		domains := list.(*api.DomainList).Items
+		Expect(domains).To(HaveLen(1))
+		Expect(domains[0].ObjectMeta.Namespace).To(Equal("test-ns"))
+		Expect(domains[0].ObjectMeta.Name).To(Equal("test-vmi"))
+		Expect(domains[0].ObjectMeta.DeletionTimestamp).ToNot(BeNil())
+	})
+
+	// TODO add the reachable socket
+	It("should handle mix of reachable, unreachable, and missing sockets", func() {
+		socketDir := GinkgoT().TempDir()
+
+		unreachablePath := filepath.Join(socketDir, "unreachable.sock")
+		err := os.WriteFile(unreachablePath, []byte{}, 0600)
+		Expect(err).ToNot(HaveOccurred())
+		err = GhostRecordGlobalStore.Add("ns1", "unreachable-vmi", unreachablePath, "uid-1")
+		Expect(err).ToNot(HaveOccurred())
+
+		missingPath := filepath.Join(socketDir, "missing.sock")
+		err = GhostRecordGlobalStore.Add("ns2", "missing-vmi", missingPath, "uid-2")
+		Expect(err).ToNot(HaveOccurred())
+
+		list, err := List(context.TODO(), metav1.ListOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		domains := list.(*api.DomainList).Items
+		Expect(domains).To(HaveLen(2))
+
+		var unknownDomain, deletedDomain *api.Domain
+		for _, d := range domains {
+			if d.Status.Status == api.Unknown {
+				unknownDomain = &d
+			}
+			if d.ObjectMeta.DeletionTimestamp != nil {
+				deletedDomain = &d
+			}
+		}
+
+		Expect(unknownDomain).ToNot(BeNil())
+		Expect(unknownDomain.ObjectMeta.Name).To(Equal("unreachable-vmi"))
+
+		Expect(deletedDomain).ToNot(BeNil())
+		Expect(deletedDomain.ObjectMeta.Name).To(Equal("missing-vmi"))
+	})
+
+	// TODO Test with fake server
+
+})
+
 func runCMDServer(wg *sync.WaitGroup, socketPath string,
 	domainManager virtwrap.DomainManager,
 	stopChan chan struct{},

--- a/pkg/virt-handler/cache/cache_test.go
+++ b/pkg/virt-handler/cache/cache_test.go
@@ -227,8 +227,7 @@ var _ = Describe("Domain informer", func() {
 			Expect(err).ToNot(HaveOccurred())
 			client.Close()
 
-			listResults, err := listAllKnownDomains()
-			Expect(err).ToNot(HaveOccurred())
+			listResults := listAllKnownDomains()
 
 			Expect(listResults).To(HaveLen(1))
 		})
@@ -251,8 +250,7 @@ var _ = Describe("Domain informer", func() {
 			Expect(err).ToNot(HaveOccurred())
 			client.Close()
 
-			listResults, err := listAllKnownDomains()
-			Expect(err).ToNot(HaveOccurred())
+			listResults := listAllKnownDomains()
 
 			// includes both the domain with an active socket and the ghost record with deleted socket
 			Expect(listResults).To(HaveLen(2))

--- a/pkg/virt-handler/cache/domain-watcher.go
+++ b/pkg/virt-handler/cache/domain-watcher.go
@@ -258,8 +258,9 @@ func (d *domainWatcher) handleStaleSocketConnections(ctx context.Context, watchd
 func listAllKnownDomains() ([]*api.Domain, error) {
 	var domains []*api.Domain
 
-	socketFiles := listSockets(GhostRecordGlobalStore.list())
-	for _, socketFile := range socketFiles {
+	ghostRecords := (GhostRecordGlobalStore.list())
+	for _, record := range ghostRecords {
+		socketFile := record.SocketFile
 
 		exists, err := diskutils.FileExists(socketFile)
 		if err != nil {
@@ -268,15 +269,12 @@ func listAllKnownDomains() ([]*api.Domain, error) {
 		}
 
 		if !exists {
-			record, recordExists := GhostRecordGlobalStore.findBySocket(socketFile)
-			if recordExists {
-				domain := api.NewMinimalDomainWithNS(record.Namespace, record.Name)
-				domain.ObjectMeta.UID = record.UID
-				now := metav1.Now()
-				domain.ObjectMeta.DeletionTimestamp = &now
-				log.Log.Object(domain).Warning("detected stale domain from ghost record")
-				domains = append(domains, domain)
-			}
+			domain := api.NewMinimalDomainWithNS(record.Namespace, record.Name)
+			domain.ObjectMeta.UID = record.UID
+			now := metav1.Now()
+			domain.ObjectMeta.DeletionTimestamp = &now
+			log.Log.Object(domain).Warning("detected stale domain from ghost record")
+			domains = append(domains, domain)
 			continue
 		}
 
@@ -284,14 +282,11 @@ func listAllKnownDomains() ([]*api.Domain, error) {
 		client, err := cmdclient.NewClient(socketFile)
 		if err != nil {
 			log.Log.Reason(err).Warningf("failed to connect to cmd client socket %s, preserving domain with Unknown status", socketFile)
-			record, recordExists := GhostRecordGlobalStore.findBySocket(socketFile)
-			if recordExists {
-				domain := api.NewMinimalDomainWithNS(record.Namespace, record.Name)
-				domain.ObjectMeta.UID = record.UID
-				domain.Spec.Metadata.KubeVirt.UID = record.UID
-				domain.Status.Status = api.Unknown
-				domains = append(domains, domain)
-			}
+			domain := api.NewMinimalDomainWithNS(record.Namespace, record.Name)
+			domain.ObjectMeta.UID = record.UID
+			domain.Spec.Metadata.KubeVirt.UID = record.UID
+			domain.Status.Status = api.Unknown
+			domains = append(domains, domain)
 			continue
 		}
 		defer client.Close()
@@ -299,14 +294,11 @@ func listAllKnownDomains() ([]*api.Domain, error) {
 		domain, exists, err := client.GetDomain()
 		if err != nil {
 			log.Log.Reason(err).Warningf("failed to list domains on cmd client socket %s, preserving domain with Unknown status", socketFile)
-			record, recordExists := GhostRecordGlobalStore.findBySocket(socketFile)
-			if recordExists {
-				domain := api.NewMinimalDomainWithNS(record.Namespace, record.Name)
-				domain.ObjectMeta.UID = record.UID
-				domain.Spec.Metadata.KubeVirt.UID = record.UID
-				domain.Status.Status = api.Unknown
-				domains = append(domains, domain)
-			}
+			domain := api.NewMinimalDomainWithNS(record.Namespace, record.Name)
+			domain.ObjectMeta.UID = record.UID
+			domain.Spec.Metadata.KubeVirt.UID = record.UID
+			domain.Status.Status = api.Unknown
+			domains = append(domains, domain)
 			continue
 		}
 		if exists {

--- a/pkg/virt-handler/cache/domain-watcher.go
+++ b/pkg/virt-handler/cache/domain-watcher.go
@@ -33,7 +33,6 @@ import (
 
 	"kubevirt.io/client-go/log"
 
-	diskutils "kubevirt.io/kubevirt/pkg/ephemeral-disk-utils"
 	cmdclient "kubevirt.io/kubevirt/pkg/virt-handler/cmd-client"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )
@@ -253,59 +252,6 @@ func (d *domainWatcher) handleStaleSocketConnections(ctx context.Context, watchd
 	}
 
 	return nil
-}
-
-func listAllKnownDomains() ([]*api.Domain, error) {
-	var domains []*api.Domain
-
-	ghostRecords := (GhostRecordGlobalStore.list())
-	for _, record := range ghostRecords {
-		socketFile := record.SocketFile
-
-		exists, err := diskutils.FileExists(socketFile)
-		if err != nil {
-			log.Log.Reason(err).Error("failed access cmd client socket")
-			continue
-		}
-
-		if !exists {
-			domain := api.NewMinimalDomainWithNS(record.Namespace, record.Name)
-			domain.ObjectMeta.UID = record.UID
-			now := metav1.Now()
-			domain.ObjectMeta.DeletionTimestamp = &now
-			log.Log.Object(domain).Warning("detected stale domain from ghost record")
-			domains = append(domains, domain)
-			continue
-		}
-
-		log.Log.V(3).Infof("List domains from sock %s", socketFile)
-		client, err := cmdclient.NewClient(socketFile)
-		if err != nil {
-			log.Log.Reason(err).Warningf("failed to connect to cmd client socket %s, preserving domain with Unknown status", socketFile)
-			domain := api.NewMinimalDomainWithNS(record.Namespace, record.Name)
-			domain.ObjectMeta.UID = record.UID
-			domain.Spec.Metadata.KubeVirt.UID = record.UID
-			domain.Status.Status = api.Unknown
-			domains = append(domains, domain)
-			continue
-		}
-		defer client.Close()
-
-		domain, exists, err := client.GetDomain()
-		if err != nil {
-			log.Log.Reason(err).Warningf("failed to list domains on cmd client socket %s, preserving domain with Unknown status", socketFile)
-			domain := api.NewMinimalDomainWithNS(record.Namespace, record.Name)
-			domain.ObjectMeta.UID = record.UID
-			domain.Spec.Metadata.KubeVirt.UID = record.UID
-			domain.Status.Status = api.Unknown
-			domains = append(domains, domain)
-			continue
-		}
-		if exists {
-			domains = append(domains, domain)
-		}
-	}
-	return domains, nil
 }
 
 func (d *domainWatcher) Stop() {

--- a/pkg/virt-handler/cache/domain-watcher.go
+++ b/pkg/virt-handler/cache/domain-watcher.go
@@ -152,11 +152,7 @@ func (d *domainWatcher) recordNotifyServerFailureEvent(err error) {
 }
 
 func (d *domainWatcher) handleResync(ctx context.Context) {
-	socketFiles, err := listSockets(GhostRecordGlobalStore.list())
-	if err != nil {
-		log.Log.Reason(err).Error("failed to list sockets")
-		return
-	}
+	socketFiles := listSockets(GhostRecordGlobalStore.list())
 
 	log.Log.Infof("resyncing virt-launcher domains")
 	for _, socket := range socketFiles {
@@ -190,11 +186,7 @@ func (d *domainWatcher) handleResync(ctx context.Context) {
 func (d *domainWatcher) handleStaleSocketConnections(ctx context.Context, watchdogTimeout int) error {
 	var unresponsive []string
 
-	socketFiles, err := listSockets(GhostRecordGlobalStore.list())
-	if err != nil {
-		log.Log.Reason(err).Error("failed to list sockets")
-		return err
-	}
+	socketFiles := listSockets(GhostRecordGlobalStore.list())
 
 	for _, socket := range socketFiles {
 		sock, err := net.DialTimeout("unix", socket, time.Duration(socketDialTimeout)*time.Second)
@@ -266,10 +258,7 @@ func (d *domainWatcher) handleStaleSocketConnections(ctx context.Context, watchd
 func listAllKnownDomains() ([]*api.Domain, error) {
 	var domains []*api.Domain
 
-	socketFiles, err := listSockets(GhostRecordGlobalStore.list())
-	if err != nil {
-		return nil, err
-	}
+	socketFiles := listSockets(GhostRecordGlobalStore.list())
 	for _, socketFile := range socketFiles {
 
 		exists, err := diskutils.FileExists(socketFile)
@@ -336,12 +325,12 @@ func (d *domainWatcher) ResultChan() <-chan watch.Event {
 	return d.result
 }
 
-func listSockets(ghostRecords []ghostRecord) ([]string, error) {
+func listSockets(ghostRecords []ghostRecord) []string {
 	var sockets []string
 
 	for _, record := range ghostRecords {
 		sockets = append(sockets, record.SocketFile)
 	}
 
-	return sockets, nil
+	return sockets
 }

--- a/pkg/virt-handler/cache/domain-watcher_test.go
+++ b/pkg/virt-handler/cache/domain-watcher_test.go
@@ -46,8 +46,7 @@ var _ = Describe("Domain Watcher", func() {
 			err := ghostRecordStore.Add("test-ns", "test-domain", socketPath, podUID)
 			Expect(err).ToNot(HaveOccurred())
 
-			socketFiles, err := listSockets(ghostRecordStore.list())
-			Expect(err).ToNot(HaveOccurred())
+			socketFiles := listSockets(ghostRecordStore.list())
 			Expect(socketFiles).To(HaveLen(1))
 			Expect(socketFiles[0]).To(Equal(socketPath))
 

--- a/pkg/virt-handler/cache/domain-watcher_test.go
+++ b/pkg/virt-handler/cache/domain-watcher_test.go
@@ -22,15 +22,11 @@ package cache
 import (
 	"context"
 	"fmt"
-	"os"
-	"path/filepath"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/watch"
-
-	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )
 
 var _ = Describe("Domain Watcher", func() {
@@ -124,80 +120,4 @@ var _ = Describe("Domain Watcher", func() {
 		})
 	})
 
-	Context("listAllKnownDomains", func() {
-		var ghostCacheDir string
-
-		BeforeEach(func() {
-			ghostCacheDir = GinkgoT().TempDir()
-			InitializeGhostRecordCache(NewIterableCheckpointManager(ghostCacheDir))
-		})
-
-		It("should return domain with Unknown status when socket exists but connection fails", func() {
-			socketDir := GinkgoT().TempDir()
-			socketPath := filepath.Join(socketDir, "cmd.sock")
-
-			err := os.WriteFile(socketPath, []byte{}, 0600)
-			Expect(err).ToNot(HaveOccurred())
-
-			err = GhostRecordGlobalStore.Add("test-ns", "test-vmi", socketPath, "uid-1234")
-			Expect(err).ToNot(HaveOccurred())
-
-			domains, err := listAllKnownDomains()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(domains).To(HaveLen(1))
-			Expect(domains[0].ObjectMeta.Namespace).To(Equal("test-ns"))
-			Expect(domains[0].ObjectMeta.Name).To(Equal("test-vmi"))
-			Expect(domains[0].ObjectMeta.UID).To(BeEquivalentTo("uid-1234"))
-			Expect(domains[0].Status.Status).To(Equal(api.Unknown))
-			Expect(domains[0].ObjectMeta.DeletionTimestamp).To(BeNil())
-		})
-
-		It("should return domain with DeletionTimestamp when socket file does not exist", func() {
-			socketPath := "/nonexistent/path/cmd.sock"
-
-			err := GhostRecordGlobalStore.Add("test-ns", "test-vmi", socketPath, "uid-1234")
-			Expect(err).ToNot(HaveOccurred())
-
-			domains, err := listAllKnownDomains()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(domains).To(HaveLen(1))
-			Expect(domains[0].ObjectMeta.Namespace).To(Equal("test-ns"))
-			Expect(domains[0].ObjectMeta.Name).To(Equal("test-vmi"))
-			Expect(domains[0].ObjectMeta.DeletionTimestamp).ToNot(BeNil())
-		})
-
-		It("should handle mix of reachable, unreachable, and missing sockets", func() {
-			socketDir := GinkgoT().TempDir()
-
-			unreachablePath := filepath.Join(socketDir, "unreachable.sock")
-			err := os.WriteFile(unreachablePath, []byte{}, 0600)
-			Expect(err).ToNot(HaveOccurred())
-			err = GhostRecordGlobalStore.Add("ns1", "unreachable-vmi", unreachablePath, "uid-1")
-			Expect(err).ToNot(HaveOccurred())
-
-			missingPath := filepath.Join(socketDir, "missing.sock")
-			err = GhostRecordGlobalStore.Add("ns2", "missing-vmi", missingPath, "uid-2")
-			Expect(err).ToNot(HaveOccurred())
-
-			domains, err := listAllKnownDomains()
-			Expect(err).ToNot(HaveOccurred())
-			Expect(domains).To(HaveLen(2))
-
-			var unknownDomain, deletedDomain *api.Domain
-			for _, d := range domains {
-				if d.Status.Status == api.Unknown {
-					unknownDomain = d
-				}
-				if d.ObjectMeta.DeletionTimestamp != nil {
-					deletedDomain = d
-				}
-			}
-
-			Expect(unknownDomain).ToNot(BeNil())
-			Expect(unknownDomain.ObjectMeta.Name).To(Equal("unreachable-vmi"))
-
-			Expect(deletedDomain).ToNot(BeNil())
-			Expect(deletedDomain.ObjectMeta.Name).To(Equal("missing-vmi"))
-		})
-	})
 })


### PR DESCRIPTION
### What this PR does
As part of https://github.com/kubevirt/kubevirt/pull/17752 we introduced a bit of unnecessary complexity. We iterate over sockets retrieved from ghost records and then reverse find the ghost record from socket if some error occurs to insert minimal domain. This is not required as of https://github.com/kubevirt/kubevirt/pull/15323/changes#diff-07e61cbce5c97bbbffac2a5087d7c3f3f3027c7b07f054797b5233fa40eea9b6

In this PR we drop the filtering and iteration on sockets and rather iterate through ghost records themself, this allow us to drop the reverse search. 

While at it we also refactor out the `List` function, change tests to test the `List` function rather than the internal `listAllKnownDomains` and move everything into files where it is more intuitive to be located.

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
I added some todos as I noticed the tests are incomplete. 

<!-- optional -->


### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

