### PR TITLE
virt-controller: Count only PVC volumes when checking hotplug pod

### DIFF
--- a/pkg/virt-controller/watch/vmi/volume-hotplug.go
+++ b/pkg/virt-controller/watch/vmi/volume-hotplug.go
@@ -409,15 +409,14 @@ func (c *Controller) deleteAttachmentPod(vmi *v1.VirtualMachineInstance, attachm
 }
 
 func podVolumesMatchesReadyVolumes(attachmentPod *k8sv1.Pod, volumes []*v1.Volume) bool {
-	// -2 for empty dir and token
-	if len(attachmentPod.Spec.Volumes)-2 != len(volumes) {
-		return false
-	}
 	podVolumeMap := make(map[string]k8sv1.Volume)
 	for _, volume := range attachmentPod.Spec.Volumes {
 		if volume.PersistentVolumeClaim != nil {
 			podVolumeMap[volume.Name] = volume
 		}
+	}
+	if len(podVolumeMap) != len(volumes) {
+		return false
 	}
 	for _, volume := range volumes {
 		delete(podVolumeMap, volume.Name)


### PR DESCRIPTION
### What this PR does
#### Before this PR:
`podVolumesMatchesReadyVolumes` decided whether an existing attachment
pod already carries the desired hotplug volumes by subtracting a
hard-coded `2` (for the empty-dir and service-account token volumes)
from `len(attachmentPod.Spec.Volumes)` and comparing that number to
the length of the desired volumes slice.

Any change to the attachment pod spec that adds or removes a non-PVC
volume silently breaks the comparison: the length check either fails
when the pod is actually up-to-date (triggering an unnecessary
recreation) or passes when it isn't (leaving a stale pod in place).

#### After this PR:
The check now builds the PVC-only volume map first and compares its
length directly against the desired volumes. The comparison no longer
depends on the exact number of auxiliary volumes the attachment pod
happens to carry.

### References
- Fixes #18801

### Special notes for your reviewer

PR https://github.com/kubevirt/kubevirt/pull/18814 fixes the same issue but both are complementary according to [@akalenyu
 comment](https://github.com/kubevirt/kubevirt/issues/18801#issuecomment-5272175374)

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
virt-controller: Count only PVC volumes when matching pod
```

