### PR TITLE
[release-1.7] monitoring: Add mandatory cluster-scoped namespace to alerts

### DIFF
--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -109,25 +109,26 @@ tests:
 
     # Alert to test when there are VMIs running on a node with an unready virt-handler pod
     # Alert should not fire for node with no running VMIs.
+    # virt-handler is in the install namespace; virt-launcher is in a VM namespace.
   - interval: 1m
     input_series:
-      - series: 'kube_pod_info{pod="virt-handler-asdf", node="node01"}'
+      - series: 'kube_pod_info{pod="virt-handler-asdf", namespace="ci", node="node01"}'
         values: '1 1 1 1 1 1 1 1 1 1 1'
-      - series: 'kube_pod_status_ready{pod="virt-handler-asdf", condition="true"}'
+      - series: 'kube_pod_status_ready{pod="virt-handler-asdf", namespace="ci", condition="true"}'
         values: '0 0 0 0 0 0 0 0 0 0 0'
-      - series: 'kube_pod_info{pod="virt-launcher-testvm-123", node="node01"}'
+      - series: 'kube_pod_info{pod="virt-launcher-testvm-123", namespace="vm-ns", node="node01"}'
         values: '1 1 1 1 1 1 1 1 1 1 1'
-      - series: 'kube_pod_info{pod="virt-handler-asdfg", node="node02"}'
+      - series: 'kube_pod_info{pod="virt-handler-asdfg", namespace="ci", node="node02"}'
         values: '1 1 1 1 1 1 1 1 1 1 1'
-      - series: 'kube_pod_status_ready{pod="virt-handler-asdfg", condition="true"}'
+      - series: 'kube_pod_status_ready{pod="virt-handler-asdfg", namespace="ci", condition="true"}'
         values: '1 1 1 1 1 1 1 1 1 1 1'
-      - series: 'kube_pod_info{pod="virt-launcher-vmi", node="node02"}'
+      - series: 'kube_pod_info{pod="virt-launcher-vmi", namespace="vm-ns", node="node02"}'
         values: '1 1 1 1 1 1 1 1 1 1 1'
-      - series: 'kube_pod_info{pod="virt-handler-abcd", node="node03"}'
+      - series: 'kube_pod_info{pod="virt-handler-abcd", namespace="ci", node="node03"}'
         values: '1 1 1 1 1 1 1 1 1 1 1'
-      - series: 'kube_pod_status_ready{pod="virt-handler-abcd", condition="true"}'
+      - series: 'kube_pod_status_ready{pod="virt-handler-abcd", namespace="ci", condition="true"}'
         values: '0 0 0 0 0 0 0 0 0 0 0'
-      - series: 'kube_pod_info{pod="virt-launcher-novmi", node="node03"}'
+      - series: 'kube_pod_info{pod="virt-launcher-novmi", namespace="vm-ns", node="node03"}'
         values: '_ _ _ _ _ _ _ _ _ _ _'
 
     alert_rule_test:
@@ -143,8 +144,9 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/OrphanedVirtualMachineInstances"
             exp_labels:
               node: "node01"
+              namespace: "ci"
               severity: "warning"
-              operator_health_impact: "none"
+              operator_health_impact: "warning"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
 
@@ -152,23 +154,23 @@ tests:
     # Alert should not fire for node with no running VMIs.
   - interval: 1m
     input_series:
-      - series: 'kube_pod_info{pod="virt-handler-asdf", node="node01"}'
+      - series: 'kube_pod_info{pod="virt-handler-asdf", namespace="ci", node="node01"}'
         values: '_ _ _ _ _ _ _ _ _ _ _'
-      - series: 'kube_pod_status_ready{pod="virt-handler-asdf", condition="true"}'
+      - series: 'kube_pod_status_ready{pod="virt-handler-asdf", namespace="ci", condition="true"}'
         values: '_ _ _ _ _ _ _ _ _ _ _'
-      - series: 'kube_pod_info{pod="virt-launcher-testvm-123", node="node01"}'
+      - series: 'kube_pod_info{pod="virt-launcher-testvm-123", namespace="vm-ns", node="node01"}'
         values: '1 1 1 1 1 1 1 1 1 1 1'
