### PR TITLE
virt-api: fix nil pointer dereference in admitHotplugCPU webhook

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-update-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-update-admitter.go
@@ -193,6 +193,10 @@ func admitHotplug(
 
 func admitHotplugCPU(oldCPUTopology, newCPUTopology *v1.CPU) *admissionv1.AdmissionResponse {
 
+	if oldCPUTopology == nil || newCPUTopology == nil {
+		return nil
+	}
+
 	if oldCPUTopology.MaxSockets != newCPUTopology.MaxSockets {
 		return webhookutils.ToAdmissionResponse([]metav1.StatusCause{
 			{

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-update-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-update-admitter_test.go
@@ -490,7 +490,23 @@ var _ = Describe("Validating VMIUpdate Admitter", func() {
 			&v1.CPU{
 				MaxSockets: 8,
 			},
-			BeFalse()))
+			BeFalse()),
+		Entry("admit when old CPU topology is nil",
+			nil,
+			&v1.CPU{
+				MaxSockets: 8,
+			},
+			BeTrue()),
+		Entry("admit when new CPU topology is nil",
+			&v1.CPU{
+				MaxSockets: 16,
+			},
+			nil,
+			BeTrue()),
+		Entry("admit when both CPU topologies are nil",
+			nil,
+			nil,
+			BeTrue()))
 
 	It("should reject updates to maxGuest", func() {
 		vmi := api.NewMinimalVMI("testvmi")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
`admitHotplugCPU` in the VMI update admission webhook dereferences `oldCPUTopology.MaxSockets` and `newCPUTopology.MaxSockets` without checking whether either pointer is nil. `spec.domain.cpu` is an optional VMI field, so a VMI update where either the old or the new object has no CPU topology defined panics the webhook's request handler. The panic drops the connection mid-request rather than producing a normal admission response, and because this webhook is registered with `failurePolicy: Fail`, kube-apiserver rejects the original VMI update as an Internal Server Error instead of virt-api returning a proper admission decision.

#### After this PR:
`admitHotplugCPU` returns `nil` (no objection) immediately when either the old or new CPU topology is nil, mirroring the identical nil guard already present in the sibling `admitHotplugMemory` function. VMI updates where `spec.domain.cpu` is nil are now admitted normally instead of panicking the webhook.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #16959
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:
None — this follows the exact pattern already established by the sibling `admitHotplugMemory` function in the same file, so there is no new design decision being introduced.

The following alternatives were considered:
None; a nil guard is the minimal, root-cause fix for a nil pointer dereference, and matches existing repo convention.

Links to places where the discussion took place: none beyond the linked issue.

### Special notes for your reviewer
This repo's CI runs via Prow and is gated behind an `ok-to-test` label for non-member contributors, so I could not trigger the test lanes myself. I validated the change locally instead: `go build`/`go vet` (GOOS=linux GOARCH=amd64), `golangci-lint run --new-from-rev=HEAD` (0 new issues), and by actually running `go test ./pkg/virt-api/webhooks/validating-webhook/admitters/... -run TestValidatingWebhook` on native Linux (this dev machine is macOS, so I used a local Linux VM since some kubevirt packages are Linux-only) — the full suite passes. To confirm this is a genuine failing-then-passing fix rather than a no-op, I mechanically reverted only the 4-line nil guard, reran the "Updates in CPU topology" spec, and confirmed it panicked with exactly `runtime error: invalid memory address or nil pointer dereference` inside `admitHotplugCPU` for the old-nil and new-nil cases; restoring the guard made all specs pass again. CI on this repo requires a maintainer to add `ok-to-test` — happy to address anything it surfaces.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed a nil pointer dereference panic in the virt-api VMI update admission webhook when a VirtualMachineInstance has no spec.domain.cpu defined.
```

---
AI assistance: this change was drafted with Claude Code.