### PR TITLE
snapshot: fall back to crash-consistent snapshot when filesystem freeze fails

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -22932,6 +22932,10 @@
      "error": {
       "$ref": "#/definitions/v1beta1.Error"
      },
+     "freezeFailures": {
+      "type": "integer",
+      "format": "int32"
+     },
      "readyToUse": {
       "type": "boolean"
      },

--- a/pkg/storage/snapshot/snapshot.go
+++ b/pkg/storage/snapshot/snapshot.go
@@ -68,6 +68,11 @@ const (
 	snapshotRetryInterval = 5 * time.Second
 
 	contentDeletionInterval = 5 * time.Second
+
+	// A freeze operation can normally take up to 60s to complete. During that
+	// time, each retry cycle takes ~15s (10s HTTP timeout + 5s reconcile interval),
+	// so 4 retries cover the 60s window, plus 2 for margin.
+	MaxFreezeRetries = 6
 )
 
 // Indication messages
@@ -76,6 +81,7 @@ var snapshotIndicationMessages = map[snapshotv1.Indication]string{
 	snapshotv1.VMSnapshotGuestAgentIndication:      "Guest agent was active and attempted to quiesce the filesystem for application consistency.",
 	snapshotv1.VMSnapshotNoGuestAgentIndication:    "Guest agent was not available. Snapshot is crash-consistent and may not be application-consistent.",
 	snapshotv1.VMSnapshotQuiesceTimeoutIndication:  "Guest agent quiesced the filesystem, but the freeze window timed out before completion. Snapshot is crash-consistent and may not be application-consistent.",
+	snapshotv1.VMSnapshotQuiesceFailedIndication:   "Filesystem quiescing failed after exhausting retries. Snapshot is crash-consistent and may not be application-consistent.",
 	snapshotv1.VMSnapshotPausedIndication:          "Snapshot taken while the VM was paused. Snapshot is crash-consistent and may not be application-consistent.",
 	snapshotv1.VMSnapshotPartialSnapshotIndication: "Not all snapshotable volumes were included in the snapshot. Check status.snapshotVolumes for excluded volumes and VM VolumeSnapshotStatus for details.",
 }
@@ -419,20 +425,28 @@ func (ctrl *VMSnapshotController) updateVMSnapshotContent(content *snapshotv1.Vi
 					return 0, fmt.Errorf("unable to get snapshot source")
 				}
 
-				if err := source.Freeze(); err != nil {
-					contentCpy.Status.Error = &snapshotv1.Error{
-						Time:    currentTime(),
-						Message: pointer.P(err.Error()),
+				if content.Status != nil && content.Status.FreezeFailures > 0 &&
+					content.Status.Error != nil && content.Status.Error.Time != nil {
+					if elapsed := time.Since(content.Status.Error.Time.Time); elapsed < snapshotRetryInterval {
+						return snapshotRetryInterval - elapsed, nil
 					}
-					contentCpy.Status.ReadyToUse = pointer.P(false)
-					// Retry again in 5 seconds
-					return 5 * time.Second, ctrl.updateVmSnapshotContentStatus(content, contentCpy)
 				}
 
-				// assuming that VM is frozen once Freeze() returns
-				// which should be the case
-				// if Freeze() were async, we'd have to return
-				// and only continue when source.Frozen() == true
+				if err := source.Freeze(); err != nil {
+					contentCpy.Status.FreezeFailures++
+
+					if contentCpy.Status.FreezeFailures >= MaxFreezeRetries {
+						log.Log.Warningf("Freeze failed after %d attempts for snapshot %s/%s, proceeding with crash-consistent snapshot: %v",
+							contentCpy.Status.FreezeFailures, vmSnapshot.Namespace, vmSnapshot.Name, err)
+					} else {
+						contentCpy.Status.Error = &snapshotv1.Error{
+							Time:    currentTime(),
+							Message: pointer.P(err.Error()),
+						}
+						contentCpy.Status.ReadyToUse = pointer.P(false)
+						return snapshotRetryInterval, ctrl.updateVmSnapshotContentStatus(content, contentCpy)
+					}
+				}
 
 				didFreeze = true
 			}
@@ -822,7 +836,7 @@ func (ctrl *VMSnapshotController) updateSnapshotStatus(vmSnapshot *snapshotv1.Vi
 				updateSnapshotCondition(vmSnapshotCpy, newProgressingCondition(corev1.ConditionFalse, source.LockMsg()))
 			}
 
-			updateSnapshotSourceIndications(vmSnapshotCpy, source)
+			updateSnapshotSourceIndications(vmSnapshotCpy, source, content)
 		} else {
 			updateSnapshotCondition(vmSnapshotCpy, newProgressingCondition(corev1.ConditionFalse, "Source does not exist"))
 		}
