### PR TITLE
hack: default to CentOS Stream 10 builder image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 export GO15VENDOREXPERIMENT := 1
 
-KUBEVIRT_CENTOS_STREAM_VERSION ?= 9
+KUBEVIRT_CENTOS_STREAM_VERSION ?= 10
 
 ifeq (${CI}, true)
   # If we're running under a test lane, enable timestamps and disable progress output

--- a/hack/dockerized
+++ b/hack/dockerized
@@ -13,7 +13,7 @@ fi
 fail_if_cri_bin_missing
 
 kubevirt_builder_version="2606301323-b9f50e380a"
-kubevirt_cs10_builder_version=${KUBEVIRT_CS10_BUILDER_VERSION:-""}
+kubevirt_cs10_builder_version=${KUBEVIRT_CS10_BUILDER_VERSION:-"2606301559-b9f50e380a"}
 
 # CentOS Stream 9 builder images (default)
 default_kubevirt_builder_image="quay.io/kubevirt/builder:${kubevirt_builder_version}"


### PR DESCRIPTION
### What this PR does
#### Before this PR:
`KUBEVIRT_CENTOS_STREAM_VERSION` defaults to `9`, so `make test` and all other `hack/dockerized` targets use the CentOS Stream 9 builder image. Using the CS10 image requires setting `KUBEVIRT_CS10_BUILDER_VERSION` externally — there is no hardcoded default.

#### After this PR:
`KUBEVIRT_CENTOS_STREAM_VERSION` defaults to `10` and `hack/dockerized` hardcodes the published CS10 builder image version (`2606301559-b9f50e380a`), so `make test` and all other dockerized targets use `quay.io/kubevirt/builder-cs10:2606301559-b9f50e380a` by default without any extra env vars.

CentOS Stream 9 remains available via `KUBEVIRT_CENTOS_STREAM_VERSION=9` or the existing `make rpm-deps-cs9` / `make rpm-deps-all` targets.

### References
- Follows from CS10 rpm-deps work: #18785
- Enables containerised `make test-integration` once the envtest builder image PR merges: #18841

### Why we need it and why it was done in this way
The following tradeoffs were made:
- Changing the Makefile default (rather than wrapping individual targets) moves all `hack/dockerized` targets to CS10 in one place, keeping the change minimal and consistent.
- Hardcoding the CS10 version in `hack/dockerized` mirrors how the CS9 version is handled, so the workflow is identical.

The following alternatives were considered:
- Wrapping only `bazel-test` with `KUBEVIRT_CENTOS_STREAM_VERSION=10` — rejected because it would leave other targets on CS9 inconsistently.

Links to places where the discussion took place: https://github.com/kubevirt/enhancements/pull/348

### Special notes for your reviewer

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required — build infrastructure only, no VEP required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required — builder image only, no production code change
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test — validated by running `make test` against the CS10 builder
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required — not required
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
NONE
```