### PR TITLE
Adding kubevirt_vmi_resource_requests metric

### DIFF
--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -84,6 +84,7 @@
 | kubevirt_vmi_phase_transition_time_from_creation_seconds | Metric | Histogram | Histogram of VM phase transitions duration from creation time in seconds. |
 | kubevirt_vmi_phase_transition_time_from_deletion_seconds | Metric | Histogram | Histogram of VM phase transitions duration from deletion time in seconds. |
 | kubevirt_vmi_phase_transition_time_seconds | Metric | Histogram | Histogram of VM phase transitions duration between different phases in seconds. |
+| kubevirt_vmi_resource_requests | Metric | Gauge | Resources requested by Virtual Machine Instance. Reports memory and CPU requests from the VMI specification and from the virt-launcher pod. |
 | kubevirt_vmi_status_addresses | Metric | Gauge | The addresses of a VirtualMachineInstance. This metric provides the address of an available network interface associated with the VMI in the 'address' label, and about the type of address, such as internal IP, in the 'type' label. |
 | kubevirt_vmi_storage_flush_requests_total | Metric | Counter | Total storage flush requests. |
 | kubevirt_vmi_storage_flush_times_seconds_total | Metric | Counter | Total time spent on cache flushing. |

--- a/pkg/monitoring/metrics/virt-controller/vmistats_collector.go
+++ b/pkg/monitoring/metrics/virt-controller/vmistats_collector.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/rhobs/operator-observability-toolkit/pkg/operatormetrics"
 	k8sv1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/cache"
@@ -36,8 +37,10 @@ import (
 	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/hypervisor"
 	netresources "kubevirt.io/kubevirt/pkg/network/resources"
+	"kubevirt.io/kubevirt/pkg/util/hardware"
 	"kubevirt.io/kubevirt/pkg/util/migrations"
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter/vcpu"
 )
 
 const (
@@ -47,6 +50,7 @@ const (
 
 	annotationPrefix        = "vm.kubevirt.io/"
 	instancetypeVendorLabel = "instancetype.kubevirt.io/vendor"
+	computeContainerName    = "compute"
 )
 
 var (
@@ -64,6 +68,7 @@ var (
 			vmiMigrationEndTime,
 			vmiVnicInfo,
 			vmiLauncherMemoryOverhead,
+			vmiResourceRequests,
 		},
 		CollectCallback: vmiStatsCollectorCallback,
 	}
@@ -139,6 +144,14 @@ var (
 		},
 		[]string{"namespace", "name"},
 	)
+
+	vmiResourceRequests = operatormetrics.NewGaugeVec(
+		operatormetrics.MetricOpts{
+			Name: "kubevirt_vmi_resource_requests",
+			Help: "Resources requested by Virtual Machine Instance. Reports memory and CPU requests from the VMI specification and from the virt-launcher pod.",
+		},
+		[]string{"name", "namespace", "resource", "unit", "source"},
+	)
 )
 
 func vmiStatsCollectorCallback() []operatormetrics.CollectorResult {
@@ -166,6 +179,7 @@ func reportVmisStats(vmis []*k6tv1.VirtualMachineInstance) []operatormetrics.Col
 		crs = append(crs, collectVMIMigrationTime(vmi)...)
 		crs = append(crs, CollectVmisVnicInfo(vmi)...)
 		crs = append(crs, collectVMILauncherMemoryOverhead(vmi))
+		crs = append(crs, collectVMIResourceRequests(vmi)...)
 	}
 
 	return crs
