### PR TITLE
Use PVC preallocation status instead of file-size heuristic for offline disk expansion

### DIFF
--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -159,6 +159,11 @@ func SetDriverCacheMode(disk *api.Disk, directIOChecker DirectIOChecker) error {
 	return nil
 }
 
+// Deprecated: this is not a reliable signal of a volume's declared
+// preallocation. It only reflects whether the backing file happens to be
+// fully allocated right now, and a thin-provisioned disk that is simply
+// full evaluates to true - exactly the case CNV-95002 hit. Read
+// VolumeStatus.PersistentVolumeClaimInfo.Preallocated instead.
 func IsPreAllocated(path string) bool {
 	diskInf, err := disk.GetDiskInfo(path)
 	if err != nil {

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -1045,7 +1045,7 @@ func (l *LibvirtDomainManager) preStartHook(vmi *v1.VirtualMachineInstance, doma
 		if err != nil {
 			return domain, err
 		}
-		converter.SetOptimalIOMode(&domain.Spec.Devices.Disks[i], converter.IsPreAllocated)
+		converter.SetOptimalIOMode(&domain.Spec.Devices.Disks[i], converter.IsPreAllocated) //nolint:staticcheck
 	}
 
 	if err := l.credManager.HandleQemuAgentAccessCredentials(vmi); err != nil {
@@ -1604,7 +1604,7 @@ func (l *LibvirtDomainManager) syncDisks(
 		if err != nil {
 			return err
 		}
-		converter.SetOptimalIOMode(&attachDisk, converter.IsPreAllocated)
+		converter.SetOptimalIOMode(&attachDisk, converter.IsPreAllocated) //nolint:staticcheck
 
 		attachBytes, err := xml.Marshal(attachDisk)
 		if err != nil {

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -1067,10 +1067,20 @@ func isPVCBacked(volumeName string, vmi *v1.VirtualMachineInstance) bool {
 	return false
 }
 
+func isPVCPreallocated(volumeName string, vmi *v1.VirtualMachineInstance) bool {
+	for _, vs := range vmi.Status.VolumeStatus {
+		if vs.Name == volumeName && vs.PersistentVolumeClaimInfo != nil {
+			return vs.PersistentVolumeClaimInfo.Preallocated
+		}
+	}
+	return false
+}
+
 func expandDiskImagesOffline(vmi *v1.VirtualMachineInstance, domain *api.Domain) {
 	logger := log.Log.Object(vmi)
 	for _, disk := range domain.Spec.Devices.Disks {
-		if !isPVCBacked(disk.Alias.GetName(), vmi) {
+		volumeName := disk.Alias.GetName()
+		if !isPVCBacked(volumeName, vmi) {
 			continue
 		}
 		if shouldExpandOffline(disk) {
@@ -1080,7 +1090,7 @@ func expandDiskImagesOffline(vmi *v1.VirtualMachineInstance, domain *api.Domain)
 				logger.Errorf("Failed to get possible guest size from disk")
 				continue
 			}
-			err := expandDiskImageOffline(ds.SourcePath(), possibleGuestSize)
+			err := expandDiskImageOffline(ds.SourcePath(), possibleGuestSize, isPVCPreallocated(volumeName, vmi))
 			if err != nil {
 				logger.Reason(err).Errorf("failed to expand disk image %v at boot", disk)
 			}
@@ -1088,20 +1098,33 @@ func expandDiskImagesOffline(vmi *v1.VirtualMachineInstance, domain *api.Domain)
 	}
 }
 
-func expandDiskImageOffline(imagePath string, size int64) error {
-	log.Log.Infof("pre-start expansion of image %s to size %d", imagePath, size)
+func qemuImgResizeArgs(imagePath string, size int64, preallocated bool) ([]string, error) {
 	var preallocateFlag string
-	if converter.IsPreAllocated(imagePath) {
+	if preallocated {
 		preallocateFlag = "--preallocation=falloc"
 	} else {
 		preallocateFlag = "--preallocation=off"
 	}
 	size = kutil.AlignImageSizeTo1MiB(size, log.Log.With("image", imagePath))
 	if size == 0 {
-		return fmt.Errorf("%s must be at least 1MiB", imagePath)
+		return nil, fmt.Errorf("%s must be at least 1MiB", imagePath)
 	}
-	cmd := exec.Command("/usr/bin/qemu-img", "resize", preallocateFlag, imagePath, strconv.FormatInt(size, 10))
-	out, err := cmd.CombinedOutput()
+	return []string{"resize", preallocateFlag, imagePath, strconv.FormatInt(size, 10)}, nil
+}
+
+// runQemuImgResize is a variable so tests can substitute it and observe the
+// args qemu-img would be invoked with, without running the real binary.
+var runQemuImgResize = func(args []string) ([]byte, error) {
+	return exec.Command("/usr/bin/qemu-img", args...).CombinedOutput()
+}
+
+func expandDiskImageOffline(imagePath string, size int64, preallocated bool) error {
+	log.Log.Infof("pre-start expansion of image %s to size %d", imagePath, size)
+	args, err := qemuImgResizeArgs(imagePath, size, preallocated)
+	if err != nil {
+		return err
+	}
+	out, err := runQemuImgResize(args)
 	if err != nil {
 		return fmt.Errorf("expanding image failed with error: %v, output: %s", err, out)
 	}

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -28,6 +28,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 
@@ -51,6 +52,8 @@ import (
 	"kubevirt.io/kubevirt/pkg/ephemeral-disk/fake"
 	cmdv1 "kubevirt.io/kubevirt/pkg/handler-launcher-com/cmd/v1"
 	hostdisk "kubevirt.io/kubevirt/pkg/host-disk"
+	"kubevirt.io/kubevirt/pkg/libvmi"
+	libvmistatus "kubevirt.io/kubevirt/pkg/libvmi/status"
 	"kubevirt.io/kubevirt/pkg/liveupdate/memory"
 	osdisk "kubevirt.io/kubevirt/pkg/os/disk"
 	virtpointer "kubevirt.io/kubevirt/pkg/pointer"
@@ -4337,6 +4340,61 @@ var _ = Describe("Manager helper functions", func() {
 				},
 			}
 			Expect(isPVCBacked("nonexistent", vmi)).To(BeFalse())
+		})
+	})
+
+	Context("expandDiskImageOffline preallocation flag", func() {
+		const (
+			volumeName = "pvc-disk"
+			imagePath  = "/data/disk.img"
+			newSize    = 2 * 1024 * 1024
+		)
+
+		var (
+			origRunQemuImgResize func([]string) ([]byte, error)
+			capturedArgs         []string
+		)
+
+		BeforeEach(func() {
+			origRunQemuImgResize = runQemuImgResize
+			capturedArgs = nil
+			runQemuImgResize = func(args []string) ([]byte, error) {
+				capturedArgs = args
+				return nil, nil
+			}
+		})
+
+		AfterEach(func() {
+			runQemuImgResize = origRunQemuImgResize
+		})
+
+		expandedPVCVMI := func(preallocated bool) *v1.VirtualMachineInstance {
+			return libvmi.New(
+				libvmistatus.WithStatus(libvmistatus.New(
+					libvmistatus.WithVolumeStatus(v1.VolumeStatus{
+						Name: volumeName,
+						PersistentVolumeClaimInfo: &v1.PersistentVolumeClaimInfo{
+							Preallocated: preallocated,
+						},
+					}),
+				)),
+			)
+		}
+
+		It("should request --preallocation=falloc when the PVC is preallocated", func() {
+			vmi := expandedPVCVMI(true)
+
+			Expect(expandDiskImageOffline(imagePath, newSize, isPVCPreallocated(volumeName, vmi))).To(Succeed())
+
+			Expect(capturedArgs).To(ConsistOf("resize", "--preallocation=falloc", imagePath, strconv.FormatInt(newSize, 10)))
+		})
+
+		It("should request --preallocation=off when the PVC is not preallocated", func() {
+			vmi := expandedPVCVMI(false)
+
+			Expect(expandDiskImageOffline(imagePath, newSize, isPVCPreallocated(volumeName, vmi))).To(Succeed())
+
+			Expect(capturedArgs).To(ConsistOf("resize", "--preallocation=off", imagePath, strconv.FormatInt(newSize, 10)))
 		})
 	})
 


### PR DESCRIPTION
virt-launcher decided whether to pass --preallocation=falloc or --preallocation=off to `qemu-img resize` during offline PVC expansion by comparing the disk's virtual size to its actual allocated size (converter.IsPreAllocated). That heuristic incorrectly evaluates to "preallocated" for thin-provisioned disks that happen to be full, which is exactly the case that triggers a PVC expansion in the first place, forcing unnecessary preallocation of the expanded space.

Use the PVC/DV's actual preallocation status instead, sourced from the cdi.kubevirt.io/storage.preallocation (or storage.thick-provisioned) annotation via VolumeStatus.PersistentVolumeClaimInfo.Preallocated, which virt-handler already surfaces to virt-launcher as
options.PreallocatedVolumes for the discard=unmap decision.

Fixes CNV-95002.

### What this PR does
#### Before this PR:
Full thin disks that are extended get preallocated extension space

#### After this PR:
Keen thin disks thin.

### References
- Fixes CNV-95002

### Special notes for your reviewer

Considered to add tests, but for full end to end testing it would need qemu-img. Also considered extracting the qemu img argument build into a separate function and testing the --prealloc option, but thats not a full end to end test.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [X] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [X] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [?] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [X] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [X] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
Fix PVC expansion preallocating new space on full thin provisioned disks
```

