### PR TITLE
fix(hotplug): Apply interface preferences to hotplugged network   interfaces

### DIFF
--- a/pkg/instancetype/controller/network/BUILD.bazel
+++ b/pkg/instancetype/controller/network/BUILD.bazel
@@ -1,0 +1,39 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["controller.go"],
+    importpath = "kubevirt.io/kubevirt/pkg/instancetype/controller/network",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/instancetype/preference/apply:go_default_library",
+        "//pkg/instancetype/preference/find:go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/api/instancetype/v1beta1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//vendor/k8s.io/client-go/tools/cache:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "controller_suite_test.go",
+        "controller_test.go",
+    ],
+    race = "on",
+    deps = [
+        ":go_default_library",
+        "//pkg/libvmi:go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/api/instancetype/v1beta1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//staging/src/kubevirt.io/client-go/kubevirt/fake:go_default_library",
+        "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/go.uber.org/mock/gomock:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+    ],
+)

--- a/pkg/instancetype/controller/network/controller.go
+++ b/pkg/instancetype/controller/network/controller.go
@@ -1,0 +1,59 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ */
+
+package network
+
+import (
+	"k8s.io/client-go/tools/cache"
+
+	v1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/kubecli"
+
+	instancetypev1beta1 "kubevirt.io/api/instancetype/v1beta1"
+
+	"kubevirt.io/kubevirt/pkg/instancetype/preference/apply"
+	"kubevirt.io/kubevirt/pkg/instancetype/preference/find"
+)
+
+type preferenceFinder interface {
+	FindPreference(vm *v1.VirtualMachine) (*instancetypev1beta1.VirtualMachinePreferenceSpec, error)
+}
+
+type controller struct {
+	finder preferenceFinder
+}
+
+func New(store, clusterStore, revisionStore cache.Store, clientSet kubecli.KubevirtClient) *controller {
+	return &controller{
+		finder: find.NewSpecFinder(store, clusterStore, revisionStore, clientSet),
+	}
+}
+
+func (a *controller) ApplyInterfacePreferences(vm *v1.VirtualMachine, vmiSpec *v1.VirtualMachineInstanceSpec) error {
+	if vm.Spec.Preference == nil || len(vmiSpec.Domain.Devices.Interfaces) == 0 {
+		return nil
+	}
+	preferenceSpec, err := a.finder.FindPreference(vm)
+	if err != nil {
+		return err
+	}
+	if preferenceSpec != nil {
+		apply.ApplyInterfacePreferences(preferenceSpec, vmiSpec)
+	}
+	return nil
+}

--- a/pkg/instancetype/controller/network/controller_suite_test.go
+++ b/pkg/instancetype/controller/network/controller_suite_test.go
@@ -1,0 +1,29 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ */
+
+package network_test
+
+import (
+	"testing"
+
+	"kubevirt.io/client-go/testutils"
+)
+
+func TestNetwork(t *testing.T) {
+	testutils.KubeVirtTestSuiteSetup(t)
+}

