### PR TITLE
docs: Use the kubevirtci path in the debugging patch example

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -115,7 +115,7 @@ Having scaled down virt-operator, patch or edit the respective k8s workload mani
 Here's a working example of a `virt-controller` deployment patch 
 
 ```bash
-cluster-up/kubectl.sh --namespace kubevirt patch deployment virt-controller --type='json' -p '[
+kubevirtci/cluster-up/kubectl.sh --namespace kubevirt patch deployment virt-controller --type='json' -p '[
    {
       "op":"add",
       "path":"/spec/template/spec/containers/-",


### PR DESCRIPTION
### What this PR does
#### Before this PR:

`docs/debugging.md:118` gives the `virt-controller` patch example starting with
`cluster-up/kubectl.sh`. There is no `cluster-up/` directory at the repository root, so
pasting it returns `command not found`.

#### After this PR:

The same line uses `kubevirtci/cluster-up/kubectl.sh`, which is where the script is, and which
the other six commands in the file already use.

### References

- Fixes #18848

### Why we need it and why it was done in this way

`92624b1a35` ("kubevirtci: move into it's own folder to allow OWNERS", 2024-09-18) moved the
directory. The document was updated at the time and this one line was missed: lines 4, 12, 15,
25, 36 and 48 all say `kubevirtci/cluster-up/kubectl.sh` and line 118 did not.

It is the one command in the file a reader copies whole, because it is introduced as *"Here's a
working example of a `virt-controller` deployment patch"* and runs to twenty-odd lines of JSON.

One line, no prose changes.

### Special notes for your reviewer

The issue said a human here would sign the DCO off properly rather than have it added on
someone's behalf. That is what happened: the sign-off is Melbin's own, given explicitly for
this class of change. The finding came from
[docproof](https://github.com/melbinjp/docproof), which resolves documented paths against the
repository and its git history.

```release-note
NONE
```
