### PR TITLE
Remove legacy containerdisk CRC32 checksum computation

### DIFF
--- a/api/api-rule-violations-known.list
+++ b/api/api-rule-violations-known.list
@@ -108,6 +108,7 @@ API rule violation: names_match,kubevirt.io/api/core/v1,CDRomTarget,ReadOnly
 API rule violation: names_match,kubevirt.io/api/core/v1,CPU,DedicatedCPUPlacement
 API rule violation: names_match,kubevirt.io/api/core/v1,CloudInitConfigDriveSource,UserDataSecretRef
 API rule violation: names_match,kubevirt.io/api/core/v1,CloudInitNoCloudSource,UserDataSecretRef
+API rule violation: names_match,kubevirt.io/api/core/v1,ContainerDiskInfo,DeprecatedChecksum
 API rule violation: names_match,kubevirt.io/api/core/v1,DeveloperConfiguration,LessPVCSpaceToleration
 API rule violation: names_match,kubevirt.io/api/core/v1,Devices,GPUs
 API rule violation: names_match,kubevirt.io/api/core/v1,Devices,NetworkInterfaceMultiQueue
@@ -122,10 +123,12 @@ API rule violation: names_match,kubevirt.io/api/core/v1,FeatureSpinlocks,Retries
 API rule violation: names_match,kubevirt.io/api/core/v1,FeatureVendorID,VendorID
 API rule violation: names_match,kubevirt.io/api/core/v1,HPETTimer,Enabled
 API rule violation: names_match,kubevirt.io/api/core/v1,HypervTimer,Enabled
+API rule violation: names_match,kubevirt.io/api/core/v1,InitrdInfo,DeprecatedChecksum
 API rule violation: names_match,kubevirt.io/api/core/v1,InterfaceBindingMethod,DeprecatedMacvtap
 API rule violation: names_match,kubevirt.io/api/core/v1,InterfaceBindingMethod,DeprecatedPasst
 API rule violation: names_match,kubevirt.io/api/core/v1,InterfaceBindingMethod,DeprecatedSlirp
 API rule violation: names_match,kubevirt.io/api/core/v1,KVMTimer,Enabled
+API rule violation: names_match,kubevirt.io/api/core/v1,KernelInfo,DeprecatedChecksum
 API rule violation: names_match,kubevirt.io/api/core/v1,KubeVirtConfiguration,DeprecatedMinCPUModel
 API rule violation: names_match,kubevirt.io/api/core/v1,KubeVirtConfiguration,MigrationConfiguration
 API rule violation: names_match,kubevirt.io/api/core/v1,KubeVirtConfiguration,NetworkConfiguration

--- a/api/api-rule-violations.list
+++ b/api/api-rule-violations.list
@@ -108,6 +108,7 @@ API rule violation: names_match,kubevirt.io/api/core/v1,CDRomTarget,ReadOnly
 API rule violation: names_match,kubevirt.io/api/core/v1,CPU,DedicatedCPUPlacement
 API rule violation: names_match,kubevirt.io/api/core/v1,CloudInitConfigDriveSource,UserDataSecretRef
 API rule violation: names_match,kubevirt.io/api/core/v1,CloudInitNoCloudSource,UserDataSecretRef
+API rule violation: names_match,kubevirt.io/api/core/v1,ContainerDiskInfo,DeprecatedChecksum
 API rule violation: names_match,kubevirt.io/api/core/v1,DeveloperConfiguration,LessPVCSpaceToleration
 API rule violation: names_match,kubevirt.io/api/core/v1,Devices,GPUs
 API rule violation: names_match,kubevirt.io/api/core/v1,Devices,NetworkInterfaceMultiQueue
@@ -122,10 +123,12 @@ API rule violation: names_match,kubevirt.io/api/core/v1,FeatureSpinlocks,Retries
 API rule violation: names_match,kubevirt.io/api/core/v1,FeatureVendorID,VendorID
 API rule violation: names_match,kubevirt.io/api/core/v1,HPETTimer,Enabled
 API rule violation: names_match,kubevirt.io/api/core/v1,HypervTimer,Enabled
+API rule violation: names_match,kubevirt.io/api/core/v1,InitrdInfo,DeprecatedChecksum
 API rule violation: names_match,kubevirt.io/api/core/v1,InterfaceBindingMethod,DeprecatedMacvtap
 API rule violation: names_match,kubevirt.io/api/core/v1,InterfaceBindingMethod,DeprecatedPasst
 API rule violation: names_match,kubevirt.io/api/core/v1,InterfaceBindingMethod,DeprecatedSlirp
 API rule violation: names_match,kubevirt.io/api/core/v1,KVMTimer,Enabled
