### PR TITLE
monitoring: fix namespace on cluster-scoped alerts

### DIFF
--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -147,25 +147,26 @@ tests:
 
     # Alert to test when there are VMIs running on a node with an unready virt-handler pod
     # Alert should not fire for node with no running VMIs.
+    # virt-handler is in the install namespace; virt-launcher is in a VM namespace.
   - interval: 1m
     input_series:
-      - series: 'kube_pod_info{pod="virt-handler-asdf", node="node01"}'
+      - series: 'kube_pod_info{pod="virt-handler-asdf", namespace="ci", node="node01"}'
         values: '1 1 1 1 1 1 1 1 1 1 1'
-      - series: 'kube_pod_status_ready{pod="virt-handler-asdf", condition="true"}'
+      - series: 'kube_pod_status_ready{pod="virt-handler-asdf", namespace="ci", condition="true"}'
         values: '0 0 0 0 0 0 0 0 0 0 0'
-      - series: 'kube_pod_info{pod="virt-launcher-testvm-123", node="node01"}'
+      - series: 'kube_pod_info{pod="virt-launcher-testvm-123", namespace="vm-ns", node="node01"}'
         values: '1 1 1 1 1 1 1 1 1 1 1'
-      - series: 'kube_pod_info{pod="virt-handler-asdfg", node="node02"}'
+      - series: 'kube_pod_info{pod="virt-handler-asdfg", namespace="ci", node="node02"}'
         values: '1 1 1 1 1 1 1 1 1 1 1'
-      - series: 'kube_pod_status_ready{pod="virt-handler-asdfg", condition="true"}'
+      - series: 'kube_pod_status_ready{pod="virt-handler-asdfg", namespace="ci", condition="true"}'
         values: '1 1 1 1 1 1 1 1 1 1 1'
-      - series: 'kube_pod_info{pod="virt-launcher-vmi", node="node02"}'
+      - series: 'kube_pod_info{pod="virt-launcher-vmi", namespace="vm-ns", node="node02"}'
         values: '1 1 1 1 1 1 1 1 1 1 1'
-      - series: 'kube_pod_info{pod="virt-handler-abcd", node="node03"}'
+      - series: 'kube_pod_info{pod="virt-handler-abcd", namespace="ci", node="node03"}'
         values: '1 1 1 1 1 1 1 1 1 1 1'
-      - series: 'kube_pod_status_ready{pod="virt-handler-abcd", condition="true"}'
+      - series: 'kube_pod_status_ready{pod="virt-handler-abcd", namespace="ci", condition="true"}'
         values: '0 0 0 0 0 0 0 0 0 0 0'
-      - series: 'kube_pod_info{pod="virt-launcher-novmi", node="node03"}'
+      - series: 'kube_pod_info{pod="virt-launcher-novmi", namespace="vm-ns", node="node03"}'
         values: '_ _ _ _ _ _ _ _ _ _ _'
 
     alert_rule_test:
@@ -181,6 +182,7 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/OrphanedVirtualMachineInstances"
             exp_labels:
               node: "node01"
+              namespace: "ci"
               severity: "warning"
               operator_health_impact: "warning"
               kubernetes_operator_part_of: "kubevirt"
@@ -190,23 +192,23 @@ tests:
     # Alert should not fire for node with no running VMIs.
   - interval: 1m
     input_series:
-      - series: 'kube_pod_info{pod="virt-handler-asdf", node="node01"}'
+      - series: 'kube_pod_info{pod="virt-handler-asdf", namespace="ci", node="node01"}'
         values: '_ _ _ _ _ _ _ _ _ _ _'
-      - series: 'kube_pod_status_ready{pod="virt-handler-asdf", condition="true"}'
+      - series: 'kube_pod_status_ready{pod="virt-handler-asdf", namespace="ci", condition="true"}'
         values: '_ _ _ _ _ _ _ _ _ _ _'
-      - series: 'kube_pod_info{pod="virt-launcher-testvm-123", node="node01"}'
+      - series: 'kube_pod_info{pod="virt-launcher-testvm-123", namespace="vm-ns", node="node01"}'
         values: '1 1 1 1 1 1 1 1 1 1 1'
