### PR TITLE
tests: cover soft reboot ACPI rejection in a unit test

### DIFF
--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -39,6 +39,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/disksource"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/network"
 
+	k8sv1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -2831,6 +2832,53 @@ var _ = Describe("Manager", func() {
 			Entry("running", libvirt.DOMAIN_RUNNING),
 			Entry("paused", libvirt.DOMAIN_PAUSED),
 		)
+	})
+	Context("on soft reboot", func() {
+		withAgentConnected := func(vmi *v1.VirtualMachineInstance) {
+			vmi.Status.Conditions = append(vmi.Status.Conditions, v1.VirtualMachineInstanceCondition{
+				Type:   v1.VirtualMachineInstanceAgentConnected,
+				Status: k8sv1.ConditionTrue,
+			})
+		}
+		withACPI := func(vmi *v1.VirtualMachineInstance, enabled bool) {
+			vmi.Spec.Domain.Features = &v1.Features{
+				ACPI: v1.FeatureState{Enabled: virtpointer.P(enabled)},
+			}
+		}
+
+		It("should reboot via the guest agent when the agent is connected", func() {
+			vmi := newVMI(testNamespace, testVmName)
+			withAgentConnected(vmi)
+			// ACPI is irrelevant to the guest-agent reboot path.
+			withACPI(vmi, false)
+
+			mockLibvirt.ConnectionEXPECT().LookupDomainByName(testDomainName).DoAndReturn(mockDomainWithFreeExpectation)
+			mockLibvirt.DomainEXPECT().Reboot(libvirt.DOMAIN_REBOOT_GUEST_AGENT).Return(nil)
+			manager, _ := newLibvirtDomainManagerDefault()
+
+			Expect(manager.SoftRebootVMI(vmi)).To(Succeed())
+		})
+		It("should reboot via the ACPI power button when the agent is not connected and ACPI is enabled", func() {
+			vmi := newVMI(testNamespace, testVmName)
+			withACPI(vmi, true)
+
+			mockLibvirt.ConnectionEXPECT().LookupDomainByName(testDomainName).DoAndReturn(mockDomainWithFreeExpectation)
+			mockLibvirt.DomainEXPECT().Reboot(libvirt.DOMAIN_REBOOT_ACPI_POWER_BTN).Return(nil)
+			manager, _ := newLibvirtDomainManagerDefault()
+
+			Expect(manager.SoftRebootVMI(vmi)).To(Succeed())
+		})
+		It("should fail without issuing a reboot when the agent is not connected and ACPI is disabled", func() {
+			vmi := newVMI(testNamespace, testVmName)
+			withACPI(vmi, false)
+
+			// No LookupDomainByName/Reboot expectations: the rejection is
+			// derived purely from the VMI spec, before touching the domain.
+			manager, _ := newLibvirtDomainManagerDefault()
+
+			err := manager.SoftRebootVMI(vmi)
+			Expect(err).To(MatchError(ContainSubstring("VMI neither have the agent connected nor the ACPI feature enabled")))
+		})
 	})
 	DescribeTable("on successful list all domains",
 		func(state libvirt.DomainState, kubevirtState api.LifeCycle, libvirtReason int, kubevirtReason api.StateChangeReason) {

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -50,7 +50,6 @@ import (
 	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/hypervisor"
 	"kubevirt.io/kubevirt/pkg/libvmi"
-	"kubevirt.io/kubevirt/pkg/pointer"
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"
 	device_manager "kubevirt.io/kubevirt/pkg/virt-handler/device-manager"
 	"kubevirt.io/kubevirt/tests/console"
@@ -1166,7 +1165,10 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 		const vmiLaunchTimeout = 360
 
 		It("soft reboot vmi with agent connected should succeed", decorators.Conformance, decorators.WgS390x, func() {
-			vmi := libvmops.RunVMIAndExpectLaunch(libvmifact.NewFedora(withoutACPI()), vmiLaunchTimeout)
+			// The agent reboot path does not depend on ACPI, so ACPI is left
+			// at its default (enabled) to keep the guest bootable on firmware
+			// that no longer synthesizes ACPI tables when ACPI is disabled.
+			vmi := libvmops.RunVMIAndExpectLaunch(libvmifact.NewFedora(), vmiLaunchTimeout)
 
 			Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 			bootID, err := readBootID(vmi, console.LoginToFedora)
@@ -1197,15 +1199,11 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 			waitForBootIDChange(vmi, console.LoginToFedora, bootID)
 		})
 
-		It("soft reboot vmi neither have the agent connected nor the ACPI feature enabled should fail", decorators.WgS390x, decorators.Conformance, func() {
-			vmi := libvmops.RunVMIAndExpectLaunch(libvmifact.NewAlpine(withoutACPI()), vmiLaunchTimeout)
-
-			Expect(console.LoginToAlpine(vmi)).To(Succeed())
-			Eventually(matcher.ThisVMI(vmi), 30*time.Second, 2*time.Second).Should(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineInstanceAgentConnected))
-
-			err := kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).SoftReboot(context.Background(), vmi.Name)
-			Expect(err).To(MatchError(ContainSubstring("VMI neither have the agent connected nor the ACPI feature enabled")))
-		})
+		// The "neither agent connected nor ACPI enabled" rejection is a
+		// spec-level check in the domain manager and is covered deterministically
+		// by a unit test (pkg/virt-launcher/virtwrap/manager_test.go). It is not
+		// exercised here because it would require booting a BIOS guest with ACPI
+		// disabled, which modern SeaBIOS (>=1.17.0) no longer supports.
 
 		It("soft reboot vmi should fail to soft reboot a paused vmi", decorators.WgS390x, func() {
 			vmi := libvmops.RunVMIAndExpectLaunch(libvmifact.NewFedora(), vmiLaunchTimeout)
@@ -1560,10 +1558,3 @@ func waitForBootIDChange(vmi *v1.VirtualMachineInstance, login console.LoginToFu
 	}, 300*time.Second, 5*time.Second).ShouldNot(Equal(preRebootBootID), "expected guest to reboot (boot_id change)")
 }
 
-func withoutACPI() libvmi.Option {
-	return func(vmi *v1.VirtualMachineInstance) {
-		vmi.Spec.Domain.Features = &v1.Features{
-			ACPI: v1.FeatureState{Enabled: pointer.P(false)},
-		}
-	}
-}


### PR DESCRIPTION
### What this PR does
#### Before this PR:

Two `SoftRebootVMI` e2e tests in `tests/vmi_lifecycle_test.go` relied on
SeaBIOS silently regenerating ACPI tables at runtime:

- The "soft reboot without guest agent" test created a Fedora VMI with ACPI
  explicitly disabled (`withoutACPI()`), yet still expected an ACPI power
  button reboot to succeed. That only worked because SeaBIOS was quietly
  papering over the missing tables — it was testing a fiction, not the
  documented behaviour.
- A separate "neither agent nor ACPI" e2e test exercised a purely
  spec-level rejection that does not need a live cluster.

#### After this PR:

- Drop the spurious `withoutACPI()` from the no-agent soft reboot test so it
  exercises the real, supported path (ACPI enabled, no guest agent →
  `DOMAIN_REBOOT_ACPI_POWER_BTN`).
- Move the spec-level rejection (no agent **and** ACPI disabled →
  `SoftReboot` is refused) into a deterministic unit test in
  `pkg/virt-launcher/virtwrap/manager_test.go`, covering all three reboot
  paths:
  - agent connected → `DOMAIN_REBOOT_GUEST_AGENT`
  - no agent, ACPI enabled → `DOMAIN_REBOOT_ACPI_POWER_BTN`
  - no agent, ACPI disabled → error, with no libvirt call made
- Remove the now-unused `withoutACPI()` helper and pointer import.

### Why we need it and why it was done in this way

The soft reboot tests were only passing because SeaBIOS < 1.17 generates ACPI
tables internally even when libvirt emits `acpi=off`. SeaBIOS 1.17.0 dropped
that internal generator, which surfaced the tests as relying on undefined
behaviour (see kubevirt/kubevirt#18839). Rather than depend on that quirk,
the spec-level rejection is now asserted deterministically in a unit test and
the e2e test exercises the genuinely supported path.

### Special notes for your reviewer

Companion to kubevirt/kubevirt#18839 (which temporarily pins SeaBIOS to
1.16.3 on CS10). This PR removes the test reliance on the dropped SeaBIOS
ACPI fallback.

### Release note
```release-note
NONE
```

- Partially addresses #18878