--- a/pkg/instancetype/controller/network/controller_test.go
+++ b/pkg/instancetype/controller/network/controller_test.go
@@ -1,0 +1,160 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ */
+
+package network_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+
+	k8sv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "kubevirt.io/api/core/v1"
+	instancetypev1beta1 "kubevirt.io/api/instancetype/v1beta1"
+	"kubevirt.io/client-go/kubecli"
+	"kubevirt.io/client-go/kubevirt/fake"
+
+	"kubevirt.io/kubevirt/pkg/instancetype/controller/network"
+	"kubevirt.io/kubevirt/pkg/libvmi"
+)
+
+var _ = Describe("Network Controller", func() {
+	const (
+		preferredModel = "virtio"
+		preferenceName = "test-preference"
+	)
+
+	type networkController interface {
+		ApplyInterfacePreferences(*v1.VirtualMachine, *v1.VirtualMachineInstanceSpec) error
+	}
+
+	var (
+		ctrl          networkController
+		fakeClientset *fake.Clientset
+		virtClient    *kubecli.MockKubevirtClient
+	)
+
+	BeforeEach(func() {
+		mockCtrl := gomock.NewController(GinkgoT())
+		virtClient = kubecli.NewMockKubevirtClient(mockCtrl)
+		fakeClientset = fake.NewSimpleClientset()
+
+		virtClient.EXPECT().VirtualMachinePreference(metav1.NamespaceDefault).Return(
+			fakeClientset.InstancetypeV1beta1().VirtualMachinePreferences(metav1.NamespaceDefault)).AnyTimes()
+		virtClient.EXPECT().VirtualMachineClusterPreference().Return(
+			fakeClientset.InstancetypeV1beta1().VirtualMachineClusterPreferences()).AnyTimes()
+
+		preference := &instancetypev1beta1.VirtualMachinePreference{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      preferenceName,
+				Namespace: metav1.NamespaceDefault,
+			},
+			Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{
+				Devices: &instancetypev1beta1.DevicePreferences{
+					PreferredInterfaceModel: preferredModel,
+				},
+			},
+		}
+		_, err := fakeClientset.InstancetypeV1beta1().VirtualMachinePreferences(metav1.NamespaceDefault).
+			Create(context.Background(), preference, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		ctrl = network.New(nil, nil, nil, virtClient)
+	})
+
+	DescribeTable("ApplyInterfacePreferences does nothing when", func(vm *v1.VirtualMachine) {
+		originalVMSpec := vm.Spec.Template.Spec.DeepCopy()
+		Expect(ctrl.ApplyInterfacePreferences(vm, &vm.Spec.Template.Spec)).To(Succeed())
+		Expect(&vm.Spec.Template.Spec).To(Equal(originalVMSpec))
+	},
+		Entry("the VM has no preference reference",
+			libvmi.NewVirtualMachine(libvmi.New(
+				libvmi.WithInterface(libvmi.NewInterface("default", libvmi.WithMasqueradeBinding())),
+				libvmi.WithNetwork(v1.DefaultPodNetwork()),
+			)),
+		),
+		Entry("the VM has no interfaces",
+			libvmi.NewVirtualMachine(libvmi.New(
+				libvmi.WithNamespace(k8sv1.NamespaceDefault),
+				libvmi.WithNetwork(v1.DefaultPodNetwork()),
+			), libvmi.WithPreference(preferenceName)),
+		),
+	)
+
+	It("should apply the preferred interface model to interfaces without a model", func() {
+		vm := libvmi.NewVirtualMachine(libvmi.New(
+			libvmi.WithNamespace(k8sv1.NamespaceDefault),
+			libvmi.WithInterface(libvmi.NewInterface("default", libvmi.WithMasqueradeBinding())),
+			libvmi.WithNetwork(v1.DefaultPodNetwork()),
+			libvmi.WithInterface(libvmi.NewInterface("secondary", libvmi.WithBridgeBinding())),
+			libvmi.WithNetwork(libvmi.MultusNetwork("secondary", "some-nad"))),
+			libvmi.WithPreference(preferenceName),
+		)
+
+		Expect(ctrl.ApplyInterfacePreferences(vm, &vm.Spec.Template.Spec)).To(Succeed())
+
+		for _, iface := range vm.Spec.Template.Spec.Domain.Devices.Interfaces {
+			Expect(iface.Model).To(Equal(preferredModel), "interface %q should have the preferred model", iface.Name)
+		}
+	})
+
+	It("should not override an interface model that is already set", func() {
+		const existingModel = "e1000e"
+		vm := libvmi.NewVirtualMachine(libvmi.New(
+			libvmi.WithNamespace(k8sv1.NamespaceDefault),
+			libvmi.WithInterface(libvmi.NewInterface("default", libvmi.WithMasqueradeBinding(), libvmi.WithModel(existingModel))),
+			libvmi.WithNetwork(v1.DefaultPodNetwork()),
+			libvmi.WithInterface(libvmi.NewInterface("secondary", libvmi.WithBridgeBinding())),
+			libvmi.WithNetwork(libvmi.MultusNetwork("secondary", "some-nad")),
+		), libvmi.WithPreference(preferenceName))
+
+		Expect(ctrl.ApplyInterfacePreferences(vm, &vm.Spec.Template.Spec)).To(Succeed())
+
+		Expect(vm.Spec.Template.Spec.Domain.Devices.Interfaces[0].Model).To(Equal(existingModel),
+			"existing model should not be overridden")
+		Expect(vm.Spec.Template.Spec.Domain.Devices.Interfaces[1].Model).To(Equal(preferredModel),
+			"empty model should get the preferred model")
+	})
+
+	It("should do nothing when the preference has no device preferences", func() {
+		noDevicePreference := &instancetypev1beta1.VirtualMachinePreference{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "no-device-preference",
+				Namespace: metav1.NamespaceDefault,
+			},
+			Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{},
+		}
+		_, err := fakeClientset.InstancetypeV1beta1().VirtualMachinePreferences(metav1.NamespaceDefault).
+			Create(context.Background(), noDevicePreference, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		vm := libvmi.NewVirtualMachine(libvmi.New(
+			libvmi.WithNamespace(k8sv1.NamespaceDefault),
+			libvmi.WithInterface(libvmi.NewInterface("default", libvmi.WithMasqueradeBinding())),
+			libvmi.WithNetwork(v1.DefaultPodNetwork()),
+		), libvmi.WithPreference(noDevicePreference.Name))
+
+		originalVM := vm.DeepCopy()
+		Expect(ctrl.ApplyInterfacePreferences(vm, &vm.Spec.Template.Spec)).To(Succeed())
+		Expect(vm.Spec.Template.Spec.Domain.Devices.Interfaces).To(Equal(originalVM.Spec.Template.Spec.Domain.Devices.Interfaces))
+	})
+})

