### PR TITLE
define two consts closest to their single user

### DIFF
--- a/cmd/virt-launcher/BUILD.bazel
+++ b/cmd/virt-launcher/BUILD.bazel
@@ -23,7 +23,6 @@ go_library(
         "//pkg/hotplug-disk:go_default_library",
         "//pkg/ignition:go_default_library",
         "//pkg/storage/nbdclient:go_default_library",
-        "//pkg/util:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//pkg/virt-handler/cmd-client:go_default_library",
         "//pkg/virt-launcher:go_default_library",

--- a/cmd/virt-launcher/virt-launcher.go
+++ b/cmd/virt-launcher/virt-launcher.go
@@ -48,7 +48,6 @@ import (
 	hotplugdisk "kubevirt.io/kubevirt/pkg/hotplug-disk"
 	"kubevirt.io/kubevirt/pkg/ignition"
 	"kubevirt.io/kubevirt/pkg/storage/nbdclient"
-	putil "kubevirt.io/kubevirt/pkg/util"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	cmdclient "kubevirt.io/kubevirt/pkg/virt-handler/cmd-client"
 	virtlauncher "kubevirt.io/kubevirt/pkg/virt-launcher"
@@ -122,7 +121,8 @@ func createLibvirtConnection(runWithNonRoot bool) virtcli.Connection {
 	libvirtUri := "qemu:///system"
 	user := ""
 	if runWithNonRoot {
-		user = putil.NonRootUserString
+		const nonRootUserString = "qemu"
+		user = nonRootUserString
 		libvirtUri = "qemu+unix:///session?socket=/var/run/libvirt/virtqemud-sock"
 	}
 

--- a/pkg/container-disk/container-disk.go
+++ b/pkg/container-disk/container-disk.go
@@ -478,12 +478,13 @@ func getMinimalInitContainerDiskResources(vmi *v1.VirtualMachineInstance, config
 
 // CreateImageVolumeInitContainer creates a single init container for ImageVolume feature
 func CreateImageVolumeInitContainer(vmi *v1.VirtualMachineInstance, config *virtconfig.ClusterConfig, name, image string, imagePullPolicy kubev1.PullPolicy) kubev1.Container {
+	const containerBinary = "/container-disk-binary"
 	resources := getMinimalInitContainerDiskResources(vmi, config)
 	return kubev1.Container{
 		Name:            fmt.Sprintf("volume%s", name),
 		Image:           image,
 		ImagePullPolicy: imagePullPolicy,
-		Command:         []string{filepath.Join(util.ContainerBinary, "/usr/bin/container-disk")},
+		Command:         []string{filepath.Join(containerBinary, "/usr/bin/container-disk")},
 		Args:            []string{"--no-op"},
 		Resources:       resources,
 		SecurityContext: &kubev1.SecurityContext{
@@ -496,7 +497,7 @@ func CreateImageVolumeInitContainer(vmi *v1.VirtualMachineInstance, config *virt
 		},
 		VolumeMounts: []kubev1.VolumeMount{{
 			Name:      LauncherVolume,
-			MountPath: util.ContainerBinary,
+			MountPath: containerBinary,
 			ReadOnly:  true,
 		}},
 	}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -29,9 +29,8 @@ const (
 	HostRootMount                             = "/proc/1/root/"
 	ContainerBinary                           = "/container-disk-binary"
 
-	NonRootUID        = 107
-	NonRootUserString = "qemu"
-	RootUser          = 0
+	NonRootUID = 107
+	RootUser   = 0
 
 	// extensive log verbosity threshold after which libvirt debug logs will be enabled
 	EXT_LOG_VERBOSITY_THRESHOLD         = 5

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -27,7 +27,6 @@ const (
 	KubeletRoot                               = "/var/lib/kubelet"
 	KubeletPodsDir                            = KubeletRoot + "/pods"
 	HostRootMount                             = "/proc/1/root/"
-	ContainerBinary                           = "/container-disk-binary"
 
 	NonRootUID = 107
 	RootUser   = 0


### PR DESCRIPTION
util.go is a bag of unrelated stuff. Making it a bit shorter and making virt-launcher not directly depend on it are noble causes.

/kind cleanup

```release-note
NONE
```