@@ -863,7 +877,7 @@ func IndicationMessage(indication snapshotv1.Indication) string {
 }
 
 // updateSnapshotSourceIndications updates both the old and new indication fields
-func updateSnapshotSourceIndications(snapshot *snapshotv1.VirtualMachineSnapshot, source snapshotSource) {
+func updateSnapshotSourceIndications(snapshot *snapshotv1.VirtualMachineSnapshot, source snapshotSource, content *snapshotv1.VirtualMachineSnapshotContent) {
 	if source.Online() {
 		indications := sets.New(snapshot.Status.Indications...)
 		indications = sets.Insert(indications, snapshotv1.VMSnapshotOnlineSnapshotIndication)
@@ -876,6 +890,10 @@ func updateSnapshotSourceIndications(snapshot *snapshotv1.VirtualMachineSnapshot
 			if snapErr != nil && snapErr.Message != nil &&
 				strings.Contains(*snapErr.Message, VSSFreezeLimitReached) {
 				indications = sets.Insert(indications, snapshotv1.VMSnapshotQuiesceTimeoutIndication)
+			}
+			if content != nil && content.Status != nil &&
+				content.Status.FreezeFailures >= MaxFreezeRetries {
+				indications = sets.Insert(indications, snapshotv1.VMSnapshotQuiesceFailedIndication)
 			}
 		} else {
 			indications = sets.Insert(indications, snapshotv1.VMSnapshotNoGuestAgentIndication)

--- a/pkg/storage/snapshot/snapshot_test.go
+++ b/pkg/storage/snapshot/snapshot_test.go
@@ -1625,6 +1625,7 @@ var _ = Describe("Snapshot controlleer", func() {
 						Time:    timeFunc(),
 						Message: &errorMessage,
 					},
+					FreezeFailures: 1,
 				}
 
 				volumeSnapshotClass := createVolumeSnapshotClasses()[0]
@@ -1634,6 +1635,116 @@ var _ = Describe("Snapshot controlleer", func() {
 				updateStatusCalls := expectVMSnapshotContentUpdateStatus(vmSnapshotClient, updatedContent)
 
 				controller.processVMSnapshotContentWorkItem()
+				Expect(*updateStatusCalls).To(Equal(1))
+			})
+
+			It("should fall back to crash-consistent snapshot after max freeze retries", func() {
+				storageClass := createStorageClass()
+				storageClassSource.Add(storageClass)
+
+				vmSnapshot := createVMSnapshotInProgress()
+				vmSnapshotSource.Add(vmSnapshot)
+
+				vmSnapshotContent := createVMSnapshotContent()
+				vmSnapshotContent.UID = contentUID
+				vmSnapshotContent.Status = &snapshotv1.VirtualMachineSnapshotContentStatus{
+					FreezeFailures: MaxFreezeRetries - 1,
+				}
+				vmSnapshotContentSource.Add(vmSnapshotContent)
+
+				vm := createLockedVM()
+				vmSource.Add(vm)
+
+				vmi := createVMI(vm)
+				agentCondition := v1.VirtualMachineInstanceCondition{
+					Type:          v1.VirtualMachineInstanceAgentConnected,
+					LastProbeTime: metav1.Now(),
+					Status:        corev1.ConditionTrue,
+				}
+				vmi.Status.Conditions = append(vmi.Status.Conditions, agentCondition)
+				vmiSource.Add(vmi)
+
+				updatedContent := vmSnapshotContent.DeepCopy()
+				updatedContent.ResourceVersion = "1"
+				updatedContent.Status = &snapshotv1.VirtualMachineSnapshotContentStatus{
+					ReadyToUse:     pointer.P(false),
+					FreezeFailures: MaxFreezeRetries,
+				}
+
+				volumeSnapshots := createVolumeSnapshots(vmSnapshotContent)
+				for i := range volumeSnapshots {
+					vss := snapshotv1.VolumeSnapshotStatus{
+						VolumeSnapshotName: volumeSnapshots[i].Name,
+					}
+					updatedContent.Status.VolumeSnapshotStatus = append(updatedContent.Status.VolumeSnapshotStatus, vss)
+				}
+
+				volumeSnapshotClass := createVolumeSnapshotClasses()[0]
+				addVolumeSnapshotClass(volumeSnapshotClass)
+
+				errorMessage := "Guest agent is not responding"
+				vmiInterface.EXPECT().Freeze(context.Background(), vm.Name, 0*time.Second).Return(fmt.Errorf("%s", errorMessage)).Times(1)
+				snapshotCreates := expectVolumeSnapshotCreates(k8sSnapshotClient, volumeSnapshotClass.Name, vmSnapshotContent)
+				updateStatusCalls := expectVMSnapshotContentUpdateStatus(vmSnapshotClient, updatedContent)
+
+				controller.processVMSnapshotContentWorkItem()
+				testutils.ExpectEvent(recorder, "SuccessfulVolumeSnapshotCreate")
+				Expect(*snapshotCreates).To(Equal(1))
+				Expect(*updateStatusCalls).To(Equal(1))
+			})
+
+			It("should set QuiesceFailed indication when content has max freeze attempts", func() {
+				vm := createLockedVM()
+				vmSource.Add(vm)
+				vmi := createVMI(vm)
+				agentCondition := v1.VirtualMachineInstanceCondition{
+					Type:          v1.VirtualMachineInstanceAgentConnected,
+					LastProbeTime: metav1.Now(),
+					Status:        corev1.ConditionTrue,
+				}
+				vmi.Status.Conditions = append(vmi.Status.Conditions, agentCondition)
+				vmiSource.Add(vmi)
+
+				vmSnapshotContent := createVMSnapshotContent()
+				vmSnapshotContent.Status = &snapshotv1.VirtualMachineSnapshotContentStatus{
+					ReadyToUse:     pointer.P(false),
+					FreezeFailures: MaxFreezeRetries,
+				}
+				vmSnapshotContentSource.Add(vmSnapshotContent)
+
+				vmSnapshot := createVMSnapshotInProgress()
+				addVirtualMachineSnapshot(vmSnapshot)
+
+				updatedSnapshot := vmSnapshot.DeepCopy()
+				updatedSnapshot.Status.VirtualMachineSnapshotContentName = &vmSnapshotContent.Name
+				updatedSnapshot.Status.ReadyToUse = pointer.P(false)
+				updatedSnapshot.Status.Indications = []snapshotv1.Indication{
+					snapshotv1.VMSnapshotGuestAgentIndication,
+					snapshotv1.VMSnapshotOnlineSnapshotIndication,
+					snapshotv1.VMSnapshotQuiesceFailedIndication,
+				}
+				updatedSnapshot.Status.SourceIndications = []snapshotv1.SourceIndication{
+					{
+						Indication: snapshotv1.VMSnapshotGuestAgentIndication,
+						Message:    IndicationMessage(snapshotv1.VMSnapshotGuestAgentIndication),
+					},
+					{
+						Indication: snapshotv1.VMSnapshotOnlineSnapshotIndication,
+						Message:    IndicationMessage(snapshotv1.VMSnapshotOnlineSnapshotIndication),
+					},
+					{
+						Indication: snapshotv1.VMSnapshotQuiesceFailedIndication,
+						Message:    IndicationMessage(snapshotv1.VMSnapshotQuiesceFailedIndication),
+					},
+				}
+				updatedSnapshot.Status.Conditions = []snapshotv1.Condition{
+					newProgressingCondition(corev1.ConditionTrue, "Source locked and operation in progress"),
+					newReadyCondition(corev1.ConditionFalse, "Not ready"),
+				}
+
+				updateStatusCalls := expectVMSnapshotUpdateStatus(vmSnapshotClient, updatedSnapshot)
+
+				controller.processVMSnapshotWorkItem()
 				Expect(*updateStatusCalls).To(Equal(1))
 			})
 

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -33776,6 +33776,8 @@ var CRDsValidation map[string]string = map[string]string{
               format: date-time
               type: string
           type: object
+        freezeFailures:
+          type: integer
         readyToUse:
           type: boolean
         volumeSnapshotStatus:

--- a/staging/src/kubevirt.io/api/snapshot/v1alpha1/types.go
+++ b/staging/src/kubevirt.io/api/snapshot/v1alpha1/types.go
@@ -81,6 +81,7 @@ const (
 	VMSnapshotNoGuestAgentIndication    Indication = "NoGuestAgent"
 	VMSnapshotGuestAgentIndication      Indication = "GuestAgent"
 	VMSnapshotQuiesceTimeoutIndication  Indication = "QuiesceTimeout"
+	VMSnapshotQuiesceFailedIndication   Indication = "QuiesceFailed"
 	VMSnapshotPausedIndication          Indication = "Paused"
 	VMSnapshotPartialSnapshotIndication Indication = "PartialSnapshot"
 )
@@ -283,6 +284,9 @@ type VirtualMachineSnapshotContentStatus struct {
 
 	// +optional
 	VolumeSnapshotStatus []VolumeSnapshotStatus `json:"volumeSnapshotStatus,omitempty"`
+
+	// +optional
+	FreezeFailures int `json:"freezeFailures,omitempty"`
 }
 
 // VirtualMachineSnapshotContentList is a list of VirtualMachineSnapshot resources

--- a/staging/src/kubevirt.io/api/snapshot/v1alpha1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/snapshot/v1alpha1/types_swagger_generated.go
@@ -121,6 +121,7 @@ func (VirtualMachineSnapshotContentStatus) SwaggerDoc() map[string]string {
 		"readyToUse":           "+optional",
 		"error":                "+optional",
 		"volumeSnapshotStatus": "+optional",
+		"freezeFailures":       "+optional",
 	}
 }
 

--- a/staging/src/kubevirt.io/api/snapshot/v1beta1/types.go
+++ b/staging/src/kubevirt.io/api/snapshot/v1beta1/types.go
@@ -82,6 +82,7 @@ const (
 	VMSnapshotNoGuestAgentIndication    Indication = "NoGuestAgent"
 	VMSnapshotGuestAgentIndication      Indication = "GuestAgent"
 	VMSnapshotQuiesceTimeoutIndication  Indication = "QuiesceTimeout"
+	VMSnapshotQuiesceFailedIndication   Indication = "QuiesceFailed"
 	VMSnapshotPausedIndication          Indication = "Paused"
 	VMSnapshotPartialSnapshotIndication Indication = "PartialSnapshot"
 )
@@ -287,6 +288,9 @@ type VirtualMachineSnapshotContentStatus struct {
 	// +optional
 	// +listType=atomic
 	VolumeSnapshotStatus []VolumeSnapshotStatus `json:"volumeSnapshotStatus,omitempty"`
+
+	// +optional
+	FreezeFailures int `json:"freezeFailures,omitempty"`
 }
 
 // VirtualMachineSnapshotContentList is a list of VirtualMachineSnapshot resources

--- a/staging/src/kubevirt.io/api/snapshot/v1beta1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/snapshot/v1beta1/types_swagger_generated.go
@@ -121,6 +121,7 @@ func (VirtualMachineSnapshotContentStatus) SwaggerDoc() map[string]string {
 		"readyToUse":           "+optional",
 		"error":                "+optional",
 		"volumeSnapshotStatus": "+optional\n+listType=atomic",
+		"freezeFailures":       "+optional",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -35535,6 +35535,12 @@ func schema_kubevirtio_api_snapshot_v1alpha1_VirtualMachineSnapshotContentStatus
 							},
 						},
 					},
+					"freezeFailures": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"integer"},
+							Format: "int32",
+						},
+					},
 				},
 			},
 		},
