### PR TITLE
Fix hotplug attachment pod swap to delete old pod earlier

### DIFF
--- a/pkg/virt-controller/watch/vmi/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi/vmi_test.go
@@ -4593,6 +4593,131 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			Expect(err).ToNot(HaveOccurred())
 			expectPodExists(oldPod.Namespace, oldPod.Name)
 		})
+
+		It("should delete old running pod when replacement pod exists but is not running yet", func() {
+			vmi := watchtesting.NewRunningVirtualMachine("testvmi", &k8sv1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testnode",
+				},
+			})
+			vmi.Spec.Volumes = []virtv1.Volume{
+				{
+					Name: "active-vol",
+					VolumeSource: virtv1.VolumeSource{
+						PersistentVolumeClaim: &virtv1.PersistentVolumeClaimVolumeSource{
+							PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
+								ClaimName: "active-pvc",
+							},
+							Hotpluggable: true,
+						},
+					},
+				},
+			}
+			vmi.Status.VolumeStatus = []virtv1.VolumeStatus{
+				{
+					Name:  "active-vol",
+					Phase: virtv1.VolumeReady,
+					HotplugVolume: &virtv1.HotplugVolumeStatus{
+						AttachPodName: "old-pod",
+						AttachPodUID:  "old-uid",
+					},
+				},
+			}
+
+			readyVolumes := []*virtv1.Volume{{}}
+			oldPod := &k8sv1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "old-pod",
+					Namespace: vmi.Namespace,
+				},
+				Spec: k8sv1.PodSpec{
+					Volumes: []k8sv1.Volume{
+						{Name: "active-vol"},
+					},
+				},
+				Status: k8sv1.PodStatus{
+					Phase: k8sv1.PodRunning,
+				},
+			}
+			currentPod := &k8sv1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "new-pod",
+					Namespace: vmi.Namespace,
+				},
+				Status: k8sv1.PodStatus{
+					Phase: k8sv1.PodPending,
+				},
+			}
+			addPod(oldPod)
+			addPod(currentPod)
+
+			err := controller.cleanupAttachmentPods(currentPod, []*k8sv1.Pod{oldPod}, vmi, len(readyVolumes))
+			Expect(err).ToNot(HaveOccurred())
+			testutils.ExpectEvent(recorder, kvcontroller.SuccessfulDeletePodReason)
+			expectPodDoesNotExist(oldPod.Namespace, oldPod.Name)
+		})
+
+		It("should keep old running pod when replacement pod is failed", func() {
+			vmi := watchtesting.NewRunningVirtualMachine("testvmi", &k8sv1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "testnode",
+				},
+			})
+			vmi.Spec.Volumes = []virtv1.Volume{
+				{
+					Name: "active-vol",
+					VolumeSource: virtv1.VolumeSource{
+						PersistentVolumeClaim: &virtv1.PersistentVolumeClaimVolumeSource{
+							PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
+								ClaimName: "active-pvc",
+							},
+							Hotpluggable: true,
+						},
+					},
+				},
+			}
+			vmi.Status.VolumeStatus = []virtv1.VolumeStatus{
+				{
+					Name:  "active-vol",
+					Phase: virtv1.VolumeReady,
+					HotplugVolume: &virtv1.HotplugVolumeStatus{
+						AttachPodName: "old-pod",
+						AttachPodUID:  "old-uid",
+					},
+				},
+			}
+
+			readyVolumes := []*virtv1.Volume{{}}
+			oldPod := &k8sv1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "old-pod",
+					Namespace: vmi.Namespace,
+				},
+				Spec: k8sv1.PodSpec{
+					Volumes: []k8sv1.Volume{
+						{Name: "active-vol"},
+					},
+				},
+				Status: k8sv1.PodStatus{
+					Phase: k8sv1.PodRunning,
+				},
+			}
+			currentPod := &k8sv1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "new-pod",
+					Namespace: vmi.Namespace,
+				},
+				Status: k8sv1.PodStatus{
+					Phase: k8sv1.PodFailed,
+				},
+			}
+			addPod(oldPod)
+			addPod(currentPod)
+
+			err := controller.cleanupAttachmentPods(currentPod, []*k8sv1.Pod{oldPod}, vmi, len(readyVolumes))
+			Expect(err).ToNot(HaveOccurred())
+			expectPodExists(oldPod.Namespace, oldPod.Name)
+		})
 	})
 
 	Context("topology hints", func() {

--- a/pkg/virt-controller/watch/vmi/volume-hotplug.go
+++ b/pkg/virt-controller/watch/vmi/volume-hotplug.go
@@ -69,7 +69,7 @@ func getActiveAndOldAttachmentPods(readyHotplugVolumes []*v1.Volume, hotplugAtta
 }
 
 // cleanupAttachmentPods deletes all old attachment pods when the following is true
-// 1. There is a currentPod that is running. (not nil and phase.Status == Running)
+// 1. There is a replacement currentPod object that is not down.
 // 2. There are no readyVolumes (numReadyVolumes == 0)
 // 3. The newest oldPod is not running and not marked for deletion.
 // If any of those are true, it will not delete the newest oldPod, since that one is the latest
@@ -92,12 +92,12 @@ func (c *Controller) cleanupAttachmentPods(currentPod *k8sv1.Pod, oldPods []*k8s
 		}
 	}
 
-	currentPodIsNotRunning := currentPod == nil || currentPod.Status.Phase != k8sv1.PodRunning
+	currentPodMissing := currentPod == nil || controller.PodIsDown(currentPod)
 	for _, attachmentPod := range oldPods {
 		if !foundRunning &&
 			attachmentPod.Status.Phase == k8sv1.PodRunning && attachmentPod.DeletionTimestamp == nil &&
 			numReadyVolumes > 0 &&
-			currentPodIsNotRunning &&
+			currentPodMissing &&
 			podContainsVolumesToPreserve(attachmentPod, statusMap, specHotplugVolumes) {
 			foundRunning = true
 			continue
@@ -137,7 +137,7 @@ func volumeReadyForPodDelete(phase v1.VolumePhase) bool {
 
 // podContainsVolumesToPreserve returns true if the pod contains at least one
 // hotplug volume that justifies keeping the pod alive as a fallback:
-// - A volume still in the VMI spec (the VMI needs it until the new pod is Running)
+// - A volume still in the VMI spec (the VMI needs it until a replacement pod exists and is not down)
 // - A volume being detached but whose phase still blocks pod deletion
 // An old pod whose hotplug volumes are all in Detaching/UnMounted phase provides
 // no fallback value and should not block PVC cleanup on other VMIs.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Delete the old running attachment pod as soon as a non-terminal replacement pod exists to avoid CSI multi-attach deadlocks during hotplug updates, while still preserving fallback behavior when the replacement pod is down.

#### Before this PR:
The deletion of the attachment pod would wait for the new attachment pod to be ready before deleting the old one to ensure that at no point in time there were no attachment pods actually using the volume. This is to prevent some issues with some CSI drivers that would immediately detach the volume from the node even though it is still in use by the VM.

#### After this PR:
The deletion of the original attachment pod does not wait for the new pod to be ready. It only checks if the the new attachment pod is not down (successful/failed) and deletes the original attachment pod. The reason for this is that some CSI driver will prevent the second pod from starting because the original pod is using it. This behavior is not correct according to the kubernetes specification, but some drivers do enforce it. It should only be enforced on RWOP volumes, not RWO volumes, where multiple pods on the same node should be able to access the volume. It could be a limitation of that specific CSI driver.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [X] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [X] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [X] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: delete attachment pod as long as a new attachment pod exists and is not down (failed/completed)
```