-      - series: 'kube_pod_info{pod="virt-handler-asdfg", node="node02"}'
+      - series: 'kube_pod_info{pod="virt-handler-asdfg", namespace="ci", node="node02"}'
         values: '1 1 1 1 1 1 1 1 1 1 1'
-      - series: 'kube_pod_status_ready{pod="virt-handler-asdfg", condition="true"}'
+      - series: 'kube_pod_status_ready{pod="virt-handler-asdfg", namespace="ci", condition="true"}'
         values: '1 1 1 1 1 1 1 1 1 1 1'
-      - series: 'kube_pod_info{pod="virt-launcher-vmi", node="node02"}'
+      - series: 'kube_pod_info{pod="virt-launcher-vmi", namespace="vm-ns", node="node02"}'
         values: '1 1 1 1 1 1 1 1 1 1 1'
-      - series: 'kube_pod_info{pod="virt-handler-abcd", node="node03"}'
+      - series: 'kube_pod_info{pod="virt-handler-abcd", namespace="ci", node="node03"}'
         values: '_ _ _ _ _ _ _ _ _ _ _'
-      - series: 'kube_pod_status_ready{pod="virt-handler-abcd", condition="true"}'
+      - series: 'kube_pod_status_ready{pod="virt-handler-abcd", namespace="ci", condition="true"}'
         values: '_ _ _ _ _ _ _ _ _ _ _'
-      - series: 'kube_pod_info{pod="virt-launcher-novmi", node="node03"}'
+      - series: 'kube_pod_info{pod="virt-launcher-novmi", namespace="vm-ns", node="node03"}'
         values: '_ _ _ _ _ _ _ _ _ _ _'
 
 
@@ -223,6 +225,53 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/OrphanedVirtualMachineInstances"
             exp_labels:
               node: "node01"
+              namespace: "ci"
+              severity: "warning"
+              operator_health_impact: "warning"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+
+    # Ready virt-handler in the install namespace must not fire for
+    # virt-launchers that run in other namespaces on the same node.
+  - interval: 1m
+    input_series:
+      - series: 'kube_pod_info{pod="virt-handler-asdf", namespace="ci", node="node01"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1'
+      - series: 'kube_pod_status_ready{pod="virt-handler-asdf", namespace="ci", condition="true"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1'
+      - series: 'kube_pod_info{pod="virt-launcher-vm-a", namespace="ns-a", node="node01"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1'
+      - series: 'kube_pod_info{pod="virt-launcher-vm-b", namespace="ns-b", node="node01"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1'
+
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: OrphanedVirtualMachineInstances
+        exp_alerts: [ ]
+
+    # Unready virt-handler plus virt-launchers in two VM namespaces on the
+    # same node must produce a single alert labeled with the install namespace.
+  - interval: 1m
+    input_series:
+      - series: 'kube_pod_info{pod="virt-handler-asdf", namespace="ci", node="node01"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1'
+      - series: 'kube_pod_status_ready{pod="virt-handler-asdf", namespace="ci", condition="true"}'
+        values: '0 0 0 0 0 0 0 0 0 0 0'
+      - series: 'kube_pod_info{pod="virt-launcher-vm-a", namespace="ns-a", node="node01"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1'
+      - series: 'kube_pod_info{pod="virt-launcher-vm-b", namespace="ns-b", node="node01"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1'
+
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: OrphanedVirtualMachineInstances
+        exp_alerts:
+          - exp_annotations:
+              summary: "No ready virt-handler pod detected on node node01 with running vmis for more than 10 minutes"
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/OrphanedVirtualMachineInstances"
+            exp_labels:
+              node: "node01"
+              namespace: "ci"
               severity: "warning"
               operator_health_impact: "warning"
               kubernetes_operator_part_of: "kubevirt"
@@ -979,8 +1028,8 @@ tests:
   # Mass Failed virt-launcher pods should trigger critical alert after 10m
   - interval: 1m
     input_series:
-      # Single series at value 200 so the sum() recording rule reaches threshold for 10m
-      - series: 'kube_pod_status_phase{pod="virt-launcher-test", phase="Failed"}'
+      # Single series at value 200 so the cluster-wide sum reaches threshold for 10m
+      - series: 'kube_pod_status_phase{pod="virt-launcher-test", namespace="vm-ns", phase="Failed"}'
         values: '200x11'
     alert_rule_test:
       # no alert before 10 minutes
@@ -998,6 +1047,32 @@ tests:
               operator_health_impact: "critical"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
+              namespace: "ci"
+
+    # Failed virt-launchers split across VM namespaces must still fire once
+    # the cluster-wide count reaches 200, labeled with the install namespace.
+  - interval: 1m
+    input_series:
+      - series: 'kube_pod_status_phase{pod="virt-launcher-a", namespace="ns-a", phase="Failed"}'
+        values: '150x11'
+      - series: 'kube_pod_status_phase{pod="virt-launcher-b", namespace="ns-b", phase="Failed"}'
+        values: '150x11'
+    alert_rule_test:
+      - eval_time: 9m
+        alertname: VirtLauncherPodsStuckFailed
+        exp_alerts: []
+      - eval_time: 10m
+        alertname: VirtLauncherPodsStuckFailed
+        exp_alerts:
+          - exp_annotations:
+              summary: "At least 200 virt-launcher pods are stuck in Failed state and not deleted for 10 minutes."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtLauncherPodsStuckFailed"
+            exp_labels:
+              severity: "critical"
+              operator_health_impact: "critical"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+              namespace: "ci"
 
   # Excessive VMI Migrations in a period of time
   - interval: 1h

