### PR TITLE
chore(test.sh): Auto-detect CentOS Stream version from kubevirtci provider

### DIFF
--- a/automation/repeated_test.sh
+++ b/automation/repeated_test.sh
@@ -222,6 +222,8 @@ export KUBEVIRT_NFS_DIR=${KUBEVIRT_NFS_DIR:-/var/lib/containers/nfs-data}
 
 export KUBEVIRT_PROVIDER="${TEST_LANE}"
 
+detect_centos_stream_version
+
 # add_to_label_filter appends the given label and separator to
 # $label_filter which is passed to Ginkgo --filter-label flag.
 # How to use:

--- a/automation/test.sh
+++ b/automation/test.sh
@@ -187,6 +187,8 @@ case "$TARGET" in
     ;;
 esac
 
+detect_centos_stream_version
+
 # Single-node single-replica test lanes need nfs csi to run sig-storage tests
 if [[ $KUBEVIRT_NUM_NODES = "1" && $KUBEVIRT_INFRA_REPLICAS = "1" ]]; then
   export KUBEVIRT_DEPLOY_NFS_CSI=true

--- a/hack/config-default.sh
+++ b/hack/config-default.sh
@@ -46,6 +46,26 @@ test_image_replicas=${KUBEVIRT_E2E_PARALLEL_NODES:-6}
 base_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 kubevirt_test_config=${KUBEVIRT_TEST_CONFIG:-$(if [[ "${KUBEVIRT_STORAGE:-}" == rook-ceph* ]]; then echo "${base_dir}/tests/default-ceph-config.json"; else echo "${base_dir}/tests/default-config.json"; fi)}
 
+# Detect CentOS Stream version from the kubevirtci provider.
+# k8s >= 1.37 providers are based on CentOS Stream 10; older ones use CS9.
+# Respects KUBEVIRT_CENTOS_STREAM_VERSION if already set
+# Must be called after KUBEVIRT_PROVIDER is resolved.
+detect_centos_stream_version() {
+    if [ -n "${KUBEVIRT_CENTOS_STREAM_VERSION:-}" ]; then
+        return
+    fi
+    local provider_version
+    provider_version=$(echo "${KUBEVIRT_PROVIDER:-}" | sed -n 's/^k8s-\([0-9]*\.[0-9]*\).*/\1/p')
+    if [ -n "$provider_version" ]; then
+        local min_cs10_version="1.37"
+        if [ "$(printf '%s\n' "$min_cs10_version" "$provider_version" | sort -V | head -n1)" = "$min_cs10_version" ]; then
+            export KUBEVIRT_CENTOS_STREAM_VERSION=10
+            return
+        fi
+    fi
+    export KUBEVIRT_CENTOS_STREAM_VERSION=9
+}
+
 # try to derive csv_version from docker tag. But it must start with x.y.z, without leading v
 default_csv_version="${docker_tag/latest/0.0.0}"
 default_csv_version="${default_csv_version/devel/0.0.0}"


### PR DESCRIPTION
### What this PR does
#### Before this PR:
Every k8s-1.37 e2e Prow job needed `KUBEVIRT_CENTOS_STREAM_VERSION=10` set explicitly in the job config. 

#### After this PR:
`automation/test.sh` and `automation/repeated_test.sh` auto-detects the CentOS Stream version from the kubevirtci provider. 
k8s >= 1.37 -> CS10
k8s < 1.37 -> CS9. 
Explicit `KUBEVIRT_CENTOS_STREAM_VERSION` overrides are still respected.

This only affects the e2e test entry point (`automation/test.sh` and `automation/repeated_test.sh`). Build, unit test, and other non-e2e paths are unchanged.


### Why we need it and why it was done in this way
With the addition of k8s-1.37 providers based on CentOS Stream 10, the number of places that need KUBEVIRT_CENTOS_STREAM_VERSION=10` keeps growing. Auto-detection from the provider version eliminates this manual step for e2e jobs.


### Special notes for your reviewer
/cc @dollierp @oshoval 


