### PR TITLE
tests: Retry prometheus metric assertions to handle NOWAIT stats

### DIFF
--- a/tests/infrastructure/prometheus.go
+++ b/tests/infrastructure/prometheus.go
@@ -306,20 +306,14 @@ var _ = Describe(SIGSerial("[rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com]
 			}
 		}
 	},
-		Entry("[QUARANTINE][test_id:4142] storage flush requests metric", decorators.Quarantine,
-			"kubevirt_vmi_storage_flush_requests_total", ">="),
-		Entry("[test_id:4142] time spent on cache flushing metric",
-			"kubevirt_vmi_storage_flush_times_seconds_total", ">="),
+		Entry("[test_id:4142] storage flush requests metric", "kubevirt_vmi_storage_flush_requests_total", ">="),
+		Entry("[test_id:4142] time spent on cache flushing metric", "kubevirt_vmi_storage_flush_times_seconds_total", ">="),
 		Entry("[test_id:4142] I/O read operations metric", "kubevirt_vmi_storage_iops_read_total", ">="),
 		Entry("[test_id:4142] I/O write operations metric", "kubevirt_vmi_storage_iops_write_total", ">="),
-		Entry("[test_id:4142] storage read operation time metric",
-			"kubevirt_vmi_storage_read_times_seconds_total", ">="),
-		Entry("[QUARANTINE][test_id:4142] storage read traffic in bytes metric", decorators.Quarantine,
-			"kubevirt_vmi_storage_read_traffic_bytes_total", ">="),
-		Entry("[QUARANTINE][test_id:4142] storage write operation time metric", decorators.Quarantine,
-			"kubevirt_vmi_storage_write_times_seconds_total", ">="),
-		Entry("[QUARANTINE][test_id:4142] storage write traffic in bytes metric", decorators.Quarantine,
-			"kubevirt_vmi_storage_write_traffic_bytes_total", ">="),
+		Entry("[test_id:4142] storage read operation time metric", "kubevirt_vmi_storage_read_times_seconds_total", ">="),
+		Entry("[test_id:4142] storage read traffic in bytes metric", "kubevirt_vmi_storage_read_traffic_bytes_total", ">="),
+		Entry("[test_id:4142] storage write operation time metric", "kubevirt_vmi_storage_write_times_seconds_total", ">="),
+		Entry("[test_id:4142] storage write traffic in bytes metric", "kubevirt_vmi_storage_write_traffic_bytes_total", ">="),
 	)
 
 	DescribeTable("should include metrics for a running VM", func(metricSubstring, operator string) {

--- a/tests/infrastructure/prometheus.go
+++ b/tests/infrastructure/prometheus.go
@@ -285,23 +285,24 @@ var _ = Describe(SIGSerial("[rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com]
 	})
 
 	DescribeTable("should include the storage metrics for a running VM", func(metricName, operator string) {
-		metricsPayload := libmonitoring.GetKubevirtVMMetrics(pod)
-
 		By("Checking the collected metrics")
 		for _, vmi := range preparedVMIs {
 			for _, vol := range vmi.Spec.Volumes {
-				fetcher := metricsutil.NewMetricsFetcher("")
-				fetcher.AddNameFilter(metricName)
-				fetcher.AddLabelFilter("name", vmi.Name, "drive", vol.Name)
+				Eventually(func(g Gomega) {
+					metricsPayload := libmonitoring.GetKubevirtVMMetrics(pod)
+					fetcher := metricsutil.NewMetricsFetcher("")
+					fetcher.AddNameFilter(metricName)
+					fetcher.AddLabelFilter("name", vmi.Name, "drive", vol.Name)
 
-				metrics, err := fetcher.LoadMetrics(metricsPayload)
-				Expect(err).ToNot(HaveOccurred(), "should load metrics without error")
+					metrics, err := fetcher.LoadMetrics(metricsPayload)
+					g.Expect(err).ToNot(HaveOccurred(), "should load metrics without error")
 
-				results := metrics[metricName]
-				Expect(results).ToNot(BeEmpty(), "Expected to find metric for VMI %s and disk %s", vmi.Name, vol.Name)
+					results := metrics[metricName]
+					g.Expect(results).ToNot(BeEmpty(), "Expected to find metric for VMI %s and disk %s", vmi.Name, vol.Name)
 
-				GinkgoLogr.Info("Metric value", "value", results[0].Value)
-				Expect(results[0].Value).To(BeNumerically(operator, 0.0))
+					GinkgoLogr.Info("Metric value", "value", results[0].Value)
+					g.Expect(results[0].Value).To(BeNumerically(operator, 0.0))
+				}, 15*time.Second, 2*time.Second).Should(Succeed())
 			}
 		}
 	},
@@ -322,20 +323,22 @@ var _ = Describe(SIGSerial("[rfe_id:3187][crit:medium][vendor:cnv-qe@redhat.com]
 	)
 
 	DescribeTable("should include metrics for a running VM", func(metricSubstring, operator string) {
-		metricsPayload := libmonitoring.GetKubevirtVMMetrics(pod)
+		Eventually(func(g Gomega) {
+			metricsPayload := libmonitoring.GetKubevirtVMMetrics(pod)
 
-		fetcher := metricsutil.NewMetricsFetcher("")
-		fetcher.AddNameFilter(metricSubstring)
+			fetcher := metricsutil.NewMetricsFetcher("")
+			fetcher.AddNameFilter(metricSubstring)
 
-		metrics, err := fetcher.LoadMetrics(metricsPayload)
-		Expect(err).ToNot(HaveOccurred(), "should load metrics without error")
-		Expect(metrics).ToNot(BeEmpty(), "Expected at least one metric to be collected for %s", metricSubstring)
+			metrics, err := fetcher.LoadMetrics(metricsPayload)
+			g.Expect(err).ToNot(HaveOccurred(), "should load metrics without error")
+			g.Expect(metrics).ToNot(BeEmpty(), "Expected at least one metric to be collected for %s", metricSubstring)
 
-		for _, results := range metrics {
-			for _, result := range results {
-				Expect(result.Value).To(BeNumerically(operator, float64(0.0)))
+			for _, results := range metrics {
+				for _, result := range results {
+					g.Expect(result.Value).To(BeNumerically(operator, float64(0.0)))
+				}
 			}
-		}
+		}, 15*time.Second, 2*time.Second).Should(Succeed())
 	},
 		Entry("[test_id:4143] network metrics", "kubevirt_vmi_network_", ">="),
 		Entry("[test_id:4144] memory metrics", "kubevirt_vmi_memory", ">="),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
The `CONNECT_GET_ALL_DOMAINS_STATS_NOWAIT` flag added in PR #18362
causes libvirt to return immediately without waiting for stats
to be ready. Stats requiring computation may be omitted on any
single scrape, leading to flaky test failures.

Wrap the storage and VMI metric assertions in Eventually blocks
so they retry scraping until the metrics become available.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```

/kind flake
/priority critical-urgent