-      - series: 'kube_pod_info{pod="virt-handler-asdfg", node="node02"}'
+      - series: 'kube_pod_info{pod="virt-handler-asdfg", namespace="ci", node="node02"}'
         values: '1 1 1 1 1 1 1 1 1 1 1'
-      - series: 'kube_pod_status_ready{pod="virt-handler-asdfg", condition="true"}'
+      - series: 'kube_pod_status_ready{pod="virt-handler-asdfg", namespace="ci", condition="true"}'
         values: '1 1 1 1 1 1 1 1 1 1 1'
-      - series: 'kube_pod_info{pod="virt-launcher-vmi", node="node02"}'
+      - series: 'kube_pod_info{pod="virt-launcher-vmi", namespace="vm-ns", node="node02"}'
         values: '1 1 1 1 1 1 1 1 1 1 1'
-      - series: 'kube_pod_info{pod="virt-handler-abcd", node="node03"}'
+      - series: 'kube_pod_info{pod="virt-handler-abcd", namespace="ci", node="node03"}'
         values: '_ _ _ _ _ _ _ _ _ _ _'
-      - series: 'kube_pod_status_ready{pod="virt-handler-abcd", condition="true"}'
+      - series: 'kube_pod_status_ready{pod="virt-handler-abcd", namespace="ci", condition="true"}'
         values: '_ _ _ _ _ _ _ _ _ _ _'
-      - series: 'kube_pod_info{pod="virt-launcher-novmi", node="node03"}'
+      - series: 'kube_pod_info{pod="virt-launcher-novmi", namespace="vm-ns", node="node03"}'
         values: '_ _ _ _ _ _ _ _ _ _ _'
 
 
@@ -185,8 +187,55 @@ tests:
               runbook_url: "https://kubevirt.io/monitoring/runbooks/OrphanedVirtualMachineInstances"
             exp_labels:
               node: "node01"
+              namespace: "ci"
               severity: "warning"
-              operator_health_impact: "none"
+              operator_health_impact: "warning"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+
+    # Ready virt-handler in the install namespace must not fire for
+    # virt-launchers that run in other namespaces on the same node.
+  - interval: 1m
+    input_series:
+      - series: 'kube_pod_info{pod="virt-handler-asdf", namespace="ci", node="node01"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1'
+      - series: 'kube_pod_status_ready{pod="virt-handler-asdf", namespace="ci", condition="true"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1'
+      - series: 'kube_pod_info{pod="virt-launcher-vm-a", namespace="ns-a", node="node01"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1'
+      - series: 'kube_pod_info{pod="virt-launcher-vm-b", namespace="ns-b", node="node01"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1'
+
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: OrphanedVirtualMachineInstances
+        exp_alerts: [ ]
+
+    # Unready virt-handler plus virt-launchers in two VM namespaces on the
+    # same node must produce a single alert labeled with the install namespace.
+  - interval: 1m
+    input_series:
+      - series: 'kube_pod_info{pod="virt-handler-asdf", namespace="ci", node="node01"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1'
+      - series: 'kube_pod_status_ready{pod="virt-handler-asdf", namespace="ci", condition="true"}'
+        values: '0 0 0 0 0 0 0 0 0 0 0'
+      - series: 'kube_pod_info{pod="virt-launcher-vm-a", namespace="ns-a", node="node01"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1'
+      - series: 'kube_pod_info{pod="virt-launcher-vm-b", namespace="ns-b", node="node01"}'
+        values: '1 1 1 1 1 1 1 1 1 1 1'
+
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: OrphanedVirtualMachineInstances
+        exp_alerts:
+          - exp_annotations:
+              summary: "No ready virt-handler pod detected on node node01 with running vmis for more than 10 minutes"
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/OrphanedVirtualMachineInstances"
+            exp_labels:
+              node: "node01"
+              namespace: "ci"
+              severity: "warning"
+              operator_health_impact: "warning"
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
 

