### PR TITLE
virt-api: include the constraint index in topologySpreadConstraints labelSelector errors

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/validate-k8s-utils.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/validate-k8s-utils.go
@@ -285,7 +285,7 @@ func validateTopologySpreadConstraints(constraints []core.TopologySpreadConstrai
 
 		// this is missing in upstream codebase https://github.com/kubernetes/kubernetes/blob/master/pkg/apis/core/validation/validation.go#L6571-L6600
 		// issue captured here https://github.com/kubernetes/kubernetes/issues/111791#issuecomment-1211184962
-		allErrs = append(allErrs, unversionedvalidation.ValidateLabelSelector(constraint.LabelSelector, unversionedvalidation.LabelSelectorValidationOptions{}, fldPath.Child("labelSelector"))...)
+		allErrs = append(allErrs, unversionedvalidation.ValidateLabelSelector(constraint.LabelSelector, unversionedvalidation.LabelSelectorValidationOptions{}, subFldPath.Child("labelSelector"))...)
 
 		// tuple {topologyKey, whenUnsatisfiable} denotes one kind of spread constraint
 		if err := ValidateSpreadConstraintNotRepeat(subFldPath.Child("{topologyKey, whenUnsatisfiable}"), constraint, constraints[i+1:]); err != nil {

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -3685,8 +3685,8 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			resp := vmiCreateAdmitter.Admit(context.Background(), ar)
 			Expect(resp.Allowed).To(BeFalse())
 			Expect(resp.Result.Details.Causes).To(HaveLen(1))
-			Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.topologySpreadConstraints.labelSelector.matchExpressions[0].values"))
-			Expect(resp.Result.Details.Causes[0].Message).To(Equal("spec.topologySpreadConstraints.labelSelector.matchExpressions[0].values: Required value: must be specified when `operator` is 'In' or 'NotIn'"))
+			Expect(resp.Result.Details.Causes[0].Field).To(Equal("spec.topologySpreadConstraints[0].labelSelector.matchExpressions[0].values"))
+			Expect(resp.Result.Details.Causes[0].Message).To(Equal("spec.topologySpreadConstraints[0].labelSelector.matchExpressions[0].values: Required value: must be specified when `operator` is 'In' or 'NotIn'"))
 		})
 	})
 


### PR DESCRIPTION
**What this PR does / why we need it**

`validateTopologySpreadConstraints` derives `subFldPath := fldPath.Index(i)` at the top of its loop and uses it for `maxSkew`, `topologyKey`, `whenUnsatisfiable` and the duplicate-pair check. The `labelSelector` validation sitting between them uses the unindexed `fldPath` instead.

The result is that an invalid selector is always reported against `spec.topologySpreadConstraints.labelSelector`, with no index, no matter which constraint it came from.

Given a VMI with two constraints where only the second has an invalid selector:

```yaml
spec:
  topologySpreadConstraints:
    - maxSkew: 1
      topologyKey: zone
      whenUnsatisfiable: DoNotSchedule
      labelSelector:
        matchLabels:
          app: valid
    - maxSkew: 1
      topologyKey: hostname
      whenUnsatisfiable: DoNotSchedule
      labelSelector:
        matchExpressions:
          - key: app
            operator: In     # values omitted -> invalid
```

the rejection points at `spec.topologySpreadConstraints.labelSelector.matchExpressions[0].values`, which the user cannot map back to the offending constraint. Every sibling check in the same loop already reports `spec.topologySpreadConstraints[1].<field>`.

**Verification**

Reverting only the one-line fix and running the existing suite:

    [FAILED] Expected
        <string>: spec.topologySpreadConstraints.labelSelector.matchExpressions[0].values
    to equal
        <string>: spec.topologySpreadConstraints[0].labelSelector.matchExpressions[0].values

With the fix applied, the package is green.

**Special notes for your reviewer**

This file deliberately mirrors upstream Kubernetes validation, so divergence here is worth scrutiny. The `labelSelector` line is not part of that mirrored code — it is a KubeVirt addition, and the comment directly above it links kubernetes/kubernetes#111791 as the reason it exists. This change therefore does not move the file further from its upstream counterpart.

The assertion in `vmi-create-admitter_test.go` encoded the unindexed path and is updated in the same commit. That test exercises a single constraint, where the missing index was harmless, which is likely why this went unnoticed.

This is an error-reporting fix only. No validation outcome changes: the same specs are accepted and rejected as before, and only the `Field` and `Message` of the returned `StatusCause` differ.

**Release note**

```release-note
Field paths in VirtualMachineInstance topologySpreadConstraints labelSelector validation errors now include the constraint index.
```**What this PR does / why we need it**

`validateTopologySpreadConstraints` derives `subFldPath := fldPath.Index(i)` at the top of its loop and uses it for `maxSkew`, `topologyKey`, `whenUnsatisfiable` and the duplicate-pair check. The `labelSelector` validation sitting between them uses the unindexed `fldPath` instead.

The result is that an invalid selector is always reported against `spec.topologySpreadConstraints.labelSelector`, with no index, no matter which constraint it came from.

Given a VMI with two constraints where only the second has an invalid selector:

```yaml
spec:
  topologySpreadConstraints:
    - maxSkew: 1
      topologyKey: zone
      whenUnsatisfiable: DoNotSchedule
      labelSelector:
        matchLabels:
          app: valid
    - maxSkew: 1
      topologyKey: hostname
      whenUnsatisfiable: DoNotSchedule
      labelSelector:
        matchExpressions:
          - key: app
            operator: In     # values omitted -> invalid
```

the rejection points at `spec.topologySpreadConstraints.labelSelector.matchExpressions[0].values`, which the user cannot map back to the offending constraint. Every sibling check in the same loop already reports `spec.topologySpreadConstraints[1].<field>`.

**Verification**

Reverting only the one-line fix and running the existing suite:

    [FAILED] Expected
        <string>: spec.topologySpreadConstraints.labelSelector.matchExpressions[0].values
    to equal
        <string>: spec.topologySpreadConstraints[0].labelSelector.matchExpressions[0].values

With the fix applied, the package is green.

**Special notes for reviewers**

This file deliberately mirrors upstream Kubernetes validation, so divergence here is worth scrutiny. The `labelSelector` line is not part of that mirrored code it is a KubeVirt addition, and the comment directly above it links kubernetes/kubernetes#111791 as the reason it exists. This change therefore does not move the file further from its upstream counterpart.

The assertion in `vmi-create-admitter_test.go` encoded the unindexed path and is updated in the same commit. That test exercises a single constraint, where the missing index was harmless, which is likely why this went unnoticed.

This is an error-reporting fix only. No validation outcome changes: the same specs are accepted and rejected as before, and only the `Field` and `Message` of the returned `StatusCause` differ.

**Release note**

```release-note
Field paths in VirtualMachineInstance topologySpreadConstraints labelSelector validation errors now include the constraint index.
```