### PR TITLE
[release-1.9] monitoring: Add mandatory cluster-scoped namespace to alerts

### DIFF
--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -139,25 +139,26 @@ tests:
 
     # Alert to test when there are VMIs running on a node with an unready virt-handler pod
     # Alert should not fire for node with no running VMIs.
+    # virt-handler is in the install namespace; virt-launcher is in a VM namespace.
   - interval: 1m
     input_series:
-      - series: 'kube_pod_info{pod="virt-handler-asdf", node="node01"}'
+      - series: 'kube_pod_info{pod="virt-handler-asdf", namespace="ci", node="node01"}'
         values: '1 1 1 1 1 1 1 1 1 1 1'
-      - series: 'kube_pod_status_ready{pod="virt-handler-asdf", condition="true"}'
+      - series: 'kube_pod_status_ready{pod="virt-handler-asdf", namespace="ci", condition="true"}'
         values: '0 0 0 0 0 0 0 0 0 0 0'
-      - series: 'kube_pod_info{pod="virt-launcher-testvm-123", node="node01"}'
+      - series: 'kube_pod_info{pod="virt-launcher-testvm-123", namespace="vm-ns", node="node01"}'
         values: '1 1 1 1 1 1 1 1 1 1 1'
-      - series: 'kube_pod_info{pod="virt-handler-asdfg", node="node02"}'
+      - series: 'kube_pod_info{pod="virt-handler-asdfg", namespace="ci", node="node02"}'
         values: '1 1 1 1 1 1 1 1 1 1 1'
-      - series: 'kube_pod_status_ready{pod="virt-handler-asdfg", condition="true"}'
+      - series: 'kube_pod_status_ready{pod="virt-handler-asdfg", namespace="ci", condition="true"}'
         values: '1 1 1 1 1 1 1 1 1 1 1'
-      - series: 'kube_pod_info{pod="virt-launcher-vmi", node="node02"}'
+      - series: 'kube_pod_info{pod="virt-launcher-vmi", namespace="vm-ns", node="node02"}'
         values: '1 1 1 1 1 1 1 1 1 1 1'
-      - series: 'kube_pod_info{pod="virt-handler-abcd", node="node03"}'
+      - series: 'kube_pod_info{pod="virt-handler-abcd", namespace="ci", node="node03"}'
         values: '1 1 1 1 1 1 1 1 1 1 1'
-      - series: 'kube_pod_status_ready{pod="virt-handler-abcd", condition="true"}'
+      - series: 'kube_pod_status_ready{pod="virt-handler-abcd", namespace="ci", condition="true"}'
         values: '0 0 0 0 0 0 0 0 0 0 0'
-      - series: 'kube_pod_info{pod="virt-launcher-novmi", node="node03"}'
+      - series: 'kube_pod_info{pod="virt-launcher-novmi", namespace="vm-ns", node="node03"}'
         values: '_ _ _ _ _ _ _ _ _ _ _'
 
     alert_rule_test:
@@ -173,6 +174,7 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/OrphanedVirtualMachineInstances"
             exp_labels:
               node: "node01"
+              namespace: "ci"
               severity: "warning"
               operator_health_impact: "warning"
               kubernetes_operator_part_of: "kubevirt"
@@ -182,23 +184,23 @@ tests:
     # Alert should not fire for node with no running VMIs.
   - interval: 1m
     input_series:
-      - series: 'kube_pod_info{pod="virt-handler-asdf", node="node01"}'
+      - series: 'kube_pod_info{pod="virt-handler-asdf", namespace="ci", node="node01"}'
         values: '_ _ _ _ _ _ _ _ _ _ _'
-      - series: 'kube_pod_status_ready{pod="virt-handler-asdf", condition="true"}'
+      - series: 'kube_pod_status_ready{pod="virt-handler-asdf", namespace="ci", condition="true"}'
         values: '_ _ _ _ _ _ _ _ _ _ _'
-      - series: 'kube_pod_info{pod="virt-launcher-testvm-123", node="node01"}'
+      - series: 'kube_pod_info{pod="virt-launcher-testvm-123", namespace="vm-ns", node="node01"}'
         values: '1 1 1 1 1 1 1 1 1 1 1'