@@ -274,9 +288,22 @@ func getVMIMachine(vmi *k6tv1.VirtualMachineInstance) (guestOSMachineType string
 }
 
 func getVMIPod(vmi *k6tv1.VirtualMachineInstance) string {
+	pod := findRunningVMIPod(vmi)
+	if pod == nil {
+		return none
+	}
+
+	return pod.Name
+}
+
+func findRunningVMIPod(vmi *k6tv1.VirtualMachineInstance) *k8sv1.Pod {
+	if indexers == nil || indexers.KVPod == nil {
+		return nil
+	}
+
 	objs, err := indexers.KVPod.ByIndex(cache.NamespaceIndex, vmi.Namespace)
 	if err != nil {
-		return none
+		return nil
 	}
 
 	for _, obj := range objs {
@@ -285,14 +312,14 @@ func getVMIPod(vmi *k6tv1.VirtualMachineInstance) string {
 			continue
 		}
 
-		if pod.Labels["kubevirt.io/created-by"] == string(vmi.UID) && pod.Status.Phase == k8sv1.PodRunning {
+		if pod.Labels[k6tv1.CreatedByLabel] == string(vmi.UID) && pod.Status.Phase == k8sv1.PodRunning {
 			if vmi.Status.NodeName == pod.Spec.NodeName {
-				return pod.Name
+				return pod
 			}
 		}
 	}
 
-	return none
+	return nil
 }
 
 func getVMIInstancetype(vmi *k6tv1.VirtualMachineInstance) string {
@@ -501,4 +528,195 @@ func CollectVmisVnicInfo(vmi *k6tv1.VirtualMachineInstance) []operatormetrics.Co
 	}
 
 	return results
+}
+
+func collectVMIResourceRequests(vmi *k6tv1.VirtualMachineInstance) []operatormetrics.CollectorResult {
+	var results []operatormetrics.CollectorResult
+
+	results = append(results, collectVMIMemoryResourceRequests(vmi)...)
+	results = append(results, collectVMICPUResourceRequestsFromDomainCPU(vmi)...)
+	results = append(results, collectVMICPUResourceRequestsFromDomainResources(vmi)...)
+	results = append(results, collectVMIAllocatedCPUValues(vmi)...)
+	results = append(results, collectVMIAllocatedMemoryValues(vmi)...)
+	results = append(results, collectVMIPodResourceRequests(vmi)...)
+
+	return results
+}
+
+func collectVMIMemoryResourceRequests(vmi *k6tv1.VirtualMachineInstance) []operatormetrics.CollectorResult {
+	var cr []operatormetrics.CollectorResult
+
+	memoryRequested := vmi.Spec.Domain.Resources.Requests.Memory()
+	if !memoryRequested.IsZero() {
+		cr = append(cr, operatormetrics.CollectorResult{
+			Metric: vmiResourceRequests,
+			Value:  float64(memoryRequested.Value()),
+			Labels: []string{vmi.Name, vmi.Namespace, "memory", "bytes", "domain"},
+		})
+	}
+
+	if vmi.Spec.Domain.Memory == nil {
+		return cr
+	}
+
+	guestMemory := vmi.Spec.Domain.Memory.Guest
+	if guestMemory != nil && !guestMemory.IsZero() {
+		cr = append(cr, operatormetrics.CollectorResult{
+			Metric: vmiResourceRequests,
+			Value:  float64(guestMemory.Value()),
+			Labels: []string{vmi.Name, vmi.Namespace, "memory", "bytes", "guest"},
+		})
+	}
+
+	hugepagesMemory := vmi.Spec.Domain.Memory.Hugepages
+	if hugepagesMemory != nil {
+		quantity, err := resource.ParseQuantity(hugepagesMemory.PageSize)
+		if err == nil {
+			cr = append(cr, operatormetrics.CollectorResult{
+				Metric: vmiResourceRequests,
+				Value:  float64(quantity.Value()),
+				Labels: []string{vmi.Name, vmi.Namespace, "memory", "bytes", "hugepages"},
+			})
+		}
+	}
+
+	return cr
+}
+
+func collectVMICPUResourceRequestsFromDomainCPU(vmi *k6tv1.VirtualMachineInstance) []operatormetrics.CollectorResult {
+	var cr []operatormetrics.CollectorResult
+
+	if vmi.Spec.Domain.CPU == nil {
+		return cr
+	}
+
+	if vmi.Spec.Domain.CPU.Cores != 0 {
+		cr = append(cr, operatormetrics.CollectorResult{
+			Metric: vmiResourceRequests,
+			Value:  float64(vmi.Spec.Domain.CPU.Cores),
+			Labels: []string{vmi.Name, vmi.Namespace, "cpu", "cores", "domain"},
+		})
+	}
+	if vmi.Spec.Domain.CPU.Threads != 0 {
+		cr = append(cr, operatormetrics.CollectorResult{
+			Metric: vmiResourceRequests,
+			Value:  float64(vmi.Spec.Domain.CPU.Threads),
+			Labels: []string{vmi.Name, vmi.Namespace, "cpu", "threads", "domain"},
+		})
+	}
+	if vmi.Spec.Domain.CPU.Sockets != 0 {
+		cr = append(cr, operatormetrics.CollectorResult{
+			Metric: vmiResourceRequests,
+			Value:  float64(vmi.Spec.Domain.CPU.Sockets),
+			Labels: []string{vmi.Name, vmi.Namespace, "cpu", "sockets", "domain"},
+		})
+	}
+	return cr
+}
+
+func collectVMICPUResourceRequestsFromDomainResources(vmi *k6tv1.VirtualMachineInstance) []operatormetrics.CollectorResult {
+	var cr []operatormetrics.CollectorResult
+
+	cpuRequests := vmi.Spec.Domain.Resources.Requests.Cpu()
+	if cpuRequests == nil || cpuRequests.IsZero() {
+		// If no CPU requests and no Domain CPU are set, default to 1 thread with 1 core and 1 socket
+		if vmi.Spec.Domain.CPU == nil {
+			return append(cr,
+				operatormetrics.CollectorResult{
+					Metric: vmiResourceRequests, Value: 1.0,
+					Labels: []string{vmi.Name, vmi.Namespace, "cpu", "cores", "default"},
+				},
+				operatormetrics.CollectorResult{
+					Metric: vmiResourceRequests, Value: 1.0,
+					Labels: []string{vmi.Name, vmi.Namespace, "cpu", "threads", "default"},
+				},
+				operatormetrics.CollectorResult{
+					Metric: vmiResourceRequests, Value: 1.0,
+					Labels: []string{vmi.Name, vmi.Namespace, "cpu", "sockets", "default"},
+				},
+			)
+		}
+		return cr
+	}
+
+	cr = append(cr, operatormetrics.CollectorResult{
+		Metric: vmiResourceRequests,
+		Value:  float64(cpuRequests.ScaledValue(resource.Milli)) / 1000,
+		Labels: []string{vmi.Name, vmi.Namespace, "cpu", "cores", "requests"},
+	})
+	return cr
+}
+
+func collectVMIAllocatedCPUValues(vmi *k6tv1.VirtualMachineInstance) []operatormetrics.CollectorResult {
+	var cr []operatormetrics.CollectorResult
+
+	if vmi.Spec.Domain.CPU != nil {
+		allocatedVCPUs := hardware.GetNumberOfVCPUs(vmi.Spec.Domain.CPU)
+		cr = append(cr, operatormetrics.CollectorResult{
+			Metric: vmiResourceRequests,
+			Value:  float64(allocatedVCPUs),
+			Labels: []string{vmi.Name, vmi.Namespace, "cpu", "cores", "guest_effective"},
+		})
+	} else {
+		cr = append(cr, operatormetrics.CollectorResult{
+			Metric: vmiResourceRequests,
+			Value:  1.0,
+			Labels: []string{vmi.Name, vmi.Namespace, "cpu", "cores", "guest_effective"},
+		})
+	}
+	return cr
+}
+
+func collectVMIAllocatedMemoryValues(vmi *k6tv1.VirtualMachineInstance) []operatormetrics.CollectorResult {
+	var cr []operatormetrics.CollectorResult
+
+	allocatedMemory := vcpu.GetVirtualMemory(vmi)
+	if allocatedMemory != nil && !allocatedMemory.IsZero() {
+		cr = append(cr, operatormetrics.CollectorResult{
+			Metric: vmiResourceRequests,
+			Value:  float64(allocatedMemory.Value()),
+			Labels: []string{vmi.Name, vmi.Namespace, "memory", "bytes", "guest_effective"},
+		})
+	}
+	return cr
+}
+
+func collectVMIPodResourceRequests(vmi *k6tv1.VirtualMachineInstance) []operatormetrics.CollectorResult {
+	pod := findRunningVMIPod(vmi)
+	if pod == nil {
+		return nil
+	}
+
+	var compute *k8sv1.Container
+	for i := range pod.Spec.Containers {
+		if pod.Spec.Containers[i].Name == computeContainerName {
+			compute = &pod.Spec.Containers[i]
+			break
+		}
+	}
+	if compute == nil {
+		return nil
+	}
+
+	var cr []operatormetrics.CollectorResult
+
+	memoryRequested := compute.Resources.Requests.Memory()
+	if memoryRequested != nil && !memoryRequested.IsZero() {
+		cr = append(cr, operatormetrics.CollectorResult{
+			Metric: vmiResourceRequests,
+			Value:  float64(memoryRequested.Value()),
+			Labels: []string{vmi.Name, vmi.Namespace, "memory", "bytes", "pod"},
+		})
+	}
+
+	cpuRequested := compute.Resources.Requests.Cpu()
+	if cpuRequested != nil && !cpuRequested.IsZero() {
+		cr = append(cr, operatormetrics.CollectorResult{
+			Metric: vmiResourceRequests,
+			Value:  float64(cpuRequested.ScaledValue(resource.Milli)) / 1000,
+			Labels: []string{vmi.Name, vmi.Namespace, "cpu", "cores", "pod"},
+		})
+	}
+
+	return cr
 }

