### PR TITLE
tests: add SNO cases for LowKVM and LowVirt* alerts

### DIFF
--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -857,6 +857,28 @@ tests:
         alertname: LowKVMNodesCount
         exp_alerts: []
 
+  # Single node with KVM (SNO) - must not fire; live migration is not expected
+  - interval: 1m
+    input_series:
+      - series: 'kube_node_status_allocatable{resource="devices_kubevirt_io_kvm", node="sno"}'
+        values: "110 110 110 110 110 110"
+
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: LowKVMNodesCount
+        exp_alerts: []
+
+  # Single node without KVM (SNO) - must not fire; the rule requires allocatable nodes > 1
+  - interval: 1m
+    input_series:
+      - series: 'kube_node_status_allocatable{resource="devices_kubevirt_io_kvm", node="sno"}'
+        values: "0 0 0 0 0 0 0"
+
+    alert_rule_test:
+      - eval_time: 6m
+        alertname: LowKVMNodesCount
+        exp_alerts: []
+
   # Test recording rule
   - interval: 1m
     input_series:
@@ -1994,6 +2016,61 @@ tests:
     alert_rule_test:
       - eval_time: 60m
         alertname: LowVirtOperatorCount
+        exp_alerts: []
+
+  # SNO: a single desired replica that is running must not fire LowVirt*Count
+  - interval: 1m
+    input_series:
+      - series: 'kube_pod_status_phase{namespace="ci", pod="virt-api-1", phase="Running"}'
+        values: '1+0x61'
+      - series: 'kube_deployment_spec_replicas{deployment="virt-api", namespace="ci"}'
+        values: '1+0x61'
+
+    alert_rule_test:
+      - eval_time: 60m
+        alertname: LowVirtAPICount
+        exp_alerts: []
+
+  - interval: 1m
+    input_series:
+      - series: 'kube_pod_status_phase{namespace="ci", pod="virt-controller-1", phase="Running"}'
+        values: '1+0x11'
+      - series: 'kube_deployment_spec_replicas{deployment="virt-controller", namespace="ci"}'
+        values: '1+0x11'
+
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: LowVirtControllersCount
+        exp_alerts: []
+
+  - interval: 1m
+    input_series:
+      - series: 'kube_pod_status_phase{namespace="ci", pod="virt-operator-1", phase="Running"}'
+        values: '1+0x61'
+      - series: 'kube_deployment_spec_replicas{deployment="virt-operator", namespace="ci"}'
+        values: '1+0x61'
+
+    alert_rule_test:
+      - eval_time: 60m
+        alertname: LowVirtOperatorCount
+        exp_alerts: []
+
+  # SNO + extra worker: desired replicas stay 1. Extra nodes must not fire
+  # LowVirtAPICount because the expression uses spec.replicas, not node count.
+  - interval: 1m
+    input_series:
+      - series: 'kube_pod_status_phase{namespace="ci", pod="virt-api-1", phase="Running"}'
+        values: '1+0x61'
+      - series: 'kube_deployment_spec_replicas{deployment="virt-api", namespace="ci"}'
+        values: '1+0x61'
+      - series: 'kube_node_status_allocatable{resource="cpu", node="sno"}'
+        values: '8+0x61'
+      - series: 'kube_node_status_allocatable{resource="cpu", node="worker"}'
+        values: '8+0x61'
+
+    alert_rule_test:
+      - eval_time: 60m
+        alertname: LowVirtAPICount
         exp_alerts: []
 
   # VM non-recoverable OS panic


### PR DESCRIPTION
### What this PR does
#### Before this PR:
`LowKVMNodesCount` and `LowVirt*Count` had no `promtool` coverage for a
single-node cluster, or for the day-2 case of an extra worker while
desired replicas stay 1.

#### After this PR:
`hack/prom-rule-ci/prom-rules-tests.yaml` asserts that:

- `LowKVMNodesCount` does not fire on one node (with or without KVM)
- `LowVirtAPICount`, `LowVirtControllersCount`, and
  `LowVirtOperatorCount` do not fire when one desired replica is
  running (`spec.replicas=1`)
- `LowVirtAPICount` still does not fire when a second node exists and
  desired replicas stay 1 (the expression uses `spec.replicas`, not
  node count)

### References
- https://issues.redhat.com/browse/CNV-43404
- https://issues.redhat.com/browse/CNV-42568

### Why we need it and why it was done in this way
The following tradeoffs were made:
These are unit-level `promtool` cases only. They lock the current
PromQL; they do not change alert expressions.

The following alternatives were considered:
Wait for SNO e2e dumps before adding any tests. Unit tests can already
prove the 1-node and replicas=1 behavior without a cluster.

### Special notes for your reviewer
Run `make prom-rules-verify` (or
`hack/prom-rule-ci/verify-rules.sh` with a built rule-spec-dumper).

### Checklist

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
NONE
```

Signed-off-by: Shirly Radco <sradco@redhat.com>
Co-authored-by: AI Assistant <noreply@cursor.com>

Made with [Cursor](https://cursor.com)