-      - series: 'kube_pod_info{pod="virt-handler-asdfg", node="node02"}'
+      - series: 'kube_pod_info{pod="virt-handler-asdfg", namespace="ci", node="node02"}'
         values: '1 1 1 1 1 1 1 1 1 1 1'
-      - series: 'kube_pod_status_ready{pod="virt-handler-asdfg", condition="true"}'
+      - series: 'kube_pod_status_ready{pod="virt-handler-asdfg", namespace="ci", condition="true"}'
         values: '1 1 1 1 1 1 1 1 1 1 1'
-      - series: 'kube_pod_info{pod="virt-launcher-vmi", node="node02"}'
+      - series: 'kube_pod_info{pod="virt-launcher-vmi", namespace="vm-ns", node="node02"}'
         values: '1 1 1 1 1 1 1 1 1 1 1'
-      - series: 'kube_pod_info{pod="virt-handler-abcd", node="node03"}'
+      - series: 'kube_pod_info{pod="virt-handler-abcd", namespace="ci", node="node03"}'
         values: '_ _ _ _ _ _ _ _ _ _ _'
-      - series: 'kube_pod_status_ready{pod="virt-handler-abcd", condition="true"}'
+      - series: 'kube_pod_status_ready{pod="virt-handler-abcd", namespace="ci", condition="true"}'
         values: '_ _ _ _ _ _ _ _ _ _ _'
-      - series: 'kube_pod_info{pod="virt-launcher-novmi", node="node03"}'
+      - series: 'kube_pod_info{pod="virt-launcher-novmi", namespace="vm-ns", node="node03"}'
         values: '_ _ _ _ _ _ _ _ _ _ _'
 
 
@@ -215,6 +217,53 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/OrphanedVirtualMachineInstances"
             exp_labels:
               node: "node01"
+              namespace: "ci"
+              severity: "warning"
+              operator_health_impact: "warning"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+
+    # Ready virt-handler in the install namespace must not fire for
+    # virt-launchers that run in other namespaces on the same node.
+  - interval: 1m
+    input_series:
+      - series: 'kube_pod_info{pod="virt-handler-asdf", namespace="ci", node="node01"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1'
+      - series: 'kube_pod_status_ready{pod="virt-handler-asdf", namespace="ci", condition="true"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1'
+      - series: 'kube_pod_info{pod="virt-launcher-vm-a", namespace="ns-a", node="node01"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1'
+      - series: 'kube_pod_info{pod="virt-launcher-vm-b", namespace="ns-b", node="node01"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1'
+
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: OrphanedVirtualMachineInstances
+        exp_alerts: [ ]
+
+    # Unready virt-handler plus virt-launchers in two VM namespaces on the
+    # same node must produce a single alert labeled with the install namespace.
+  - interval: 1m
+    input_series:
+      - series: 'kube_pod_info{pod="virt-handler-asdf", namespace="ci", node="node01"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1'
+      - series: 'kube_pod_status_ready{pod="virt-handler-asdf", namespace="ci", condition="true"}'
+        values: '0 0 0 0 0 0 0 0 0 0 0'
+      - series: 'kube_pod_info{pod="virt-launcher-vm-a", namespace="ns-a", node="node01"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1'
+      - series: 'kube_pod_info{pod="virt-launcher-vm-b", namespace="ns-b", node="node01"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1'
+
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: OrphanedVirtualMachineInstances
+        exp_alerts:
+          - exp_annotations:
+              summary: "No ready virt-handler pod detected on node node01 with running vmis for more than 10 minutes"
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/OrphanedVirtualMachineInstances"
+            exp_labels:
+              node: "node01"
+              namespace: "ci"
               severity: "warning"
               operator_health_impact: "warning"
               kubernetes_operator_part_of: "kubevirt"
@@ -831,8 +880,8 @@ tests:
   # Mass Failed virt-launcher pods should trigger critical alert after 10m
   - interval: 1m
     input_series:
