### PR TITLE
virt-controller: Disable SA token automount in hotplug pods

### DIFF
--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1160,6 +1160,7 @@ func (t *TemplateService) RenderHotplugAttachmentPodTemplate(volumes []*v1.Volum
 			Tolerations:                   tolerations,
 			Volumes:                       []k8sv1.Volume{emptyDirVolume(hotplugDisks)},
 			TerminationGracePeriodSeconds: &zero,
+			AutomountServiceAccountToken:  pointer.P(false),
 		},
 	}
 
@@ -1309,6 +1310,7 @@ func (t *TemplateService) RenderHotplugAttachmentTriggerPodTemplate(volume *v1.V
 				emptyDirVolume(hotplugDisks),
 			},
 			TerminationGracePeriodSeconds: &zero,
+			AutomountServiceAccountToken:  pointer.P(false),
 		},
 	}
 

--- a/pkg/virt-controller/watch/vmi/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi/vmi_test.go
@@ -3247,12 +3247,6 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 					EmptyDir: &k8sv1.EmptyDirVolumeSource{},
 				},
 			})
-			pod.Spec.Volumes = append(pod.Spec.Volumes, k8sv1.Volume{
-				Name: "token",
-				VolumeSource: k8sv1.VolumeSource{
-					Secret: &k8sv1.SecretVolumeSource{},
-				},
-			})
 			for _, index := range indexes {
 				pod.Spec.Volumes = append(pod.Spec.Volumes, k8sv1.Volume{
 					Name: fmt.Sprintf("volume%d", index),
@@ -5580,18 +5574,12 @@ func newPodForVirtlauncher(virtlauncher *k8sv1.Pod, name, uid string, phase k8sv
 			Phase: phase,
 		},
 		Spec: k8sv1.PodSpec{
-			// +2 for empty dir and token
+			// + empty dir
 			Volumes: []k8sv1.Volume{
 				{
 					Name: "hotplug-disks",
 					VolumeSource: k8sv1.VolumeSource{
 						EmptyDir: &k8sv1.EmptyDirVolumeSource{},
-					},
-				},
-				{
-					Name: "default-token",
-					VolumeSource: k8sv1.VolumeSource{
-						Secret: &k8sv1.SecretVolumeSource{},
 					},
 				},
 			},

--- a/pkg/virt-controller/watch/vmi/volume-hotplug.go
+++ b/pkg/virt-controller/watch/vmi/volume-hotplug.go
@@ -409,8 +409,8 @@ func (c *Controller) deleteAttachmentPod(vmi *v1.VirtualMachineInstance, attachm
 }
 
 func podVolumesMatchesReadyVolumes(attachmentPod *k8sv1.Pod, volumes []*v1.Volume) bool {
-	// -2 for empty dir and token
-	if len(attachmentPod.Spec.Volumes)-2 != len(volumes) {
+	// -1 for empty dir
+	if len(attachmentPod.Spec.Volumes)-1 != len(volumes) {
 		return false
 	}
 	podVolumeMap := make(map[string]k8sv1.Volume)


### PR DESCRIPTION
### What this PR does
The hotplug attachment pod do not talk to the Kubernetes API. Stop assuming the token volume is present and set AutomountServiceAccountToken to false, so we are sure the default service account token secret is no longer projected into these short-lived helper pods.

Adjust the volume-count check in podVolumesMatchesReadyVolumes from -2 to -1 and drop the token volume from the virt-launcher test fixtures to match the new pod spec.

#### Before this PR:
Hotplug pod may or may not have mounted token depending on default namespace config. 
If mounted everything go well.
If not mounted hotplug pod is considered as invalid and is always recreated/terminated as show in #18801 

#### After this PR:
Hotplug pod is explicitly configured to NOT mount the token (as it is not needed) and not expected to be present.

### References
- Fixes #18801

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
virt-controller: Disable SA token automount in hotplug pods
```

