### PR TITLE
kubecli: gate generated mock behind kubevirt_mock build tag

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -27,6 +27,8 @@ run:crossbuild-s390x  --incompatible_enable_cc_toolchain_resolution --platforms=
 test:crossbuild-s390x --platforms=@io_bazel_rules_go//go/toolchain:linux_s390x_cgo --host_javabase=@local_jdk//:jdk
 
 build --define gotags=selinux
+test --define gotags=selinux,kubevirt_mock
+coverage --define gotags=selinux,kubevirt_mock
 
 # CentOS Stream version selection (default to CS9)
 build --define=centos_stream_version=9

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -77,7 +77,7 @@ function build_func_tests_image() {
 # Use this environment variable to specify additional tags for the go build in hack/build-go.sh.
 # To specify tags in the bazel build modify/overwrite the build target in .bazelrc instead.
 if [ -z "$KUBEVIRT_GO_BUILD_TAGS" ]; then
-    KUBEVIRT_GO_BUILD_TAGS="selinux"
+    KUBEVIRT_GO_BUILD_TAGS="selinux,kubevirt_mock"
 else
     KUBEVIRT_GO_BUILD_TAGS="selinux,${KUBEVIRT_GO_BUILD_TAGS}"
 fi

--- a/staging/src/kubevirt.io/client-go/kubecli/BUILD.bazel
+++ b/staging/src/kubevirt.io/client-go/kubecli/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "instancetype.go",
         "kubecli.go",
         "kubevirt.go",
+        "kubevirt_mock_utils.go",
         "kubevirt_test_utils.go",
         "kv.go",
         "migration.go",

--- a/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
@@ -6,6 +6,8 @@
 //	mockgen -destination=generated_mock_kubevirt.go -package=kubecli kubevirt.io/client-go/kubecli KubevirtClient,VirtualMachineInstanceInterface,ReplicaSetInterface,VirtualMachineInstancePresetInterface,VirtualMachineInterface,VirtualMachineInstanceMigrationInterface,KubeVirtInterface,ServerVersionInterface,ExpandSpecInterface
 //
 
+//go:build kubevirt_mock
+
 // Package kubecli is a generated GoMock package.
 package kubecli
 

--- a/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kubevirt.go
@@ -23,6 +23,8 @@ package kubecli
 
 /*
  ATTENTION: Rerun code generators when interface signatures are modified.
+ generated_mock_kubevirt.go must retain the //go:build kubevirt_mock constraint so downstream
+ consumers on k8s.io/client-go v0.35+ are not forced to compile the mock.
 */
 
 import (

--- a/staging/src/kubevirt.io/client-go/kubecli/kubevirt_mock_utils.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kubevirt_mock_utils.go
@@ -1,0 +1,32 @@
+//go:build kubevirt_mock
+
+package kubecli
+
+import (
+	"errors"
+
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// GetMockKubevirtClientFromClientConfig, MockKubevirtClientInstance are used to create a mechanism
+// for overriding the actual kubevirt client access. This is useful when the unit tested code invokes GetKubevirtClientFromClientConfig()
+// and therefore the unit test code cannot generate the mock client directly. In such a case following steps are needed:
+// (1) Override the GetKubevirtClientFromClientConfig() closure with GetMockKubevirtClientFromClientConfig() or
+//     GetInvalidKubevirtClientFromClientConfig()
+// (2) Then create the instance of the client, and assign into MockKubevirtClientInstance before the tests start:
+//     ctrl := gomock.NewController(GinkgoT())
+//     kubecli.MockKubevirtClientInstance = kubecli.NewMockKubevirtClient(ctrl)
+// (3) Rest of the kubevirt mocking is automatically generated in generated_mock_kubevirt.go
+
+// MockKubevirtClientInstance is a reference to the kubevirt client that could be manipulated by the test code
+var MockKubevirtClientInstance *MockKubevirtClient
+
+// GetMockKubevirtClientFromClientConfig is an entry point for testing, could be used to override GetKubevirtClientFromClientConfig
+func GetMockKubevirtClientFromClientConfig(cmdConfig clientcmd.ClientConfig) (KubevirtClient, error) {
+	return MockKubevirtClientInstance, nil
+}
+
+// GetInvalidKubevirtClientFromClientConfig is an entry point for testing case where client should be invalid
+func GetInvalidKubevirtClientFromClientConfig(cmdConfig clientcmd.ClientConfig) (KubevirtClient, error) {
+	return nil, errors.New("invalid fake client")
+}

--- a/staging/src/kubevirt.io/client-go/kubecli/kubevirt_test_utils.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/kubevirt_test_utils.go
@@ -1,40 +1,14 @@
 package kubecli
 
 import (
-	"errors"
-
 	clone "kubevirt.io/api/clone/v1beta1"
 
 	"kubevirt.io/api/migrations/v1alpha1"
 
 	k8smetav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/tools/clientcmd"
 
 	v1 "kubevirt.io/api/core/v1"
 )
-
-// GetMockKubevirtClientFromClientConfig, MockKubevirtClientInstance are used to create a mechanism
-// for overriding the actual kubevirt client access. This is useful when the unit tested code invokes GetKubevirtClientFromClientConfig()
-// and therefore the unit test code cannot generate the mock client directly. In such a case following steps are needed:
-// (1) Override the GetKubevirtClientFromClientConfig() closure with GetMockKubevirtClientFromClientConfig() or
-//     GetInvalidKubevirtClientFromClientConfig()
-// (2) Then create the instance of the client, and assign into MockKubevirtClientInstance before the tests start:
-//     ctrl := gomock.NewController(GinkgoT())
-//     kubecli.MockKubevirtClientInstance = kubecli.NewMockKubevirtClient(ctrl)
-// (3) Rest of the kubevirt mocking is automatically generated in generated_mock_kubevirt.go
-
-// MockKubevirtClientInstance is a reference to the kubevirt client that could be manipulated by the test code
-var MockKubevirtClientInstance *MockKubevirtClient
-
-// GetMockKubevirtClientFromClientConfig is an entry point for testing, could be used to override GetKubevirtClientFromClientConfig
-func GetMockKubevirtClientFromClientConfig(cmdConfig clientcmd.ClientConfig) (KubevirtClient, error) {
-	return MockKubevirtClientInstance, nil
-}
-
-// GetInvalidKubevirtClientFromClientConfig is an entry point for testing case where client should be invalid
-func GetInvalidKubevirtClientFromClientConfig(cmdConfig clientcmd.ClientConfig) (KubevirtClient, error) {
-	return nil, errors.New("invalid fake client")
-}
 
 func NewMinimalMigration(name string) *v1.VirtualMachineInstanceMigration {
 	return &v1.VirtualMachineInstanceMigration{TypeMeta: k8smetav1.TypeMeta{APIVersion: v1.GroupVersion.String(), Kind: "VirtualMachineInstanceMigration"}, ObjectMeta: k8smetav1.ObjectMeta{Name: name}}


### PR DESCRIPTION
## Summary

- Gate `generated_mock_kubevirt.go` and mock test helpers behind the `kubevirt_mock` build tag so `kubecli` compiles for downstream consumers already on `k8s.io/client-go` v0.35+
- Enable the tag for KubeVirt unit tests via `.bazelrc` (`test`/`coverage`) and `hack/common.sh` (`KUBEVIRT_GO_BUILD_TAGS`)

## Problem

`kubecli/generated_mock_kubevirt.go` is always compiled as part of the `kubecli` package and imports `k8s.io/client-go/kubernetes/typed/storagemigration/v1alpha1`, which was removed in client-go v0.35. This blocks any downstream module on client-go v0.35+ from importing `kubevirt.io/client-go/kubecli`, even when mocks are not used.

## Solution

The mock is only needed for KubeVirt unit tests. Gating it behind `kubevirt_mock` keeps production/downstream builds lean while preserving existing test workflows.

Fixes #18382

## Test plan

- [ ] `go build` a fresh module importing `kubevirt.io/client-go/kubecli` with `k8s.io/client-go` v0.35+ (no `kubevirt_mock` tag) succeeds
- [ ] KubeVirt unit tests pass with `-tags kubevirt_mock` (Bazel `test` / `make go-test`)