@@ -36579,6 +36585,12 @@ func schema_kubevirtio_api_snapshot_v1beta1_VirtualMachineSnapshotContentStatus(
 									},
 								},
 							},
+						},
+					},
+					"freezeFailures": {
+						SchemaProps: spec.SchemaProps{
+							Type:   []string{"integer"},
+							Format: "int32",
 						},
 					},
 				},

--- a/tests/storage/BUILD.bazel
+++ b/tests/storage/BUILD.bazel
@@ -37,6 +37,7 @@ go_library(
         "//pkg/storage/backend-storage:go_default_library",
         "//pkg/storage/cbt:go_default_library",
         "//pkg/storage/export/virt-exportserver:go_default_library",
+        "//pkg/storage/snapshot:go_default_library",
         "//pkg/storage/types:go_default_library",
         "//pkg/storage/velero:go_default_library",
         "//pkg/util:go_default_library",

--- a/tests/storage/snapshot.go
+++ b/tests/storage/snapshot.go
@@ -29,6 +29,7 @@ import (
 	libvmici "kubevirt.io/kubevirt/pkg/libvmi/cloudinit"
 	"kubevirt.io/kubevirt/pkg/pointer"
 	virtpointer "kubevirt.io/kubevirt/pkg/pointer"
+	snapshotcontroller "kubevirt.io/kubevirt/pkg/storage/snapshot"
 
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/framework/matcher"
@@ -632,7 +633,7 @@ var _ = Describe(SIG("VirtualMachineSnapshot Tests", func() {
 				}
 			})
 
-			It("should report appropriate event when freeze fails", func() {
+			FIt("should fall back to crash-consistent snapshot when freeze fails", func() {
 				// Activate SELinux and reboot machine so we can force fsfreeze failure
 				const userData = "#cloud-config\n" +
 					"password: fedora\n" +
@@ -690,27 +691,22 @@ var _ = Describe(SIG("VirtualMachineSnapshot Tests", func() {
 
 				objectEventWatcher := watcher.New(vmi).SinceWatchedObjectResourceVersion().Timeout(time.Duration(30) * time.Second)
 				objectEventWatcher.WaitFor(context.Background(), watcher.WarningEvent, "FreezeError")
+
 				Eventually(func() *snapshotv1.VirtualMachineSnapshotStatus {
 					snapshot, err = virtClient.VirtualMachineSnapshot(vm.Namespace).Get(context.Background(), snapshot.Name, metav1.GetOptions{})
 					Expect(err).ToNot(HaveOccurred())
 					return snapshot.Status
-				}, time.Minute, 2*time.Second).Should(gstruct.PointTo(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
-					"Conditions": ContainElements(
-						gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
-							"Type":   Equal(snapshotv1.ConditionReady),
-							"Status": Equal(corev1.ConditionFalse),
-							"Reason": Equal("Not ready")}),
-						gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
-							"Type":   Equal(snapshotv1.ConditionProgressing),
-							"Status": Equal(corev1.ConditionFalse),
-							"Reason": Equal("In error state")}),
-					),
-					"Phase": Equal(snapshotv1.InProgress),
-					"Error": gstruct.PointTo(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
-						"Message": gstruct.PointTo(ContainSubstring("command Freeze failed")),
-					})),
-					"CreationTime": BeNil(),
+				}, 3*time.Minute, 2*time.Second).Should(gstruct.PointTo(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+					"Phase":       Equal(snapshotv1.Succeeded),
+					"ReadyToUse":  gstruct.PointTo(BeTrue()),
+					"Indications": ContainElement(snapshotv1.VMSnapshotQuiesceFailedIndication),
 				})))
+
+				contentName := *snapshot.Status.VirtualMachineSnapshotContentName
+				content, err := virtClient.VirtualMachineSnapshotContent(vm.Namespace).Get(context.Background(), contentName, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(content.Status).ToNot(BeNil())
+				Expect(content.Status.FreezeFailures).To(BeNumerically(">=", snapshotcontroller.MaxFreezeRetries))
 			})
 
 			Context("with memory dump", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
When the guest agent is present but filesystem freeze fails (due to permissions, agent errors, or the freeze still being in progress), the snapshot controller retries the freeze every 5 seconds until the FailureDeadline (default 5 min) is exceeded, then fails the entire snapshot. No snapshot is created, even though a crash-consistent snapshot could still be taken successfully, just as it already works when no guest agent is present.
#### After this PR:
Freeze errors are retried up to 10 times with a 5s interval. After 10 failed attempts the controller proceeds without quiescing and marks the snapshot with a QuiesceFailed indication, signaling that quiescing was attempted but failed and the snapshot fell back to crash-consistent.

The retry count covers both immediate freeze failures and transient errors from in-progress freezes that exceed the HTTP call timeout. The bound (10) is derived from the 60s freeze operation timeout divided by the 10s HTTP timeout, with additional margin.

QuiesceFailed was previously in the codebase but was removed by #16739, which narrowed the indication to QuiesceTimeout (Windows VSS-only). Since the previous behavior simply failed the snapshot on freeze errors, there was no need for it. Now that we fall back to crash-consistent, re-adding it gives users visibility into what happened.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
Jira: https://redhat.atlassian.net/browse/CNV-83919
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->


<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fall back to crash-consistent snapshot when filesystem quiescing fails instead of failing the entire snapshot operation
```

