### PR TITLE
virt-handler: fix stale domain blocking new VMI after force-delete

### DIFF
--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -381,7 +381,7 @@ func (c *VirtualMachineController) execute(key string) error {
 			c.queue.AddAfter(controller.VirtualMachineInstanceKey(vmi), time.Second*1)
 			return nil
 		} else if expired {
-			c.logger.Object(oldVMI).Infof("Detected stale vmi %s that still needs cleanup before new vmi %s with identical name/namespace can be processed", oldVMI.UID, vmi.UID)
+			c.logger.Object(oldVMI).Infof("Cleaning up stale domain for vmi %s/%s (uid %s) so new vmi (uid %s) can be processed", oldVMI.Namespace, oldVMI.Name, oldVMI.UID, vmi.UID)
 			err = c.processVmCleanup(oldVMI)
 			if err != nil {
 				return err
@@ -389,6 +389,12 @@ func (c *VirtualMachineController) execute(key string) error {
 			// Make sure we re-enqueue the key to ensure this new VMI is processed
 			// after the stale domain is removed
 			c.queue.AddAfter(controller.VirtualMachineInstanceKey(vmi), time.Second*5)
+		} else {
+			c.logger.Object(oldVMI).Infof("Cleaning up stale domain for vmi %s/%s (uid %s) so new vmi (uid %s) can be processed", oldVMI.Namespace, oldVMI.Name, oldVMI.UID, vmi.UID)
+			err = c.processVmCleanup(oldVMI)
+			if err != nil {
+				return err
+			}
 		}
 
 		return nil

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -566,7 +566,7 @@ var _ = Describe("VirtualMachineInstance", func() {
 			Expect(hasExpired).To(BeFalse())
 		})
 
-		It("should do nothing if vmi and domain do not match", func() {
+		It("should clean up stale domain if vmi and domain do not match", func() {
 			vmi := api2.NewMinimalVMI("testvmi")
 			vmi.UID = "other uuid"
 			oldVMI := api2.NewMinimalVMI("testvmi")
@@ -574,13 +574,12 @@ var _ = Describe("VirtualMachineInstance", func() {
 			domain := api.NewMinimalDomainWithUUID("testvmi", oldVMI.UID)
 			domain.Status.Status = api.Running
 
+			mockHotplugVolumeMounter.EXPECT().UnmountAll(gomock.Any(), gomock.Any()).Return(nil)
+
 			initGracePeriodHelper(1, vmi, domain)
 			addVMI(vmi, domain)
 
-			sanityExecute()
-			Expect(mockQueue.Len()).To(Equal(0))
-			Expect(mockQueue.GetRateLimitedEnqueueCount()).To(Equal(0))
-
+			sanityExecuteNoDomain()
 		})
 
 		It("should silently retry if the command socket is not yet ready", func() {
@@ -717,6 +716,29 @@ var _ = Describe("VirtualMachineInstance", func() {
 				Expect(err).NotTo(HaveOccurred())
 				Expect(updatedVMI.Status.Phase).To(Equal(v1.Running))
 			})
+		})
+
+		It("should clean up stale domain when UID mismatches new VMI and old launcher is not yet unresponsive", func() {
+			staleDomainUID := uuid.NewUUID()
+
+			vmi := api2.NewMinimalVMI("testvmi")
+			vmi.UID = vmiTestUUID
+			vmi.ObjectMeta.ResourceVersion = "1"
+			vmi.Status.Phase = v1.Scheduled
+			vmi = addActivePods(vmi, podTestUUID, host)
+
+			domain := api.NewMinimalDomainWithUUID("testvmi", staleDomainUID)
+			domain.Status.Status = api.Running
+
+			controller.launcherClients = &launcherclients.MockLauncherClientManager{
+				Initialized:  true,
+				UnResponsive: false,
+			}
+
+			mockHotplugVolumeMounter.EXPECT().UnmountAll(gomock.Any(), gomock.Any()).Return(nil)
+
+			addVMI(vmi, domain)
+			sanityExecuteNoDomain()
 		})
 
 		It("should cleanup if vmi is finalized and domain does not exist", func() {

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -1346,6 +1346,37 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 				Should(Or(matcher.BeInPhase(v1.Succeeded), matcher.BeInPhase(v1.Failed)))
 		})
 	})
+	Describe("Force-delete a VirtualMachineInstance's Pod", decorators.WgS390x, func() {
+		It("should allow a new VMI with the same name to start", func() {
+			vmiName := "force-delete-test-" + rand.String(12)
+
+			By("Creating the first VirtualMachineInstance")
+			vmi := libvmops.RunVMIAndExpectLaunch(libvmifact.NewGuestless(libvmi.WithName(vmiName)), startupTimeout)
+			ns := testsuite.GetTestNamespace(vmi)
+
+			By("Force-deleting the virt-launcher pod")
+			pod, err := libpod.GetPodByVirtualMachineInstance(vmi, ns)
+			Expect(err).ToNot(HaveOccurred())
+			err = kubevirt.Client().CoreV1().Pods(pod.Namespace).Delete(context.Background(), pod.Name, metav1.DeleteOptions{
+				GracePeriodSeconds: pointer.P(int64(0)),
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Waiting for the first VMI to reach a finalized state")
+			Eventually(matcher.ThisVMI(vmi)).WithTimeout(time.Minute).WithPolling(time.Second).
+				Should(Or(matcher.BeInPhase(v1.Succeeded), matcher.BeInPhase(v1.Failed)))
+
+			By("Deleting the first VMI")
+			err = kubevirt.Client().VirtualMachineInstance(ns).Delete(context.Background(), vmiName, metav1.DeleteOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Eventually(matcher.ThisVMI(vmi)).WithTimeout(time.Minute).WithPolling(time.Second).Should(matcher.BeGone())
+
+			By("Creating a second VMI with the same name")
+			newVMI := libvmops.RunVMIAndExpectLaunch(libvmifact.NewGuestless(libvmi.WithName(vmiName)), startupTimeout)
+			Expect(newVMI.UID).ToNot(Equal(vmi.UID))
+		})
+	})
+
 	Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:component]Delete a VirtualMachineInstance", func() {
 		Context("with an active pod.", decorators.WgS390x, func() {
 			It("[test_id:1651]should result in pod being terminated", func() {


### PR DESCRIPTION
### What this PR does
When a virt-launcher pod is force-deleted (--grace-period=0 --force), the domain cache may retain a stale "Running" entry from the old pod. If a new VMI with the same name is then created, execute() detects the UID mismatch between the new VMI and the cached domain and calls IsLauncherClientUnresponsive to check the old launcher's status.

When the old launcher client is initialized (was previously connected) but not yet expired (socket file still exists on disk because kubelet hasn't finished cleaning the emptyDir), the code returned nil without re-queuing. This silently dropped the reconciliation key from the work queue, preventing the new VMI from ever receiving a SyncVMI call. The new virt-launcher would wait ~4.5 minutes and then panic with "timed out waiting for domain to be defined".

Add an else branch that re-queues the key after 5 seconds, so we keep retrying until kubelet removes the old socket and cleanup can proceed.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
