### PR TITLE
Fix VFIO cdev passthrough on kernels without CONFIG_VFIO_DEVICE_CDEV

### DIFF
--- a/pkg/virt-handler/device-manager/common.go
+++ b/pkg/virt-handler/device-manager/common.go
@@ -304,7 +304,16 @@ func formatVFIOCdevDeviceSpecs(pciAddress string) []*v1beta1.DeviceSpec {
 
 	devSpecs := make([]*v1beta1.DeviceSpec, 0, len(entries))
 	for _, entry := range entries {
-		cdevPath := filepath.Join("/dev/vfio/devices", entry.Name())
+		cdevPath := filepath.Join(vfioDevicesRoot, entry.Name())
+		// Only add the device spec if the actual device file exists
+		if _, err := os.Stat(cdevPath); err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				log.DefaultLogger().V(4).Infof("VFIO cdev %s does not exist, skipping", cdevPath)
+			} else {
+				log.DefaultLogger().Reason(err).Warningf("Failed to stat VFIO cdev %s", cdevPath)
+			}
+			continue
+		}
 		devSpecs = append(devSpecs, &v1beta1.DeviceSpec{
 			HostPath:      cdevPath,
 			ContainerPath: cdevPath,

--- a/pkg/virt-handler/device-manager/common_test.go
+++ b/pkg/virt-handler/device-manager/common_test.go
@@ -33,10 +33,14 @@ import (
 
 var _ = Describe("PCI device plugin VFIO cdev allocation", func() {
 	var tmpDir string
+	var vfioDevicesDir string
 
 	BeforeEach(func() {
 		tmpDir = GinkgoT().TempDir()
+		vfioDevicesDir = filepath.Join(tmpDir, "dev-vfio-devices")
+		Expect(os.MkdirAll(vfioDevicesDir, 0755)).To(Succeed())
 		DeferCleanup(devicemanager.SetPCIBasePath(tmpDir))
+		DeferCleanup(devicemanager.SetVFIODevicesRoot(vfioDevicesDir))
 	})
 
 	It("should include VFIO cdev device specs in Allocate response", func() {
@@ -45,6 +49,8 @@ var _ = Describe("PCI device plugin VFIO cdev allocation", func() {
 		vfioDevDir := filepath.Join(tmpDir, pciAddr, "vfio-dev")
 		Expect(os.MkdirAll(vfioDevDir, 0755)).To(Succeed())
 		Expect(os.WriteFile(filepath.Join(vfioDevDir, "vfio0"), []byte{}, 0644)).To(Succeed())
+		// Create the actual device file in the mocked /dev/vfio/devices directory
+		Expect(os.WriteFile(filepath.Join(vfioDevicesDir, "vfio0"), []byte{}, 0644)).To(Succeed())
 
 		dpi := devicemanager.NewPCIDevicePluginForTest(map[string]string{iommuGroup: pciAddr})
 
@@ -57,10 +63,11 @@ var _ = Describe("PCI device plugin VFIO cdev allocation", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(resp.ContainerResponses).To(HaveLen(1))
 
+		expectedPath := filepath.Join(vfioDevicesDir, "vfio0")
 		Expect(resp.ContainerResponses[0].Devices).To(ContainElement(
 			BeEquivalentTo(&pluginapi.DeviceSpec{
-				HostPath:      "/dev/vfio/devices/vfio0",
-				ContainerPath: "/dev/vfio/devices/vfio0",
+				HostPath:      expectedPath,
+				ContainerPath: expectedPath,
 				Permissions:   "mrw",
 			})))
 	})
@@ -83,6 +90,38 @@ var _ = Describe("PCI device plugin VFIO cdev allocation", func() {
 		for _, spec := range resp.ContainerResponses[0].Devices {
 			devicePaths = append(devicePaths, spec.ContainerPath)
 		}
+		Expect(devicePaths).ToNot(ContainElement(ContainSubstring(vfioDevicesDir)))
+	})
+
+	It("should skip VFIO cdev device specs when sysfs dir exists but device files don't", func() {
+		// This simulates kernels without CONFIG_VFIO_DEVICE_CDEV where the
+		// vfio-dev directory exists in sysfs but the actual character devices
+		// in /dev/vfio/devices/ don't exist
+		pciAddr := "0000:08:00.0"
+		iommuGroup := "42"
+		vfioDevDir := filepath.Join(tmpDir, pciAddr, "vfio-dev")
+		Expect(os.MkdirAll(vfioDevDir, 0755)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(vfioDevDir, "vfio0"), []byte{}, 0644)).To(Succeed())
+
+		// Note: we don't create /dev/vfio/devices/vfio0, simulating the missing device
+
+		dpi := devicemanager.NewPCIDevicePluginForTest(map[string]string{iommuGroup: pciAddr})
+
+		resp, err := dpi.Allocate(context.Background(), &pluginapi.AllocateRequest{
+			ContainerRequests: []*pluginapi.ContainerAllocateRequest{
+				{DevicesIDs: []string{iommuGroup}},
+			},
+		})
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(resp.ContainerResponses).To(HaveLen(1))
+
+		// Should only contain legacy VFIO group devices, not cdev devices
+		devicePaths := make([]string, 0)
+		for _, spec := range resp.ContainerResponses[0].Devices {
+			devicePaths = append(devicePaths, spec.ContainerPath)
+		}
 		Expect(devicePaths).ToNot(ContainElement(ContainSubstring("/dev/vfio/devices/")))
+		Expect(devicePaths).To(ContainElement("/dev/vfio/vfio"))
 	})
 })

--- a/pkg/virt-handler/device-manager/export_test.go
+++ b/pkg/virt-handler/device-manager/export_test.go
@@ -33,3 +33,9 @@ func SetPCIBasePath(p string) func() {
 	pciBasePath = p
 	return func() { pciBasePath = old }
 }
+
+func SetVFIODevicesRoot(p string) func() {
+	old := vfioDevicesRoot
+	vfioDevicesRoot = p
+	return func() { vfioDevicesRoot = old }
+}

--- a/pkg/virt-handler/device-manager/pci_device.go
+++ b/pkg/virt-handler/device-manager/pci_device.go
@@ -44,7 +44,10 @@ const (
 	vfioMount      = "/dev/vfio/vfio"
 )
 
-var pciBasePath = "/sys/bus/pci/devices"
+var (
+	pciBasePath     = "/sys/bus/pci/devices"
+	vfioDevicesRoot = "/dev/vfio/devices"
+)
 
 type PCIDevice struct {
 	pciID      string


### PR DESCRIPTION
### What this PR does
#### Before this PR:
On KubeVirt v1.9.0+, VMs with PCI passthrough devices (e.g., GPUs) fail to start on hosts running kernels without `CONFIG_VFIO_DEVICE_CDEV` support (e.g., Debian 13 with kernel 7.1.8), even when the `IOMMUFD` feature gate is disabled.

The error encountered:
```
Error: failed to generate container spec: failed to generate spec:
lstat /dev/vfio/devices/vfio0: no such file or directory
```

`formatVFIOCdevDeviceSpecs()` unconditionally adds device specs for `/dev/vfio/devices/*` (IOMMUFD cdev interface) based solely on sysfs directory existence, without verifying the actual device files exist. On kernels lacking IOMMUFD support, the sysfs `vfio-dev` directory may exist but `/dev/vfio/devices/*` character devices are not created, causing containerd to fail.

#### After this PR:
`formatVFIOCdevDeviceSpecs()` now verifies each device file exists in `/dev/vfio/devices/` before adding it to the device specs. 

- **Kernels with IOMMUFD support:** VFIO cdev devices are properly exposed (no change in behavior)
- **Kernels without IOMMUFD support:** Non-existent cdev devices are skipped, gracefully falling back to the legacy VFIO group interface (`/dev/vfio/<group>`)

PCI passthrough works correctly on all kernel configurations regardless of `IOMMUFD` feature gate setting.

### References

- Fixes #18895

### Special notes for your reviewer

### Release note
```release-note
Fix PCI passthrough regression on kernels without CONFIG_VFIO_DEVICE_CDEV support. VMs with GPU/PCI host devices now correctly fall back to legacy VFIO group interface when IOMMUFD cdev is unavailable.
```

/cc @lyarwood @xpivarc 