### PR TITLE
[Cleanup] plugins (VEP 190): unify field naming, rename NewBaseEnv, self-contain vmi

### DIFF
--- a/pkg/plugins/cel/evaluator.go
+++ b/pkg/plugins/cel/evaluator.go
@@ -103,7 +103,7 @@ func getBaseEnv() (*cel.Env, error) {
 	return baseEnv, baseEnvErr
 }
 
-func NewBaseEvaluator(opts ...Option) (*cel.Env, error) {
+func NewBaseEnv(opts ...Option) (*cel.Env, error) {
 	cfg := &config{}
 	for _, o := range opts {
 		o(cfg)
@@ -148,7 +148,7 @@ func NewBaseEvaluator(opts ...Option) (*cel.Env, error) {
 
 func NewEvaluator(opts ...Option) (*Evaluator, error) {
 	envOpts := append([]Option{WithNativeTypesJSON(reflect.TypeOf(&v1.VirtualMachineInstance{}))}, opts...)
-	env, err := NewBaseEvaluator(envOpts...)
+	env, err := NewBaseEnv(envOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create CEL environment: %w", err)
 	}

--- a/pkg/plugins/cel/evaluator.go
+++ b/pkg/plugins/cel/evaluator.go
@@ -38,11 +38,10 @@ type variable struct {
 }
 
 type config struct {
-	variables       []variable
-	containers      []string
-	nativeTypes     []reflect.Type
-	nativeTypesJSON []reflect.Type
-	typeProvider    func(types.Provider) types.Provider
+	variables    []variable
+	containers   []string
+	nativeTypes  []reflect.Type
+	typeProvider func(types.Provider) types.Provider
 }
 
 type Option func(*config)
@@ -62,12 +61,6 @@ func WithContainer(name string) Option {
 func WithNativeTypes(types ...reflect.Type) Option {
 	return func(c *config) {
 		c.nativeTypes = append(c.nativeTypes, types...)
-	}
-}
-
-func WithNativeTypesJSON(types ...reflect.Type) Option {
-	return func(c *config) {
-		c.nativeTypesJSON = append(c.nativeTypesJSON, types...)
 	}
 }
 
@@ -118,10 +111,6 @@ func NewBaseEnv(opts ...Option) (*cel.Env, error) {
 		envOpts = append(envOpts, ext.NativeTypes(t))
 	}
 
-	for _, t := range cfg.nativeTypesJSON {
-		envOpts = append(envOpts, ext.NativeTypes(t, ext.ParseStructTag("json")))
-	}
-
 	for _, container := range cfg.containers {
 		envOpts = append(envOpts, cel.Container(container))
 	}
@@ -142,12 +131,12 @@ func NewBaseEnv(opts ...Option) (*cel.Env, error) {
 		}
 	}
 
-	return env, err
+	return env, nil
 }
 
 func NewEvaluator(opts ...Option) (*Evaluator, error) {
 	envOpts := append([]Option{
-		WithNativeTypesJSON(reflect.TypeOf(&v1.VirtualMachineInstance{})),
+		WithNativeTypes(reflect.TypeOf(&v1.VirtualMachineInstance{})),
 		WithVariable("vmi", cel.ObjectType("v1.VirtualMachineInstance")),
 	}, opts...)
 	env, err := NewBaseEnv(envOpts...)

--- a/pkg/plugins/cel/evaluator.go
+++ b/pkg/plugins/cel/evaluator.go
@@ -95,7 +95,6 @@ func getBaseEnv() (*cel.Env, error) {
 			ext.Strings(),
 			ext.Math(),
 			ext.Lists(),
-			cel.Variable("vmi", cel.ObjectType("v1.VirtualMachineInstance")),
 			cel.CrossTypeNumericComparisons(true),
 			cel.EagerlyValidateDeclarations(true),
 		)
@@ -147,7 +146,10 @@ func NewBaseEnv(opts ...Option) (*cel.Env, error) {
 }
 
 func NewEvaluator(opts ...Option) (*Evaluator, error) {
-	envOpts := append([]Option{WithNativeTypesJSON(reflect.TypeOf(&v1.VirtualMachineInstance{}))}, opts...)
+	envOpts := append([]Option{
+		WithNativeTypesJSON(reflect.TypeOf(&v1.VirtualMachineInstance{})),
+		WithVariable("vmi", cel.ObjectType("v1.VirtualMachineInstance")),
+	}, opts...)
 	env, err := NewBaseEnv(envOpts...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create CEL environment: %w", err)

--- a/pkg/plugins/cel/evaluator_test.go
+++ b/pkg/plugins/cel/evaluator_test.go
@@ -69,9 +69,9 @@ var _ = Describe("CEL Evaluator", func() {
 		}
 	})
 
-	Context("NewBaseEvaluator", func() {
+	Context("NewBaseEnv", func() {
 		It("should create base evaluator", func() {
-			_, err := cel.NewBaseEvaluator()
+			_, err := cel.NewBaseEnv()
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})
@@ -143,7 +143,7 @@ var _ = Describe("CEL Evaluator", func() {
 		})
 
 		It("should accept go struct parsing when default tag parser is not JSON", func() {
-			eval, err := cel.NewBaseEvaluator(
+			eval, err := cel.NewBaseEnv(
 				cel.WithNativeTypes(reflect.TypeOf(&v1.VirtualMachineInstance{})),
 			)
 			Expect(err).ToNot(HaveOccurred())

--- a/pkg/plugins/cel/evaluator_test.go
+++ b/pkg/plugins/cel/evaluator_test.go
@@ -20,8 +20,6 @@
 package cel_test
 
 import (
-	"reflect"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -79,7 +77,7 @@ var _ = Describe("CEL Evaluator", func() {
 	Context("VMI field access", func() {
 		It("should evaluate VMI name", func() {
 			result, err := evaluator.EvaluateCondition(
-				`vmi.metadata.name == "test-vmi"`,
+				`vmi.Name == "test-vmi"`,
 				map[string]any{"vmi": vmi},
 			)
 			Expect(err).ToNot(HaveOccurred())
@@ -88,7 +86,7 @@ var _ = Describe("CEL Evaluator", func() {
 
 		It("should evaluate CPU cores", func() {
 			result, err := evaluator.EvaluateCondition(
-				`vmi.spec.domain.cpu.cores > 2`,
+				`vmi.Spec.Domain.CPU.Cores > 2`,
 				map[string]any{"vmi": vmi},
 			)
 			Expect(err).ToNot(HaveOccurred())
@@ -97,7 +95,7 @@ var _ = Describe("CEL Evaluator", func() {
 
 		It("should evaluate labels", func() {
 			result, err := evaluator.EvaluateCondition(
-				`"app" in vmi.metadata.labels`,
+				`"app" in vmi.Labels`,
 				map[string]any{"vmi": vmi},
 			)
 			Expect(err).ToNot(HaveOccurred())
@@ -106,7 +104,7 @@ var _ = Describe("CEL Evaluator", func() {
 
 		It("should return false for non-matching condition", func() {
 			result, err := evaluator.EvaluateCondition(
-				`vmi.spec.domain.cpu.cores < 2`,
+				`vmi.Spec.Domain.CPU.Cores < 2`,
 				map[string]any{"vmi": vmi},
 			)
 			Expect(err).ToNot(HaveOccurred())
@@ -116,46 +114,36 @@ var _ = Describe("CEL Evaluator", func() {
 
 	Context("Compile-time validation", func() {
 		It("should detect field typos at compile time", func() {
-			err := evaluator.CompileCondition(`vmi.spec.doman.cpu.cores > 2`)
+			err := evaluator.CompileCondition(`vmi.Spec.Doman.CPU.Cores > 2`)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("compilation failed"))
 		})
 
 		It("should detect invalid syntax", func() {
-			err := evaluator.CompileCondition(`vmi.spec.domain.cpu.cores >`)
+			err := evaluator.CompileCondition(`vmi.Spec.Domain.CPU.Cores >`)
 			Expect(err).To(HaveOccurred())
 		})
 
 		It("should reject non-bool expressions", func() {
-			err := evaluator.CompileCondition(`vmi.metadata.name`)
+			err := evaluator.CompileCondition(`vmi.Name`)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("must return bool"))
 		})
 
 		It("should accept valid expressions", func() {
-			err := evaluator.CompileCondition(`vmi.spec.domain.cpu.cores > 0`)
-			Expect(err).ToNot(HaveOccurred())
-		})
-
-		It("should reject go struct parsing when default tag parser is JSON", func() {
 			err := evaluator.CompileCondition(`vmi.Spec.Domain.CPU.Cores > 0`)
-			Expect(err).To(HaveOccurred())
+			Expect(err).ToNot(HaveOccurred())
 		})
 
-		It("should accept go struct parsing when default tag parser is not JSON", func() {
-			eval, err := cel.NewBaseEnv(
-				cel.WithNativeTypes(reflect.TypeOf(&v1.VirtualMachineInstance{})),
-			)
-			Expect(err).ToNot(HaveOccurred())
-
-			_, issue := eval.Compile(`vmi.Spec.Domain.CPU.Cores > 0`)
-			Expect(issue.Err()).ToNot(HaveOccurred())
+		It("should reject JSON-style field access now that syntax is unified on Go field names", func() {
+			err := evaluator.CompileCondition(`vmi.spec.domain.cpu.cores > 0`)
+			Expect(err).To(HaveOccurred())
 		})
 	})
 
 	Context("Expression caching", func() {
 		It("should cache compiled expressions", func() {
-			expr := `vmi.spec.domain.cpu.cores > 2`
+			expr := `vmi.Spec.Domain.CPU.Cores > 2`
 			vars := map[string]any{"vmi": vmi}
 
 			result1, err := evaluator.EvaluateCondition(expr, vars)
@@ -168,7 +156,7 @@ var _ = Describe("CEL Evaluator", func() {
 		})
 
 		It("should produce correct results with different inputs on cached expression", func() {
-			expr := `vmi.spec.domain.cpu.cores > 2`
+			expr := `vmi.Spec.Domain.CPU.Cores > 2`
 
 			result, err := evaluator.EvaluateCondition(expr, map[string]any{"vmi": vmi})
 			Expect(err).ToNot(HaveOccurred())
@@ -198,7 +186,7 @@ var _ = Describe("CEL Evaluator", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			result, err := eval.EvaluateCondition(
-				`vmi.spec.domain.cpu.cores > threshold`,
+				`vmi.Spec.Domain.CPU.Cores > threshold`,
 				map[string]any{"vmi": vmi, "threshold": int64(2)},
 			)
 			Expect(err).ToNot(HaveOccurred())
@@ -220,7 +208,7 @@ var _ = Describe("CEL Evaluator", func() {
 
 		It("should return error for missing variable at evaluation time", func() {
 			_, err := evaluator.EvaluateCondition(
-				`vmi.spec.domain.cpu.cores > 0`,
+				`vmi.Spec.Domain.CPU.Cores > 0`,
 				map[string]any{},
 			)
 			Expect(err).To(HaveOccurred())

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/plugin-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/plugin-admitter_test.go
@@ -207,7 +207,7 @@ var _ = Describe("Validating Plugin Admitter", func() {
 		p.Spec.NodeHooks = []pluginv1alpha1.NodeHook{{
 			Socket:         "/var/run/kubevirt/plugins/test.sock",
 			PermittedHooks: []pluginv1alpha1.NodeHookPoint{pluginv1alpha1.NodeHookPreVMStart},
-			Condition:      `vmi.spec.domain.cpu.cores > 0`,
+			Condition:      `vmi.Spec.Domain.CPU.Cores > 0`,
 		}}
 		resp := admit(p)
 		Expect(resp.Allowed).To(BeTrue())

--- a/pkg/virt-handler/plugins/manager_test.go
+++ b/pkg/virt-handler/plugins/manager_test.go
@@ -115,7 +115,7 @@ var _ = Describe("NodeHookManager", func() {
 
 		It("should skip plugin when plugin-level condition does not match", func() {
 			plugin := newPlugin("test-plugin", pluginv1alpha1.NodeHookPreVMStart)
-			plugin.Spec.Condition = "vmi.metadata.name == 'nonexistent'"
+			plugin.Spec.Condition = "vmi.Name == 'nonexistent'"
 			Expect(pluginStore.Add(plugin)).To(Succeed())
 
 			Expect(manager.CallNodeHooks(pluginv1alpha1.NodeHookPreVMStart, vmi, "test-node")).To(Succeed())
@@ -123,7 +123,7 @@ var _ = Describe("NodeHookManager", func() {
 
 		It("should attempt to call plugin when plugin-level condition matches", func() {
 			plugin := newPlugin("test-plugin", pluginv1alpha1.NodeHookPreVMStart)
-			plugin.Spec.Condition = "vmi.metadata.name == 'test-vmi'"
+			plugin.Spec.Condition = "vmi.Name == 'test-vmi'"
 			Expect(pluginStore.Add(plugin)).To(Succeed())
 
 			err := manager.CallNodeHooks(pluginv1alpha1.NodeHookPreVMStart, vmi, "test-node")

--- a/pkg/virt-launcher/virtwrap/plugins/cel/evaluator.go
+++ b/pkg/virt-launcher/virtwrap/plugins/cel/evaluator.go
@@ -63,6 +63,7 @@ func NewEvaluator() (*Evaluator, error) {
 			reflect.TypeOf(&v1.VirtualMachineInstance{})),
 		celutil.WithContainer("libvirtxml"),
 		celutil.WithCustomTypeProvider(func(wrap types.Provider) types.Provider { return &sparseProvider{delegate: wrap} }),
+		celutil.WithVariable("vmi", cel.ObjectType("v1.VirtualMachineInstance")),
 		celutil.WithVariable("domainSpec", cel.ObjectType("libvirtxml.Domain")),
 	)
 	if err != nil {

--- a/pkg/virt-launcher/virtwrap/plugins/cel/evaluator.go
+++ b/pkg/virt-launcher/virtwrap/plugins/cel/evaluator.go
@@ -58,7 +58,7 @@ func GetEvaluator() *Evaluator {
 }
 
 func NewEvaluator() (*Evaluator, error) {
-	env, err := celutil.NewBaseEvaluator(
+	env, err := celutil.NewBaseEnv(
 		celutil.WithNativeTypes(reflect.TypeOf(&libvirtxml.Domain{}),
 			reflect.TypeOf(&v1.VirtualMachineInstance{})),
 		celutil.WithContainer("libvirtxml"),

--- a/tests/plugin_test.go
+++ b/tests/plugin_test.go
@@ -646,7 +646,7 @@ var _ = Describe("[sig-compute]Plugin node hooks", Serial, decorators.SigCompute
 		ds := createPluginDaemonSet(virtClient, pluginName, pluginSocketPath, pluginMarkerDir)
 		DeferCleanup(cleanupPluginDaemonSet, virtClient, ds)
 
-		celCondition := `has(vmi.metadata.labels.testLabel) && vmi.metadata.labels.testLabel == "match"`
+		celCondition := `has(vmi.Labels.testLabel) && vmi.Labels.testLabel == "match"`
 		plugin := createPluginCR(virtClient, pluginName, pluginSocketPath,
 			[]pluginv1alpha1.NodeHookPoint{pluginv1alpha1.NodeHookPreVMStart},
 			pluginv1alpha1.FailureStrategyFail, celCondition)


### PR DESCRIPTION
### What this PR does

Follow-up cleanup to #18624 (CEL evaluator consolidation), addressing three issues found during review:

- Renamed `NewBaseEvaluator()` to `NewBaseEnv()` - it returns `*cel.Env`, not `*Evaluator`.
- Unified all plugin CEL syntax on Go field names (`vmi.Name`, `vmi.Spec.Domain.CPU.Cores`) across node-hook and domain-hook types. `libvirtxml.Domain` has no JSON tags, so JSON-style syntax never worked for domain hooks - this makes Go names the one consistent convention everywhere.
- Moved the `vmi` variable declaration out of the shared base env into each evaluator, alongside its own VMI type registration. The base previously declared `vmi` without registering its type, so it looked usable standalone while any `vmi.*` expression would actually fail to compile.

Split into 3 commits: rename, move `vmi`, unify syntax (the only behavior-changing one).

### References

- Follows up on #18624 (branch `aio-interruption`, not yet merged to main)
- VEP: https://github.com/kubevirt/enhancements/issues/190

### Checklist

- [x] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (VEP 190) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] ~~Upgrade: Impact of this change on upgrade flows was considered and addressed if required~~ (not applicable, internal CEL syntax change)
- [x] Testing: Unit tests for all 4 affected packages pass, plugin functional tests (18 specs) pass with 0 failures
- [ ] ~~Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required~~ (not required, alpha feature)
- [ ] ~~Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered~~ (not required, internal cleanup)
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md)

### Release note

```release-note
NONE
```
