### PR TITLE
[release-1.9] Disable PCI hotplug on occupied pcie-root-port controllers

### DIFF
--- a/pkg/virt-launcher/virtwrap/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/BUILD.bazel
@@ -71,6 +71,7 @@ go_library(
         "//pkg/virt-launcher/virtwrap/efi:go_default_library",
         "//pkg/virt-launcher/virtwrap/errors:go_default_library",
         "//pkg/virt-launcher/virtwrap/network:go_default_library",
+        "//pkg/virt-launcher/virtwrap/pci:go_default_library",
         "//pkg/virt-launcher/virtwrap/plugins:go_default_library",
         "//pkg/virt-launcher/virtwrap/stats:go_default_library",
         "//pkg/virt-launcher/virtwrap/statsconv:go_default_library",

--- a/pkg/virt-launcher/virtwrap/api/schema.go
+++ b/pkg/virt-launcher/virtwrap/api/schema.go
@@ -107,6 +107,7 @@ const (
 	AddressCCW     = "ccw"
 
 	ControllerTypePCI              = "pci"
+	ControllerModelPCIRoot         = "pci-root"
 	ControllerModelPCIeRoot        = "pcie-root"
 	ControllerModelPCIeRootPort    = "pcie-root-port"
 	ControllerModelPCIeExpanderBus = "pcie-expander-bus"
@@ -804,6 +805,7 @@ type PCIHole64 struct {
 
 // BEGIN ControllerTarget
 type ControllerTarget struct {
+	Hotplug  string  `xml:"hotplug,attr,omitempty"`
 	BusNr    *uint32 `xml:"busNr,attr,omitempty"`
 	NUMANode *uint32 `xml:"node,omitempty"`
 }

--- a/pkg/virt-launcher/virtwrap/converter/translate/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/converter/translate/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
+        "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/libvirt.org/go/libvirtxml:go_default_library",
     ],
 )

--- a/pkg/virt-launcher/virtwrap/converter/translate/translate.go
+++ b/pkg/virt-launcher/virtwrap/converter/translate/translate.go
@@ -22,8 +22,12 @@ package translate
 import (
 	"encoding/xml"
 	"fmt"
+	"io"
+	"strings"
 
 	libvirtxml "libvirt.org/go/libvirtxml"
+
+	"kubevirt.io/client-go/log"
 
 	api "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )
@@ -63,29 +67,106 @@ func FromLibvirtDomain(domain *libvirtxml.Domain) (*api.DomainSpec, error) {
 	if err := xml.Unmarshal([]byte(xmlStr), spec); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal XML into DomainSpec: %w", err)
 	}
-	transferQEMUCommandline(domain, spec)
+	TransferQEMUCommandline(xmlStr, spec)
 	return spec, nil
 }
 
 const qemuNamespace = "http://libvirt.org/schemas/domain/qemu/1.0"
 
-// transferQEMUCommandline copies QEMU commandline args and envs from the
-// libvirtxml Domain to the KubeVirt DomainSpec. Go's encoding/xml cannot
-// unmarshal elements with namespace-prefixed struct tags (e.g. xml:"qemu:commandline"),
-// so this transfer must be done at the struct level.
-func transferQEMUCommandline(domain *libvirtxml.Domain, spec *api.DomainSpec) {
-	if domain.QEMUCommandline == nil {
+// TransferQEMUCommandline extracts qemu:commandline args and envs from raw
+// domain XML and applies them to the KubeVirt DomainSpec. Go's encoding/xml
+// cannot unmarshal namespace-prefixed struct tags (e.g. xml:"qemu:commandline"),
+// so this function uses token-level parsing via xml.Decoder, which resolves
+// namespace URIs correctly. Only elements in the QEMU namespace are inspected;
+// the rest of the domain XML is skipped, so this works with any well-formed
+// XML regardless of schema strictness.
+func TransferQEMUCommandline(domainXML string, spec *api.DomainSpec) {
+	args, envs, hasCommandline := parseQEMUCommandline(domainXML)
+
+	if !hasCommandline {
+		log.Log.Warning("no qemu:commandline section found in domain XML")
 		return
 	}
 	spec.XmlNS = qemuNamespace
-	if len(domain.QEMUCommandline.Args) == 0 && len(domain.QEMUCommandline.Envs) == 0 {
+	if len(args) == 0 && len(envs) == 0 {
 		return
 	}
-	spec.QEMUCmd = &api.Commandline{}
-	for _, arg := range domain.QEMUCommandline.Args {
-		spec.QEMUCmd.QEMUArg = append(spec.QEMUCmd.QEMUArg, api.Arg{Value: arg.Value})
+	spec.QEMUCmd = &api.Commandline{
+		QEMUArg: args,
+		QEMUEnv: envs,
 	}
-	for _, env := range domain.QEMUCommandline.Envs {
-		spec.QEMUCmd.QEMUEnv = append(spec.QEMUCmd.QEMUEnv, api.Env{Name: env.Name, Value: env.Value})
+}
+
+func parseQEMUCommandline(domainXML string) ([]api.Arg, []api.Env, bool) {
+	decoder := xml.NewDecoder(strings.NewReader(domainXML))
+
+	var (
+		args           []api.Arg
+		envs           []api.Env
+		inCommandline  bool
+		hasCommandline bool
+	)
+
+	for {
+		token, err := decoder.Token()
+		if err != nil {
+			if err != io.EOF {
+				log.Log.Warningf("unexpected error parsing domain XML for QEMUCmd: %v", err)
+			}
+			break
+		}
+
+		switch t := token.(type) {
+		case xml.StartElement:
+			if t.Name.Space != qemuNamespace {
+				continue
+			}
+			switch t.Name.Local {
+			case "commandline":
+				inCommandline = true
+				hasCommandline = true
+			case "arg":
+				if inCommandline {
+					args = append(args, parseArgAttrs(t))
+				}
+			case "env":
+				if inCommandline {
+					if env, ok := parseEnvAttrs(t); ok {
+						envs = append(envs, env)
+					}
+				}
+			}
+		case xml.EndElement:
+			if t.Name.Space == qemuNamespace && t.Name.Local == "commandline" {
+				inCommandline = false
+			}
+		}
 	}
+
+	return args, envs, hasCommandline
+}
+
+func parseArgAttrs(t xml.StartElement) api.Arg {
+	for _, attr := range t.Attr {
+		if attr.Name.Local == "value" {
+			return api.Arg{Value: attr.Value}
+		}
+	}
+	return api.Arg{}
+}
+
+func parseEnvAttrs(t xml.StartElement) (api.Env, bool) {
+	var env api.Env
+	for _, attr := range t.Attr {
+		switch attr.Name.Local {
+		case "name":
+			env.Name = attr.Value
+		case "value":
+			env.Value = attr.Value
+		}
+	}
+	if env.Name == "" {
+		return api.Env{}, false
+	}
+	return env, true
 }

--- a/pkg/virt-launcher/virtwrap/converter/translate/translate_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/translate/translate_test.go
@@ -206,6 +206,146 @@ var _ = Describe("Domain translation", func() {
 		})
 	})
 
+	Context("TransferQEMUCommandline", func() {
+		It("should extract args and envs from domain XML", func() {
+			domainXML := `<domain type="kvm" xmlns:qemu="http://libvirt.org/schemas/domain/qemu/1.0">
+				<name>test-vm</name>
+				<qemu:commandline>
+					<qemu:arg value="-fw_cfg"/>
+					<qemu:arg value="name=opt/com.coreos/config,file=/data.ign"/>
+					<qemu:env name="QEMU_AUDIO_DRV" value="none"/>
+				</qemu:commandline>
+			</domain>`
+
+			spec := &api.DomainSpec{}
+			TransferQEMUCommandline(domainXML, spec)
+
+			Expect(spec.XmlNS).To(Equal("http://libvirt.org/schemas/domain/qemu/1.0"))
+			Expect(spec.QEMUCmd).NotTo(BeNil())
+			Expect(spec.QEMUCmd.QEMUArg).To(HaveLen(2))
+			Expect(spec.QEMUCmd.QEMUArg[0].Value).To(Equal("-fw_cfg"))
+			Expect(spec.QEMUCmd.QEMUArg[1].Value).To(Equal("name=opt/com.coreos/config,file=/data.ign"))
+			Expect(spec.QEMUCmd.QEMUEnv).To(HaveLen(1))
+			Expect(spec.QEMUCmd.QEMUEnv[0].Name).To(Equal("QEMU_AUDIO_DRV"))
+			Expect(spec.QEMUCmd.QEMUEnv[0].Value).To(Equal("none"))
+		})
+
+		It("should set XmlNS but not QEMUCmd for empty commandline", func() {
+			domainXML := `<domain type="kvm" xmlns:qemu="http://libvirt.org/schemas/domain/qemu/1.0">
+				<name>test-vm</name>
+				<qemu:commandline></qemu:commandline>
+			</domain>`
+
+			spec := &api.DomainSpec{}
+			TransferQEMUCommandline(domainXML, spec)
+
+			Expect(spec.XmlNS).To(Equal("http://libvirt.org/schemas/domain/qemu/1.0"))
+			Expect(spec.QEMUCmd).To(BeNil())
+		})
+
+		It("should not modify spec when no qemu namespace is present", func() {
+			domainXML := `<domain type="kvm">
+				<name>test-vm</name>
+				<devices><disk type="file"/></devices>
+			</domain>`
+
+			spec := &api.DomainSpec{}
+			TransferQEMUCommandline(domainXML, spec)
+
+			Expect(spec.XmlNS).To(BeEmpty())
+			Expect(spec.QEMUCmd).To(BeNil())
+		})
+
+		It("should handle envs without value attribute", func() {
+			domainXML := `<domain type="kvm" xmlns:qemu="http://libvirt.org/schemas/domain/qemu/1.0">
+				<name>test-vm</name>
+				<qemu:commandline>
+					<qemu:env name="DISPLAY"/>
+				</qemu:commandline>
+			</domain>`
+
+			spec := &api.DomainSpec{}
+			TransferQEMUCommandline(domainXML, spec)
+
+			Expect(spec.QEMUCmd).NotTo(BeNil())
+			Expect(spec.QEMUCmd.QEMUEnv).To(HaveLen(1))
+			Expect(spec.QEMUCmd.QEMUEnv[0].Name).To(Equal("DISPLAY"))
+			Expect(spec.QEMUCmd.QEMUEnv[0].Value).To(BeEmpty())
+		})
+
+		It("should skip env entries without a name attribute", func() {
+			domainXML := `<domain type="kvm" xmlns:qemu="http://libvirt.org/schemas/domain/qemu/1.0">
+				<name>test-vm</name>
+				<qemu:commandline>
+					<qemu:env value="orphan"/>
+					<qemu:env name="VALID" value="yes"/>
+				</qemu:commandline>
+			</domain>`
+
+			spec := &api.DomainSpec{}
+			TransferQEMUCommandline(domainXML, spec)
+
+			Expect(spec.QEMUCmd).NotTo(BeNil())
+			Expect(spec.QEMUCmd.QEMUEnv).To(HaveLen(1))
+			Expect(spec.QEMUCmd.QEMUEnv[0].Name).To(Equal("VALID"))
+		})
+
+		It("should include arg with empty value attribute", func() {
+			domainXML := `<domain type="kvm" xmlns:qemu="http://libvirt.org/schemas/domain/qemu/1.0">
+				<name>test-vm</name>
+				<qemu:commandline>
+					<qemu:arg value=""/>
+					<qemu:arg value="-nographic"/>
+				</qemu:commandline>
+			</domain>`
+
+			spec := &api.DomainSpec{}
+			TransferQEMUCommandline(domainXML, spec)
+
+			Expect(spec.QEMUCmd).NotTo(BeNil())
+			Expect(spec.QEMUCmd.QEMUArg).To(HaveLen(2))
+			Expect(spec.QEMUCmd.QEMUArg[0].Value).To(BeEmpty())
+			Expect(spec.QEMUCmd.QEMUArg[1].Value).To(Equal("-nographic"))
+		})
+
+		It("should aggregate args across multiple commandline blocks", func() {
+			domainXML := `<domain type="kvm" xmlns:qemu="http://libvirt.org/schemas/domain/qemu/1.0">
+				<name>test-vm</name>
+				<qemu:commandline>
+					<qemu:arg value="-fw_cfg"/>
+				</qemu:commandline>
+				<qemu:commandline>
+					<qemu:arg value="-device"/>
+				</qemu:commandline>
+			</domain>`
+
+			spec := &api.DomainSpec{}
+			TransferQEMUCommandline(domainXML, spec)
+
+			Expect(spec.QEMUCmd).NotTo(BeNil())
+			Expect(spec.QEMUCmd.QEMUArg).To(HaveLen(2))
+			Expect(spec.QEMUCmd.QEMUArg[0].Value).To(Equal("-fw_cfg"))
+			Expect(spec.QEMUCmd.QEMUArg[1].Value).To(Equal("-device"))
+		})
+
+		It("should skip qemu elements outside commandline block", func() {
+			domainXML := `<domain type="kvm" xmlns:qemu="http://libvirt.org/schemas/domain/qemu/1.0">
+				<name>test-vm</name>
+				<qemu:arg value="stray"/>
+				<qemu:commandline>
+					<qemu:arg value="real"/>
+				</qemu:commandline>
+			</domain>`
+
+			spec := &api.DomainSpec{}
+			TransferQEMUCommandline(domainXML, spec)
+
+			Expect(spec.QEMUCmd).NotTo(BeNil())
+			Expect(spec.QEMUCmd.QEMUArg).To(HaveLen(1))
+			Expect(spec.QEMUCmd.QEMUArg[0].Value).To(Equal("real"))
+		})
+	})
+
 	Context("Round-trip fidelity", func() {
 		It("should round-trip a DomainSpec with metadata", func() {
 			spec := api.NewMinimalDomainSpec("test-vm")

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -49,6 +49,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/hypervisor"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/device/hostdevice/dra"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/network"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/pci"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/storage"
 
 	"libvirt.org/go/libvirt"
@@ -1691,11 +1692,14 @@ func (l *LibvirtDomainManager) allocateHotplugPorts(
 	// providing genuine hotplug capacity.
 	if extraControllers > 0 {
 		appendPCIeRootPortControllers(domainSpec, extraControllers)
-		dom.Free()
-		dom, err = l.setDomainSpecWithHooks(vmi, domainSpec)
-		if err != nil {
-			return nil, err
-		}
+	}
+
+	pci.DisableHotplugOnOccupiedRootPorts(domainSpec)
+
+	dom.Free()
+	dom, err = l.setDomainSpecWithHooks(vmi, domainSpec)
+	if err != nil {
+		return nil, err
 	}
 
 	return dom, nil

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -1686,6 +1686,17 @@ func (l *LibvirtDomainManager) allocateHotplugPorts(
 		return nil, err
 	}
 
+	// When placeholderCount == 0, WithNetworkIfacesResources skips the
+	// read-back, so domainSpec lacks libvirt-assigned Target.BusNr values
+	// needed by DisableHotplugOnOccupiedRootPorts.
+	if placeholderCount == 0 {
+		readBack, readErr := util.GetDomainSpecWithFlags(dom, libvirt.DOMAIN_XML_INACTIVE)
+		if readErr != nil {
+			return nil, readErr
+		}
+		readBack.Devices.DeepCopyInto(&domainSpec.Devices)
+	}
+
 	// Extra controllers must be added AFTER WithNetworkIfacesResources so
 	// that libvirt has already assigned devices to root ports. Controllers
 	// appended here get indices above the occupied ports and remain empty,
@@ -1696,7 +1707,9 @@ func (l *LibvirtDomainManager) allocateHotplugPorts(
 
 	pci.DisableHotplugOnOccupiedRootPorts(domainSpec)
 
-	dom.Free()
+	if freeErr := dom.Free(); freeErr != nil {
+		err = errors.Join(err, freeErr)
+	}
 	dom, err = l.setDomainSpecWithHooks(vmi, domainSpec)
 	if err != nil {
 		return nil, err

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -460,6 +460,11 @@ var _ = Describe("Manager", func() {
 			Expect(err).ToNot(HaveOccurred())
 			extraControllers, err := calculateExtraControllerCount(vmi, domainSpec, placeholderCount)
 			Expect(err).ToNot(HaveOccurred())
+			if placeholderCount == 0 {
+				domainXML, err := xml.MarshalIndent(domainSpec, "", "\t")
+				Expect(err).ToNot(HaveOccurred())
+				mockLibvirt.DomainEXPECT().GetXMLDesc(libvirt.DOMAIN_XML_INACTIVE).MaxTimes(1).Return(string(domainXML), nil)
+			}
 			if extraControllers > 0 {
 				appendPCIeRootPortControllers(domainSpec, extraControllers)
 				// The xmlns:qemu attribute is lost during the XML marshal/unmarshal
@@ -503,6 +508,9 @@ var _ = Describe("Manager", func() {
 				mockLibvirt.ConnectionEXPECT().DomainDefineXML(string(domainXMLWithExtra)).DoAndReturn(mockDomainWithFreeExpectation)
 			}
 			mockLibvirt.DomainEXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).MaxTimes(3).Return(string(domainXML), nil)
+			if placeholderCount == 0 {
+				mockLibvirt.DomainEXPECT().GetXMLDesc(libvirt.DOMAIN_XML_INACTIVE).MaxTimes(1).Return(string(domainXML), nil)
+			}
 		}
 
 		It("should define and start a new VirtualMachineInstance", func() {
@@ -772,6 +780,7 @@ var _ = Describe("Manager", func() {
 			mockLibvirt.DomainEXPECT().GetState().Return(libvirt.DOMAIN_SHUTDOWN, 1, nil)
 			mockLibvirt.DomainEXPECT().CreateWithFlags(libvirt.DOMAIN_NONE).Return(nil)
 			mockLibvirt.DomainEXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).MaxTimes(3).Return(string(xmlDomain), nil)
+			mockLibvirt.DomainEXPECT().GetXMLDesc(libvirt.DOMAIN_XML_INACTIVE).MaxTimes(1).Return(string(xmlDomain), nil)
 
 			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, "fake", "fake", nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false)
 			newspec, err := manager.SyncVMI(vmi, true, &cmdv1.VirtualMachineOptions{
@@ -1012,6 +1021,7 @@ var _ = Describe("Manager", func() {
 			mockLibvirt.DomainEXPECT().CreateWithFlags(libvirt.DOMAIN_NONE).Return(nil)
 			mockLibvirt.DomainEXPECT().DetachDeviceFlags(strings.ToLower(string(detachBytes)), affectDeviceLiveAndConfigLibvirtFlags)
 			mockLibvirt.DomainEXPECT().GetXMLDesc(libvirt.DomainXMLFlags(0)).MaxTimes(3).Return(string(xmlDomain), nil)
+			mockLibvirt.DomainEXPECT().GetXMLDesc(libvirt.DOMAIN_XML_INACTIVE).MaxTimes(1).Return(string(xmlDomain), nil)
 			manager, _ := newLibvirtDomainManager(mockLibvirt.VirtConnection, testVirtShareDir, testEphemeralDiskDir, nil, virtconfig.DefaultARCHOVMFPath, ephemeralDiskCreatorMock, mockDirectIOChecker, metadataCache, nil, virtconfig.DefaultDiskVerificationMemoryLimitBytes, fakeCpuSetGetter, false, false, nil, v1.KvmHypervisorName, nil, "", false, false, false)
 			newspec, err := manager.SyncVMI(vmi, true, &cmdv1.VirtualMachineOptions{VirtualMachineSMBios: &cmdv1.SMBios{}})
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/virt-launcher/virtwrap/pci/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/pci/BUILD.bazel
@@ -1,0 +1,27 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["hotplug.go"],
+    importpath = "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/pci",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/virt-launcher/virtwrap/api:go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "hotplug_test.go",
+        "pci_suite_test.go",
+    ],
+    deps = [
+        ":go_default_library",
+        "//pkg/virt-launcher/virtwrap/api:go_default_library",
+        "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+    ],
+)

--- a/pkg/virt-launcher/virtwrap/pci/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/pci/BUILD.bazel
@@ -17,9 +17,11 @@ go_test(
         "hotplug_test.go",
         "pci_suite_test.go",
     ],
+    race = "on",
     deps = [
         ":go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",

--- a/pkg/virt-launcher/virtwrap/pci/hotplug.go
+++ b/pkg/virt-launcher/virtwrap/pci/hotplug.go
@@ -1,0 +1,127 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package pci
+
+import (
+	"strconv"
+	"strings"
+
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
+)
+
+func busNrFromTarget(target *api.ControllerTarget) (int, bool) {
+	if target == nil || target.BusNr == nil {
+		return 0, false
+	}
+	return int(*target.BusNr), true
+}
+
+// DisableHotplugOnOccupiedRootPorts sets hotplug="off" on pcie-root-port
+// controllers that have a non-interface device behind them, preventing guests
+// from ejecting critical devices (disks, balloon, RNG, etc.) at runtime.
+// Interface (NIC) ports are left hotpluggable to preserve NIC hot-unplug.
+//
+// Must be called after the libvirt read-back so that Target.BusNr is populated.
+//
+// Note: when the PlacePCIDevicesOnRootComplex annotation is set, devices sit
+// directly on the root bus with slot-based addressing (no pcie-root-ports),
+// so they remain ejectable regardless of this function.
+func DisableHotplugOnOccupiedRootPorts(spec *api.DomainSpec) {
+	occupiedBuses := collectOccupiedPCIBuses(spec)
+
+	for i, controller := range spec.Devices.Controllers {
+		if controller.Model != api.ControllerModelPCIeRootPort {
+			continue
+		}
+		bus, ok := busNrFromTarget(controller.Target)
+		if !ok {
+			continue
+		}
+		if _, occupied := occupiedBuses[bus]; occupied {
+			if spec.Devices.Controllers[i].Target == nil {
+				spec.Devices.Controllers[i].Target = &api.ControllerTarget{}
+			}
+			spec.Devices.Controllers[i].Target.Hotplug = "off"
+		}
+	}
+}
+
+func collectOccupiedPCIBuses(spec *api.DomainSpec) map[int]struct{} {
+	addrs := collectNonInterfacePCIAddresses(spec)
+
+	buses := make(map[int]struct{}, len(addrs))
+	for _, addr := range addrs {
+		if addr == nil || addr.Bus == "" {
+			continue
+		}
+		if bus, err := strconv.ParseInt(strings.TrimPrefix(addr.Bus, "0x"), 16, 32); err == nil {
+			buses[int(bus)] = struct{}{}
+		}
+	}
+	return buses
+}
+
+// collectNonInterfacePCIAddresses returns PCI addresses of all devices except
+// network interfaces, which are excluded to keep their root ports hotpluggable.
+func collectNonInterfacePCIAddresses(spec *api.DomainSpec) []*api.Address {
+	var addrs []*api.Address
+	for i, disk := range spec.Devices.Disks {
+		if disk.Target.Bus != v1.DiskBusVirtio {
+			continue
+		}
+		addrs = append(addrs, spec.Devices.Disks[i].Address)
+	}
+	for _, controller := range spec.Devices.Controllers {
+		if controller.Model == api.ControllerModelPCIRoot ||
+			controller.Model == api.ControllerModelPCIeRoot ||
+			controller.Model == api.ControllerModelPCIeRootPort ||
+			controller.Model == api.ControllerModelPCIeExpanderBus {
+			continue
+		}
+		addrs = append(addrs, controller.Address)
+	}
+	for i, input := range spec.Devices.Inputs {
+		if input.Bus != v1.VirtIO {
+			continue
+		}
+		addrs = append(addrs, spec.Devices.Inputs[i].Address)
+	}
+	for i := range spec.Devices.Watchdogs {
+		addrs = append(addrs, spec.Devices.Watchdogs[i].Address)
+	}
+	for _, hostDev := range spec.Devices.HostDevices {
+		if hostDev.Type != api.HostDevicePCI {
+			continue
+		}
+		addrs = append(addrs, hostDev.Address)
+	}
+	if spec.Devices.Ballooning != nil {
+		addrs = append(addrs, spec.Devices.Ballooning.Address)
+	}
+	if spec.Devices.Rng != nil {
+		addrs = append(addrs, spec.Devices.Rng.Address)
+	}
+	if spec.Devices.Memory != nil {
+		addrs = append(addrs, spec.Devices.Memory.Address)
+	}
+	return addrs
+}

--- a/pkg/virt-launcher/virtwrap/pci/hotplug.go
+++ b/pkg/virt-launcher/virtwrap/pci/hotplug.go
@@ -57,9 +57,6 @@ func DisableHotplugOnOccupiedRootPorts(spec *api.DomainSpec) {
 			continue
 		}
 		if _, occupied := occupiedBuses[bus]; occupied {
-			if spec.Devices.Controllers[i].Target == nil {
-				spec.Devices.Controllers[i].Target = &api.ControllerTarget{}
-			}
 			spec.Devices.Controllers[i].Target.Hotplug = "off"
 		}
 	}

--- a/pkg/virt-launcher/virtwrap/pci/hotplug_test.go
+++ b/pkg/virt-launcher/virtwrap/pci/hotplug_test.go
@@ -1,0 +1,239 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package pci_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/pci"
+)
+
+var _ = Describe("DisableHotplugOnOccupiedRootPorts", func() {
+	pciAddr := func(bus string) *api.Address {
+		return &api.Address{Type: api.AddressPCI, Domain: "0x0000", Bus: bus, Slot: "0x00", Function: "0x0"}
+	}
+
+	uint32Ptr := func(v uint32) *uint32 { return &v }
+
+	newRootPortController := func(index string, busNr uint32) api.Controller {
+		return api.Controller{
+			Type:   api.ControllerTypePCI,
+			Index:  index,
+			Model:  api.ControllerModelPCIeRootPort,
+			Target: &api.ControllerTarget{BusNr: uint32Ptr(busNr)},
+		}
+	}
+
+	expectHotplugOff := func(controller api.Controller, desc string) {
+		ExpectWithOffset(1, controller.Target).NotTo(BeNil(), desc)
+		ExpectWithOffset(1, controller.Target.Hotplug).To(Equal("off"), desc)
+	}
+
+	expectHotplugUnchanged := func(controller api.Controller, desc string) {
+		if controller.Target == nil {
+			return
+		}
+		ExpectWithOffset(1, controller.Target.Hotplug).To(BeEmpty(), desc)
+	}
+
+	It("should disable hotplug on occupied ports and leave empty ones unchanged", func() {
+		spec := &api.DomainSpec{
+			Devices: api.Devices{
+				Controllers: []api.Controller{
+					{Type: api.ControllerTypePCI, Index: "0", Model: api.ControllerModelPCIeRoot},
+					newRootPortController("1", 1),
+					newRootPortController("2", 2),
+					newRootPortController("3", 3),
+				},
+				Interfaces: []api.Interface{{Address: pciAddr("0x01")}},
+				Ballooning: &api.MemBalloon{Address: pciAddr("0x02")},
+			},
+		}
+
+		pci.DisableHotplugOnOccupiedRootPorts(spec)
+
+		expectHotplugUnchanged(spec.Devices.Controllers[1], "port with NIC stays hotpluggable")
+		expectHotplugOff(spec.Devices.Controllers[2], "port with balloon")
+		expectHotplugUnchanged(spec.Devices.Controllers[3], "empty port")
+	})
+
+	It("should detect all non-interface PCI device types", func() {
+		spec := &api.DomainSpec{
+			Devices: api.Devices{
+				Controllers: []api.Controller{
+					{Type: api.ControllerTypePCI, Index: "0", Model: api.ControllerModelPCIeRoot},
+					newRootPortController("1", 1), newRootPortController("2", 2), newRootPortController("3", 3), newRootPortController("4", 4),
+					newRootPortController("5", 5), newRootPortController("6", 6), newRootPortController("7", 7), newRootPortController("8", 8),
+					newRootPortController("9", 9),
+				},
+				Interfaces:  []api.Interface{{Address: pciAddr("0x01")}},
+				Disks:       []api.Disk{{Target: api.DiskTarget{Bus: v1.DiskBusVirtio}, Address: pciAddr("0x02")}},
+				Inputs:      []api.Input{{Bus: v1.VirtIO, Address: pciAddr("0x03")}},
+				Watchdogs:   []api.Watchdog{{Address: pciAddr("0x04")}},
+				HostDevices: []api.HostDevice{{Type: api.HostDevicePCI, Address: pciAddr("0x05")}},
+				Ballooning:  &api.MemBalloon{Address: pciAddr("0x06")},
+				Rng:         &api.Rng{Address: pciAddr("0x07")},
+				Memory:      &api.MemoryDevice{Address: pciAddr("0x08")},
+			},
+		}
+
+		pci.DisableHotplugOnOccupiedRootPorts(spec)
+
+		expectHotplugUnchanged(spec.Devices.Controllers[1], "NIC port stays hotpluggable")
+		expectHotplugOff(spec.Devices.Controllers[2], "virtio disk on bus 2")
+		expectHotplugOff(spec.Devices.Controllers[3], "virtio input on bus 3")
+		expectHotplugOff(spec.Devices.Controllers[4], "watchdog on bus 4")
+		expectHotplugOff(spec.Devices.Controllers[5], "PCI host device on bus 5")
+		expectHotplugOff(spec.Devices.Controllers[6], "memory balloon on bus 6")
+		expectHotplugOff(spec.Devices.Controllers[7], "RNG on bus 7")
+		expectHotplugOff(spec.Devices.Controllers[8], "memory device on bus 8")
+		expectHotplugUnchanged(spec.Devices.Controllers[9], "empty port")
+	})
+
+	It("should not modify non-pcie-root-port controllers", func() {
+		spec := &api.DomainSpec{
+			Devices: api.Devices{
+				Controllers: []api.Controller{
+					{Type: api.ControllerTypePCI, Index: "0", Model: api.ControllerModelPCIeRoot},
+					{Type: "usb", Index: "0", Model: "none"},
+					{Type: "scsi", Index: "0", Model: "virtio-scsi", Address: pciAddr("0x05")},
+				},
+			},
+		}
+
+		pci.DisableHotplugOnOccupiedRootPorts(spec)
+
+		for _, ctrl := range spec.Devices.Controllers {
+			Expect(ctrl.Target).To(BeNil())
+		}
+	})
+
+	It("should skip root ports with nil Target (no BusNr available)", func() {
+		spec := &api.DomainSpec{
+			Devices: api.Devices{
+				Controllers: []api.Controller{
+					{Type: api.ControllerTypePCI, Index: "1", Model: api.ControllerModelPCIeRootPort},
+				},
+				Ballooning: &api.MemBalloon{Address: pciAddr("0x01")},
+			},
+		}
+
+		pci.DisableHotplugOnOccupiedRootPorts(spec)
+
+		expectHotplugUnchanged(spec.Devices.Controllers[0], "nil Target means no BusNr, port skipped")
+	})
+
+	It("should preserve existing Target fields when setting hotplug off", func() {
+		busNr := uint32(1)
+		numaNode := uint32(0)
+		spec := &api.DomainSpec{
+			Devices: api.Devices{
+				Controllers: []api.Controller{
+					{
+						Type:  api.ControllerTypePCI,
+						Index: "1",
+						Model: api.ControllerModelPCIeRootPort,
+						Target: &api.ControllerTarget{
+							BusNr:    &busNr,
+							NUMANode: &numaNode,
+						},
+					},
+				},
+				Ballooning: &api.MemBalloon{Address: pciAddr("0x01")},
+			},
+		}
+
+		pci.DisableHotplugOnOccupiedRootPorts(spec)
+
+		target := spec.Devices.Controllers[0].Target
+		Expect(target).NotTo(BeNil())
+		Expect(target.Hotplug).To(Equal("off"))
+		Expect(target.BusNr).To(Equal(&busNr))
+		Expect(target.NUMANode).To(Equal(&numaNode))
+	})
+
+	It("should mark a root port as occupied when a child controller sits on its bus", func() {
+		spec := &api.DomainSpec{
+			Devices: api.Devices{
+				Controllers: []api.Controller{
+					{Type: api.ControllerTypePCI, Index: "0", Model: api.ControllerModelPCIeRoot},
+					newRootPortController("1", 1),
+					newRootPortController("5", 5),
+					{Type: "scsi", Index: "0", Model: "virtio-scsi", Address: pciAddr("0x05")},
+				},
+				Ballooning: &api.MemBalloon{Address: pciAddr("0x01")},
+			},
+		}
+
+		pci.DisableHotplugOnOccupiedRootPorts(spec)
+
+		expectHotplugOff(spec.Devices.Controllers[1], "balloon on bus 1")
+		expectHotplugOff(spec.Devices.Controllers[2], "SCSI controller on bus 5")
+	})
+
+	It("should not mark interface ports as occupied to preserve NIC hot-unplug", func() {
+		spec := &api.DomainSpec{
+			Devices: api.Devices{
+				Controllers: []api.Controller{
+					{Type: api.ControllerTypePCI, Index: "0", Model: api.ControllerModelPCIeRoot},
+					newRootPortController("1", 1),
+					newRootPortController("2", 2),
+					newRootPortController("3", 3),
+				},
+				Interfaces: []api.Interface{
+					{Address: pciAddr("0x01")},
+					{Address: pciAddr("0x02")},
+					{Address: pciAddr("0x03")},
+				},
+			},
+		}
+
+		pci.DisableHotplugOnOccupiedRootPorts(spec)
+
+		expectHotplugUnchanged(spec.Devices.Controllers[1], "NIC on bus 1")
+		expectHotplugUnchanged(spec.Devices.Controllers[2], "NIC on bus 2")
+		expectHotplugUnchanged(spec.Devices.Controllers[3], "NIC on bus 3")
+	})
+
+	It("should ignore non-PCI device addresses (SATA disks, USB inputs)", func() {
+		driveAddr := &api.Address{Type: "drive", Bus: "0", Controller: "0", Target: "0", Unit: "0"}
+		usbAddr := &api.Address{Type: "usb", Bus: "0"}
+
+		spec := &api.DomainSpec{
+			Devices: api.Devices{
+				Controllers: []api.Controller{
+					newRootPortController("0", 0),
+					newRootPortController("1", 1),
+				},
+				Disks:  []api.Disk{{Target: api.DiskTarget{Bus: "sata"}, Address: driveAddr}},
+				Inputs: []api.Input{{Type: "tablet", Bus: "usb", Address: usbAddr}},
+			},
+		}
+
+		pci.DisableHotplugOnOccupiedRootPorts(spec)
+
+		expectHotplugUnchanged(spec.Devices.Controllers[0], "SATA disk drive address must not match")
+		expectHotplugUnchanged(spec.Devices.Controllers[1], "USB input address must not match")
+	})
+})

--- a/pkg/virt-launcher/virtwrap/pci/pci_suite_test.go
+++ b/pkg/virt-launcher/virtwrap/pci/pci_suite_test.go
@@ -1,0 +1,30 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package pci_test
+
+import (
+	"testing"
+
+	"kubevirt.io/client-go/testutils"
+)
+
+func TestPCI(t *testing.T) {
+	testutils.KubeVirtTestSuiteSetup(t)
+}

--- a/pkg/virt-launcher/virtwrap/util/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/util/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//pkg/virt-launcher/virtwrap/cli:go_default_library",
         "//pkg/virt-launcher/virtwrap/converter/compute:go_default_library",
+        "//pkg/virt-launcher/virtwrap/converter/translate:go_default_library",
         "//pkg/virt-launcher/virtwrap/plugins:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/api/plugin/v1alpha1:go_default_library",

--- a/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
+++ b/pkg/virt-launcher/virtwrap/util/libvirt_helper.go
@@ -22,6 +22,7 @@ import (
 	"libvirt.org/go/libvirt"
 
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter/compute"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter/translate"
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
@@ -152,6 +153,12 @@ func ApplySidecarHooks(vmi *v1.VirtualMachineInstance, wantedSpec *api.DomainSpe
 		return "", err
 	}
 	domainSpecObj.DeepCopyInto(wantedSpec)
+
+	// Go's encoding/xml cannot unmarshal namespace-prefixed struct tags
+	// (e.g. xml:"qemu:commandline"), so QEMUCmd is silently lost during
+	// the round-trip above. Re-extract it from the hook-returned XML
+	// using namespace-aware token parsing.
+	translate.TransferQEMUCommandline(domainSpec, wantedSpec)
 
 	return domainSpec, nil
 }

--- a/pkg/virt-launcher/virtwrap/util/libvirt_helper_test.go
+++ b/pkg/virt-launcher/virtwrap/util/libvirt_helper_test.go
@@ -276,6 +276,146 @@ var _ = Describe("LibvirtHelper", func() {
 		Expect(wantedSpec.Devices.Disks).To(Equal(mutatedSpec.Devices.Disks))
 	})
 
+	Context("QEMUCmd preservation across sidecar hooks", func() {
+		var (
+			vmi             *v1.VirtualMachineInstance
+			ctrl            *gomock.Controller
+			mockHookManager *hooks.MockManager
+		)
+
+		BeforeEach(func() {
+			ctrl = gomock.NewController(GinkgoT())
+			vmi = api2.NewMinimalVMIWithNS("test-namespace", "test-vmi")
+			v1.SetObjectDefaults_VirtualMachineInstance(vmi)
+			mockHookManager = hooks.NewMockManager(ctrl)
+			getHookManager = func() hooks.Manager {
+				return mockHookManager
+			}
+		})
+
+		AfterEach(func() {
+			getHookManager = hooks.GetManager
+		})
+
+		marshalSpec := func(spec *api.DomainSpec, _ *v1.VirtualMachineInstance) (string, error) {
+			xmlBytes, err := xml.MarshalIndent(spec, "", "\t")
+			if err != nil {
+				return "", err
+			}
+			return string(xmlBytes), nil
+		}
+
+		It("should preserve QEMUCmd args and envs across the round-trip", func() {
+			wantedSpec := &api.DomainSpec{
+				Type:  "kvm",
+				XmlNS: "http://libvirt.org/schemas/domain/qemu/1.0",
+				Name:  "test-vm",
+				QEMUCmd: &api.Commandline{
+					QEMUArg: []api.Arg{
+						{Value: "-fw_cfg"},
+						{Value: "name=opt/com.coreos/config,file=/var/run/test/data.ign"},
+					},
+					QEMUEnv: []api.Env{
+						{Name: "QEMU_AUDIO_DRV", Value: "none"},
+					},
+				},
+			}
+
+			mockHookManager.EXPECT().OnDefineDomain(wantedSpec, vmi).DoAndReturn(marshalSpec)
+
+			_, err := ApplySidecarHooks(vmi, wantedSpec)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(wantedSpec.QEMUCmd).NotTo(BeNil())
+			Expect(wantedSpec.QEMUCmd.QEMUArg).To(HaveLen(2))
+			Expect(wantedSpec.QEMUCmd.QEMUArg[0].Value).To(Equal("-fw_cfg"))
+			Expect(wantedSpec.QEMUCmd.QEMUArg[1].Value).To(
+				Equal("name=opt/com.coreos/config,file=/var/run/test/data.ign"))
+			Expect(wantedSpec.QEMUCmd.QEMUEnv).To(HaveLen(1))
+			Expect(wantedSpec.QEMUCmd.QEMUEnv[0].Name).To(Equal("QEMU_AUDIO_DRV"))
+			Expect(wantedSpec.QEMUCmd.QEMUEnv[0].Value).To(Equal("none"))
+		})
+
+		It("should not introduce QEMUCmd when the spec has none", func() {
+			wantedSpec := &api.DomainSpec{
+				Type: "kvm",
+				Name: "test-vm",
+			}
+
+			mockHookManager.EXPECT().OnDefineDomain(wantedSpec, vmi).DoAndReturn(marshalSpec)
+
+			_, err := ApplySidecarHooks(vmi, wantedSpec)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(wantedSpec.QEMUCmd).To(BeNil())
+		})
+
+		It("should capture hook-added QEMUCmd args", func() {
+			wantedSpec := &api.DomainSpec{
+				Type:  "kvm",
+				XmlNS: "http://libvirt.org/schemas/domain/qemu/1.0",
+				Name:  "test-vm",
+				QEMUCmd: &api.Commandline{
+					QEMUArg: []api.Arg{
+						{Value: "-fw_cfg"},
+						{Value: "name=opt/com.coreos/config,file=/var/run/test/data.ign"},
+					},
+				},
+			}
+
+			mockHookManager.EXPECT().OnDefineDomain(wantedSpec, vmi).DoAndReturn(
+				func(spec *api.DomainSpec, _ *v1.VirtualMachineInstance) (string, error) {
+					modified := spec.DeepCopy()
+					modified.QEMUCmd.QEMUArg = append(modified.QEMUCmd.QEMUArg,
+						api.Arg{Value: "-device"},
+						api.Arg{Value: "virtio-rng"},
+					)
+					xmlBytes, err := xml.MarshalIndent(modified, "", "\t")
+					if err != nil {
+						return "", err
+					}
+					return string(xmlBytes), nil
+				},
+			)
+
+			_, err := ApplySidecarHooks(vmi, wantedSpec)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(wantedSpec.QEMUCmd).NotTo(BeNil())
+			Expect(wantedSpec.QEMUCmd.QEMUArg).To(HaveLen(4))
+			Expect(wantedSpec.QEMUCmd.QEMUArg[2].Value).To(Equal("-device"))
+			Expect(wantedSpec.QEMUCmd.QEMUArg[3].Value).To(Equal("virtio-rng"))
+		})
+
+		It("should not restore QEMUCmd when the hook removed it", func() {
+			wantedSpec := &api.DomainSpec{
+				Type:  "kvm",
+				XmlNS: "http://libvirt.org/schemas/domain/qemu/1.0",
+				Name:  "test-vm",
+				QEMUCmd: &api.Commandline{
+					QEMUArg: []api.Arg{
+						{Value: "-fw_cfg"},
+						{Value: "name=opt/com.coreos/config,file=/var/run/test/data.ign"},
+					},
+				},
+			}
+
+			mockHookManager.EXPECT().OnDefineDomain(wantedSpec, vmi).DoAndReturn(
+				func(spec *api.DomainSpec, _ *v1.VirtualMachineInstance) (string, error) {
+					stripped := spec.DeepCopy()
+					stripped.QEMUCmd = nil
+					stripped.XmlNS = ""
+					xmlBytes, err := xml.MarshalIndent(stripped, "", "\t")
+					if err != nil {
+						return "", err
+					}
+					return string(xmlBytes), nil
+				},
+			)
+
+			_, err := ApplySidecarHooks(vmi, wantedSpec)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(wantedSpec.QEMUCmd).To(BeNil())
+		})
+	})
+
 	Context("getLibvirtLogFilters()", func() {
 
 		DescribeTable("should return customLogFilters if defined and not empty with", func(libvirtLogVerbosityEnvVar *string, libvirtDebugLogsEnvVarDefined bool) {


### PR DESCRIPTION
### What this PR does
Backport of #17605 to `release-1.9`.

Prevents guest operating systems from ejecting critical PCI devices (virtio disks, memory balloon, RNG, watchdog, SCSI/USB/virtio-serial controllers) by setting `hotplug="off"` on `pcie-root-port` controllers that have a non-NIC device behind them. NIC ports are intentionally left hotpluggable to preserve the existing NIC hot-unplug functionality.

#### Before this PR:
- All `pcie-root-port` controllers default to `hotplug="on"`.
- The guest OS can eject any PCI device - on Windows via the "Safely Remove Hardware" tray icon, on Linux via `echo 1 > /sys/bus/pci/.../power/control`.
- A user or automated guest agent can accidentally remove a virtio disk (risking data corruption), the memory balloon (breaking memory management), or the RNG device.

#### After this PR:
- After libvirt assigns PCI addresses, a new `pci.DisableHotplugOnOccupiedRootPorts` pass walks the domain spec, identifies which PCI bus numbers host non-NIC devices, and sets `hotplug="off"` on the corresponding `pcie-root-port` controllers before the final domain definition.
- Placeholder ports reserved for future NIC hotplug remain with `hotplug="on"` so dynamic attachment continues to work.

### Backport conflicts
Four of the five commits cherry-picked cleanly. One conflict occurred:

- **`pkg/virt-launcher/virtwrap/manager_test.go`** (commit `manager: read back domain spec when placeholderCount is zero`): the incoming change added a `GetXMLDesc(libvirt.DOMAIN_XML_INACTIVE)` mock expectation on the same line region as a `newLibvirtDomainManager(...)` call. On `main` that constructor takes an extra trailing `nil` argument that does not exist on `release-1.9`, so the two hunks overlapped. Resolved by keeping the `release-1.9` constructor signature (without the trailing `nil`) and adding the new `GetXMLDesc(libvirt.DOMAIN_XML_INACTIVE)` expectation - i.e. taking the test-logic change from the commit while preserving the older signature. The signature difference is unrelated to this PR.

### References
- Original PR: https://github.com/kubevirt/kubevirt/pull/17605
- Fixes: https://issues.redhat.com/browse/CNV-77514
- libvirt `<target hotplug>` docs: https://libvirt.org/formatdomain.html#controllers

### Release note
```release-note
Bug fix: Prevent guest OS from ejecting critical PCI devices (disks, memory balloon, RNG, watchdog) via hotplug mechanisms like the Windows "Safely Remove Hardware" tray menu. PCI root ports hosting non-NIC devices are now marked as non-hotpluggable, while NIC ports and empty ports reserved for future hotplug remain available.
```
