### PR TITLE
[release-1.6] consider migrated volumes in completionTimeoutPerGiB calculation

### DIFF
--- a/pkg/storage/types/BUILD.bazel
+++ b/pkg/storage/types/BUILD.bazel
@@ -40,6 +40,7 @@ go_test(
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/go.uber.org/mock/gomock:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",

--- a/pkg/storage/types/pvc.go
+++ b/pkg/storage/types/pvc.go
@@ -376,23 +376,14 @@ func IsMigratedVolume(name string, vmi *virtv1.VirtualMachineInstance) bool {
 
 func GetTotalSizeMigratedVolumes(vmi *virtv1.VirtualMachineInstance) *resource.Quantity {
 	size := int64(0)
-	srcVols := make(map[string]bool)
 	for _, v := range vmi.Status.MigratedVolumes {
 		if v.SourcePVCInfo == nil {
 			continue
 		}
-		srcVols[v.SourcePVCInfo.ClaimName] = true
-	}
-	for _, vstatus := range vmi.Status.VolumeStatus {
-		if vstatus.PersistentVolumeClaimInfo == nil {
-			continue
-		}
-		if _, ok := srcVols[vstatus.PersistentVolumeClaimInfo.ClaimName]; ok {
-			if s := GetDiskCapacity(vstatus.PersistentVolumeClaimInfo); s != nil {
-				size += *s
-			}
+		if s := GetDiskCapacity(v.SourcePVCInfo); s != nil {
+			size += *s
 		}
 	}
 
-	return resource.NewScaledQuantity(size, resource.Giga)
+	return resource.NewQuantity(size, resource.BinarySI)
 }

--- a/pkg/storage/types/pvc_test.go
+++ b/pkg/storage/types/pvc_test.go
@@ -22,9 +22,13 @@ package types
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	k8sv1 "k8s.io/api/core/v1"
 	kubev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
+
+	v1 "kubevirt.io/api/core/v1"
 )
 
 var _ = Describe("PVC utils test", func() {
@@ -98,4 +102,95 @@ var _ = Describe("PVC utils test", func() {
 		})
 	})
 
+	Context("GetTotalSizeMigratedVolumes", func() {
+		It("should return 0 when no migrated volumes", func() {
+			vmi := &v1.VirtualMachineInstance{
+				Status: v1.VirtualMachineInstanceStatus{
+					MigratedVolumes: []v1.StorageMigratedVolumeInfo{},
+				},
+			}
+			result := GetTotalSizeMigratedVolumes(vmi)
+			Expect(result.Value()).To(Equal(int64(0)))
+		})
+
+		It("should return 0 when SourcePVCInfo is nil", func() {
+			vmi := &v1.VirtualMachineInstance{
+				Status: v1.VirtualMachineInstanceStatus{
+					MigratedVolumes: []v1.StorageMigratedVolumeInfo{
+						{
+							VolumeName:    "test-vol",
+							SourcePVCInfo: nil,
+						},
+					},
+				},
+			}
+			result := GetTotalSizeMigratedVolumes(vmi)
+			Expect(result.Value()).To(Equal(int64(0)))
+		})
+
+		It("should calculate size correctly for 10Gi volume using SourcePVCInfo", func() {
+			tenGi := resource.MustParse("10Gi")
+			vmi := &v1.VirtualMachineInstance{
+				Status: v1.VirtualMachineInstanceStatus{
+					MigratedVolumes: []v1.StorageMigratedVolumeInfo{
+						{
+							VolumeName: "test-vol",
+							SourcePVCInfo: &v1.PersistentVolumeClaimInfo{
+								ClaimName: "source-pvc",
+								Capacity: k8sv1.ResourceList{
+									k8sv1.ResourceStorage: tenGi,
+								},
+								Requests: k8sv1.ResourceList{
+									k8sv1.ResourceStorage: tenGi,
+								},
+							},
+							DestinationPVCInfo: &v1.PersistentVolumeClaimInfo{
+								ClaimName: "dest-pvc",
+							},
+						},
+					},
+				},
+			}
+			result := GetTotalSizeMigratedVolumes(vmi)
+			Expect(result.Value()).To(Equal(tenGi.Value()))
+		})
+
+		It("should sum multiple migrated volumes", func() {
+			tenGi := resource.MustParse("10Gi")
+			fiveGi := resource.MustParse("5Gi")
+			vmi := &v1.VirtualMachineInstance{
+				Status: v1.VirtualMachineInstanceStatus{
+					MigratedVolumes: []v1.StorageMigratedVolumeInfo{
+						{
+							VolumeName: "vol1",
+							SourcePVCInfo: &v1.PersistentVolumeClaimInfo{
+								ClaimName: "source-pvc-1",
+								Capacity: k8sv1.ResourceList{
+									k8sv1.ResourceStorage: tenGi,
+								},
+								Requests: k8sv1.ResourceList{
+									k8sv1.ResourceStorage: tenGi,
+								},
+							},
+						},
+						{
+							VolumeName: "vol2",
+							SourcePVCInfo: &v1.PersistentVolumeClaimInfo{
+								ClaimName: "source-pvc-2",
+								Capacity: k8sv1.ResourceList{
+									k8sv1.ResourceStorage: fiveGi,
+								},
+								Requests: k8sv1.ResourceList{
+									k8sv1.ResourceStorage: fiveGi,
+								},
+							},
+						},
+					},
+				},
+			}
+			result := GetTotalSizeMigratedVolumes(vmi)
+			expectedSize := tenGi.Value() + fiveGi.Value()
+			Expect(result.Value()).To(Equal(expectedSize))
+		})
+	})
 })