--- a/pkg/monitoring/metrics/virt-controller/vmistats_collector_test.go
+++ b/pkg/monitoring/metrics/virt-controller/vmistats_collector_test.go
@@ -577,6 +577,203 @@ var _ = Describe("VMI Stats Collector", func() {
 			Expect(metric1.Value).To(BeNumerically("<", metric2.Value))
 		})
 	})
+
+	Context("VMI Resource Requests", func() {
+		const (
+			testMetricVMIResourceRequests = "kubevirt_vmi_resource_requests"
+			testVMIName                   = "test-vmi"
+			testVMINamespace              = "test-ns"
+		)
+
+		findRequest := func(crs []operatormetrics.CollectorResult, resourceName, unit, source string) *operatormetrics.CollectorResult {
+			for i, cr := range crs {
+				if cr.Metric.GetOpts().Name == testMetricVMIResourceRequests &&
+					len(cr.Labels) == 5 &&
+					cr.Labels[0] == testVMIName && cr.Labels[1] == testVMINamespace &&
+					cr.Labels[2] == resourceName && cr.Labels[3] == unit && cr.Labels[4] == source {
+					return &crs[i]
+				}
+			}
+			return nil
+		}
+
+		It("should report default CPU when no CPU topology is set", func() {
+			vmi := &k6tv1.VirtualMachineInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testVMIName,
+					Namespace: testVMINamespace,
+				},
+			}
+
+			crs := collectVMIResourceRequests(vmi)
+
+			Expect(findRequest(crs, "cpu", "cores", "default")).ToNot(BeNil())
+			Expect(findRequest(crs, "cpu", "threads", "default").Value).To(BeEquivalentTo(1))
+			Expect(findRequest(crs, "cpu", "sockets", "default").Value).To(BeEquivalentTo(1))
+			Expect(findRequest(crs, "cpu", "cores", "guest_effective").Value).To(BeEquivalentTo(1))
+		})
+
+		It("should report guest and domain memory so overcommit can be compared", func() {
+			guestMemory := resource.MustParse("4Gi")
+			requestMemory := resource.MustParse("2Gi")
+			vmi := &k6tv1.VirtualMachineInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testVMIName,
+					Namespace: testVMINamespace,
+				},
+				Spec: k6tv1.VirtualMachineInstanceSpec{
+					Domain: k6tv1.DomainSpec{
+						Memory: &k6tv1.Memory{Guest: &guestMemory},
+						Resources: k6tv1.ResourceRequirements{
+							Requests: k8sv1.ResourceList{
+								k8sv1.ResourceMemory: requestMemory,
+							},
+						},
+					},
+				},
+			}
+
+			crs := collectVMIResourceRequests(vmi)
+
+			domain := findRequest(crs, "memory", "bytes", "domain")
+			Expect(domain).ToNot(BeNil())
+			Expect(domain.Value).To(BeEquivalentTo(float64(requestMemory.Value())))
+
+			guest := findRequest(crs, "memory", "bytes", "guest")
+			Expect(guest).ToNot(BeNil())
+			Expect(guest.Value).To(BeEquivalentTo(float64(guestMemory.Value())))
+
+			effective := findRequest(crs, "memory", "bytes", "guest_effective")
+			Expect(effective).ToNot(BeNil())
+			Expect(effective.Value).To(BeEquivalentTo(float64(guestMemory.Value())))
+		})
+
+		It("should collect domain CPU metrics and guest_effective from topology", func() {
+			vmi := &k6tv1.VirtualMachineInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testVMIName,
+					Namespace: testVMINamespace,
+				},
+				Spec: k6tv1.VirtualMachineInstanceSpec{
+					Domain: k6tv1.DomainSpec{
+						CPU: &k6tv1.CPU{
+							Cores:   2,
+							Threads: 4,
+							Sockets: 1,
+						},
+					},
+				},
+			}
+
+			crs := collectVMIResourceRequests(vmi)
+
+			Expect(findRequest(crs, "cpu", "cores", "domain").Value).To(BeEquivalentTo(2))
+			Expect(findRequest(crs, "cpu", "threads", "domain").Value).To(BeEquivalentTo(4))
+			Expect(findRequest(crs, "cpu", "sockets", "domain").Value).To(BeEquivalentTo(1))
+			Expect(findRequest(crs, "cpu", "cores", "guest_effective").Value).To(BeEquivalentTo(8))
+			Expect(findRequest(crs, "cpu", "cores", "default")).To(BeNil())
+		})
+
+		It("should collect CPU requests when resources are set", func() {
+			vmi := &k6tv1.VirtualMachineInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testVMIName,
+					Namespace: testVMINamespace,
+				},
+				Spec: k6tv1.VirtualMachineInstanceSpec{
+					Domain: k6tv1.DomainSpec{
+						Resources: k6tv1.ResourceRequirements{
+							Requests: k8sv1.ResourceList{
+								k8sv1.ResourceCPU: *resource.NewMilliQuantity(500, resource.BinarySI),
+							},
+						},
+					},
+				},
+			}
+
+			crs := collectVMIResourceRequests(vmi)
+
+			req := findRequest(crs, "cpu", "cores", "requests")
+			Expect(req).ToNot(BeNil())
+			Expect(req.Value).To(BeEquivalentTo(0.5))
+			Expect(findRequest(crs, "cpu", "cores", "guest_effective").Value).To(BeEquivalentTo(1))
+		})
+
+		It("should collect hugepages memory", func() {
+			vmi := &k6tv1.VirtualMachineInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testVMIName,
+					Namespace: testVMINamespace,
+				},
+				Spec: k6tv1.VirtualMachineInstanceSpec{
+					Domain: k6tv1.DomainSpec{
+						Memory: &k6tv1.Memory{
+							Hugepages: &k6tv1.Hugepages{PageSize: "2Mi"},
+						},
+					},
+				},
+			}
+
+			crs := collectVMIResourceRequests(vmi)
+
+			hugepages := findRequest(crs, "memory", "bytes", "hugepages")
+			Expect(hugepages).ToNot(BeNil())
+			pageSize := resource.MustParse("2Mi")
+			Expect(hugepages.Value).To(BeEquivalentTo(float64(pageSize.Value())))
+		})
+
+		It("should collect virt-launcher pod resource requests", func() {
+			setupTestCollector()
+
+			vmi := &k6tv1.VirtualMachineInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testVMIName,
+					Namespace: testVMINamespace,
+					UID:       "test-vmi-resource-uid",
+				},
+				Status: k6tv1.VirtualMachineInstanceStatus{
+					NodeName: "test-node",
+				},
+			}
+
+			podMemory := resource.MustParse("2Gi")
+			podCPU := resource.MustParse("500m")
+			Expect(indexers.KVPod.Add(&k8sv1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "virt-launcher-test-vmi",
+					Namespace: testVMINamespace,
+					Labels:    map[string]string{k6tv1.CreatedByLabel: string(vmi.UID)},
+				},
+				Spec: k8sv1.PodSpec{
+					NodeName: "test-node",
+					Containers: []k8sv1.Container{
+						{
+							Name: computeContainerName,
+							Resources: k8sv1.ResourceRequirements{
+								Requests: k8sv1.ResourceList{
+									k8sv1.ResourceMemory: podMemory,
+									k8sv1.ResourceCPU:    podCPU,
+								},
+							},
+						},
+					},
+				},
+				Status: k8sv1.PodStatus{
+					Phase: k8sv1.PodRunning,
+				},
+			})).To(Succeed())
+
+			crs := collectVMIResourceRequests(vmi)
+
+			podMem := findRequest(crs, "memory", "bytes", "pod")
+			Expect(podMem).ToNot(BeNil())
+			Expect(podMem.Value).To(BeEquivalentTo(float64(podMemory.Value())))
+
+			podCPUResult := findRequest(crs, "cpu", "cores", "pod")
+			Expect(podCPUResult).ToNot(BeNil())
+			Expect(podCPUResult.Value).To(BeEquivalentTo(0.5))
+		})
+	})
 })
 
 func setupMigrationPods() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
KubeVirt exposed `kubevirt_vm_resource_requests` from the VM spec (guest memory, domain CPU, and so on), but there was no equivalent for a running VMI.
That made it impossible to compare guest-allocated CPU/memory with the actual VMI/pod request after memory overcommit. VMs that were already running keep a 1:1 request until they get a new VMI, so cluster overcommit config alone is not enough to know which workloads are actually overcommitted.

#### After this PR:
Adds `kubevirt_vmi_resource_requests`, collected by virt-controller, with the same label set as the VM metric: `name`, `namespace`, `resource`, `unit`, `source`.
It reports:
- VMI spec requests (`domain`, `guest`, `guest_effective`, hugepages, CPU topology/defaults)
- virt-launcher compute-container requests (`source=pod`), which is the value Kubernetes actually scheduled and therefore reflects overcommit applied when that VMI was created
Operators can now compute actual overcommit.
### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://redhat.atlassian.net/browse/CNV-64391
```

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Adding kubevirt_vmi_resource_requests metric
```

