### PR TITLE
Add name label to kubevirt_vmi_gpu_info

### DIFF
--- a/pkg/monitoring/metrics/virt-handler/gpuinfo/BUILD.bazel
+++ b/pkg/monitoring/metrics/virt-handler/gpuinfo/BUILD.bazel
@@ -11,7 +11,6 @@ go_library(
     deps = [
         "//pkg/monitoring/metrics/virt-handler/gpuinfo/podresources:go_default_library",
         "//pkg/util:go_default_library",
-        "//pkg/util/net/dns:go_default_library",
         "//pkg/util/net/grpc:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",

--- a/pkg/monitoring/metrics/virt-handler/gpuinfo/BUILD.bazel
+++ b/pkg/monitoring/metrics/virt-handler/gpuinfo/BUILD.bazel
@@ -11,7 +11,9 @@ go_library(
     deps = [
         "//pkg/monitoring/metrics/virt-handler/gpuinfo/podresources:go_default_library",
         "//pkg/util:go_default_library",
+        "//pkg/util/net/dns:go_default_library",
         "//pkg/util/net/grpc:go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/log:go_default_library",
         "//vendor/github.com/rhobs/operator-observability-toolkit/pkg/operatormetrics:go_default_library",
         "//vendor/k8s.io/client-go/tools/cache:go_default_library",
@@ -27,8 +29,10 @@ go_test(
     embed = [":go_default_library"],
     race = "on",
     deps = [
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
     ],
 )

--- a/pkg/monitoring/metrics/virt-handler/gpuinfo/collector.go
+++ b/pkg/monitoring/metrics/virt-handler/gpuinfo/collector.go
@@ -20,18 +20,26 @@ package gpuinfo
 
 import (
 	"context"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/rhobs/operator-observability-toolkit/pkg/operatormetrics"
 	"k8s.io/client-go/tools/cache"
+
+	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/log"
 
 	"kubevirt.io/kubevirt/pkg/monitoring/metrics/virt-handler/gpuinfo/podresources"
 	"kubevirt.io/kubevirt/pkg/util"
+	"kubevirt.io/kubevirt/pkg/util/net/dns"
 	kvgrpc "kubevirt.io/kubevirt/pkg/util/net/grpc"
 )
+
+// launcherPodSuffix matches the random suffix Kubernetes appends to a
+// virt-launcher pod's GenerateName ("virt-launcher-<hostname>-<suffix>").
+var launcherPodSuffix = regexp.MustCompile(`^[a-z0-9]{5}$`)
 
 const (
 	podResourcesSocket = util.KubeletRoot + "/pod-resources/kubelet.sock"
@@ -51,6 +59,7 @@ var (
 type GPUAllocation struct {
 	Namespace string
 	PodName   string
+	VMIName   string
 	Resource  string
 	UUID      string
 }
@@ -63,9 +72,10 @@ type gpuInfoCache struct {
 	lastRefresh time.Time
 }
 
-func Setup(nodeName string) {
+func Setup(nodeName string, vmiInformer cache.SharedIndexInformer) {
 	gpuCache = &gpuInfoCache{
-		nodeName: nodeName,
+		nodeName:    nodeName,
+		vmiInformer: vmiInformer,
 	}
 }
 
@@ -111,6 +121,8 @@ func (c *gpuInfoCache) fetchGPUAllocations() ([]GPUAllocation, error) {
 			continue
 		}
 
+		vmiName := resolveVMIName(pod.Namespace, pod.Name, c.vmisInNamespace(pod.Namespace))
+
 		for _, container := range pod.Containers {
 			for _, device := range container.Devices {
 				if !strings.HasPrefix(device.ResourceName, "nvidia.com") {
@@ -120,6 +132,7 @@ func (c *gpuInfoCache) fetchGPUAllocations() ([]GPUAllocation, error) {
 					allocations = append(allocations, GPUAllocation{
 						Namespace: pod.Namespace,
 						PodName:   pod.Name,
+						VMIName:   vmiName,
 						Resource:  device.ResourceName,
 						UUID:      uuid,
 					})
@@ -129,6 +142,45 @@ func (c *gpuInfoCache) fetchGPUAllocations() ([]GPUAllocation, error) {
 	}
 
 	return allocations, nil
+}
+
+// vmisInNamespace returns the node-local VMIs in the given namespace, using the
+// informer's namespace index to avoid scanning the whole store. The returned
+// values are pointers into the shared informer cache and must not be mutated.
+func (c *gpuInfoCache) vmisInNamespace(namespace string) []*v1.VirtualMachineInstance {
+	objs, err := c.vmiInformer.GetIndexer().ByIndex(cache.NamespaceIndex, namespace)
+	if err != nil {
+		log.Log.Warningf("Failed to look up VMIs in namespace %s: %v", namespace, err)
+		return nil
+	}
+
+	vmis := make([]*v1.VirtualMachineInstance, 0, len(objs))
+	for _, obj := range objs {
+		if vmi, ok := obj.(*v1.VirtualMachineInstance); ok {
+			vmis = append(vmis, vmi)
+		}
+	}
+	return vmis
+}
+
+// resolveVMIName returns the name of the VMI owning the given virt-launcher
+// pod, by recomputing each node-local VMI's expected pod-name prefix with the
+// same sanitization KubeVirt uses to build it and validating the trailing
+// GenerateName suffix. Returns "" when no VMI matches.
+func resolveVMIName(namespace, podName string, vmis []*v1.VirtualMachineInstance) string {
+	for _, vmi := range vmis {
+		if vmi.Namespace != namespace {
+			continue
+		}
+		prefix := "virt-launcher-" + dns.SanitizeHostname(vmi) + "-"
+		if !strings.HasPrefix(podName, prefix) {
+			continue
+		}
+		if launcherPodSuffix.MatchString(podName[len(prefix):]) {
+			return vmi.Name
+		}
+	}
+	return ""
 }
 
 func collectCallback() []operatormetrics.CollectorResult {
@@ -146,6 +198,7 @@ func collectCallback() []operatormetrics.CollectorResult {
 				"node":      gpuCache.nodeName,
 				"namespace": alloc.Namespace,
 				"pod":       alloc.PodName,
+				"name":      alloc.VMIName,
 				"resource":  alloc.Resource,
 				"uuid":      alloc.UUID,
 			},

--- a/pkg/monitoring/metrics/virt-handler/gpuinfo/collector.go
+++ b/pkg/monitoring/metrics/virt-handler/gpuinfo/collector.go
@@ -33,12 +33,11 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/monitoring/metrics/virt-handler/gpuinfo/podresources"
 	"kubevirt.io/kubevirt/pkg/util"
-	"kubevirt.io/kubevirt/pkg/util/net/dns"
 	kvgrpc "kubevirt.io/kubevirt/pkg/util/net/grpc"
 )
 
 // launcherPodSuffix matches the random suffix Kubernetes appends to a
-// virt-launcher pod's GenerateName ("virt-launcher-<hostname>-<suffix>").
+// virt-launcher pod's GenerateName ("virt-launcher-<vmi.Name>-<suffix>").
 var launcherPodSuffix = regexp.MustCompile(`^[a-z0-9]{5}$`)
 
 const (
@@ -164,15 +163,15 @@ func (c *gpuInfoCache) vmisInNamespace(namespace string) []*v1.VirtualMachineIns
 }
 
 // resolveVMIName returns the name of the VMI owning the given virt-launcher
-// pod, by recomputing each node-local VMI's expected pod-name prefix with the
-// same sanitization KubeVirt uses to build it and validating the trailing
-// GenerateName suffix. Returns "" when no VMI matches.
+// pod, by recomputing each node-local VMI's expected pod-name prefix from
+// vmi.Name (the value KubeVirt uses to build the pod's GenerateName) and
+// validating the trailing GenerateName suffix. Returns "" when no VMI matches.
 func resolveVMIName(namespace, podName string, vmis []*v1.VirtualMachineInstance) string {
 	for _, vmi := range vmis {
 		if vmi.Namespace != namespace {
 			continue
 		}
-		prefix := "virt-launcher-" + dns.SanitizeHostname(vmi) + "-"
+		prefix := "virt-launcher-" + vmi.Name + "-"
 		if !strings.HasPrefix(podName, prefix) {
 			continue
 		}

--- a/pkg/monitoring/metrics/virt-handler/gpuinfo/collector_test.go
+++ b/pkg/monitoring/metrics/virt-handler/gpuinfo/collector_test.go
@@ -23,7 +23,18 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "kubevirt.io/api/core/v1"
 )
+
+func newVMI(namespace, name, hostname string) *v1.VirtualMachineInstance {
+	return &v1.VirtualMachineInstance{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+		Spec:       v1.VirtualMachineInstanceSpec{Hostname: hostname},
+	}
+}
 
 var _ = Describe("GPU Info Collector", func() {
 	Context("collectCallback", func() {
@@ -41,12 +52,14 @@ var _ = Describe("GPU Info Collector", func() {
 					{
 						Namespace: "test-ns",
 						PodName:   "virt-launcher-test-vmi-abc123",
+						VMIName:   "test-vmi",
 						Resource:  "nvidia.com/NVIDIA_A2-2Q",
 						UUID:      "gpu-uuid-123",
 					},
 					{
 						Namespace: "test-ns",
 						PodName:   "virt-launcher-test-vmi-abc123",
+						VMIName:   "test-vmi",
 						Resource:  "nvidia.com/NVIDIA_A2-2Q",
 						UUID:      "gpu-uuid-456",
 					},
@@ -60,6 +73,7 @@ var _ = Describe("GPU Info Collector", func() {
 			Expect(results[0].ConstLabels["node"]).To(Equal("worker-1"))
 			Expect(results[0].ConstLabels["namespace"]).To(Equal("test-ns"))
 			Expect(results[0].ConstLabels["pod"]).To(Equal("virt-launcher-test-vmi-abc123"))
+			Expect(results[0].ConstLabels["name"]).To(Equal("test-vmi"))
 			Expect(results[0].ConstLabels["resource"]).To(Equal("nvidia.com/NVIDIA_A2-2Q"))
 			Expect(results[0].ConstLabels["uuid"]).To(Equal("gpu-uuid-123"))
 
@@ -74,6 +88,38 @@ var _ = Describe("GPU Info Collector", func() {
 
 			results := collectCallback()
 			Expect(results).To(BeEmpty())
+		})
+	})
+
+	Context("resolveVMIName", func() {
+		It("returns the VMI name for the matching virt-launcher pod", func() {
+			vmis := []*v1.VirtualMachineInstance{newVMI("test-ns", "my-vmi", "")}
+			Expect(resolveVMIName("test-ns", "virt-launcher-my-vmi-abc12", vmis)).To(Equal("my-vmi"))
+		})
+
+		It("disambiguates hyphenated VMI names using the launcher suffix", func() {
+			vmis := []*v1.VirtualMachineInstance{
+				newVMI("test-ns", "foo", ""),
+				newVMI("test-ns", "foo-bar", ""),
+			}
+			Expect(resolveVMIName("test-ns", "virt-launcher-foo-bar-abc12", vmis)).To(Equal("foo-bar"))
+			Expect(resolveVMIName("test-ns", "virt-launcher-foo-abc12", vmis)).To(Equal("foo"))
+		})
+
+		It("respects the VMI Spec.Hostname override", func() {
+			vmis := []*v1.VirtualMachineInstance{newVMI("test-ns", "my-vmi", "custom-host")}
+			Expect(resolveVMIName("test-ns", "virt-launcher-custom-host-abc12", vmis)).To(Equal("my-vmi"))
+		})
+
+		It("returns empty string when no VMI matches by name or namespace", func() {
+			vmis := []*v1.VirtualMachineInstance{newVMI("test-ns", "my-vmi", "")}
+			Expect(resolveVMIName("test-ns", "virt-launcher-other-abc12", vmis)).To(BeEmpty())
+			Expect(resolveVMIName("other-ns", "virt-launcher-my-vmi-abc12", vmis)).To(BeEmpty())
+		})
+
+		It("returns empty string when the pod suffix is not a valid launcher suffix", func() {
+			vmis := []*v1.VirtualMachineInstance{newVMI("test-ns", "my-vmi", "")}
+			Expect(resolveVMIName("test-ns", "virt-launcher-my-vmi-toolongsuffix", vmis)).To(BeEmpty())
 		})
 	})
 })

--- a/pkg/monitoring/metrics/virt-handler/gpuinfo/collector_test.go
+++ b/pkg/monitoring/metrics/virt-handler/gpuinfo/collector_test.go
@@ -106,9 +106,19 @@ var _ = Describe("GPU Info Collector", func() {
 			Expect(resolveVMIName("test-ns", "virt-launcher-foo-abc12", vmis)).To(Equal("foo"))
 		})
 
-		It("respects the VMI Spec.Hostname override", func() {
+		It("matches on the VMI name even when Spec.Hostname is set", func() {
+			// The launcher pod's GenerateName is derived from vmi.Name, not the
+			// sanitized hostname, so matching must use vmi.Name regardless of Spec.Hostname.
 			vmis := []*v1.VirtualMachineInstance{newVMI("test-ns", "my-vmi", "custom-host")}
-			Expect(resolveVMIName("test-ns", "virt-launcher-custom-host-abc12", vmis)).To(Equal("my-vmi"))
+			Expect(resolveVMIName("test-ns", "virt-launcher-my-vmi-abc12", vmis)).To(Equal("my-vmi"))
+			Expect(resolveVMIName("test-ns", "virt-launcher-custom-host-abc12", vmis)).To(BeEmpty())
+		})
+
+		It("matches VMI names containing dots", func() {
+			// vmi.Name may be a DNS subdomain containing dots; the pod name keeps
+			// the full name rather than truncating at the first dot.
+			vmis := []*v1.VirtualMachineInstance{newVMI("test-ns", "my.vmi", "")}
+			Expect(resolveVMIName("test-ns", "virt-launcher-my.vmi-abc12", vmis)).To(Equal("my.vmi"))
 		})
 
 		It("returns empty string when no VMI matches by name or namespace", func() {

--- a/pkg/monitoring/metrics/virt-handler/metrics.go
+++ b/pkg/monitoring/metrics/virt-handler/metrics.go
@@ -54,7 +54,7 @@ func SetupMetrics(
 	ReportDeprecatedMachineTypes(machines, nodeName)
 
 	domainstats.SetupDomainStatsCollector(maxRequestsInFlight, vmiInformer)
-	gpuinfo.Setup(nodeName)
+	gpuinfo.Setup(nodeName, vmiInformer)
 
 	if err := migrationdomainstats.SetupMigrationStatsCollector(vmiInformer); err != nil {
 		return err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:

kubevirt_vmi_gpu_info does not have vmi name label

#### After this PR:

kubevirt_vmi_gpu_info has vmi name label

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add name label to kubevirt_vmi_gpu_info
```