--- a/pkg/monitoring/rules/alerts/virt-controller.go
+++ b/pkg/monitoring/rules/alerts/virt-controller.go
@@ -96,6 +96,22 @@ func virtControllerAlerts(namespace string) []promv1.Rule {
 			},
 		},
 		{
+			// Cluster-wide count of failed virt-launcher pods, not a
+			// per-namespace alert. Do not sum by namespace: that would
+			// split the 200-pod threshold across VM namespaces. The
+			// install namespace is applied as a static label in Register().
+			Alert: "VirtLauncherPodsStuckFailed",
+			Expr:  intstr.FromString("sum(kube_pod_status_phase{phase='Failed', pod=~'virt-launcher-.*'}) >= 200"),
+			For:   ptr.To(promv1.Duration("10m")),
+			Annotations: map[string]string{
+				summaryAnnotationKey: "At least 200 virt-launcher pods are stuck in Failed state and not deleted for 10 minutes.",
+			},
+			Labels: map[string]string{
+				severityAlertLabelKey:        "critical",
+				operatorHealthImpactLabelKey: "critical",
+			},
+		},
+		{
 			Alert: "VirtControllerRESTErrorsBurst",
 			Expr:  intstr.FromString(getErrorRatio(namespace, "virt-controller", "(4|5)[0-9][0-9]", fiveMinutes) + " >= 0.8"),
 			For:   ptr.To(promv1.Duration("5m")),

--- a/pkg/monitoring/rules/alerts/virt-handler.go
+++ b/pkg/monitoring/rules/alerts/virt-handler.go
@@ -68,6 +68,26 @@ func virtHandlerAlerts(namespace string) []promv1.Rule {
 			},
 		},
 		{
+			// Node-level virt-handler gap, not a per-VM alert. Aggregate by
+			// node only so virt-launcher namespaces cannot split the series
+			// and produce false positives. The install namespace is applied
+			// as a static label in Register().
+			Alert: "OrphanedVirtualMachineInstances",
+			Expr: intstr.FromString(
+				"(((max by (node) (kube_pod_status_ready{condition='true',pod=~'virt-handler.*'} " +
+					"* on(pod) group_left(node) max by(pod,node)(kube_pod_info{pod=~'virt-handler.*',node!=''})) ) == 1) " +
+					"or (count by (node)( kube_pod_info{pod=~'virt-launcher.*',node!=''})*0)) == 0",
+			),
+			For: ptr.To(promv1.Duration("10m")),
+			Annotations: map[string]string{
+				summaryAnnotationKey: "No ready virt-handler pod detected on node {{ $labels.node }} with running vmis for more than 10 minutes",
+			},
+			Labels: map[string]string{
+				severityAlertLabelKey:        "warning",
+				operatorHealthImpactLabelKey: "warning",
+			},
+		},
+		{
 			Alert: "VirtHandlerDaemonSetRolloutFailing",
 			Expr: intstr.FromString(
 				fmt.Sprintf("(%s - %s) != 0",

--- a/pkg/monitoring/rules/alerts/vms.go
+++ b/pkg/monitoring/rules/alerts/vms.go
@@ -37,34 +37,6 @@ const excludedFilesystemTypesRegex = "CDFS|iso9660|udf|squashfs|cramfs|tmpfs|dev
 
 var vmsAlerts = []promv1.Rule{
 	{
-		Alert: "VirtLauncherPodsStuckFailed",
-		Expr:  intstr.FromString("sum by (namespace) (kube_pod_status_phase{phase='Failed', pod=~'virt-launcher-.*'}) >= 200"),
-		For:   ptr.To(promv1.Duration("10m")),
-		Annotations: map[string]string{
-			summaryAnnotationKey: "At least 200 virt-launcher pods are stuck in Failed state and not deleted for 10 minutes.",
-		},
-		Labels: map[string]string{
-			severityAlertLabelKey:        "critical",
-			operatorHealthImpactLabelKey: "critical",
-		},
-	},
-	{
-		Alert: "OrphanedVirtualMachineInstances",
-		Expr: intstr.FromString(
-			"(((max by (namespace, node) (kube_pod_status_ready{condition='true',pod=~'virt-handler.*'} " +
-				"* on(pod, namespace) group_left(node) max by(namespace,pod,node)(kube_pod_info{pod=~'virt-handler.*',node!=''})) ) == 1) " +
-				"or (count by (namespace, node)( kube_pod_info{pod=~'virt-launcher.*',node!=''})*0)) == 0",
-		),
-		For: ptr.To(promv1.Duration("10m")),
-		Annotations: map[string]string{
-			summaryAnnotationKey: "No ready virt-handler pod detected on node {{ $labels.node }} with running vmis for more than 10 minutes",
-		},
-		Labels: map[string]string{
-			severityAlertLabelKey:        "warning",
-			operatorHealthImpactLabelKey: "warning",
-		},
-	},
-	{
 		Alert: "VMCannotBeEvicted",
 		Expr: intstr.FromString(
 			"kubevirt_vmi_non_evictable * on(name, namespace) group_left() " +


### PR DESCRIPTION
## What this PR does

Treat `OrphanedVirtualMachineInstances` and
`VirtLauncherPodsStuckFailed` as cluster/node
component alerts.

#17995 added `namespace` to their PromQL so they
would carry a namespace label. That split series
across VM namespaces:

- `OrphanedVirtualMachineInstances` fired once
  per VM namespace even when virt-handler was
  ready ([CNV-95456](https://redhat.atlassian.net/browse/CNV-95456)).
- `VirtLauncherPodsStuckFailed` required 200
  failed launchers in a single namespace instead
  of cluster-wide
  ([CNV-95457](https://redhat.atlassian.net/browse/CNV-95457)).

Restore node/cluster aggregation and stamp the
KubeVirt install namespace as a static label in
`Register()`.

## Why we need it

False-positive `OrphanedVirtualMachineInstances`
alerts have `operator_health_impact=warning` and
mark OpenShift Virtualization as Degraded.

## Special notes for your reviewer

Both alerts still have a `namespace` label. It
comes from `Register()` (install namespace), not
from virt-launcher series.

## Checklist

This patch:

- [x] Fixes 1 or more issues
- [x] Adds tests
- [ ] Is documentation only
- [ ] Is a user API change

```release-note
Fix OrphanedVirtualMachineInstances false positives and VirtLauncherPodsStuckFailed per-namespace threshold by restoring cluster-scoped evaluation with a static install-namespace label
```

Fixes:
Jira-URL: https://redhat.atlassian.net/browse/CNV-95456
Jira-URL: https://redhat.atlassian.net/browse/CNV-95457

Signed-off-by: Shirly Radco <sradco@redhat.com>
Co-authored-by: AI Assistant <noreply@cursor.com>