### PR TITLE
fix: reject setting serial disk number for lun disks

### DIFF
--- a/pkg/storage/admitters/disks.go
+++ b/pkg/storage/admitters/disks.go
@@ -52,6 +52,7 @@ func ValidateDisks(field *k8sfield.Path, disks []v1.Disk) []metav1.StatusCause {
 		causes = append(causes, validatePciAddress(field, idx, disk)...)
 		causes = append(causes, validateBootOrderValue(field, idx, disk)...)
 		causes = append(causes, validateBusSupport(field, idx, disk)...)
+		causes = append(causes, validateSerialDevice(field, idx, disk)...)
 		causes = append(causes, validateSerialNumValue(field, idx, disk)...)
 		causes = append(causes, validateSerialNumLength(field, idx, disk)...)
 		causes = append(causes, validateCacheMode(field, idx, disk)...)
@@ -225,6 +226,18 @@ func validateBusSupport(field *k8sfield.Path, idx int, disk v1.Disk) []metav1.St
 			Type:    metav1.CauseTypeFieldValueNotSupported,
 			Message: fmt.Sprintf("IOThreads are not supported for disks on a %s bus", bus),
 			Field:   field.Child("domain", "devices", "disks").Index(idx).String(),
+		})
+	}
+	return causes
+}
+
+func validateSerialDevice(field *k8sfield.Path, idx int, disk v1.Disk) []metav1.StatusCause {
+	var causes []metav1.StatusCause
+	if disk.Serial != "" && getDiskBus(disk) == v1.DiskBusSCSI && getDiskType(disk) == "lun" {
+		causes = append(causes, metav1.StatusCause{
+			Type:    metav1.CauseTypeFieldValueNotSupported,
+			Message: "Serial definition is not supported for LUN disks",
+			Field:   field.Index(idx).Child("serial").String(),
 		})
 	}
 	return causes

--- a/pkg/storage/admitters/disks_test.go
+++ b/pkg/storage/admitters/disks_test.go
@@ -347,6 +347,37 @@ var _ = Describe("Disk Validation", func() {
 			Expect(causes[0].Field).To(Equal("fake[0].serial"))
 		})
 
+		It("should reject serial set for lun disk", func() {
+			vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
+				Name:   "lun-disk",
+				Serial: "testserial",
+				DiskDevice: v1.DiskDevice{
+					LUN: &v1.LunTarget{
+						Bus: v1.DiskBusSCSI,
+					},
+				},
+			})
+
+			causes := ValidateDisks(k8sfield.NewPath("fake"), vmi.Spec.Domain.Devices.Disks)
+			Expect(causes).To(HaveLen(1))
+			Expect(causes[0].Field).To(Equal("fake[0].serial"))
+		})
+
+		It("should accept serial set for scsi disk", func() {
+			vmi.Spec.Domain.Devices.Disks = append(vmi.Spec.Domain.Devices.Disks, v1.Disk{
+				Name:   "scsi-disk",
+				Serial: "testserial",
+				DiskDevice: v1.DiskDevice{
+					Disk: &v1.DiskTarget{
+						Bus: v1.DiskBusSCSI,
+					},
+				},
+			})
+
+			causes := ValidateDisks(k8sfield.NewPath("fake"), vmi.Spec.Domain.Devices.Disks)
+			Expect(causes).To(BeEmpty())
+		})
+
 		It("should reject SN > maxStrLen characters", func() {
 			order := uint(1)
 			sn := strings.Repeat("1", maxStrLen+1)

--- a/pkg/virtctl/vm/add_volume.go
+++ b/pkg/virtctl/vm/add_volume.go
@@ -173,6 +173,9 @@ func addVolume(vmiName, volumeName, diskName, namespace string, virtClient kubec
 		if bus != v1.DiskBusSCSI {
 			return fmt.Errorf("Invalid bus type '%s' for LUN disk. Only '%s' bus is supported.", busType, v1.DiskBusSCSI)
 		}
+		if serial != "" {
+			return fmt.Errorf("Serial definition is not supported for LUN disks")
+		}
 		hotplugRequest.Disk.DiskDevice.LUN = &v1.LunTarget{
 			Bus: bus,
 		}

--- a/pkg/virtctl/vm/add_volume_test.go
+++ b/pkg/virtctl/vm/add_volume_test.go
@@ -215,6 +215,11 @@ var _ = Describe("Add volume command", func() {
 					MatchError(ContainSubstring("Invalid bus type 'virtio' for LUN disk. Only 'scsi' bus is supported.")))
 			})
 
+			It("should fail addvolume with LUN and serial", func() {
+				Expect(runCmd("--disk-type=lun --bus=scsi --serial=test")).To(
+					MatchError(ContainSubstring("Serial definition is not supported for LUN disks")))
+			})
+
 			DescribeTable("when volume name exceeds 63 chars", func(valid bool) {
 				longVolName := rand.String(64)
 				_, err := cdiClient.CdiV1beta1().DataVolumes(metav1.NamespaceDefault).Create(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
[LibVirt](https://libvirt.org/formatdomain.html#hard-drives-floppy-disks-cdroms) does not allow specifying a disk serial number for LUN disks and are currently silently ignored when set.

This PR adds new check at the disk spec validation layer to reject VMs that are configured with LUN disks containing a serial. Add similar rejection to the `addvolume` API call so this specific disk configuration cannot be hotplugged.

#### Before this PR:
#### After this PR:

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
reject setting serial disk number for lun disks
```

