### PR TITLE
ignition: tighten file creation mode

### DIFF
--- a/pkg/ignition/ignition.go
+++ b/pkg/ignition/ignition.go
@@ -21,6 +21,7 @@ package ignition
 
 import (
 	"fmt"
+	"os"
 
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
@@ -73,9 +74,19 @@ func GenerateIgnitionLocalData(vmi *v1.VirtualMachineInstance, namespace string)
 
 	ignitionFile := fmt.Sprintf("%s/%s", domainBasePath, IgnitionFile)
 	ignitionData := []byte(vmi.Annotations[v1.IgnitionAnnotation])
-	err = util.WriteFileWithNosec(ignitionFile, ignitionData)
+	err = os.WriteFile(ignitionFile, ignitionData, 0600)
 	if err != nil {
 		return err
+	}
+
+	// When virt-launcher runs as root the file is created owned by root, but
+	// it must be readable by the qemu user that runs the VM.
+	// drop this when the Root feature gate is dropped.
+	const qemuUid, qemuGid = 107, 107
+	if os.Geteuid() == 0 {
+		if err := os.Chown(ignitionFile, qemuUid, qemuGid); err != nil {
+			return err
+		}
 	}
 
 	log.Log.V(2).Infof("generated Ignition file %s", ignitionFile)

--- a/pkg/util/os_helper.go
+++ b/pkg/util/os_helper.go
@@ -56,11 +56,6 @@ func OpenFileWithNosec(pathName string, flag int) (*os.File, error) {
 	return os.OpenFile(pathName, flag, 0644)
 }
 
-func WriteFileWithNosec(pathName string, data []byte) error {
-	// #nosec G306, Expect WriteFile permissions to be 0600 or less
-	return os.WriteFile(pathName, data, 0644)
-}
-
 func WriteBytes(f *os.File, c byte, n int64) error {
 	var err error
 	var i, total int64

--- a/pkg/util/os_helper.go
+++ b/pkg/util/os_helper.go
@@ -41,7 +41,7 @@ func CloseIOAndCheckErr(c io.Closer, err *error) {
 	}
 }
 
-// The following helper functions wrap nosec annotations with os file functions that potentially assign files or directories
+// The following helper function wraps nosec annotations with os file functions that potentially assign files or directories
 // access permissions that are viewed as not secure by gosec. Since kubevirt functionality and many e2e tests rely on such
 // "unsafe" permission settings, e.g. the pathes shared between the virt-launcher and QEMU. the use of these functions avoids
 // have too many nosec annotations scattered in the code and refers back to places where the "unsafe" permissions are set.
@@ -49,11 +49,6 @@ func CloseIOAndCheckErr(c io.Closer, err *error) {
 func MkdirAllWithNosec(pathName string) error {
 	// #nosec G301, Expect directory permissions to be 0750 or less
 	return os.MkdirAll(pathName, 0755)
-}
-
-func OpenFileWithNosec(pathName string, flag int) (*os.File, error) {
-	// #nosec G304 G302, Expect file permissions to be 0600 or less
-	return os.OpenFile(pathName, flag, 0644)
 }
 
 func WriteBytes(f *os.File, c byte, n int64) error {

--- a/pkg/util/sysctl/BUILD.bazel
+++ b/pkg/util/sysctl/BUILD.bazel
@@ -5,5 +5,4 @@ go_library(
     srcs = ["sysctl.go"],
     importpath = "kubevirt.io/kubevirt/pkg/util/sysctl",
     visibility = ["//visibility:public"],
-    deps = ["//pkg/util:go_default_library"],
 )

--- a/pkg/util/sysctl/sysctl.go
+++ b/pkg/util/sysctl/sysctl.go
@@ -20,8 +20,6 @@ import (
 	"os"
 	"path"
 	"strings"
-
-	"kubevirt.io/kubevirt/pkg/util"
 )
 
 const (
@@ -64,5 +62,5 @@ func (*procSysctl) GetSysctl(sysctl string) (string, error) {
 
 // SetSysctl modifies the specified sysctl flag to the new value
 func (*procSysctl) SetSysctl(sysctl string, newVal string) error {
-	return util.WriteFileWithNosec(path.Join(sysctlBase, sysctl), []byte(newVal))
+	return os.WriteFile(path.Join(sysctlBase, sysctl), []byte(newVal), 0600)
 }


### PR DESCRIPTION
Remove two function that were designed to hide a security issue, instead of fixing it. `MkdirAllWithNosec` is probably as problematic, but left for a future PR. Creating world-accessible files is bad practice, particularly if no clear reason is provided.

```release-note
NONE
```

