### PR TITLE
Pass through NUMA node distances in guest topology

### DIFF
--- a/pkg/virt-launcher/virtwrap/converter/vcpu/numa_placement_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/vcpu/numa_placement_test.go
@@ -128,6 +128,84 @@ var _ = Describe("NumaPlacement", func() {
 			Expect(givenSpec.MemoryBacking).To(Equal(expectedMemoryBacking))
 		})
 
+		It("should pass through NUMA distances with three nodes", func() {
+			var err error
+			givenSpec.Memory, err = QuantityToByte(resource.MustParse("66Mi"))
+			Expect(err).ToNot(HaveOccurred())
+			givenSpec.CPUTune.VCPUPin = append(givenSpec.CPUTune.VCPUPin, api.CPUTuneVCPUPin{
+				VCPU: 4, CPUSet: "40",
+			})
+			givenTopology.NumaCells = append(givenTopology.NumaCells, &cmdv1.Cell{
+				Id: 5,
+				Cpus: []*cmdv1.CPU{
+					{Id: 40},
+				},
+			})
+
+			givenTopology.NumaCells[0].Distances = []*cmdv1.Sibling{
+				{Id: 0, Value: 10},
+				{Id: 4, Value: 20},
+				{Id: 5, Value: 30},
+			}
+			givenTopology.NumaCells[1].Distances = []*cmdv1.Sibling{
+				{Id: 0, Value: 20},
+				{Id: 4, Value: 10},
+				{Id: 5, Value: 20},
+			}
+			givenTopology.NumaCells[2].Distances = []*cmdv1.Sibling{
+				{Id: 0, Value: 30},
+				{Id: 4, Value: 20},
+				{Id: 5, Value: 10},
+			}
+
+			Expect(numaMapping(givenVMI, givenSpec, givenTopology)).To(Succeed())
+
+			Expect(givenSpec.CPU.NUMA.Cells[0].Distances).To(Equal(&api.NUMACellDistances{Siblings: []api.NUMACellSibling{
+				{ID: "0", Value: 10},
+				{ID: "1", Value: 20},
+				{ID: "2", Value: 30},
+			}}))
+			Expect(givenSpec.CPU.NUMA.Cells[1].Distances).To(Equal(&api.NUMACellDistances{Siblings: []api.NUMACellSibling{
+				{ID: "0", Value: 20},
+				{ID: "1", Value: 10},
+				{ID: "2", Value: 20},
+			}}))
+			Expect(givenSpec.CPU.NUMA.Cells[2].Distances).To(Equal(&api.NUMACellDistances{Siblings: []api.NUMACellSibling{
+				{ID: "0", Value: 30},
+				{ID: "1", Value: 20},
+				{ID: "2", Value: 10},
+			}}))
+		})
+
+		It("should filter out non-mapped host NUMA distances", func() {
+			givenTopology.NumaCells[0].Distances = []*cmdv1.Sibling{
+				{Id: 0, Value: 10},
+				{Id: 2, Value: 15},
+				{Id: 4, Value: 20},
+			}
+			givenTopology.NumaCells[1].Distances = []*cmdv1.Sibling{
+				{Id: 0, Value: 20},
+				{Id: 2, Value: 15},
+				{Id: 4, Value: 10},
+			}
+
+			expectedSpec.CPU.NUMA.Cells = []api.NUMACell{
+				{ID: "0", CPUs: "0,1", Memory: &MiBInBytes_32, Unit: "b",
+					Distances: &api.NUMACellDistances{Siblings: []api.NUMACellSibling{
+						{ID: "0", Value: 10},
+						{ID: "1", Value: 20},
+					}}},
+				{ID: "1", CPUs: "3", Memory: &MiBInBytes_32, Unit: "b",
+					Distances: &api.NUMACellDistances{Siblings: []api.NUMACellSibling{
+						{ID: "0", Value: 20},
+						{ID: "1", Value: 10},
+					}}},
+			}
+
+			Expect(numaMapping(givenVMI, givenSpec, givenTopology)).To(Succeed())
+			Expect(givenSpec.CPU).To(Equal(expectedSpec.CPU))
+		})
+
 		It("should detect if not enough memory is requested", func() {
 			var err error
 			memory := resource.MustParse("2Mi")

--- a/pkg/virt-launcher/virtwrap/converter/vcpu/vcpu.go
+++ b/pkg/virt-launcher/virtwrap/converter/vcpu/vcpu.go
@@ -671,31 +671,56 @@ func numaMapping(vmi *v12.VirtualMachineInstance, domain *api.DomainSpec, topolo
 		memoryBytes = memoryBytes - mod*hugepagesSize
 	}
 
-	virtualCellID := -1
+	hostToGuest := map[uint32]int{}
+	id := 0
+	for _, cell := range topology.NumaCells {
+		if _, exists := numamap[cell.Id]; exists {
+			hostToGuest[cell.Id] = id
+			id++
+		}
+	}
+
 	for _, cell := range topology.NumaCells {
 		if vcpus, exists := numamap[cell.Id]; exists {
 			var cpus []string
 			for _, cpu := range vcpus {
 				cpus = append(cpus, strconv.Itoa(int(cpu)))
 			}
-			virtualCellID++
+			guestCellID := hostToGuest[cell.Id]
+
+			var distances *api.NUMACellDistances
+			if len(cell.Distances) > 0 {
+				var siblings []api.NUMACellSibling
+				for _, hostSibling := range cell.Distances {
+					if guestSiblingID, exists := hostToGuest[hostSibling.Id]; exists {
+						siblings = append(siblings, api.NUMACellSibling{
+							ID:    strconv.Itoa(guestSiblingID),
+							Value: hostSibling.Value,
+						})
+					}
+				}
+				if len(siblings) > 0 {
+					distances = &api.NUMACellDistances{Siblings: siblings}
+				}
+			}
 
 			cellMemory := memoryBytes / uint64(len(numamap))
 			domain.CPU.NUMA.Cells = append(domain.CPU.NUMA.Cells, api.NUMACell{
-				ID:     strconv.Itoa(virtualCellID),
-				CPUs:   strings.Join(cpus, ","),
-				Memory: &cellMemory,
-				Unit:   memory.Unit,
+				ID:        strconv.Itoa(guestCellID),
+				CPUs:      strings.Join(cpus, ","),
+				Memory:    &cellMemory,
+				Unit:      memory.Unit,
+				Distances: distances,
 			})
 			domain.NUMATune.MemNodes = append(domain.NUMATune.MemNodes, api.MemNode{
-				CellID:  uint32(virtualCellID),
+				CellID:  uint32(guestCellID),
 				Mode:    "strict",
 				NodeSet: strconv.Itoa(int(cell.Id)),
 			})
 			domain.MemoryBacking.HugePages.HugePage = append(domain.MemoryBacking.HugePages.HugePage, api.HugePage{
 				Size:    strconv.Itoa(int(hugepagesSize)),
 				Unit:    hugepagesUnit,
-				NodeSet: strconv.Itoa(virtualCellID),
+				NodeSet: strconv.Itoa(guestCellID),
 			})
 		}
 	}


### PR DESCRIPTION
  ### What this PR does
  #### Before this PR:
  The `numaMapping` function in the converter builds guest NUMA cells with ID, CPUs, Memory, and Unit but does not propagate inter-node distances from the host topology. VMs spanning three or more NUMA nodes see all remote nodes as equidistant, preventing performance-sensitive applications from making optimal scheduling decisions.

  #### After this PR:
  NUMA node distances from the host are read from the protobuf topology, host node IDs are translated to sequential guest IDs, and the `Distances` field is populated on each `NUMACell`. The guest OS now sees the real distance matrix and can make smarter memory allocation decisions.

 

  ### Why we need it and why it was done in this way
  The following tradeoffs were made:
  - Distances are always passed through when available, rather than requiring an opt-in flag. This matches how other NUMA cell properties (CPUs, memory) are already handled.

  The following alternatives were considered:
  - None at this time. The approach follows the existing pattern for NUMA cell properties which are always passed through when available.

  ### Special notes for your reviewer
  The infrastructure for NUMA distances was already in place:
  - `virt-handler` reads distances from host libvirt capabilities
  - Protobuf `Cell.Distances` carries them to virt-launcher
  - `NUMACell.Distances` struct exists in `schema.go`
  - `libvirtxml/convert.go` already handles the conversion to XML

  The only missing piece was reading and translating distances in `numaMapping()`.

  ### Checklist
  - [x] PR: The PR description is expressive enough and will help future contributors
  - [x] Code: Write code that humans can understand and Keep it simple
  - [x] Testing: New code requires new unit tests. New features and bug fixes require at least one e2e test
  - [x] AI Contributions: The PR abides by the KubeVirt AI Contribution Policy.

  ### Release note
  ```release-note
  Added NUMA node distance passthrough from host topology to guest VMs, enabling performance-sensitive applications to make optimal scheduling decisions on multi-NUMA systems.
  ```