--- a/pkg/monitoring/rules/alerts/alerts.go
+++ b/pkg/monitoring/rules/alerts/alerts.go
@@ -39,6 +39,7 @@ const (
 
 	partOfAlertLabelKey    = "kubernetes_operator_part_of"
 	componentAlertLabelKey = "kubernetes_operator_component"
+	namespaceAlertLabelKey = "namespace"
 	kubevirtLabelValue     = "kubevirt"
 
 	durationFiveMinutes = "5 minutes"

--- a/pkg/monitoring/rules/alerts/virt-handler.go
+++ b/pkg/monitoring/rules/alerts/virt-handler.go
@@ -29,6 +29,26 @@ import (
 func virtHandlerAlerts(namespace string) []promv1.Rule {
 	return []promv1.Rule{
 		{
+			// Node-level virt-handler gap, not a per-VM alert.
+			// Aggregate by node only so virt-launcher namespaces
+			// cannot split the series and produce false positives.
+			Alert: "OrphanedVirtualMachineInstances",
+			Expr: intstr.FromString(
+				"(((max by (node) (kube_pod_status_ready{condition='true',pod=~'virt-handler.*'} " +
+					"* on(pod) group_left(node) max by(pod,node)(kube_pod_info{pod=~'virt-handler.*',node!=''})) ) == 1) " +
+					"or (count by (node)( kube_pod_info{pod=~'virt-launcher.*',node!=''})*0)) == 0",
+			),
+			For: ptr.To(promv1.Duration("10m")),
+			Annotations: map[string]string{
+				"summary": "No ready virt-handler pod detected on node {{ $labels.node }} with running vmis for more than 10 minutes",
+			},
+			Labels: map[string]string{
+				severityAlertLabelKey:        "warning",
+				operatorHealthImpactLabelKey: "warning",
+				namespaceAlertLabelKey:       namespace,
+			},
+		},
+		{
 			Alert: "VirtHandlerDaemonSetRolloutFailing",
 			Expr: intstr.FromString(
 				fmt.Sprintf("(%s - %s) != 0",

--- a/pkg/monitoring/rules/alerts/vms.go
+++ b/pkg/monitoring/rules/alerts/vms.go
@@ -30,18 +30,6 @@ var (
 
 	vmsAlerts = []promv1.Rule{
 		{
-			Alert: "OrphanedVirtualMachineInstances",
-			Expr:  intstr.FromString("(((max by (node) (kube_pod_status_ready{condition='true',pod=~'virt-handler.*'} * on(pod) group_left(node) max by(pod,node)(kube_pod_info{pod=~'virt-handler.*',node!=''})) ) == 1) or (count by (node)( kube_pod_info{pod=~'virt-launcher.*',node!=''})*0)) == 0"),
-			For:   ptr.To(promv1.Duration("10m")),
-			Annotations: map[string]string{
-				"summary": "No ready virt-handler pod detected on node {{ $labels.node }} with running vmis for more than 10 minutes",
-			},
-			Labels: map[string]string{
-				severityAlertLabelKey:        "warning",
-				operatorHealthImpactLabelKey: "none",
-			},
-		},
-		{
 			Alert: "VMCannotBeEvicted",
 			Expr:  intstr.FromString("kubevirt_vmi_non_evictable * on(name, namespace) group_left() kubevirt_vmi_info{phase='running'} == 1"),
 			For:   ptr.To(promv1.Duration("1m")),


### PR DESCRIPTION
This is a manual cherry-pick of #18869 onto
release-1.7. kubevirt-bot failed to apply
because of conflicts in alert files and
prom-rules-tests.yaml.

OrphanedVirtualMachineInstances is a
cluster/node alert missing a mandatory
namespace label. VirtLauncherPodsStuckFailed
does not exist on release-1.7.

Move the alert to virt-handler and stamp
the KubeVirt install namespace as a static
label.

Jira-URL: https://redhat.atlassian.net/browse/CNV-95456

(cherry picked from commit 390cf886c3db5d1e13ed18d5f0706e5473bae7f9)

```release-note
Add mandatory namespace label, cluster-scoped,
to OrphanedVirtualMachineInstances alert
```

Signed-off-by: Shirly Radco <sradco@redhat.com>
Co-authored-by: AI Assistant <noreply@cursor.com>

Made with [Cursor](https://cursor.com)