### PR TITLE
virt-launcher: Lower log severity for recoverable paths

### DIFF
--- a/cmd/virt-launcher-monitor/virt-launcher-monitor.go
+++ b/cmd/virt-launcher-monitor/virt-launcher-monitor.go
@@ -123,7 +123,7 @@ func RunAndMonitor(containerDiskDir, uid string) (int, error) {
 					wpid, err := syscall.Wait4(-1, &wstatus, syscall.WNOHANG, nil)
 					if err != nil {
 						if err == syscall.ECHILD {
-							log.Log.Reason(err).Errorf("Break reap loop")
+							log.Log.Reason(err).Infof("Break reap loop")
 							break
 						}
 						log.Log.Reason(err).Errorf("Failed to reap process %d", wpid)

--- a/pkg/virt-launcher/virtwrap/cli/libvirt.go
+++ b/pkg/virt-launcher/virtwrap/cli/libvirt.go
@@ -587,7 +587,7 @@ func (l *LibvirtConnection) reconnectIfNecessary() (err error) {
 		}
 	}
 
-	log.Log.Error("Re-registered domain and agent callbacks for new connection")
+	log.Log.Infof("Re-registered domain and agent callbacks for new connection")
 
 	if l.reconnect != nil {
 		// Notify the callback about the reconnect through channel.

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -1143,7 +1143,7 @@ func possibleGuestSize(disk api.Disk, dt disksource.ResolvedDiskSource) (int64, 
 	preferredSize := *disk.Capacity
 	usableSize, err := getUsableDiskSize(dt.BackendPath())
 	if err != nil {
-		log.DefaultLogger().Reason(err).Error("Failed to get total usable space, using disk capacity instead")
+		log.DefaultLogger().Reason(err).Infof("Failed to get total usable space, using disk capacity instead")
 		usableSize = preferredSize
 	}
 	preferredSize = min(usableSize, preferredSize)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
virt-launcher logged a few recoverable paths at error level.

#### After this PR:
These paths are logged at info level instead:
- libvirt reconnect callback re-registration
- virt-launcher monitor reap-loop exit on `ECHILD`
- guest size fallback to disk capacity when usable space lookup fails

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