--- a/pkg/virt-controller/watch/volume-migration/volume-migration.go
+++ b/pkg/virt-controller/watch/volume-migration/volume-migration.go
@@ -384,16 +384,28 @@ func GenerateMigratedVolumes(pvcStore cache.Store, vmi *virtv1.VirtualMachineIns
 		if pvc != nil && pvc.Spec.VolumeMode != nil {
 			volMode = pvc.Spec.VolumeMode
 		}
+		srcPVCInfo := &virtv1.PersistentVolumeClaimInfo{
+			ClaimName:  oldClaim,
+			VolumeMode: oldVolMode,
+		}
+		dstPVCInfo := &virtv1.PersistentVolumeClaimInfo{
+			ClaimName:  claim,
+			VolumeMode: volMode,
+		}
+		if oldPvc != nil {
+			srcPVCInfo.AccessModes = oldPvc.Spec.AccessModes
+			srcPVCInfo.Requests = oldPvc.Spec.Resources.Requests
+			srcPVCInfo.Capacity = oldPvc.Status.Capacity
+		}
+		if pvc != nil {
+			dstPVCInfo.AccessModes = pvc.Spec.AccessModes
+			dstPVCInfo.Requests = pvc.Spec.Resources.Requests
+			dstPVCInfo.Capacity = pvc.Status.Capacity
+		}
 		migVolsInfo = append(migVolsInfo, virtv1.StorageMigratedVolumeInfo{
-			VolumeName: v.Name,
-			DestinationPVCInfo: &virtv1.PersistentVolumeClaimInfo{
-				ClaimName:  claim,
-				VolumeMode: volMode,
-			},
-			SourcePVCInfo: &virtv1.PersistentVolumeClaimInfo{
-				ClaimName:  oldClaim,
-				VolumeMode: oldVolMode,
-			},
+			VolumeName:         v.Name,
+			DestinationPVCInfo: dstPVCInfo,
+			SourcePVCInfo:      srcPVCInfo,
 		})
 	}
 

--- a/pkg/virt-controller/watch/volume-migration/volume-migration_test.go
+++ b/pkg/virt-controller/watch/volume-migration/volume-migration_test.go
@@ -317,6 +317,17 @@ var _ = Describe("Volume Migration", func() {
 					ObjectMeta: metav1.ObjectMeta{Name: v, Namespace: ns},
 					Spec: k8sv1.PersistentVolumeClaimSpec{
 						VolumeMode: virtpointer.P(k8sv1.PersistentVolumeFilesystem),
+						Resources: k8sv1.VolumeResourceRequirements{
+							Requests: k8sv1.ResourceList{
+								k8sv1.ResourceStorage: resource.MustParse("1Gi"),
+							},
+						},
+						AccessModes: []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce},
+					},
+					Status: k8sv1.PersistentVolumeClaimStatus{
+						Capacity: k8sv1.ResourceList{
+							k8sv1.ResourceStorage: resource.MustParse("1Gi"),
+						},
 					},
 				})
 				alreadyAddedVols[v] = true