-      # Single series at value 200 so the sum() recording rule reaches threshold for 10m
-      - series: 'kube_pod_status_phase{pod="virt-launcher-test", phase="Failed"}'
+      # Single series at value 200 so the cluster-wide sum reaches threshold for 10m
+      - series: 'kube_pod_status_phase{pod="virt-launcher-test", namespace="vm-ns", phase="Failed"}'
         values: '200x11'
     alert_rule_test:
       # no alert before 10 minutes
@@ -850,6 +899,32 @@ tests:
               operator_health_impact: "critical"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
+              namespace: "ci"
+
+    # Failed virt-launchers split across VM namespaces must still fire once
+    # the cluster-wide count reaches 200, labeled with the install namespace.
+  - interval: 1m
+    input_series:
+      - series: 'kube_pod_status_phase{pod="virt-launcher-a", namespace="ns-a", phase="Failed"}'
+        values: '150x11'
+      - series: 'kube_pod_status_phase{pod="virt-launcher-b", namespace="ns-b", phase="Failed"}'
+        values: '150x11'
+    alert_rule_test:
+      - eval_time: 9m
+        alertname: VirtLauncherPodsStuckFailed
+        exp_alerts: []
+      - eval_time: 10m
+        alertname: VirtLauncherPodsStuckFailed
+        exp_alerts:
+          - exp_annotations:
+              summary: "At least 200 virt-launcher pods are stuck in Failed state and not deleted for 10 minutes."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtLauncherPodsStuckFailed"
+            exp_labels:
+              severity: "critical"
+              operator_health_impact: "critical"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+              namespace: "ci"
 
   # Excessive VMI Migrations in a period of time
   - interval: 1h

