### PR TITLE
virt-api: fix panic on empty clone filter

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmclone-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmclone-admitter.go
@@ -138,7 +138,7 @@ func validateFilters(filters []string, fieldName string) (causes []metav1.Status
 	const wildcardChar = "*"
 
 	for _, filter := range filters {
-		if len(filter) == 1 {
+		if len(filter) <= 1 {
 			if filter == negationChar {
 				addCause("a negation character is not a valid filter")
 			}

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmclone-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmclone-admitter_test.go
@@ -377,6 +377,7 @@ var _ = Describe("Validating VirtualMachineClone Admitter", func() {
 			Entry("wildcard only", "*"),
 			Entry("wildcard in the end", "mykey/something*"),
 			Entry("negation in the beginning", "!mykey/something"),
+			Entry("empty filter", ""),
 		)
 	})
 


### PR DESCRIPTION
**What this PR does / why we need it**

`validateFilters` panics with `slice bounds out of range [1:0]` when a
clone filter is an empty string. The `len(filter) == 1` guard lets a
zero-length filter through to `filter[1:]`.

The CRD schema declares `"default": ""` for the items of
`annotationFilters` and `labelFilters` and sets no `minLength`, so an
empty filter is accepted by the API server and reaches the webhook. This
crashes the validating webhook handler for a user-supplied
`VirtualMachineClone`.

Reproducer:

```yaml
apiVersion: clone.kubevirt.io/v1beta1
kind: VirtualMachineClone
metadata:
  name: repro
spec:
  source:
    apiGroup: kubevirt.io
    kind: VirtualMachine
    name: some-vm
  annotationFilters: [""]
```

The same path is reachable via `labelFilters`,
`template.annotationFilters` and `template.labelFilters`.

**Special notes for your reviewer**

The guard is widened to `len(filter) <= 1`, so an empty filter is
skipped rather than rejected — the minimal change, consistent with a
`nil` filter list being a no-op. Happy to make it an explicit validation
error instead if that's preferred.

**Release note**

```release-note
Fixed a panic in the VirtualMachineClone validating webhook when a label or annotation filter is an empty string.
```