@@ -329,6 +340,17 @@ var _ = Describe("Volume Migration", func() {
 					ObjectMeta: metav1.ObjectMeta{Name: v, Namespace: ns},
 					Spec: k8sv1.PersistentVolumeClaimSpec{
 						VolumeMode: virtpointer.P(k8sv1.PersistentVolumeFilesystem),
+						Resources: k8sv1.VolumeResourceRequirements{
+							Requests: k8sv1.ResourceList{
+								k8sv1.ResourceStorage: resource.MustParse("1Gi"),
+							},
+						},
+						AccessModes: []k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce},
+					},
+					Status: k8sv1.PersistentVolumeClaimStatus{
+						Capacity: k8sv1.ResourceList{
+							k8sv1.ResourceStorage: resource.MustParse("1Gi"),
+						},
 					},
 				})
 			}
@@ -355,18 +377,36 @@ var _ = Describe("Volume Migration", func() {
 					Expect(ok).To(BeTrue())
 					Expect(migVol.SourcePVCInfo).ToNot(BeNil())
 					Expect(migVol.DestinationPVCInfo).ToNot(BeNil())
-					Expect(migVol.SourcePVCInfo.ClaimName).To(Equal(v.src))
-					Expect(migVol.DestinationPVCInfo.ClaimName).To(Equal(v.dst))
-					Expect(migVol.SourcePVCInfo.VolumeMode).To(HaveValue(Equal(k8sv1.PersistentVolumeFilesystem)))
-					Expect(migVol.DestinationPVCInfo.VolumeMode).To(HaveValue(Equal(k8sv1.PersistentVolumeFilesystem)))
+					Expect(migVol.SourcePVCInfo).To(
+						PointTo(
+							MatchFields(IgnoreExtras, Fields{
+								"ClaimName":   Equal(v.src),
+								"VolumeMode":  HaveValue(Equal(k8sv1.PersistentVolumeFilesystem)),
+								"AccessModes": Equal([]k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce}),
+								"Requests":    Equal(k8sv1.ResourceList{k8sv1.ResourceStorage: resource.MustParse("1Gi")}),
+								"Capacity":    Equal(k8sv1.ResourceList{k8sv1.ResourceStorage: resource.MustParse("1Gi")}),
+							}),
+						),
+					)
+					Expect(migVol.DestinationPVCInfo).To(
+						PointTo(
+							MatchFields(IgnoreExtras, Fields{
+								"ClaimName":   Equal(v.dst),
+								"VolumeMode":  HaveValue(Equal(k8sv1.PersistentVolumeFilesystem)),
+								"AccessModes": Equal([]k8sv1.PersistentVolumeAccessMode{k8sv1.ReadWriteOnce}),
+								"Requests":    Equal(k8sv1.ResourceList{k8sv1.ResourceStorage: resource.MustParse("1Gi")}),
+								"Capacity":    Equal(k8sv1.ResourceList{k8sv1.ResourceStorage: resource.MustParse("1Gi")}),
+							}),
+						),
+					)
 				}
 			}
 		},
 			Entry("with an update of a volume", []string{"src0"}, []string{"dst0"},
-				map[string]migVolumes{generateDiskNameFromIndex(0): migVolumes{src: "src0", dst: "dst0"}}),
+				map[string]migVolumes{generateDiskNameFromIndex(0): {src: "src0", dst: "dst0"}}),
 			Entry("with an update of multiple volumes", []string{"src0", "src1"}, []string{"dst0", "dst1"},
-				map[string]migVolumes{generateDiskNameFromIndex(0): migVolumes{src: "src0", dst: "dst0"},
-					generateDiskNameFromIndex(1): migVolumes{src: "src1", dst: "dst1"}}),
+				map[string]migVolumes{generateDiskNameFromIndex(0): {src: "src0", dst: "dst0"},
+					generateDiskNameFromIndex(1): {src: "src1", dst: "dst1"}}),
 			Entry("without any update", []string{"vol0"}, []string{"vol0"}, map[string]migVolumes{}),
 		)
 

