### PR TITLE
virt-launcher: set mode="subsystem" on PCI host devices

### DIFF
--- a/pkg/virt-launcher/virtwrap/device/hostdevice/BUILD.bazel
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/BUILD.bazel
@@ -32,6 +32,7 @@ go_test(
         ":go_default_library",
         "//pkg/pointer:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
+        "//pkg/virt-launcher/virtwrap/converter/translate:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/dra/generic_hostdev.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/dra/generic_hostdev.go
@@ -106,6 +106,7 @@ func createHostDeviceForHostDevice(hd v1.HostDevice, basePath string, vmiSpecs v
 			Alias:   api.NewUserDefinedAlias(DRAHostDeviceAliasPrefix + hd.Name),
 			Source:  api.HostDeviceSource{Address: hostAddr},
 			Type:    api.HostDevicePCI,
+			Mode:    "subsystem",
 			Managed: "no",
 		}, nil
 	}

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/dra/gpu_hostdev.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/dra/gpu_hostdev.go
@@ -125,6 +125,7 @@ func createHostDeviceForGPU(gpu v1.GPU, basePath string, resourceClaims []v1.Vir
 			Alias:   api.NewUserDefinedAlias(AliasPrefix + gpu.Name),
 			Source:  api.HostDeviceSource{Address: hostAddr},
 			Type:    api.HostDevicePCI,
+			Mode:    "subsystem",
 			Managed: "no",
 		}, nil
 	}

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/generic/hostdev_test.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/generic/hostdev_test.go
@@ -79,6 +79,7 @@ var _ = Describe("Generic HostDevice", func() {
 			Alias:   api.NewUserDefinedAlias(generic.AliasPrefix + hostdevName0),
 			Source:  api.HostDeviceSource{Address: &hostPCIAddress},
 			Type:    api.HostDevicePCI,
+			Mode:    "subsystem",
 			Managed: "no",
 		}
 

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/gpu/hostdev_test.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/gpu/hostdev_test.go
@@ -77,6 +77,7 @@ var _ = Describe("GPU HostDevice", func() {
 			Alias:   api.NewUserDefinedAlias(gpu.AliasPrefix + gpuName0),
 			Source:  api.HostDeviceSource{Address: &hostPCIAddress},
 			Type:    api.HostDevicePCI,
+			Mode:    "subsystem",
 			Managed: "no",
 		}
 

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/hostdev.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/hostdev.go
@@ -146,6 +146,7 @@ func createPCIHostDevice(hostDeviceData HostDeviceMetaData, hostPCIAddress strin
 		Alias:   api.NewUserDefinedAlias(hostDeviceData.AliasPrefix + hostDeviceData.Name),
 		Source:  api.HostDeviceSource{Address: hostAddr},
 		Type:    api.HostDevicePCI,
+		Mode:    "subsystem",
 		Managed: "no",
 	}
 

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/hostdev_test.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/hostdev_test.go
@@ -29,6 +29,7 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/pointer"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/converter/translate"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/device/hostdevice"
 )
 
@@ -116,6 +117,7 @@ var _ = Describe("HostDevice", func() {
 			Alias:   newAlias(devName0),
 			Source:  api.HostDeviceSource{Address: &hostPCIAddress1},
 			Type:    api.HostDevicePCI,
+			Mode:    "subsystem",
 			Managed: "no",
 		}
 		const pciAddress1 = "0000:81:01.1"
@@ -124,6 +126,7 @@ var _ = Describe("HostDevice", func() {
 			Alias:   newAlias(devName1),
 			Source:  api.HostDeviceSource{Address: &hostPCIAddress2},
 			Type:    api.HostDevicePCI,
+			Mode:    "subsystem",
 			Managed: "no",
 		}
 
@@ -151,6 +154,22 @@ var _ = Describe("HostDevice", func() {
 
 			Expect(hostDevices, err).To(Equal([]api.HostDevice{expectHostDevice1, expectHostDevice2}))
 		})
+
+		It("creates a PCI device the libvirtxml converter accepts", func() {
+			hostDevicesMetaData := []hostdevice.HostDeviceMetaData{
+				{AliasPrefix: aliasPrefix, Name: devName0, ResourceName: resourceName0},
+			}
+			pool.AddResource(resourceName0, pciAddress0)
+
+			hostDevices, err := hostdevice.CreatePCIHostDevices(hostDevicesMetaData, pool)
+			Expect(err).ToNot(HaveOccurred())
+
+			spec := api.NewMinimalDomainSpec("test-vm")
+			spec.Devices.HostDevices = hostDevices
+
+			_, err = translate.ToLibvirtDomain(spec)
+			Expect(err).ToNot(HaveOccurred())
+		})
 	})
 
 	Context("PCI display options", func() {
@@ -159,6 +178,7 @@ var _ = Describe("HostDevice", func() {
 			Alias:   newAlias(devName0),
 			Source:  api.HostDeviceSource{Address: &hostPCIAddress0},
 			Type:    api.HostDevicePCI,
+			Mode:    "subsystem",
 			Managed: "no",
 		}
 

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/sriov/hostdev.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/sriov/hostdev.go
@@ -194,6 +194,7 @@ func CreateDRAHostDevices(vmi *v1.VirtualMachineInstance, metadataBasePath strin
 			Alias:   api.NewUserDefinedAlias(deviceinfo.SRIOVAliasPrefix + iface.Name),
 			Source:  api.HostDeviceSource{Address: hostAddr},
 			Type:    api.HostDevicePCI,
+			Mode:    "subsystem",
 			Managed: "no",
 		}
 

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/sriov/hostdev_test.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/sriov/hostdev_test.go
@@ -150,6 +150,7 @@ var _ = Describe("SRIOV HostDevice", func() {
 				Alias:   newSRIOVAlias(netname1),
 				Source:  api.HostDeviceSource{Address: &hostPCIAddress1},
 				Type:    api.HostDevicePCI,
+				Mode:    "subsystem",
 				Managed: "no",
 			}
 			hostPCIAddress2 := api.Address{Type: api.AddressPCI, Domain: "0x0000", Bus: "0x81", Slot: "0x01", Function: "0x1"}
@@ -157,6 +158,7 @@ var _ = Describe("SRIOV HostDevice", func() {
 				Alias:   newSRIOVAlias(netname1),
 				Source:  api.HostDeviceSource{Address: &hostPCIAddress2},
 				Type:    api.HostDevicePCI,
+				Mode:    "subsystem",
 				Managed: "no",
 			}
 			Expect(devices, err).To(Equal([]api.HostDevice{expectHostDevice1, expectHostDevice2}))
@@ -174,6 +176,7 @@ var _ = Describe("SRIOV HostDevice", func() {
 				Alias:   newSRIOVAlias(netname1),
 				Source:  api.HostDeviceSource{Address: &hostPCIAddress1},
 				Type:    api.HostDevicePCI,
+				Mode:    "subsystem",
 				Managed: "no",
 			}
 			hostPCIAddress2 := api.Address{Type: api.AddressPCI, Domain: "0x0000", Bus: "0x81", Slot: "0x02", Function: "0x0"}
@@ -181,6 +184,7 @@ var _ = Describe("SRIOV HostDevice", func() {
 				Alias:   newSRIOVAlias(netname2),
 				Source:  api.HostDeviceSource{Address: &hostPCIAddress2},
 				Type:    api.HostDevicePCI,
+				Mode:    "subsystem",
 				Managed: "no",
 			}
 			Expect(devices, err).To(Equal([]api.HostDevice{expectHostDevice1, expectHostDevice2}))
@@ -199,6 +203,7 @@ var _ = Describe("SRIOV HostDevice", func() {
 				Alias:   newSRIOVAlias(netname1),
 				Source:  api.HostDeviceSource{Address: &hostPCIAddress1},
 				Type:    api.HostDevicePCI,
+				Mode:    "subsystem",
 				Managed: "no",
 				Address: &guestPCIAddress1,
 			}
@@ -233,6 +238,7 @@ var _ = Describe("SRIOV HostDevice", func() {
 					Source:  api.HostDeviceSource{Address: &hostPCIAddress1},
 					Address: expectedGuestPCIAddress1,
 					Type:    api.HostDevicePCI,
+					Mode:    "subsystem",
 					Managed: "no",
 				}
 
@@ -241,6 +247,7 @@ var _ = Describe("SRIOV HostDevice", func() {
 					Source:  api.HostDeviceSource{Address: &hostPCIAddress2},
 					Address: expectedGuestPCIAddress2,
 					Type:    api.HostDevicePCI,
+					Mode:    "subsystem",
 					Managed: "no",
 				}
 
@@ -273,6 +280,7 @@ var _ = Describe("SRIOV HostDevice", func() {
 				Alias:     newSRIOVAlias(netname1),
 				Source:    api.HostDeviceSource{Address: &hostPCIAddress1},
 				Type:      api.HostDevicePCI,
+				Mode:      "subsystem",
 				Managed:   "no",
 				BootOrder: &api.BootOrder{Order: *iface.BootOrder},
 			}
@@ -303,6 +311,7 @@ var _ = Describe("SRIOV HostDevice", func() {
 					Alias:     newSRIOVAlias(netname1),
 					Source:    api.HostDeviceSource{Address: &hostPCIAddress1},
 					Type:      api.HostDevicePCI,
+					Mode:      "subsystem",
 					Managed:   "no",
 					BootOrder: expectedBootOrder1,
 				}
@@ -311,6 +320,7 @@ var _ = Describe("SRIOV HostDevice", func() {
 					Alias:     newSRIOVAlias(netname2),
 					Source:    api.HostDeviceSource{Address: &hostPCIAddress2},
 					Type:      api.HostDevicePCI,
+					Mode:      "subsystem",
 					Managed:   "no",
 					BootOrder: expectedBootOrder2,
 				}
@@ -355,6 +365,7 @@ var _ = Describe("SRIOV HostDevice", func() {
 				Alias:   newSRIOVAlias(netname1),
 				Source:  api.HostDeviceSource{Address: expectedHostAddr},
 				Type:    api.HostDevicePCI,
+				Mode:    "subsystem",
 				Managed: "no",
 				Address: expectedGuestAddr,
 			}


### PR DESCRIPTION
**What this PR does / why we need it**:

`api.HostDevice.Mode` is declared `xml:"mode,attr,omitempty"` ([schema.go#L749](https://github.com/kubevirt/kubevirt/blob/main/pkg/virt-launcher/virtwrap/api/schema.go#L749)), so a `HostDevice` constructed without it marshals to a `<hostdev>` with no `mode` attribute. Four PCI construction paths leave it unset:

| file | function |
|---|---|
| `pkg/virt-launcher/virtwrap/device/hostdevice/hostdev.go:148` | `createPCIHostDevice` — `permittedHostDevices` and classic SR-IOV |
| `pkg/virt-launcher/virtwrap/device/hostdevice/sriov/hostdev.go:196` | `CreateDRAHostDevices` |
| `pkg/virt-launcher/virtwrap/device/hostdevice/dra/gpu_hostdev.go:127` | `createHostDeviceForGPU` |
| `pkg/virt-launcher/virtwrap/device/hostdevice/dra/generic_hostdev.go:108` | `createHostDeviceForHostDevice` |

The MDEV and USB paths do set it — including, in two of those files, the branch immediately above the PCI one in the same function:

```go
	// generic_hostdev.go, MDEV branch
	Type:  api.HostDeviceMDev,
	Mode:  "subsystem",     // <-- set here
	Model: model,
	...
	// generic_hostdev.go, PCI branch, ~15 lines later
	Type:    api.HostDevicePCI,
	Managed: "no",          // <-- no Mode
```

libvirt itself defaults `mode` to `subsystem`, so QEMU has always accepted this XML and nothing was visibly broken. `libvirtxml` does not default it — `DomainHostdev.UnmarshalXML` fails unconditionally:

```go
mode, ok := getAttr(start.Attr, "mode")
if !ok {
    return fmt.Errorf("Missing 'mode' attribute on domain hostdev")
}
```

`translate.ToLibvirtDomain` marshals an `api.DomainSpec` and unmarshals it into a `libvirtxml.Domain`, so it fails for **any** VMI holding a PCI host device:

```
failed to unmarshal XML into libvirtxml.Domain: Missing 'mode' attribute on domain hostdev
```

**Why the blast radius is larger than it looks**

`plugins.ApplyDomainHooks` does the conversion at the top of the function, before it evaluates any plugin's `condition` and before `failureStrategy` is resolved:

```go
func ApplyDomainHooks(plugins []pluginv1alpha1.Plugin, vmi *v1.VirtualMachineInstance, ...) {
	if len(plugins) == 0 {
		return spec, "", nil
	}
	domain, err := translate.ToLibvirtDomain(spec)      // line 93 — fails here
	...
	for _, plugin := range sortedPlugins {
		if plugin.Spec.Condition != "" { ... }          // line 114 — condition
		...
		failureStrategy := cmp.Or(...)                  // line 136 — too late
```

And `virt-handler` sends the whole cluster-wide plugin list to every `virt-launcher` — `buildPluginsJSON` calls `pluginStore.List()` with no per-VMI filtering (`pkg/virt-handler/controller.go:187`), and `SetDomainSpecStrWithHooks` gates only on `len(pluginList) > 0`.

Taken together: **creating a single `Plugin` object anywhere in the cluster prevents every VM with a PCI host device from starting**, whether or not that plugin's `condition` would have selected it, and `failureStrategy: Ignore` gives no protection. VMs that are already running are unaffected until their next start, which makes this easy to hit well after the `Plugin` was created.

**Which issue(s) this PR fixes**:

Fixes #18861

**How this was found**

A VMI with two DRA-allocated `vfio-pci` VFs on Kubernetes 1.36.2 / KubeVirt 1.9.0 with the `Plugins` feature gate enabled. The VM had been starting fine; it stopped the moment a `Plugin` was registered, with the error above and no reference to the host devices in it.

**Special notes for your reviewer**:

- The fix sets the attribute explicitly at the four sites rather than dropping `omitempty` or teaching `libvirtxml` to default it. That matches what the MDEV/USB paths already do, matches what `virsh dumpxml` emits for a live domain, and keeps the change inside KubeVirt.
- Existing PCI expectations in four test files gained `Mode: "subsystem"` — 16 assertions, all of which exercise one of the four changed functions. No expectation became over-specified.
- One new test, `hostdevice` / `PCI` / *creates a PCI device the libvirtxml converter accepts*, pushes a device from the real `CreatePCIHostDevices` through `translate.ToLibvirtDomain`. It fails with the exact production error when the `hostdev.go` change alone is reverted. The `translate` package had no host-device coverage at all, which is why this went unnoticed.
- `pkg/virt-launcher/virtwrap/plugins`, `pkg/virt-launcher/virtwrap` and `pkg/virt-launcher` fail identically before and after this change in my environment, so I could not use them as a signal.

**Release note**:

```release-note
Fixed VMs with PCI host devices (DRA and permittedHostDevices/SR-IOV) failing to start with "Missing 'mode' attribute on domain hostdev" when any Plugin object exists in the cluster.
```