--- a/pkg/instancetype/preference/apply/device.go
+++ b/pkg/instancetype/preference/apply/device.go
@@ -99,7 +99,7 @@ func ApplyDevicePreferences(preferenceSpec *v1beta1.VirtualMachinePreferenceSpec
 
 	ApplyAutoAttachPreferences(preferenceSpec, vmiSpec)
 	applyDiskPreferences(preferenceSpec, vmiSpec)
-	applyInterfacePreferences(preferenceSpec, vmiSpec)
+	ApplyInterfacePreferences(preferenceSpec, vmiSpec)
 	applyInputPreferences(preferenceSpec, vmiSpec)
 	applyPanicDevicePreferences(preferenceSpec, vmiSpec)
 }

--- a/pkg/instancetype/preference/apply/interface.go
+++ b/pkg/instancetype/preference/apply/interface.go
@@ -38,7 +38,10 @@ func isInterfaceOnPodNetwork(interfaceName string, vmiSpec *virtv1.VirtualMachin
 	return false
 }
 
-func applyInterfacePreferences(preferenceSpec *v1beta1.VirtualMachinePreferenceSpec, vmiSpec *virtv1.VirtualMachineInstanceSpec) {
+func ApplyInterfacePreferences(preferenceSpec *v1beta1.VirtualMachinePreferenceSpec, vmiSpec *virtv1.VirtualMachineInstanceSpec) {
+	if preferenceSpec.Devices == nil || len(vmiSpec.Domain.Devices.Interfaces) == 0 {
+		return
+	}
 	for ifaceIndex := range vmiSpec.Domain.Devices.Interfaces {
 		vmiIface := &vmiSpec.Domain.Devices.Interfaces[ifaceIndex]
 		if preferenceSpec.Devices.PreferredInterfaceModel != "" && vmiIface.Model == "" {

--- a/pkg/network/controllers/BUILD.bazel
+++ b/pkg/network/controllers/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//pkg/network/vmispec:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubevirt:go_default_library",
+        "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/github.com/k8snetworkplumbingwg/network-attachment-definition-client/pkg/apis/k8s.cni.cncf.io/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/equality:go_default_library",

--- a/pkg/network/controllers/vm.go
+++ b/pkg/network/controllers/vm.go
@@ -29,14 +29,28 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 
 	"kubevirt.io/client-go/kubevirt"
+	"kubevirt.io/client-go/log"
 
 	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
 	"kubevirt.io/kubevirt/pkg/network/namescheme"
 	"kubevirt.io/kubevirt/pkg/network/vmispec"
 )
 
+type interfacePreferenceApplier interface {
+	ApplyInterfacePreferences(vm *v1.VirtualMachine, vmiSpec *v1.VirtualMachineInstanceSpec) error
+}
+
 type VMController struct {
-	clientset kubevirt.Interface
+	clientset                  kubevirt.Interface
+	interfacePreferenceApplier interfacePreferenceApplier
+}
+
+type VMControllerOption func(*VMController)
+
+func WithInterfacePreferenceApplier(applier interfacePreferenceApplier) VMControllerOption {
+	return func(c *VMController) {
+		c.interfacePreferenceApplier = applier
+	}
 }
 
 type syncError struct {
@@ -60,10 +74,14 @@ const (
 	hotPlugNetworkInterfaceErrorReason = "HotPlugNetworkInterfaceError"
 )
 
-func NewVMController(clientset kubevirt.Interface) *VMController {
-	return &VMController{
+func NewVMController(clientset kubevirt.Interface, opts ...VMControllerOption) *VMController {
+	c := &VMController{
 		clientset: clientset,
 	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c
 }
 
 func (v *VMController) Sync(vm *v1.VirtualMachine, vmi *v1.VirtualMachineInstance) (*v1.VirtualMachine, error) {
@@ -81,7 +99,7 @@ func (v *VMController) Sync(vm *v1.VirtualMachine, vmi *v1.VirtualMachineInstanc
 			func(ifaceStatus v1.VirtualMachineInstanceNetworkInterface) bool { return true },
 		)
 
-		updatedVMI := syncVMIInterfaces(vm, vmi, vmiIfaceStatusesByName)
+		updatedVMI := v.syncVMIInterfaces(vm, vmi, vmiIfaceStatusesByName)
 
 		if err := v.vmiInterfacesPatch(&updatedVMI.Spec, vmi); err != nil {
 			return vm, &syncError{
@@ -106,14 +124,14 @@ func (v *VMController) Sync(vm *v1.VirtualMachine, vmi *v1.VirtualMachineInstanc
 	return vmCopy, nil
 }
 
-func syncVMIInterfaces(
+func (v *VMController) syncVMIInterfaces(
 	vm *v1.VirtualMachine,
 	vmi *v1.VirtualMachineInstance,
 	indexedStatusIfaces map[string]v1.VirtualMachineInstanceNetworkInterface,
 ) *v1.VirtualMachineInstance {
 	vmiCopy := vmi.DeepCopy()
 	hasOrdinalIfaces := namescheme.HasOrdinalSecondaryIfaces(vmi.Spec.Networks, vmi.Status.Interfaces)
-	updatedVmiSpec := applyDynamicIfaceRequestOnVMI(vm, vmiCopy, hasOrdinalIfaces)
+	updatedVmiSpec := v.applyDynamicIfaceRequestOnVMI(vm, vmiCopy, hasOrdinalIfaces)
 	vmiCopy.Spec = *updatedVmiSpec
 
 	ifaces, networks := clearDetachedIfacesFromVMI(vmiCopy.Spec.Domain.Devices.Interfaces, vmiCopy.Spec.Networks, indexedStatusIfaces)
@@ -148,7 +166,7 @@ func (v *VMController) vmiInterfacesPatch(newVmiSpec *v1.VirtualMachineInstanceS
 	return err
 }
 
-func applyDynamicIfaceRequestOnVMI(
+func (v *VMController) applyDynamicIfaceRequestOnVMI(
 	vm *v1.VirtualMachine,
 	vmi *v1.VirtualMachineInstance,
 	hasOrdinalIfaces bool,
@@ -171,6 +189,11 @@ func applyDynamicIfaceRequestOnVMI(
 		case shouldHotplugIface:
 			vmiSpecCopy.Networks = append(vmiSpecCopy.Networks, vmIndexedNetworks[vmIface.Name])
 			vmiSpecCopy.Domain.Devices.Interfaces = append(vmiSpecCopy.Domain.Devices.Interfaces, vmIface)
+			if v.interfacePreferenceApplier != nil {
+				if err := v.interfacePreferenceApplier.ApplyInterfacePreferences(vm, vmiSpecCopy); err != nil {
+					log.Log.Object(vm).Warningf("Failed to apply interface preferences during hotplug: %v", err)
+				}
+			}
 
 		case shouldUpdateExistingIfaceState:
 			if !(hasOrdinalIfaces && vmIface.State == v1.InterfaceStateAbsent) {

--- a/pkg/network/controllers/vm_test.go
+++ b/pkg/network/controllers/vm_test.go
@@ -54,6 +54,7 @@ var _ = Describe("VM Network Controller", func() {
 		updatedNADName1   = "new-nad1"
 		updatedNADName2   = "new-nad2"
 	)
+
 	DescribeTable("sync does nothing when", func(vm *v1.VirtualMachine, vmi *v1.VirtualMachineInstance) {
 		c := controllers.NewVMController(fake.NewSimpleClientset())
 		originalVM := vm.DeepCopy()
@@ -175,6 +176,78 @@ var _ = Describe("VM Network Controller", func() {
 			State: v1.InterfaceStateLinkUp,
 		}),
 	)
+
+	It("sync applies interface preferences to hotplugged interfaces", func() {
+		const expectedModel = "virtio"
+		clientset := fake.NewSimpleClientset()
+		c := controllers.NewVMController(clientset,
+			controllers.WithInterfacePreferenceApplier(
+				&stubInterfacePreferenceApplier{model: expectedModel},
+			),
+		)
+
+		vmi := libvmi.New(
+			libvmi.WithInterface(
+				libvmi.NewInterface(
+					defaultNetName,
+					libvmi.WithMasqueradeBinding(),
+					libvmi.WithModel(expectedModel),
+				),
+			),
+			libvmi.WithNetwork(v1.DefaultPodNetwork()),
+		)
+
+		vm := libvmi.NewVirtualMachine(vmi.DeepCopy())
+
+		vm = plugNetworkInterface(vm, libvmi.NewInterface(secondaryNetName1, libvmi.WithBridgeBinding()))
+
+		_, err := clientset.KubevirtV1().VirtualMachineInstances(vmi.Namespace).Create(context.Background(), vmi, k8smetav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = c.Sync(vm, vmi)
+		Expect(err).NotTo(HaveOccurred())
+
+		updatedVMI, err := clientset.KubevirtV1().
+			VirtualMachineInstances(vmi.Namespace).
+			Get(context.Background(), vmi.Name, k8smetav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(updatedVMI.Spec.Domain.Devices.Interfaces).To(HaveLen(2))
+
+		for _, iface := range updatedVMI.Spec.Domain.Devices.Interfaces {
+			Expect(iface.Model).To(Equal(expectedModel), "interface %q should have model from preferences", iface.Name)
+		}
+	})
+
+	It("sync does not fail when interface preference applier returns an error", func() {
+		clientset := fake.NewSimpleClientset()
+		c := controllers.NewVMController(clientset,
+			controllers.WithInterfacePreferenceApplier(
+				&errorInterfacePreferenceApplier{err: errors.New("preference not found")},
+			),
+		)
+
+		vmi := libvmi.New(
+			libvmi.WithInterface(libvmi.NewInterface(defaultNetName, libvmi.WithMasqueradeBinding())),
+			libvmi.WithNetwork(v1.DefaultPodNetwork()),
+		)
+		vm := libvmi.NewVirtualMachine(vmi.DeepCopy())
+
+		vm = plugNetworkInterface(vm, libvmi.NewInterface(secondaryNetName1, libvmi.WithBridgeBinding()))
+
+		_, err := clientset.KubevirtV1().VirtualMachineInstances(vmi.Namespace).Create(context.Background(), vmi, k8smetav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		_, err = c.Sync(vm, vmi)
+		Expect(err).NotTo(HaveOccurred())
+
+		updatedVMI, err := clientset.KubevirtV1().
+			VirtualMachineInstances(vmi.Namespace).
+			Get(context.Background(), vmi.Name, k8smetav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(updatedVMI.Spec.Domain.Devices.Interfaces).To(HaveLen(2),
+			"hotplug should succeed even when preference applier fails")
+	})
 
 	It("sync does not hotplug a new absent interface", func() {
 		clientset := fake.NewSimpleClientset()
@@ -838,4 +911,25 @@ func unplugNetworkInterface(vm *v1.VirtualMachine, netName string) *v1.VirtualMa
 
 func newEmptyVM() *v1.VirtualMachine {
 	return &v1.VirtualMachine{Spec: v1.VirtualMachineSpec{Template: &v1.VirtualMachineInstanceTemplateSpec{}}}
+}
+
+type stubInterfacePreferenceApplier struct {
+	model string
+}
+
+func (s *stubInterfacePreferenceApplier) ApplyInterfacePreferences(_ *v1.VirtualMachine, vmiSpec *v1.VirtualMachineInstanceSpec) error {
+	for i := range vmiSpec.Domain.Devices.Interfaces {
+		if vmiSpec.Domain.Devices.Interfaces[i].Model == "" {
+			vmiSpec.Domain.Devices.Interfaces[i].Model = s.model
+		}
+	}
+	return nil
+}
+
+type errorInterfacePreferenceApplier struct {
+	err error
+}
+
+func (s *errorInterfacePreferenceApplier) ApplyInterfacePreferences(_ *v1.VirtualMachine, _ *v1.VirtualMachineInstanceSpec) error {
+	return s.err
 }

--- a/pkg/virt-controller/watch/BUILD.bazel
+++ b/pkg/virt-controller/watch/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "//pkg/controller:go_default_library",
         "//pkg/healthz:go_default_library",
         "//pkg/hooks:go_default_library",
+        "//pkg/instancetype/controller/network:go_default_library",
         "//pkg/instancetype/controller/vm:go_default_library",
         "//pkg/monitoring/metrics/common/client:go_default_library",
         "//pkg/monitoring/metrics/virt-controller:go_default_library",

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -82,6 +82,7 @@ import (
 	netresources "kubevirt.io/kubevirt/pkg/network/resources"
 	clusterutil "kubevirt.io/kubevirt/pkg/util/cluster"
 
+	instancetypenetworkcontroller "kubevirt.io/kubevirt/pkg/instancetype/controller/network"
 	instancetypecontroller "kubevirt.io/kubevirt/pkg/instancetype/controller/vm"
 	clientmetrics "kubevirt.io/kubevirt/pkg/monitoring/metrics/common/client"
 	metrics "kubevirt.io/kubevirt/pkg/monitoring/metrics/virt-controller"
@@ -832,6 +833,12 @@ func (vca *VirtControllerApp) initVirtualMachines() {
 		vca.clusterConfig,
 		netcontrollers.NewVMController(
 			vca.clientSet.GeneratedKubeVirtClient(),
+			netcontrollers.WithInterfacePreferenceApplier(instancetypenetworkcontroller.New(
+				vca.preferenceInformer.GetStore(),
+				vca.clusterPreferenceInformer.GetStore(),
+				vca.controllerRevisionInformer.GetStore(),
+				vca.clientSet,
+			)),
 		),
 		vm.NewFirmwareController(vca.clientSet.GeneratedKubeVirtClient()),
 		instancetypecontroller.New(

--- a/tests/libinstancetype/builder/builder.go
+++ b/tests/libinstancetype/builder/builder.go
@@ -131,6 +131,15 @@ func WithPreferredCPUTopology(topology instancetypev1beta1.PreferredCPUTopology)
 	}
 }
 
+func WithPreferredInterfaceModel(model string) PreferenceSpecOption {
+	return func(spec *instancetypev1beta1.VirtualMachinePreferenceSpec) {
+		if spec.Devices == nil {
+			spec.Devices = &instancetypev1beta1.DevicePreferences{}
+		}
+		spec.Devices.PreferredInterfaceModel = model
+	}
+}
+
 func WithPreferredDiskBus(bus v1.DiskBus) PreferenceSpecOption {
 	return func(spec *instancetypev1beta1.VirtualMachinePreferenceSpec) {
 		if spec.Devices == nil {

--- a/tests/network/BUILD.bazel
+++ b/tests/network/BUILD.bazel
@@ -54,6 +54,7 @@ go_library(
         "//tests/framework/kubevirt:go_default_library",
         "//tests/framework/matcher:go_default_library",
         "//tests/libdomain:go_default_library",
+        "//tests/libinstancetype/builder:go_default_library",
         "//tests/libkubevirt:go_default_library",
         "//tests/libkubevirt/config:go_default_library",
         "//tests/libmigration:go_default_library",

--- a/tests/network/hotplug_bridge.go
+++ b/tests/network/hotplug_bridge.go
@@ -41,6 +41,7 @@ import (
 	"kubevirt.io/kubevirt/tests/decorators"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/framework/matcher"
+	"kubevirt.io/kubevirt/tests/libinstancetype/builder"
 	"kubevirt.io/kubevirt/tests/libkubevirt"
 	"kubevirt.io/kubevirt/tests/libkubevirt/config"
 	"kubevirt.io/kubevirt/tests/libmigration"
@@ -86,19 +87,32 @@ var _ = Describe(SIG("bridge nic-hotplug", Serial, func() {
 	)
 
 	Context("a running VM", func() {
-		const guestSecondaryIfaceName = "eth1"
+		const (
+			guestSecondaryIfaceName = "eth1"
+			preferredModel          = "virtio"
+		)
 
 		var hotPluggedVM *v1.VirtualMachine
 		var hotPluggedVMI *v1.VirtualMachineInstance
 
 		BeforeEach(func() {
+			By("Creating a preference with PreferredInterfaceModel")
+			preference := builder.NewPreference(
+				builder.WithPreferredInterfaceModel(preferredModel),
+			)
+			preference, err := kubevirt.Client().VirtualMachinePreference(testsuite.GetTestNamespace(nil)).
+				Create(context.Background(), preference, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
 			By("Creating a VM")
 			vmi := libvmifact.NewAlpineWithTestTooling(
 				libvmi.WithInterface(*v1.DefaultMasqueradeNetworkInterface()),
 				libvmi.WithNetwork(v1.DefaultPodNetwork()),
 			)
-			hotPluggedVM = libvmi.NewVirtualMachine(vmi, libvmi.WithRunStrategy(v1.RunStrategyAlways))
-			var err error
+			hotPluggedVM = libvmi.NewVirtualMachine(vmi,
+				libvmi.WithRunStrategy(v1.RunStrategyAlways),
+				libvmi.WithPreference(preference.Name),
+			)
 			hotPluggedVM, err = kubevirt.Client().VirtualMachine(testsuite.GetTestNamespace(nil)).Create(context.Background(), hotPluggedVM, metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 			Eventually(matcher.ThisVM(hotPluggedVM)).WithTimeout(6 * time.Minute).WithPolling(3 * time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
@@ -136,6 +150,11 @@ var _ = Describe(SIG("bridge nic-hotplug", Serial, func() {
 
 				g.Expect(vmiIfaceStatus.MAC).To(Equal(vmIfaceSpec.MacAddress),
 					"hot-plugged iface in VMI status should have a MAC address as specified in VM template spec")
+
+				hotpluggedIface := vmispec.LookupInterfaceByName(updatedVMI.Spec.Domain.Devices.Interfaces, ifaceName)
+				g.Expect(hotpluggedIface).NotTo(BeNil())
+				g.Expect(hotpluggedIface.Model).To(Equal(preferredModel),
+					"hotplugged interface should have the preferred model from the preference")
 			}, time.Second*30, time.Second*3).Should(Succeed())
 		},
 			Entry("In place", decorators.InPlaceHotplugNICs, inPlace),


### PR DESCRIPTION
### What this PR does
#### Before this PR:

When a network interface was hotplugged to a VM referencing a VirtualMachinePreference, the preference fields (e.g. PreferredInterfaceModel) were not applied to the new interface.  The hotplug path copied interfaces raw from the VM template to the VMI without calling any preference application logic.

#### After this PR:
Interface preferences are applied to hotplugged network interfaces before the VMI is patched. The fix follows the existing  pattern: the instancetype controller exposes an ApplyInterfacePreferences method, which is injected into the network VMController and called during Sync after building the updated VMI but before patching it.

### References

  
- Fixes # [CNV-41864](https://redhat.atlassian.net/browse/CNV-41864)


### Why we need it and why it was done in this way

The following tradeoffs were made:
- ApplyInterfacePreferences was exported from the preference/apply package so it can be reused by the instancetype controller method.  A nil guard for Devices and empty Interfaces was added since it is now a public API.

- An InterfacePreferenceApplier interface was defined in the network controllers package. The instancetype controller satisfies it via structural typing, avoiding import cycles.

The following alternatives were considered:
- Injecting a raw PreferenceFinder into the network controller and having it resolve and apply preferences directly. Rejected because it breaks the established pattern where the instancetype controller owns preference resolution (as seen with ApplyAutoAttachPreferences).
- Applying preferences in the main VM controller after netSynchronizer.Sync(). Not possible because Sync patches the VMI internally before returning.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

This PR is a follow-up of https://github.com/kubevirt/kubevirt/pull/14473


### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
fix: Interface preferences (e.g. PreferredInterfaceModel) are now correctly applied to hotplugged network interfaces
```