--- a/pkg/virt-handler/migration-target.go
+++ b/pkg/virt-handler/migration-target.go
@@ -371,7 +371,10 @@ func (c *MigrationTargetController) Execute() bool {
 	return true
 }
 
-func (c *MigrationTargetController) updateVMI(vmi *v1.VirtualMachineInstance, oldStatus *v1.VirtualMachineInstanceStatus, oldLabels map[string]string) error {
+func (c *MigrationTargetController) updateVMI(vmi *v1.VirtualMachineInstance, oldSpec *v1.VirtualMachineInstanceSpec, oldStatus *v1.VirtualMachineInstanceStatus, oldLabels map[string]string) error {
+	if !equality.Semantic.DeepEqual(*oldSpec, vmi.Spec) {
+		return fmt.Errorf("spec changes illegal in updateVMI, not updating VMI")
+	}
 	// update the VMI if necessary
 	if !equality.Semantic.DeepEqual(oldStatus, vmi.Status) || !equality.Semantic.DeepEqual(oldLabels, vmi.Labels) {
 		_, err := c.clientset.VirtualMachineInstance(vmi.ObjectMeta.Namespace).Update(context.Background(), vmi, metav1.UpdateOptions{})
@@ -390,7 +393,7 @@ func (c *MigrationTargetController) updateVMI(vmi *v1.VirtualMachineInstance, ol
 // - The VMI will be removed from our informer
 // - The migration proxy for the VMI will be stopped
 // - The key will not be re-enqueued
-func (c *MigrationTargetController) finalCleanup(vmi *v1.VirtualMachineInstance, oldStatus *v1.VirtualMachineInstanceStatus, oldLabels map[string]string, domain *api.Domain) error {
+func (c *MigrationTargetController) finalCleanup(vmi *v1.VirtualMachineInstance, oldSpec *v1.VirtualMachineInstanceSpec, oldStatus *v1.VirtualMachineInstanceStatus, oldLabels map[string]string, domain *api.Domain) error {
 	if domainPausedFailedPostCopy(domain) {
 		if vmi.Status.Phase == v1.Running {
 			// In this function, we can usually clean up our (target) pod, since the migration is over.
@@ -446,10 +449,11 @@ func (c *MigrationTargetController) finalCleanup(vmi *v1.VirtualMachineInstance,
 	// Effectively removes the VMI from our VMI informer
 	delete(vmi.Labels, v1.MigrationTargetNodeNameLabel)
 	delete(vmi.Annotations, v1.CreateMigrationTarget)
-	return c.updateVMI(vmi, oldStatus, oldLabels)
+	return c.updateVMI(vmi, oldSpec, oldStatus, oldLabels)
 }
 
 func (c *MigrationTargetController) sync(vmi *v1.VirtualMachineInstance, domain *api.Domain) error {
+	oldSpec := vmi.Spec
 	oldStatus := vmi.Status
 	oldLabels := vmi.Labels
 	vmi = vmi.DeepCopy()
@@ -457,7 +461,7 @@ func (c *MigrationTargetController) sync(vmi *v1.VirtualMachineInstance, domain 
 	// post-migration clean up
 	if vmi.Status.MigrationState != nil && vmi.Status.MigrationState.EndTimestamp != nil &&
 		(vmi.Status.MigrationState.Completed || vmi.Status.MigrationState.Failed) {
-		return c.finalCleanup(vmi, &oldStatus, oldLabels, domain)
+		return c.finalCleanup(vmi, &oldSpec, &oldStatus, oldLabels, domain)
 	}
 
 	if domain != nil {
@@ -483,7 +487,7 @@ func (c *MigrationTargetController) sync(vmi *v1.VirtualMachineInstance, domain 
 	// If processVMI is just waiting for something to be ready, we can't and don't need to increase expectations.
 	// We can't because the VMI may not update before the thing is ready, deadlocking us
 	// We don't need to because every time processVMI is waiting for something it re-adds the key to the queue
-	updateVMIErr := c.updateVMI(vmi, &oldStatus, oldLabels)
+	updateVMIErr := c.updateVMI(vmi, &oldSpec, &oldStatus, oldLabels)
 	if updateVMIErr != nil {
 		return updateVMIErr
 	}
@@ -652,28 +656,29 @@ func (c *MigrationTargetController) syncVolumes(vmi *v1.VirtualMachineInstance) 
 	return nil
 }
 
-func (c *MigrationTargetController) unmountVolumes(vmi *v1.VirtualMachineInstance) error {
+func (c *MigrationTargetController) unmountVolumes(originalVMI *v1.VirtualMachineInstance) error {
 	// The VolumeStatus is used to retrieve additional information for the volume handling.
 	// For example, for filesystem PVC, the information are used to create a right size image.
 	// In the case of migrated volumes, we need to replace the original volume information with the
 	// destination volume properties.
-	replaceMigratedVolumesStatus(vmi)
-	err := hostdisk.ReplacePVCByHostDisk(vmi)
+	replaceMigratedVolumesStatus(originalVMI)
+	vmiCopy := originalVMI.DeepCopy()
+	err := hostdisk.ReplacePVCByHostDisk(vmiCopy)
 	if err != nil {
 		return err
 	}
 
-	if err = c.containerDiskMounter.Unmount(vmi); err != nil {
+	if err = c.containerDiskMounter.Unmount(vmiCopy); err != nil {
 		return err
 	}
 
 	// Mount hotplug disks
-	if attachmentPodUID := vmi.Status.MigrationState.TargetAttachmentPodUID; attachmentPodUID != types.UID("") {
-		cgroupManager, err := getCgroupManager(vmi, c.host)
+	if attachmentPodUID := vmiCopy.Status.MigrationState.TargetAttachmentPodUID; attachmentPodUID != types.UID("") {
+		cgroupManager, err := getCgroupManager(vmiCopy, c.host)
 		if err != nil {
 			return err
 		}
-		if err = c.hotplugVolumeMounter.Unmount(vmi, cgroupManager); err != nil {
+		if err = c.hotplugVolumeMounter.Unmount(vmiCopy, cgroupManager); err != nil {
 			return fmt.Errorf("failed to unmount hotplug volumes: %v", err)
 		}
 	}

--- a/pkg/virt-handler/migration-target_test.go
+++ b/pkg/virt-handler/migration-target_test.go
@@ -688,6 +688,61 @@ var _ = Describe("VirtualMachineInstance migration target", func() {
 		client.EXPECT().SignalTargetPodCleanup(vmi)
 		sanityExecute()
 	})
+
+	It("should not accidentally update VMI spec on cleanup", func() {
+		vmi := api2.NewMinimalVMI("testvmi")
+		vmi.Spec.Volumes = []v1.Volume{
+			{
+				Name: "testvol",
+				VolumeSource: v1.VolumeSource{
+					PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+						PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{ClaimName: "testclaim"},
+					},
+				},
+			},
+		}
+		vmi.Status.VolumeStatus = []v1.VolumeStatus{
+			{
+				Name: "testvol",
+				PersistentVolumeClaimInfo: &v1.PersistentVolumeClaimInfo{
+					ClaimName:  "testclaim",
+					VolumeMode: pointer.P(k8sv1.PersistentVolumeFilesystem),
+					Capacity: k8sv1.ResourceList{
+						k8sv1.ResourceStorage: resource.MustParse("1Gi"),
+					},
+					Requests: k8sv1.ResourceList{
+						k8sv1.ResourceStorage: resource.MustParse("1Gi"),
+					},
+				},
+			},
+		}
+		vmi.UID = vmiTestUUID
+		vmi.ObjectMeta.ResourceVersion = "1"
+		vmi.Status.Phase = v1.Running
+		vmi.Labels = make(map[string]string)
+		vmi.Status.NodeName = "othernode"
+		vmi.Labels[v1.MigrationTargetNodeNameLabel] = host
+		vmi.Status.MigrationState = &v1.VirtualMachineInstanceMigrationState{
+			TargetNode:   host,
+			SourceNode:   "othernode",
+			MigrationUID: "123",
+			Failed:       true,
+			EndTimestamp: pointer.P(metav1.Now()),
+		}
+		vmi = addActivePods(vmi, podTestUUID, host)
+
+		createVMI(vmi)
+
+		client.EXPECT().SignalTargetPodCleanup(vmi)
+		originalVMI := vmi.DeepCopy()
+		sanityExecute()
+
+		updatedVMI, err := virtfakeClient.KubevirtV1().VirtualMachineInstances(metav1.NamespaceDefault).Get(context.TODO(), vmi.Name, metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		// Update occured for labels but not spec
+		Expect(updatedVMI.Spec.Volumes).To(Equal(originalVMI.Spec.Volumes))
+		Expect(updatedVMI.Labels).To(Not(HaveKey(v1.MigrationTargetNodeNameLabel)))
+	})
 })
 
 type stubTargetPasstRepairHandler struct {

--- a/tests/storage/migration.go
+++ b/tests/storage/migration.go
@@ -285,17 +285,21 @@ var _ = Describe(SIG("Volumes update with migration", decorators.RequiresTwoSche
 				}
 				return vm.Status.VolumeUpdateState.VolumeMigrationState.MigratedVolumes
 			}).WithTimeout(120*time.Second).WithPolling(time.Second).Should(
-				ContainElement(virtv1.StorageMigratedVolumeInfo{
-					VolumeName: volName,
-					SourcePVCInfo: &virtv1.PersistentVolumeClaimInfo{
-						ClaimName:  src,
-						VolumeMode: pointer.P(k8sv1.PersistentVolumeFilesystem),
-					},
-					DestinationPVCInfo: &virtv1.PersistentVolumeClaimInfo{
-						ClaimName:  dst,
-						VolumeMode: pointer.P(k8sv1.PersistentVolumeFilesystem),
-					},
-				}), "The volumes migrated should be set",
+				ContainElement(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+					"VolumeName": Equal(volName),
+					"SourcePVCInfo": gstruct.PointTo(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+						"ClaimName":   Equal(src),
+						"VolumeMode":  Equal(pointer.P(k8sv1.PersistentVolumeFilesystem)),
+						"AccessModes": Not(BeEmpty()),
+						"Requests":    HaveLen(1),
+					})),
+					"DestinationPVCInfo": gstruct.PointTo(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+						"ClaimName":   Equal(dst),
+						"VolumeMode":  Equal(pointer.P(k8sv1.PersistentVolumeFilesystem)),
+						"AccessModes": Not(BeEmpty()),
+						"Requests":    HaveLen(1),
+					})),
+				})), "The volumes migrated should be set",
 			)
 			Eventually(func() bool {
 				vm, err := virtClient.VirtualMachine(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
@@ -841,17 +845,21 @@ var _ = Describe(SIG("Volumes update with migration", decorators.RequiresTwoSche
 				}
 				return vm.Status.VolumeUpdateState.VolumeMigrationState.MigratedVolumes
 			}).WithTimeout(120*time.Second).WithPolling(time.Second).Should(
-				ContainElement(virtv1.StorageMigratedVolumeInfo{
-					VolumeName: volName,
-					SourcePVCInfo: &virtv1.PersistentVolumeClaimInfo{
-						ClaimName:  dv.Name,
-						VolumeMode: pointer.P(k8sv1.PersistentVolumeFilesystem),
-					},
-					DestinationPVCInfo: &virtv1.PersistentVolumeClaimInfo{
-						ClaimName:  destPVC,
-						VolumeMode: pointer.P(k8sv1.PersistentVolumeFilesystem),
-					},
-				}), "The volumes migrated should be set",
+				ContainElement(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+					"VolumeName": Equal(volName),
+					"SourcePVCInfo": gstruct.PointTo(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+						"ClaimName":   Equal(dv.Name),
+						"VolumeMode":  Equal(pointer.P(k8sv1.PersistentVolumeFilesystem)),
+						"AccessModes": Not(BeEmpty()),
+						"Requests":    HaveLen(1),
+					})),
+					"DestinationPVCInfo": gstruct.PointTo(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
+						"ClaimName":   Equal(destPVC),
+						"VolumeMode":  Equal(pointer.P(k8sv1.PersistentVolumeFilesystem)),
+						"AccessModes": Not(BeEmpty()),
+						"Requests":    HaveLen(1),
+					})),
+				})), "The volumes migrated should be set",
 			)
 			By("Cancel the volume migration")
 			updateVMWithPVC(vm, volName, dv.Name)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Manual backport https://github.com/kubevirt/kubevirt/pull/16833

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [design document](https://github.com/kubevirt/community/tree/main/design-proposals) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: storage migration fails with Google Cloud NetApp Volumes
```