--- a/pkg/monitoring/rules/alerts/alerts.go
+++ b/pkg/monitoring/rules/alerts/alerts.go
@@ -39,6 +39,7 @@ const (
 	descriptionAnnotationKey     = "description"
 	partOfAlertLabelKey          = "kubernetes_operator_part_of"
 	componentAlertLabelKey       = "kubernetes_operator_component"
+	namespaceAlertLabelKey       = "namespace"
 	kubevirtLabelValue           = "kubevirt"
 
 	eightyPercent = 80

--- a/pkg/monitoring/rules/alerts/virt-controller.go
+++ b/pkg/monitoring/rules/alerts/virt-controller.go
@@ -83,6 +83,22 @@ func virtControllerAlerts(namespace string) []promv1.Rule {
 			},
 		},
 		{
+			// Cluster-wide count of failed virt-launcher pods, not a
+			// per-namespace alert. Do not sum by namespace: that would
+			// split the 200-pod threshold across VM namespaces.
+			Alert: "VirtLauncherPodsStuckFailed",
+			Expr:  intstr.FromString("sum(kube_pod_status_phase{phase='Failed', pod=~'virt-launcher-.*'}) >= 200"),
+			For:   ptr.To(promv1.Duration("10m")),
+			Annotations: map[string]string{
+				summaryAnnotationKey: "At least 200 virt-launcher pods are stuck in Failed state and not deleted for 10 minutes.",
+			},
+			Labels: map[string]string{
+				severityAlertLabelKey:        "critical",
+				operatorHealthImpactLabelKey: "critical",
+				namespaceAlertLabelKey:       namespace,
+			},
+		},
+		{
 			Alert: "VirtControllerRESTErrorsBurst",
 			Expr:  intstr.FromString(getErrorRatio(namespace, "virt-controller", "(4|5)[0-9][0-9]", fiveMinutes) + " >= 0.8"),
 			For:   ptr.To(promv1.Duration("5m")),

--- a/pkg/monitoring/rules/alerts/virt-handler.go
+++ b/pkg/monitoring/rules/alerts/virt-handler.go
@@ -68,6 +68,26 @@ func virtHandlerAlerts(namespace string) []promv1.Rule {
 			},
 		},
 		{
+			// Node-level virt-handler gap, not a per-VM alert. Aggregate by
+			// node only so virt-launcher namespaces cannot split the series
+			// and produce false positives.
+			Alert: "OrphanedVirtualMachineInstances",
+			Expr: intstr.FromString(
+				"(((max by (node) (kube_pod_status_ready{condition='true',pod=~'virt-handler.*'} " +
+					"* on(pod) group_left(node) max by(pod,node)(kube_pod_info{pod=~'virt-handler.*',node!=''})) ) == 1) " +
+					"or (count by (node)( kube_pod_info{pod=~'virt-launcher.*',node!=''})*0)) == 0",
+			),
+			For: ptr.To(promv1.Duration("10m")),
+			Annotations: map[string]string{
+				summaryAnnotationKey: "No ready virt-handler pod detected on node {{ $labels.node }} with running vmis for more than 10 minutes",
+			},
+			Labels: map[string]string{
+				severityAlertLabelKey:        "warning",
+				operatorHealthImpactLabelKey: "warning",
+				namespaceAlertLabelKey:       namespace,
+			},
+		},
+		{
 			Alert: "VirtHandlerDaemonSetRolloutFailing",
 			Expr: intstr.FromString(
 				fmt.Sprintf("(%s - %s) != 0",

--- a/pkg/monitoring/rules/alerts/vms.go
+++ b/pkg/monitoring/rules/alerts/vms.go
@@ -37,34 +37,6 @@ const excludedFilesystemTypesRegex = "CDFS|iso9660|udf|squashfs|cramfs|tmpfs|dev
 
 var vmsAlerts = []promv1.Rule{
 	{
-		Alert: "VirtLauncherPodsStuckFailed",
-		Expr:  intstr.FromString("sum(kube_pod_status_phase{phase='Failed', pod=~'virt-launcher-.*'}) >= 200"),
-		For:   ptr.To(promv1.Duration("10m")),
-		Annotations: map[string]string{
-			summaryAnnotationKey: "At least 200 virt-launcher pods are stuck in Failed state and not deleted for 10 minutes.",
-		},
-		Labels: map[string]string{
-			severityAlertLabelKey:        "critical",
-			operatorHealthImpactLabelKey: "critical",
-		},
-	},
-	{
-		Alert: "OrphanedVirtualMachineInstances",
-		Expr: intstr.FromString(
-			"(((max by (node) (kube_pod_status_ready{condition='true',pod=~'virt-handler.*'} " +
-				"* on(pod) group_left(node) max by(pod,node)(kube_pod_info{pod=~'virt-handler.*',node!=''})) ) == 1) " +
-				"or (count by (node)( kube_pod_info{pod=~'virt-launcher.*',node!=''})*0)) == 0",
-		),
-		For: ptr.To(promv1.Duration("10m")),
-		Annotations: map[string]string{
-			summaryAnnotationKey: "No ready virt-handler pod detected on node {{ $labels.node }} with running vmis for more than 10 minutes",
-		},
-		Labels: map[string]string{
-			severityAlertLabelKey:        "warning",
-			operatorHealthImpactLabelKey: "warning",
-		},
-	},
-	{
 		Alert: "VMCannotBeEvicted",
 		Expr: intstr.FromString(
 			"kubevirt_vmi_non_evictable * on(name, namespace) group_left() " +


### PR DESCRIPTION
This is a manual cherry-pick of #18822 onto
release-1.9. kubevirt-bot failed to apply
because of a conflict in
`pkg/monitoring/rules/alerts/vms.go`.

OrphanedVirtualMachineInstances and
VirtLauncherPodsStuckFailed are not
per-VM alerts and are missing namespace,
which is mandatory for every alert.

Added thee KubeVirt install namespace stamp 
as a static label.

Jira-URL: https://redhat.atlassian.net/browse/CNV-95456
Jira-URL: https://redhat.atlassian.net/browse/CNV-95457

(cherry picked from commit 87c77c9f1f9bd5e1e97e65466a232a029e4af7a5)

```release-note
Add mandatory namespace label,  cluster-scoped,  to OrphanedVirtualMachineInstances  and VirtLauncherPodsStuckFailed alerts
```

Signed-off-by: Shirly Radco <sradco@redhat.com>
Co-authored-by: AI Assistant <noreply@cursor.com>