### PR TITLE
virt-handler: return VFIO preparation errors

### DIFF
--- a/pkg/virt-handler/BUILD.bazel
+++ b/pkg/virt-handler/BUILD.bazel
@@ -92,6 +92,7 @@ go_test(
         "migration-source_test.go",
         "migration-target_test.go",
         "migration_test.go",
+        "non-root_test.go",
         "options_test.go",
         "retry_manager_test.go",
         "virt_handler_suite_test.go",

--- a/pkg/virt-handler/non-root.go
+++ b/pkg/virt-handler/non-root.go
@@ -130,12 +130,14 @@ func (*BaseController) prepareVFIO(res isolation.IsolationResult) error {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil
 		}
+		return err
 	}
 	vfioPath, err := safepath.JoinNoFollow(vfioBasePath, "vfio")
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
 			return nil
 		}
+		return err
 	}
 	err = safepath.ChmodAtNoFollow(vfioPath, 0666)
 	if err != nil {

--- a/pkg/virt-handler/non-root_test.go
+++ b/pkg/virt-handler/non-root_test.go
@@ -1,0 +1,81 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package virthandler
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"syscall"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+
+	"kubevirt.io/kubevirt/pkg/safepath"
+	"kubevirt.io/kubevirt/pkg/virt-handler/isolation"
+)
+
+var _ = Describe("prepareVFIO", func() {
+	var (
+		res        *isolation.MockIsolationResult
+		controller *BaseController
+	)
+
+	BeforeEach(func() {
+		res = isolation.NewMockIsolationResult(gomock.NewController(GinkgoT()))
+		controller = &BaseController{}
+	})
+
+	mountRootOf := func(dir string) *safepath.Path {
+		root, err := safepath.JoinAndResolveWithRelativeRoot(dir)
+		Expect(err).ToNot(HaveOccurred())
+		return root
+	}
+
+	It("returns the error when the mount root cannot be resolved", func() {
+		res.EXPECT().MountRoot().Return(nil, errors.New("mount root is unavailable"))
+
+		Expect(controller.prepareVFIO(res)).To(MatchError("mount root is unavailable"))
+	})
+
+	It("succeeds when the VFIO directory does not exist", func() {
+		res.EXPECT().MountRoot().Return(mountRootOf(GinkgoT().TempDir()), nil)
+
+		Expect(controller.prepareVFIO(res)).To(Succeed())
+	})
+
+	It("succeeds when the VFIO control device does not exist", func() {
+		tempDir := GinkgoT().TempDir()
+		Expect(os.MkdirAll(filepath.Join(tempDir, "dev", "vfio"), 0777)).To(Succeed())
+		res.EXPECT().MountRoot().Return(mountRootOf(tempDir), nil)
+
+		Expect(controller.prepareVFIO(res)).To(Succeed())
+	})
+
+	It("returns the error when the VFIO directory is not a directory", func() {
+		tempDir := GinkgoT().TempDir()
+		Expect(os.MkdirAll(filepath.Join(tempDir, "dev"), 0777)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(tempDir, "dev", "vfio"), nil, 0666)).To(Succeed())
+		res.EXPECT().MountRoot().Return(mountRootOf(tempDir), nil)
+
+		Expect(controller.prepareVFIO(res)).To(MatchError(syscall.ENOTDIR))
+	})
+})


### PR DESCRIPTION
### What this PR does
#### Before this PR:

`prepareVFIO` handled only `os.ErrNotExist` and fell through on every other error.

`isolation.SafeJoin` returns a nil path alongside such an error, and the following `safepath.JoinNoFollow` call dereferences it. This is a nil pointer dereference that terminates `virt-handler`, which runs one pod per node, so VM reconciliation stops for every VM on that node.

#### After this PR:

Errors other than `os.ErrNotExist` are returned to the caller, which already propagates them into a `SyncFailed` event.

### References

None.

### Why we need it and why it was done in this way

This was found during internal durability testing, while investigating VFIO device-node ownership failures on SR-IOV nodes.

The crash path is fully determined:

```
isolation.SafeJoin(...)        -> (nil, err)   when res.MountRoot() fails
safepath.JoinNoFollow(nil, "vfio")
safepath.(*Path).Raw()                         dereferences the nil receiver
```

`RealIsolationResult.MountRoot` resolves `/proc/<pid>/root` for the launcher, so failures there are not `os.ErrNotExist`.

The added unit test reproduces the panic when the fix is reverted:

```
panic: runtime error: invalid memory address or nil pointer dereference
kubevirt.io/kubevirt/pkg/safepath.(*Path).Raw(...)
        pkg/safepath/safepath.go:284
kubevirt.io/kubevirt/pkg/safepath.JoinNoFollow(0x0, ...)
        pkg/safepath/safepath.go:382
kubevirt.io/kubevirt/pkg/virt-handler.(*BaseController).prepareVFIO(...)
        pkg/virt-handler/non-root.go:134
```

The following tradeoffs were made:

Returning the error surfaces the failure through the existing caller chain (`nonRootSetup` -> `setupDevicesOwnerships` -> `handleStartingVMI` -> `processVmUpdate`) instead of terminating the process. A node-wide agent should not be crashable by a transient failure affecting a single VM.

The following alternatives were considered:

Nil-guarding `safepath.Path.Raw()` would make this class of mistake non-fatal everywhere, but it touches a shared package and has a wider blast radius, so it is deliberately left out of this change.

Links to places where the discussion took place:

None.

### Special notes for your reviewer

This particular panic was not captured from a running cluster; the evidence is the reproducer above. The condition it guards is reachable whenever launcher mount-root resolution fails, such as during launcher startup, restart, or teardown.

Question for a follow-up, not included here: should `safepath.Path.Raw()` nil-check its receiver? Happy to raise that separately if reviewers want it.

`pkg/virt-handler/non-root.go` had no unit tests. This adds `non-root_test.go` covering all four paths: a non-`ErrNotExist` error from each of the two calls is returned, and a missing VFIO directory or control device still succeeds. The new file is registered in `pkg/virt-handler/BUILD.bazel` so it runs under `make test`.

### Checklist

- [x] Design: A VEP was considered and is not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: The change is minimal and matches the existing error-handling style
- [x] Refactor: No unrelated refactoring is included
- [x] Upgrade: No upgrade-flow changes are required
- [x] Testing: Unit tests were added; no e2e test is proposed because the condition requires a failing launcher mount-root resolution
- [x] Documentation: No user-facing API or configuration changed
- [x] Community: No announcement is required
- [x] AI Contributions: The PR abides by the KubeVirt AI Contribution Policy

### Release note

```release-note
Fix a virt-handler crash that could occur when preparing VFIO device ownership fails.
```