+API rule violation: names_match,kubevirt.io/api/core/v1,KernelInfo,DeprecatedChecksum
 API rule violation: names_match,kubevirt.io/api/core/v1,KubeVirtConfiguration,DeprecatedMinCPUModel
 API rule violation: names_match,kubevirt.io/api/core/v1,KubeVirtConfiguration,MigrationConfiguration
 API rule violation: names_match,kubevirt.io/api/core/v1,KubeVirtConfiguration,NetworkConfiguration

--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -14376,7 +14376,7 @@
     "type": "object",
     "properties": {
      "checksum": {
-      "description": "Checksum is the checksum of the rootdisk or kernel artifacts inside the containerdisk",
+      "description": "deprecated; Checksum is the checksum of the rootdisk or kernel artifacts inside the containerdisk",
       "type": "integer",
       "format": "int64"
      }
@@ -15654,7 +15654,7 @@
     "type": "object",
     "properties": {
      "checksum": {
-      "description": "Checksum is the checksum of the initrd file",
+      "description": "deprecated; Checksum is the checksum of the initrd file",
       "type": "integer",
       "format": "int64"
      }
@@ -15976,7 +15976,7 @@
     "type": "object",
     "properties": {
      "checksum": {
-      "description": "Checksum is the checksum of the kernel image",
+      "description": "deprecated; Checksum is the checksum of the kernel image",
       "type": "integer",
       "format": "int64"
      }

--- a/pkg/virt-handler/container-disk/generated_mock_mount.go
+++ b/pkg/virt-handler/container-disk/generated_mock_mount.go
@@ -41,21 +41,6 @@ func (m *MockMounter) EXPECT() *MockMounterMockRecorder {
 	return m.recorder
 }
 
-// ComputeChecksums mocks base method.
-func (m *MockMounter) ComputeChecksums(vmi *v1.VirtualMachineInstance) (*DiskChecksums, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ComputeChecksums", vmi)
-	ret0, _ := ret[0].(*DiskChecksums)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ComputeChecksums indicates an expected call of ComputeChecksums.
-func (mr *MockMounterMockRecorder) ComputeChecksums(vmi any) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ComputeChecksums", reflect.TypeOf((*MockMounter)(nil).ComputeChecksums), vmi)
-}
-
 // ContainerDisksReady mocks base method.
 func (m *MockMounter) ContainerDisksReady(vmi *v1.VirtualMachineInstance, notInitializedSince time.Time) (bool, error) {
 	m.ctrl.T.Helper()

--- a/pkg/virt-handler/container-disk/mount.go
+++ b/pkg/virt-handler/container-disk/mount.go
@@ -22,8 +22,6 @@ package container_disk
 import (
 	"errors"
 	"fmt"
-	"hash/crc32"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -78,11 +76,6 @@ type Mounter interface {
 	ContainerDisksReady(vmi *v1.VirtualMachineInstance, notInitializedSince time.Time) (bool, error)
 	MountAndVerify(vmi *v1.VirtualMachineInstance) error
 	Unmount(vmi *v1.VirtualMachineInstance) error
-	// ComputeChecksums method, along with the code added in this commit, can be removed after the 1.7 release.
-	// By then, we can be sure that during upgrades older versions of virt-handler no longer expect the checksum
-	// in the VMI status.
-	// Therefore, it will no longer be necessary to include this information in the VMI status.
-	ComputeChecksums(vmi *v1.VirtualMachineInstance) (*DiskChecksums, error)
 }
 
 type vmiMountTargetEntry struct {
@@ -98,16 +91,6 @@ type vmiMountTargetRecord struct {
 type kernelArtifacts struct {
 	kernel *safepath.Path
 	initrd *safepath.Path
-}
-
-type DiskChecksums struct {
-	KernelBootChecksum     KernelBootChecksum
-	ContainerDiskChecksums map[string]uint32
-}
-
-type KernelBootChecksum struct {
-	Initrd *uint32
-	Kernel *uint32
 }
 
 func NewMounter(isoDetector isolation.PodIsolationDetector, mountStateDir string, clusterConfig *virtconfig.ClusterConfig) Mounter {
@@ -681,80 +664,6 @@ func (m *mounter) getKernelArtifactPaths(vmi *v1.VirtualMachineInstance) (*kerne
 	}
 
 	return kernelArtifacts, nil
-}
-
-func getDigest(imageFile *safepath.Path) (uint32, error) {
-	digest := crc32.NewIEEE()
-
-	err := imageFile.ExecuteNoFollow(func(path string) (err error) {
-		f, err := os.Open(path)
-		if err != nil {
-			return err
-		}
-		defer f.Close()
-
-		// 32 MiB chunks
-		chunk := make([]byte, 1024*1024*32)
-
-		_, err = io.CopyBuffer(digest, f, chunk)
-		return err
-	})
-
-	return digest.Sum32(), err
-}
-
-func (m *mounter) ComputeChecksums(vmi *v1.VirtualMachineInstance) (*DiskChecksums, error) {
-
-	diskChecksums := &DiskChecksums{
-		ContainerDiskChecksums: map[string]uint32{},
-	}
-
-	// compute for containerdisks
-	for i, volume := range vmi.Spec.Volumes {
-		if volume.VolumeSource.ContainerDisk == nil {
-			continue
-		}
-
-		path, err := m.getContainerDiskPath(vmi, &volume, i)
-		if err != nil {
-			return nil, err
-		}
-
-		checksum, err := getDigest(path)
-		if err != nil {
-			return nil, err
-		}
-
-		diskChecksums.ContainerDiskChecksums[volume.Name] = checksum
-	}
-
-	// kernel and initrd
-	if util.HasKernelBootContainerImage(vmi) {
-		kernelArtifacts, err := m.getKernelArtifactPaths(vmi)
-		if err != nil {
-			return nil, err
-		}
-
-		if kernelArtifacts.kernel != nil {
-			checksum, err := getDigest(kernelArtifacts.kernel)
-			if err != nil {
-				return nil, err
-			}
-
-			diskChecksums.KernelBootChecksum.Kernel = &checksum
-		}
-
-		if kernelArtifacts.initrd != nil {
-			checksum, err := getDigest(kernelArtifacts.initrd)
-			if err != nil {
-				return nil, err
-			}
-
-			diskChecksums.KernelBootChecksum.Initrd = &checksum
-		}
-	}
-
-	return diskChecksums, nil
 }
 
 type needsBindMountFunc func(vmi *v1.VirtualMachineInstance) (bool, error)

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -531,105 +531,6 @@ func (c *VirtualMachineController) updateHotplugVolumeStatus(vmi *v1.VirtualMach
 	return volumeStatus, needsRefresh
 }
 
-func needToComputeChecksums(vmi *v1.VirtualMachineInstance) bool {
-	containerDisks := map[string]*v1.Volume{}
-	for _, volume := range vmi.Spec.Volumes {
-		if volume.VolumeSource.ContainerDisk != nil {
-			containerDisks[volume.Name] = &volume
-		}
-	}
-
-	for i := range vmi.Status.VolumeStatus {
-		_, isContainerDisk := containerDisks[vmi.Status.VolumeStatus[i].Name]
-		if !isContainerDisk {
-			continue
-		}
-
-		if vmi.Status.VolumeStatus[i].ContainerDiskVolume == nil ||
-			vmi.Status.VolumeStatus[i].ContainerDiskVolume.Checksum == 0 {
-			return true
-		}
-	}
-
-	if util.HasKernelBootContainerImage(vmi) {
-		if vmi.Status.KernelBootStatus == nil {
-			return true
-		}
-
-		kernelBootContainer := vmi.Spec.Domain.Firmware.KernelBoot.Container
-
-		if kernelBootContainer.KernelPath != "" &&
-			(vmi.Status.KernelBootStatus.KernelInfo == nil ||
-				vmi.Status.KernelBootStatus.KernelInfo.Checksum == 0) {
-			return true
-
-		}
-
-		if kernelBootContainer.InitrdPath != "" &&
-			(vmi.Status.KernelBootStatus.InitrdInfo == nil ||
-				vmi.Status.KernelBootStatus.InitrdInfo.Checksum == 0) {
-			return true
-
-		}
-	}
-
-	return false
-}
-
-// updateChecksumInfo is kept for compatibility with older virt-handlers
-// that validate checksum calculations in vmi.status. This validation was
-// removed in PR #14021, but we had to keep the checksum calculations for upgrades.
-// Once we're sure old handlers won't interrupt upgrades, this can be removed.
-func (c *VirtualMachineController) updateChecksumInfo(vmi *v1.VirtualMachineInstance, syncError error) error {
-	// If the imageVolume feature gate is enabled, upgrade support isn't required,
-	// and we can skip the checksum calculation. By the time the feature gate is GA,
-	// the checksum calculation should be removed.
-	if syncError != nil || vmi.DeletionTimestamp != nil || !needToComputeChecksums(vmi) || c.clusterConfig.ImageVolumeEnabled() {
-		return nil
-	}
-
-	diskChecksums, err := c.containerDiskMounter.ComputeChecksums(vmi)
-	if goerror.Is(err, containerdisk.ErrDiskContainerGone) {
-		c.logger.Errorf("cannot compute checksums as containerdisk/kernelboot containers seem to have been terminated")
-		return nil
-	}
-	if err != nil {
-		return err
-	}
-
-	// containerdisks
-	for i := range vmi.Status.VolumeStatus {
-		checksum, exists := diskChecksums.ContainerDiskChecksums[vmi.Status.VolumeStatus[i].Name]
-		if !exists {
-			// not a containerdisk
-			continue
-		}
-
-		vmi.Status.VolumeStatus[i].ContainerDiskVolume = &v1.ContainerDiskInfo{
-			Checksum: checksum,
-		}
-	}
-
-	// kernelboot
-	if util.HasKernelBootContainerImage(vmi) {
-		vmi.Status.KernelBootStatus = &v1.KernelBootStatus{}
-
-		if diskChecksums.KernelBootChecksum.Kernel != nil {
-			vmi.Status.KernelBootStatus.KernelInfo = &v1.KernelInfo{
-				Checksum: *diskChecksums.KernelBootChecksum.Kernel,
-			}
-		}
-
-		if diskChecksums.KernelBootChecksum.Initrd != nil {
-			vmi.Status.KernelBootStatus.InitrdInfo = &v1.InitrdInfo{
-				Checksum: *diskChecksums.KernelBootChecksum.Initrd,
-			}
-		}
-	}
-
-	return nil
-}
-
 func (c *VirtualMachineController) updateVolumeStatusesFromDomain(vmi *v1.VirtualMachineInstance, domain *api.Domain) bool {
 	// The return value is only used by unit tests
 	hasHotplug := false
@@ -1120,11 +1021,6 @@ func (c *VirtualMachineController) updateVMIStatus(oldStatus *v1.VirtualMachineI
 	// Update conditions on VMI Status
 	err = c.updateVMIConditions(vmi, domain, condManager)
 	if err != nil {
-		return err
-	}
-
-	// Store containerdisks and kernelboot checksums
-	if err := c.updateChecksumInfo(vmi, syncError); err != nil {
 		return err
 	}
 

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -1609,62 +1609,6 @@ var _ = Describe("VirtualMachineInstance", func() {
 				Expect(mockQueue.GetRateLimitedEnqueueCount()).To(Equal(1))
 			})
 
-			It("should compute checksums for the specified containerDisks and kernelboot containers", func() {
-				config, _, _ := testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{
-					DeveloperConfiguration: &v1.DeveloperConfiguration{
-						DisabledFeatureGates: []string{featuregate.ImageVolume},
-					},
-				})
-				controller.clusterConfig = config
-				vmi := NewScheduledVMIWithContainerDisk(vmiTestUUID, podTestUUID, host)
-				vmi.Status.Phase = v1.Running
-				vmi.Status.VolumeStatus = []v1.VolumeStatus{
-					{
-						Name: vmi.Spec.Volumes[0].Name,
-					},
-				}
-				vmi.Spec.Domain.Firmware = &v1.Firmware{
-					KernelBoot: &v1.KernelBoot{
-						Container: &v1.KernelBootContainer{
-							KernelPath: "/vmlinuz",
-							InitrdPath: "/initrd",
-						},
-					},
-				}
-
-				domain := api.NewMinimalDomainWithUUID("testvmi", vmiTestUUID)
-				domain.Status.Status = api.Running
-
-				addVMI(vmi, domain)
-
-				fakeDiskChecksums := &containerdisk.DiskChecksums{
-					ContainerDiskChecksums: map[string]uint32{
-						vmi.Spec.Volumes[0].Name: uint32(1234),
-					},
-					KernelBootChecksum: containerdisk.KernelBootChecksum{
-						Kernel: pointer.P(uint32(33)),
-						Initrd: pointer.P(uint32(35)),
-					},
-				}
-
-				mockHotplugVolumeMounter.EXPECT().Mount(gomock.Any(), gomock.Any()).Return(nil)
-				mockContainerDiskMounter.EXPECT().ComputeChecksums(gomock.Any()).Return(fakeDiskChecksums, nil)
-				client.EXPECT().SyncVirtualMachine(gomock.Any(), gomock.Any()).Return(nil)
-				mockHotplugVolumeMounter.EXPECT().Unmount(gomock.Any(), gomock.Any()).Return(nil)
-
-				sanityExecute()
-
-				updatedVMI, err := virtfakeClient.KubevirtV1().VirtualMachineInstances(metav1.NamespaceDefault).Get(context.TODO(), vmi.Name, metav1.GetOptions{})
-				Expect(err).NotTo(HaveOccurred())
-				Expect(updatedVMI.Status.VolumeStatus).To(HaveLen(1))
-				Expect(updatedVMI.Status.VolumeStatus[0].ContainerDiskVolume).ToNot(BeNil())
-				Expect(updatedVMI.Status.VolumeStatus[0].ContainerDiskVolume.Checksum).To(Equal(fakeDiskChecksums.ContainerDiskChecksums[vmi.Status.VolumeStatus[0].Name]))
-				Expect(updatedVMI.Status.KernelBootStatus).ToNot(BeNil())
-				Expect(updatedVMI.Status.KernelBootStatus.KernelInfo).ToNot(BeNil())
-				Expect(updatedVMI.Status.KernelBootStatus.KernelInfo.Checksum).To(Equal(*fakeDiskChecksums.KernelBootChecksum.Kernel))
-				Expect(updatedVMI.Status.KernelBootStatus.InitrdInfo).ToNot(BeNil())
-				Expect(updatedVMI.Status.KernelBootStatus.InitrdInfo.Checksum).To(Equal(*fakeDiskChecksums.KernelBootChecksum.Initrd))
-			})
 		})
 
 		Context("reacting to a VMI with hotplug", func() {

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -15327,7 +15327,8 @@ var CRDsValidation map[string]string = map[string]string{
               description: InitrdInfo show info about the initrd file
               properties:
                 checksum:
-                  description: Checksum is the checksum of the initrd file
+                  description: deprecated; Checksum is the checksum of the initrd
+                    file
                   format: int64
                   maximum: 4294967295
                   minimum: 0
@@ -15337,7 +15338,8 @@ var CRDsValidation map[string]string = map[string]string{
               description: KernelInfo show info about the kernel image
               properties:
                 checksum:
-                  description: Checksum is the checksum of the kernel image
+                  description: deprecated; Checksum is the checksum of the kernel
+                    image
                   format: int64
                   maximum: 4294967295
                   minimum: 0
@@ -16036,8 +16038,8 @@ var CRDsValidation map[string]string = map[string]string{
                   if the volume is a containerdisk
                 properties:
                   checksum:
-                    description: Checksum is the checksum of the rootdisk or kernel
-                      artifacts inside the containerdisk
+                    description: deprecated; Checksum is the checksum of the rootdisk
+                      or kernel artifacts inside the containerdisk
                     format: int64
                     maximum: 4294967295
                     minimum: 0

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -441,8 +441,8 @@ type KernelInfo struct {
 	// +kubebuilder:validation:Format:=int64
 	// +kubebuilder:validation:Minimum:=0
 	// +kubebuilder:validation:Maximum:=4294967295
-	// Checksum is the checksum of the kernel image
-	Checksum uint32 `json:"checksum,omitempty"`
+	// deprecated; Checksum is the checksum of the kernel image
+	DeprecatedChecksum uint32 `json:"checksum,omitempty"`
 }
 
 // InitrdInfo show info about the initrd file
@@ -450,8 +450,8 @@ type InitrdInfo struct {
 	// +kubebuilder:validation:Format:=int64
 	// +kubebuilder:validation:Minimum:=0
 	// +kubebuilder:validation:Maximum:=4294967295
-	// Checksum is the checksum of the initrd file
-	Checksum uint32 `json:"checksum,omitempty"`
+	// deprecated; Checksum is the checksum of the initrd file
+	DeprecatedChecksum uint32 `json:"checksum,omitempty"`
 }
 
 // KernelBootStatus contains info about the kernelBootContainer
@@ -487,8 +487,8 @@ type ContainerDiskInfo struct {
 	// +kubebuilder:validation:Format:=int64
 	// +kubebuilder:validation:Minimum:=0
 	// +kubebuilder:validation:Maximum:=4294967295
-	// Checksum is the checksum of the rootdisk or kernel artifacts inside the containerdisk
-	Checksum uint32 `json:"checksum,omitempty"`
+	// deprecated; Checksum is the checksum of the rootdisk or kernel artifacts inside the containerdisk
+	DeprecatedChecksum uint32 `json:"checksum,omitempty"`
 }
 
 // VolumePhase indicates the current phase of the hotplug process.

--- a/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
@@ -139,14 +139,14 @@ func (VolumeStatus) SwaggerDoc() map[string]string {
 func (KernelInfo) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"":         "KernelInfo show info about the kernel image",
-		"checksum": "+kubebuilder:validation:Format:=int64\n+kubebuilder:validation:Minimum:=0\n+kubebuilder:validation:Maximum:=4294967295\nChecksum is the checksum of the kernel image",
+		"checksum": "+kubebuilder:validation:Format:=int64\n+kubebuilder:validation:Minimum:=0\n+kubebuilder:validation:Maximum:=4294967295\ndeprecated; Checksum is the checksum of the kernel image",
 	}
 }
 
 func (InitrdInfo) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"":         "InitrdInfo show info about the initrd file",
-		"checksum": "+kubebuilder:validation:Format:=int64\n+kubebuilder:validation:Minimum:=0\n+kubebuilder:validation:Maximum:=4294967295\nChecksum is the checksum of the initrd file",
+		"checksum": "+kubebuilder:validation:Format:=int64\n+kubebuilder:validation:Minimum:=0\n+kubebuilder:validation:Maximum:=4294967295\ndeprecated; Checksum is the checksum of the initrd file",
 	}
 }
 
@@ -179,7 +179,7 @@ func (HotplugVolumeStatus) SwaggerDoc() map[string]string {
 func (ContainerDiskInfo) SwaggerDoc() map[string]string {
 	return map[string]string{
 		"":         "ContainerDiskInfo shows info about the containerdisk",
-		"checksum": "+kubebuilder:validation:Format:=int64\n+kubebuilder:validation:Minimum:=0\n+kubebuilder:validation:Maximum:=4294967295\nChecksum is the checksum of the rootdisk or kernel artifacts inside the containerdisk",
+		"checksum": "+kubebuilder:validation:Format:=int64\n+kubebuilder:validation:Minimum:=0\n+kubebuilder:validation:Maximum:=4294967295\ndeprecated; Checksum is the checksum of the rootdisk or kernel artifacts inside the containerdisk",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -19616,7 +19616,7 @@ func schema_kubevirtio_api_core_v1_ContainerDiskInfo(ref common.ReferenceCallbac
 				Properties: map[string]spec.Schema{
 					"checksum": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Checksum is the checksum of the rootdisk or kernel artifacts inside the containerdisk",
+							Description: "deprecated; Checksum is the checksum of the rootdisk or kernel artifacts inside the containerdisk",
 							Type:        []string{"integer"},
 							Format:      "int64",
 						},
@@ -21994,7 +21994,7 @@ func schema_kubevirtio_api_core_v1_InitrdInfo(ref common.ReferenceCallback) comm
 				Properties: map[string]spec.Schema{
 					"checksum": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Checksum is the checksum of the initrd file",
+							Description: "deprecated; Checksum is the checksum of the initrd file",
 							Type:        []string{"integer"},
 							Format:      "int64",
 						},
@@ -22636,7 +22636,7 @@ func schema_kubevirtio_api_core_v1_KernelInfo(ref common.ReferenceCallback) comm
 				Properties: map[string]spec.Schema{
 					"checksum": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Checksum is the checksum of the kernel image",
+							Description: "deprecated; Checksum is the checksum of the kernel image",
 							Type:        []string{"integer"},
 							Format:      "int64",
 						},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
The CRC32 checksum was originally introduced as a workaround for a
CRI-O bug (cri-o/cri-o#7149) that stopped including image digests in
pod status ImageID. The validation code that consumed these checksums
was already removed in PR #14021, and the computation was kept only
for upgrade compatibility with older virt-handlers.

Since ImageVolume (Beta, enabled by default) already skips checksum
computation entirely, and no component reads these fields, the code
is now safe to remove as planned in 8f59594b39 ("Include old checksum
calculation for new handler") which stated: "All the code in this
commit can be removed after release 1.7".

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Cleanup: Remove legacy containerdisk CRC32 checksum computation
```

