### PR TITLE
metrics: add uid to kubevirt_vm_info and vmi info

### DIFF
--- a/pkg/monitoring/metrics/virt-controller/vmistats_collector.go
+++ b/pkg/monitoring/metrics/virt-controller/vmistats_collector.go
@@ -75,7 +75,7 @@ var (
 		},
 		[]string{
 			// Basic info
-			"node", "namespace", "name",
+			"node", "namespace", "name", "uid",
 			// Domain info
 			"phase", "os", "workload", "flavor",
 			// Instance type
@@ -206,7 +206,7 @@ func collectVMIInfo(vmi *k6tv1.VirtualMachineInstance) operatormetrics.Collector
 	return operatormetrics.CollectorResult{
 		Metric: vmiInfo,
 		Labels: []string{
-			vmi.Status.NodeName, vmi.Namespace, vmi.Name,
+			vmi.Status.NodeName, vmi.Namespace, vmi.Name, string(vmi.UID),
 			getVMIPhase(vmi), os, workload, flavor, instanceType, preference,
 			kernelRelease, guestOSMachineType, guestOSMachineArch, name, versionID,
 			strconv.FormatBool(isVMEvictable(vmi)),

--- a/pkg/monitoring/metrics/virt-controller/vmistats_collector_test.go
+++ b/pkg/monitoring/metrics/virt-controller/vmistats_collector_test.go
@@ -142,15 +142,31 @@ var _ = Describe("VMI Stats Collector", func() {
 				Expect(cr).ToNot(BeNil())
 				Expect(cr.Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vmi_info"))
 				Expect(cr.Value).To(BeEquivalentTo(1))
-				Expect(cr.Labels).To(HaveLen(17))
+				Expect(cr.Labels).To(HaveLen(18))
 
-				Expect(cr.Labels[3]).To(Equal(getVMIPhase(vmis[i])))
+				Expect(cr.Labels[4]).To(Equal(getVMIPhase(vmis[i])))
 				os, workload, flavor := getSystemInfoFromAnnotations(vmis[i].Annotations)
-				Expect(cr.Labels[4]).To(Equal(os))
-				Expect(cr.Labels[5]).To(Equal(workload))
-				Expect(cr.Labels[6]).To(Equal(flavor))
-				Expect(cr.Labels[16]).To(Equal(getVMIPod(vmis[i])))
+				Expect(cr.Labels[5]).To(Equal(os))
+				Expect(cr.Labels[6]).To(Equal(workload))
+				Expect(cr.Labels[7]).To(Equal(flavor))
+				Expect(cr.Labels[17]).To(Equal(getVMIPod(vmis[i])))
 			}
+		})
+
+		It("should expose the VMI Kubernetes uid", func() {
+			vmi := &k6tv1.VirtualMachineInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vmi",
+					Namespace: "test-ns",
+					UID:       "bbbbbbbb-1111-2222-3333-444444444444",
+				},
+				Status: k6tv1.VirtualMachineInstanceStatus{Phase: "Running"},
+			}
+
+			cr := collectVMIInfo(vmi)
+			uid, err := cr.GetLabelValue("uid")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(uid).To(Equal(string(vmi.UID)))
 		})
 
 		It("should update the vmi_pod label correctly after migration", func() {
@@ -162,8 +178,8 @@ var _ = Describe("VMI Stats Collector", func() {
 			Expect(cr).ToNot(BeNil())
 			Expect(cr.Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vmi_info"))
 			Expect(cr.Value).To(BeEquivalentTo(1))
-			Expect(cr.Labels).To(HaveLen(17))
-			Expect(cr.Labels[16]).To(Equal("virt-launcher-targetpod"))
+			Expect(cr.Labels).To(HaveLen(18))
+			Expect(cr.Labels[17]).To(Equal("virt-launcher-targetpod"))
 		})
 
 		It("should return the original pod when migration failed", func() {
@@ -175,8 +191,8 @@ var _ = Describe("VMI Stats Collector", func() {
 			Expect(cr).ToNot(BeNil())
 			Expect(cr.Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vmi_info"))
 			Expect(cr.Value).To(BeEquivalentTo(1))
-			Expect(cr.Labels).To(HaveLen(17))
-			Expect(cr.Labels[16]).To(Equal("virt-launcher-originalpod"))
+			Expect(cr.Labels).To(HaveLen(18))
+			Expect(cr.Labels[17]).To(Equal("virt-launcher-originalpod"))
 		})
 
 		DescribeTable("should show instance type value correctly", func(instanceTypeAnnotationKey, instanceType, expected string) {
@@ -205,8 +221,8 @@ var _ = Describe("VMI Stats Collector", func() {
 			Expect(cr).ToNot(BeNil())
 			Expect(cr.Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vmi_info"))
 			Expect(cr.Value).To(BeEquivalentTo(1))
-			Expect(cr.Labels).To(HaveLen(17))
-			Expect(cr.Labels[7]).To(Equal(expected))
+			Expect(cr.Labels).To(HaveLen(18))
+			Expect(cr.Labels[8]).To(Equal(expected))
 		},
 			Entry("with no instance type expect empty string", k6tv1.InstancetypeAnnotation, "", ""),
 			Entry("with managed instance type expect its name", k6tv1.InstancetypeAnnotation, "i-managed", "i-managed"),
@@ -242,8 +258,8 @@ var _ = Describe("VMI Stats Collector", func() {
 
 			Expect(cr.Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vmi_info"))
 			Expect(cr.Value).To(BeEquivalentTo(1))
-			Expect(cr.Labels).To(HaveLen(17))
-			Expect(cr.Labels[8]).To(Equal(expected))
+			Expect(cr.Labels).To(HaveLen(18))
+			Expect(cr.Labels[9]).To(Equal(expected))
 		},
 			Entry("with no preference expect empty string", k6tv1.PreferenceAnnotation, "", ""),
 			Entry("with managed preference expect its name", k6tv1.PreferenceAnnotation, "p-managed", "p-managed"),

--- a/pkg/monitoring/metrics/virt-controller/vmstats_collector.go
+++ b/pkg/monitoring/metrics/virt-controller/vmstats_collector.go
@@ -156,7 +156,7 @@ var (
 		},
 		[]string{
 			// Basic info
-			"name", "namespace",
+			"name", "namespace", "uid",
 
 			// VM annotations
 			"os", "workload", "flavor",
@@ -250,7 +250,7 @@ func CollectVMsInfo(vms []*k6tv1.VirtualMachine) []operatormetrics.CollectorResu
 		results = append(results, operatormetrics.CollectorResult{
 			Metric: vmInfo,
 			Labels: []string{
-				vm.Name, vm.Namespace,
+				vm.Name, vm.Namespace, string(vm.UID),
 				os, workload, flavor, machineType,
 				instanceType, preference,
 				strings.ToLower(string(vm.Status.PrintableStatus)), getVMStatusGroup(vm.Status.PrintableStatus),

--- a/pkg/monitoring/metrics/virt-controller/vmstats_collector_test.go
+++ b/pkg/monitoring/metrics/virt-controller/vmstats_collector_test.go
@@ -154,7 +154,7 @@ var _ = Describe("VM Stats Collector", func() {
 				Expect(cr).ToNot(BeNil())
 				Expect(cr.Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_info"))
 				Expect(cr.Value).To(BeEquivalentTo(1))
-				Expect(cr.Labels).To(HaveLen(10))
+				Expect(cr.Labels).To(HaveLen(11))
 
 				Expect(cr.GetLabelValue("name")).To(Equal(vms[i].ObjectMeta.Name))
 				Expect(cr.GetLabelValue("namespace")).To(Equal(vms[i].ObjectMeta.Namespace))
@@ -169,6 +169,50 @@ var _ = Describe("VM Stats Collector", func() {
 				Expect(cr.GetLabelValue("status")).To(Equal("crashloopbackoff"))
 				Expect(cr.GetLabelValue("status_group")).To(Equal("error"))
 			}
+		})
+
+		It("should expose the VM Kubernetes uid", func() {
+			vm := &k6tv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vm",
+					Namespace: "test-ns",
+					UID:       "aaaaaaaa-1111-2222-3333-444444444444",
+				},
+			}
+
+			crs := CollectVMsInfo([]*k6tv1.VirtualMachine{vm})
+			Expect(crs).To(HaveLen(1))
+			uid, err := crs[0].GetLabelValue("uid")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(uid).To(Equal(string(vm.UID)))
+		})
+
+		It("should use a different uid for a VM and its VMI", func() {
+			vm := &k6tv1.VirtualMachine{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vm",
+					Namespace: "test-ns",
+					UID:       "vm-uid-1",
+				},
+			}
+			vmi := &k6tv1.VirtualMachineInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-vm",
+					Namespace: "test-ns",
+					UID:       "vmi-uid-2",
+				},
+				Status: k6tv1.VirtualMachineInstanceStatus{Phase: "Running"},
+			}
+
+			vmCrs := CollectVMsInfo([]*k6tv1.VirtualMachine{vm})
+			Expect(vmCrs).To(HaveLen(1))
+			vmUID, err := vmCrs[0].GetLabelValue("uid")
+			Expect(err).ToNot(HaveOccurred())
+			vmiUID, err := collectVMIInfo(vmi).GetLabelValue("uid")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(vmUID).To(Equal("vm-uid-1"))
+			Expect(vmiUID).To(Equal("vmi-uid-2"))
+			Expect(vmUID).ToNot(Equal(vmiUID))
 		})
 
 		DescribeTable("should show instance type value correctly", func(instanceTypeKind, instanceTypeName, expected string) {
@@ -191,7 +235,7 @@ var _ = Describe("VM Stats Collector", func() {
 				Expect(cr).ToNot(BeNil())
 				Expect(cr.Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_info"))
 				Expect(cr.Value).To(BeEquivalentTo(1))
-				Expect(cr.Labels).To(HaveLen(10))
+				Expect(cr.Labels).To(HaveLen(11))
 				Expect(cr.GetLabelValue("instance_type")).To(Equal(expected))
 			}
 		},
@@ -226,7 +270,7 @@ var _ = Describe("VM Stats Collector", func() {
 			for _, cr := range crs {
 				Expect(cr.Metric.GetOpts().Name).To(ContainSubstring("kubevirt_vm_info"))
 				Expect(cr.Value).To(BeEquivalentTo(1))
-				Expect(cr.Labels).To(HaveLen(10))
+				Expect(cr.Labels).To(HaveLen(11))
 				Expect(cr.GetLabelValue("preference")).To(Equal(expected))
 			}
 		},


### PR DESCRIPTION
### What this PR does
#### Before this PR:
`kubevirt_vm_info` and `kubevirt_vmi_info` identified objects only by
name and namespace. Delete and recreate with the same name reused the
Prometheus time series.

#### After this PR:
Both info metrics expose a `uid` label set to the Kubernetes
object UID (`metadata.uid`). VM uid is stable across stop/start;
VMI uid changes on every start. CPU, memory, disk, vNIC, and
domainstats metrics are unchanged. Alerts and recording rules still
join and aggregate on name and namespace.

### References
- Partially addresses https://github.com/kubevirt/kubevirt/issues/11795
- CNV-95595

### Why we need it and why it was done in this way
The following tradeoffs were made:
- `uid` is only on the two info metrics (kube-state-metrics style).
  Other metrics can `group_left(uid)` when they need it.
- Alerts are not switched to uid. VM uid and VMI uid are different
  objects, so VM↔VMI joins must stay on name+namespace. Alert `for:`
  timers can still span a same-name recreate; that is existing
  behavior and can be a follow-up.

The following alternatives were considered:
- uid on every VM/VMI metric: high cardinality, not needed for joins
- guest firmware UUID: not the Kubernetes object identity
- joining VM and VMI on uid: they are different UIDs

Links to places where the discussion took place:
- https://github.com/kubevirt/kubevirt/issues/11795
- https://redhat.atlassian.net/browse/CNV-95595

### Special notes for your reviewer
`docs/observability/metrics.md` is generated from metric Help text
and does not list labels, so it is unchanged.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
Add uid label (Kubernetes object UID) to kubevirt_vm_info and kubevirt_vmi_info
```

Expose the Kubernetes object UID on VM and VMI
info metrics so delete/recreate with the same
name is a distinct time series. Joins and alerts
stay on name and namespace.

Signed-off-by: Shirly Radco <sradco@redhat.com>
Co-authored-by: AI Assistant <noreply@cursor.com>