### PR TITLE
Enable readOnlyRootFilesystem for all Kubevirt containers

### DIFF
--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -1615,6 +1615,7 @@ spec:
                   capabilities:
                     drop:
                     - ALL
+                  readOnlyRootFilesystem: true
                   seccompProfile:
                     type: RuntimeDefault
                 terminationMessagePolicy: FallbackToLogsOnError

--- a/pkg/virt-operator/resource/generate/components/daemonsets.go
+++ b/pkg/virt-operator/resource/generate/components/daemonsets.go
@@ -21,14 +21,15 @@ import (
 )
 
 const (
-	VirtHandlerName = "virt-handler"
-	kubeletPodsPath = util.KubeletRoot + "/pods"
-	runtimesPath    = "/var/run/kubevirt-libvirt-runtimes"
-	PrHelperName    = "pr-helper"
-	prVolumeName    = "pr-helper-socket-vol"
-	devDirVol       = "dev-dir"
-	SidecarShimName = "sidecar-shim"
-	etcMultipath    = "etc-multipath"
+	VirtLauncherName = "virt-launcher"
+	VirtHandlerName  = "virt-handler"
+	kubeletPodsPath  = util.KubeletRoot + "/pods"
+	runtimesPath     = "/var/run/kubevirt-libvirt-runtimes"
+	PrHelperName     = "pr-helper"
+	prVolumeName     = "pr-helper-socket-vol"
+	devDirVol        = "dev-dir"
+	SidecarShimName  = "sidecar-shim"
+	etcMultipath     = "etc-multipath"
 )
 
 func RenderPrHelperContainer(image string, pullPolicy corev1.PullPolicy) corev1.Container {
@@ -190,6 +191,15 @@ func NewHandlerDaemonSet(config *operatorutil.KubeVirtDeploymentConfig, productN
 			ImagePullPolicy: config.GetImagePullPolicy(),
 			Command:         []string{"/bin/sh", "-c"},
 			Args:            []string{"sleep infinity"},
+			SecurityContext: &corev1.SecurityContext{
+				AllowPrivilegeEscalation: pointer.P(false),
+				ReadOnlyRootFilesystem:   pointer.P(true),
+				Capabilities: &corev1.Capabilities{
+					Drop: []corev1.Capability{
+						"ALL",
+					},
+				},
+			},
 			Resources: corev1.ResourceRequirements{
 				Limits: map[corev1.ResourceName]resource.Quantity{
 					corev1.ResourceCPU:    resource.MustParse("100m"),

--- a/pkg/virt-operator/resource/generate/components/daemonsets_test.go
+++ b/pkg/virt-operator/resource/generate/components/daemonsets_test.go
@@ -16,6 +16,60 @@ var _ = Describe("Handler DaemonSet", func() {
 		config = &operatorutil.KubeVirtDeploymentConfig{}
 	})
 
+	Context("SecurityContext", func() {
+		It("should NOT set ReadOnlyRootFilesystem on privileged virt-handler container", func() {
+			ds := NewHandlerDaemonSet(config, "", "", "")
+			container := ds.Spec.Template.Spec.Containers[0]
+			Expect(container.Name).To(Equal(VirtHandlerName))
+			Expect(container.SecurityContext).ToNot(BeNil())
+			Expect(container.SecurityContext.Privileged).ToNot(BeNil())
+			Expect(*container.SecurityContext.Privileged).To(BeTrue())
+			Expect(container.SecurityContext.ReadOnlyRootFilesystem).To(BeNil(),
+				"privileged containers should not set readOnlyRootFilesystem as it provides no security benefit and breaks runtime writes")
+		})
+
+		It("should NOT set ReadOnlyRootFilesystem on privileged virt-launcher init container", func() {
+			ds := NewHandlerDaemonSet(config, "", "", "")
+			var launcher *corev1.Container
+			for i := range ds.Spec.Template.Spec.InitContainers {
+				if ds.Spec.Template.Spec.InitContainers[i].Name == VirtLauncherName {
+					launcher = &ds.Spec.Template.Spec.InitContainers[i]
+					break
+				}
+			}
+			Expect(launcher).ToNot(BeNil(), "virt-launcher init container should exist")
+			Expect(launcher.SecurityContext).ToNot(BeNil())
+			Expect(launcher.SecurityContext.Privileged).ToNot(BeNil())
+			Expect(*launcher.SecurityContext.Privileged).To(BeTrue())
+			Expect(launcher.SecurityContext.ReadOnlyRootFilesystem).To(BeNil(),
+				"privileged containers should not set readOnlyRootFilesystem as it provides no security benefit and breaks runtime writes")
+		})
+
+		It("should set ReadOnlyRootFilesystem on virt-launcher-image-holder container", func() {
+			config.AdditionalProperties = map[string]string{
+				operatorutil.AdditionalPropertiesPullSecrets: `[{"name":"test-secret"}]`,
+			}
+			ds := NewHandlerDaemonSet(config, "", "", "")
+
+			var imageHolder *corev1.Container
+			for i := range ds.Spec.Template.Spec.Containers {
+				if ds.Spec.Template.Spec.Containers[i].Name == "virt-launcher-image-holder" {
+					imageHolder = &ds.Spec.Template.Spec.Containers[i]
+					break
+				}
+			}
+			Expect(imageHolder).ToNot(BeNil(), "virt-launcher-image-holder container should exist")
+			Expect(imageHolder.SecurityContext).ToNot(BeNil())
+			Expect(imageHolder.SecurityContext.ReadOnlyRootFilesystem).ToNot(BeNil())
+			Expect(*imageHolder.SecurityContext.ReadOnlyRootFilesystem).To(BeTrue())
+			Expect(imageHolder.SecurityContext.AllowPrivilegeEscalation).ToNot(BeNil())
+			Expect(*imageHolder.SecurityContext.AllowPrivilegeEscalation).To(BeFalse())
+			Expect(imageHolder.SecurityContext.Capabilities).ToNot(BeNil())
+			Expect(imageHolder.SecurityContext.Capabilities.Drop).ToNot(BeNil())
+			Expect(imageHolder.SecurityContext.Capabilities.Drop).To(ContainElement(corev1.Capability("ALL")))
+		})
+	})
+
 	DescribeTable("should propagate imagePullPolicy to",
 		func(additionalProperties map[string]string, containerName string, isInitContainer bool, expectedPolicy corev1.PullPolicy) {
 			config.AdditionalProperties = additionalProperties

--- a/pkg/virt-operator/resource/generate/components/deployments.go
+++ b/pkg/virt-operator/resource/generate/components/deployments.go
@@ -52,7 +52,9 @@ const (
 
 	kubevirtLabelKey = "kubevirt.io"
 
-	portName = "--port"
+	portName        = "--port"
+	TmpDirName      = "tmp-dir"
+	TmpDirMountPath = "/tmp"
 )
 
 func NewPrometheusService(namespace string) *corev1.Service {
@@ -219,6 +221,21 @@ func attachProfileVolume(spec *corev1.PodSpec) {
 
 }
 
+func attachTmpVolume(spec *corev1.PodSpec) {
+	volume := corev1.Volume{
+		Name: TmpDirName,
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		},
+	}
+	volumeMount := corev1.VolumeMount{
+		Name:      TmpDirName,
+		MountPath: TmpDirMountPath,
+	}
+	spec.Volumes = append(spec.Volumes, volume)
+	spec.Containers[0].VolumeMounts = append(spec.Containers[0].VolumeMounts, volumeMount)
+}
+
 func attachOptionalCertificateSecret(spec *corev1.PodSpec, secretName string, mountPath string) {
 	attachCertificateSecretWithOptions(spec, secretName, mountPath, true)
 }
@@ -331,6 +348,7 @@ func NewApiServerDeployment(config *operatorutil.KubeVirtDeploymentConfig, produ
 	attachCertificateSecret(&deployment.Spec.Template.Spec, VirtApiCertSecretName, "/etc/virt-api/certificates")
 	attachCertificateSecret(&deployment.Spec.Template.Spec, VirtHandlerCertSecretName, "/etc/virt-handler/clientcertificates")
 	attachProfileVolume(&deployment.Spec.Template.Spec)
+	attachTmpVolume(&deployment.Spec.Template.Spec)
 
 	pod := &deployment.Spec.Template.Spec
 	pod.ServiceAccountName = ApiServiceAccountName
@@ -388,6 +406,7 @@ func NewApiServerDeployment(config *operatorutil.KubeVirtDeploymentConfig, produ
 
 	container.SecurityContext = &corev1.SecurityContext{
 		AllowPrivilegeEscalation: pointer.P(false),
+		ReadOnlyRootFilesystem:   pointer.P(true),
 		Capabilities: &corev1.Capabilities{
 			Drop: []corev1.Capability{"ALL"},
 		},
@@ -490,6 +509,7 @@ func NewControllerDeployment(config *operatorutil.KubeVirtDeploymentConfig, prod
 
 	container.SecurityContext = &corev1.SecurityContext{
 		AllowPrivilegeEscalation: pointer.P(false),
+		ReadOnlyRootFilesystem:   pointer.P(true),
 		Capabilities: &corev1.Capabilities{
 			Drop: []corev1.Capability{"ALL"},
 		},
@@ -631,6 +651,7 @@ func NewOperatorDeployment(namespace, repository, imagePrefix, version, verbosit
 							},
 							SecurityContext: &corev1.SecurityContext{
 								AllowPrivilegeEscalation: pointer.P(false),
+								ReadOnlyRootFilesystem:   pointer.P(true),
 								Capabilities: &corev1.Capabilities{
 									Drop: []corev1.Capability{"ALL"},
 								},
@@ -740,6 +761,7 @@ func NewExportProxyDeployment(config *operatorutil.KubeVirtDeploymentConfig, pro
 
 	container.SecurityContext = &corev1.SecurityContext{
 		AllowPrivilegeEscalation: pointer.P(false),
+		ReadOnlyRootFilesystem:   pointer.P(true),
 		Capabilities: &corev1.Capabilities{
 			Drop: []corev1.Capability{"ALL"},
 		},
@@ -839,6 +861,7 @@ func NewSynchronizationControllerDeployment(config *operatorutil.KubeVirtDeploym
 
 	container.SecurityContext = &corev1.SecurityContext{
 		AllowPrivilegeEscalation: pointer.P(false),
+		ReadOnlyRootFilesystem:   pointer.P(true),
 		Capabilities: &corev1.Capabilities{
 			Drop: []corev1.Capability{"ALL"},
 		},

--- a/pkg/virt-operator/resource/generate/components/deployments_test.go
+++ b/pkg/virt-operator/resource/generate/components/deployments_test.go
@@ -4,6 +4,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	operatorutil "kubevirt.io/kubevirt/pkg/virt-operator/util"
+
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -12,5 +14,95 @@ var _ = Describe("Deployments", func() {
 		service := NewPrometheusService("mynamespace")
 		Expect(service.Spec.Type).To(Equal(corev1.ServiceTypeClusterIP))
 		Expect(service.Spec.ClusterIP).To(Equal(corev1.ClusterIPNone))
+	})
+
+	Context("SecurityContext", func() {
+		DescribeTable("should set ReadOnlyRootFilesystem to true on",
+			func(createDeployment func() corev1.PodSpec) {
+				podSpec := createDeployment()
+				for _, c := range podSpec.Containers {
+					Expect(c.SecurityContext).ToNot(BeNil(),
+						"container %s should have SecurityContext", c.Name)
+					Expect(c.SecurityContext.ReadOnlyRootFilesystem).ToNot(BeNil(),
+						"container %s should have ReadOnlyRootFilesystem set", c.Name)
+					Expect(*c.SecurityContext.ReadOnlyRootFilesystem).To(BeTrue(),
+						"container %s should have ReadOnlyRootFilesystem=true", c.Name)
+				}
+			},
+			Entry(VirtAPIName, func() corev1.PodSpec {
+				d := NewApiServerDeployment(&operatorutil.KubeVirtDeploymentConfig{}, "", "", "")
+				return d.Spec.Template.Spec
+			}),
+			Entry(VirtControllerName, func() corev1.PodSpec {
+				d := NewControllerDeployment(&operatorutil.KubeVirtDeploymentConfig{}, "", "", "")
+				return d.Spec.Template.Spec
+			}),
+			Entry(VirtOperatorName, func() corev1.PodSpec {
+				d := NewOperatorDeployment("", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", corev1.PullIfNotPresent)
+				return d.Spec.Template.Spec
+			}),
+			Entry(VirtExportProxyName, func() corev1.PodSpec {
+				d := NewExportProxyDeployment(&operatorutil.KubeVirtDeploymentConfig{}, "", "", "")
+				return d.Spec.Template.Spec
+			}),
+			Entry(VirtSynchronizationControllerName, func() corev1.PodSpec {
+				d := NewSynchronizationControllerDeployment(&operatorutil.KubeVirtDeploymentConfig{}, "", "", "")
+				return d.Spec.Template.Spec
+			}),
+		)
+
+		It("should have emptyDir /tmp volume on virt-api", func() {
+			d := NewApiServerDeployment(&operatorutil.KubeVirtDeploymentConfig{}, "", "", "")
+			podSpec := d.Spec.Template.Spec
+
+			hasTmpVolume := false
+			for _, vol := range podSpec.Volumes {
+				if vol.Name == TmpDirName {
+					Expect(vol.VolumeSource.EmptyDir).ToNot(BeNil())
+					hasTmpVolume = true
+					break
+				}
+			}
+			Expect(hasTmpVolume).To(BeTrue(),
+				"virt-api should have tmp-dir emptyDir volume for os.MkdirTemp usage")
+
+			for _, c := range podSpec.Containers {
+				hasTmpMount := false
+				for _, m := range c.VolumeMounts {
+					if m.Name == TmpDirName && m.MountPath == TmpDirMountPath {
+						hasTmpMount = true
+						break
+					}
+				}
+				Expect(hasTmpMount).To(BeTrue(),
+					"container %s should mount tmp-dir at /tmp", c.Name)
+			}
+		})
+
+		DescribeTable("should NOT have tmp-dir volume on",
+			func(createDeployment func() corev1.PodSpec) {
+				podSpec := createDeployment()
+				for _, vol := range podSpec.Volumes {
+					Expect(vol.Name).ToNot(Equal(TmpDirName),
+						"deployment should not have tmp-dir volume (minimalist approach)")
+				}
+			},
+			Entry(VirtControllerName, func() corev1.PodSpec {
+				d := NewControllerDeployment(&operatorutil.KubeVirtDeploymentConfig{}, "", "", "")
+				return d.Spec.Template.Spec
+			}),
+			Entry(VirtOperatorName, func() corev1.PodSpec {
+				d := NewOperatorDeployment("", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", "", corev1.PullIfNotPresent)
+				return d.Spec.Template.Spec
+			}),
+			Entry(VirtExportProxyName, func() corev1.PodSpec {
+				d := NewExportProxyDeployment(&operatorutil.KubeVirtDeploymentConfig{}, "", "", "")
+				return d.Spec.Template.Spec
+			}),
+			Entry(VirtSynchronizationControllerName, func() corev1.PodSpec {
+				d := NewSynchronizationControllerDeployment(&operatorutil.KubeVirtDeploymentConfig{}, "", "", "")
+				return d.Spec.Template.Spec
+			}),
+		)
 	})
 })

--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -2398,6 +2398,86 @@ var _ = Describe("[sig-operator]Operator", Serial, decorators.SigOperator, func(
 			verifyAggregateLabels(kubevirt.Client(), "true")
 		})
 	})
+
+	Describe("Security", func() {
+		It("all infrastructure deployments should have readOnlyRootFilesystem set to true", func() {
+			deploymentNames := []string{components.VirtAPIName, components.VirtControllerName, components.VirtOperatorName, components.VirtExportProxyName, components.VirtSynchronizationControllerName}
+			for _, name := range deploymentNames {
+				deployment, err := virtClient.AppsV1().Deployments(originalKv.Namespace).Get(context.Background(), name, metav1.GetOptions{})
+				Expect(err).ToNot(HaveOccurred(), "getting deployment %s", name)
+
+				for _, c := range deployment.Spec.Template.Spec.Containers {
+					Expect(c.SecurityContext).ToNot(BeNil(),
+						"container %s in deployment %s should have SecurityContext", c.Name, name)
+					Expect(c.SecurityContext.ReadOnlyRootFilesystem).ToNot(BeNil(),
+						"container %s in deployment %s should have ReadOnlyRootFilesystem set", c.Name, name)
+					Expect(*c.SecurityContext.ReadOnlyRootFilesystem).To(BeTrue(),
+						"container %s in deployment %s should have ReadOnlyRootFilesystem=true", c.Name, name)
+				}
+			}
+		})
+
+		It("virt-api should have emptyDir /tmp volume", func() {
+			deployment, err := virtClient.AppsV1().Deployments(originalKv.Namespace).Get(context.Background(), components.VirtAPIName, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			hasTmpVolume := false
+			for _, vol := range deployment.Spec.Template.Spec.Volumes {
+				if vol.Name == components.TmpDirName {
+					Expect(vol.VolumeSource.EmptyDir).ToNot(BeNil())
+					hasTmpVolume = true
+					break
+				}
+			}
+			Expect(hasTmpVolume).To(BeTrue(), "virt-api should have tmp-dir emptyDir volume")
+
+			for _, c := range deployment.Spec.Template.Spec.Containers {
+				hasTmpMount := false
+				for _, m := range c.VolumeMounts {
+					if m.Name == components.TmpDirName && m.MountPath == components.TmpDirMountPath {
+						hasTmpMount = true
+						break
+					}
+				}
+				Expect(hasTmpMount).To(BeTrue(),
+					"container %s in virt-api should mount tmp-dir at /tmp", c.Name)
+			}
+		})
+
+		It("virt-handler daemonset should NOT have readOnlyRootFilesystem on privileged containers", func() {
+			dsList, err := virtClient.AppsV1().DaemonSets(originalKv.Namespace).List(context.Background(), metav1.ListOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			var handlerDS *appsv1.DaemonSet
+			for i := range dsList.Items {
+				if dsList.Items[i].Name == components.VirtHandlerName {
+					handlerDS = &dsList.Items[i]
+					break
+				}
+			}
+			Expect(handlerDS).ToNot(BeNil(), "virt-handler daemonset should exist")
+
+			for _, c := range handlerDS.Spec.Template.Spec.Containers {
+				Expect(c.SecurityContext).ToNot(BeNil(),
+					"container %s in virt-handler should have SecurityContext", c.Name)
+				if c.SecurityContext.Privileged != nil && *c.SecurityContext.Privileged {
+					Expect(c.SecurityContext.ReadOnlyRootFilesystem).To(BeNil(),
+						"privileged container %s should not set readOnlyRootFilesystem", c.Name)
+				}
+			}
+
+			for _, c := range handlerDS.Spec.Template.Spec.InitContainers {
+				if c.Name == components.VirtLauncherName {
+					Expect(c.SecurityContext).ToNot(BeNil(),
+						"init container virt-launcher should have SecurityContext")
+					Expect(c.SecurityContext.Privileged).ToNot(BeNil())
+					Expect(*c.SecurityContext.Privileged).To(BeTrue())
+					Expect(c.SecurityContext.ReadOnlyRootFilesystem).To(BeNil(),
+						"privileged init container virt-launcher should not set readOnlyRootFilesystem")
+				}
+			}
+		})
+	})
 })
 
 func patchCRD(orig *extv1.CustomResourceDefinition, modified *extv1.CustomResourceDefinition) []byte {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
KubeVirt containers (`virt-operator`, `virt-api`, `virt-controller`, `virt-exportproxy`) run without `readOnlyRootFilesystem: true`, triggering compliance scan findings.

#### After this PR:
All KubeVirt infrastructure containers have `readOnlyRootFilesystem: true` set in their SecurityContext. An emptyDir volume (`tmp-dir`) is added to `virt-api` only, because it calls `os.MkdirTemp("", ...)` to create a temporary certificates directory.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:
- A minimalist approach was chosen: emptyDir `/tmp` is added only to `virt-api`, where a confirmed write exists. Other containers don't write to `/tmp` in production code.
- `virt-controller`, `virt-operator`, `virt-exportproxy`, and `virt-synchronization-controller` do not need `/tmp` — no writes to the root filesystem were identified.
- `virt-handler` and `virt-launcher` init container are intentionally excluded: they run with `privileged: true` ([daemonsets.go#L248](https://github.com/kubevirt/kubevirt/blob/main/pkg/virt-operator/resource/generate/components/daemonsets.go#L248), [daemonsets.go#L166](https://github.com/kubevirt/kubevirt/blob/main/pkg/virt-operator/resource/generate/components/daemonsets.go#L166)). Setting `readOnlyRootFilesystem` on privileged containers provides no security benefit (a privileged container can remount the filesystem rw), while it breaks runtime functionality (`virtqemud` fails to write its pidfile).

The following alternatives were considered:
- Adding `readOnlyRootFilesystem` to all containers including privileged ones — rejected because it causes `virtqemud` pidfile write failures, preventing virt-handler rollout.

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
- `virt-synchronization-controller` is also covered since it uses the same SecurityContext pattern.
- Unit tests verify RORFS on all deployments and DaemonSet containers, plus presence/absence of `tmp-dir` volume.
- E2e tests verify the same properties on deployments in the cluster.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [X] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [X] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [X] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [X] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [X] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Enable readOnlyRootFilesystem for all KubeVirt infrastructure containers
```

