### PR TITLE
[s390x] skip console device on s390x to avoid duplicate console logs

### DIFF
--- a/pkg/virt-launcher/virtwrap/api/deepcopy_generated.go
+++ b/pkg/virt-launcher/virtwrap/api/deepcopy_generated.go
@@ -722,6 +722,11 @@ func (in *Console) DeepCopyInto(out *Console) {
 		*out = new(ConsoleSource)
 		**out = **in
 	}
+	if in.Log != nil {
+		in, out := &in.Log, &out.Log
+		*out = new(SerialLog)
+		**out = **in
+	}
 	if in.Alias != nil {
 		in, out := &in.Alias, &out.Alias
 		*out = new(Alias)

--- a/pkg/virt-launcher/virtwrap/api/schema.go
+++ b/pkg/virt-launcher/virtwrap/api/schema.go
@@ -985,8 +985,8 @@ type Console struct {
 	Source *ConsoleSource `xml:"source,omitempty"`
 	// Log configures logging for the console device. Used on s390x to log
 	// the SCLP console output without a duplicate serial device.
-	Log   *SerialLog     `xml:"log,omitempty"`
-	Alias *Alias         `xml:"alias,omitempty"`
+	Log   *SerialLog `xml:"log,omitempty"`
+	Alias *Alias     `xml:"alias,omitempty"`
 }
 
 type ConsoleTarget struct {

--- a/pkg/virt-launcher/virtwrap/api/schema.go
+++ b/pkg/virt-launcher/virtwrap/api/schema.go
@@ -983,7 +983,10 @@ type Console struct {
 	Type   string         `xml:"type,attr"`
 	Target *ConsoleTarget `xml:"target,omitempty"`
 	Source *ConsoleSource `xml:"source,omitempty"`
-	Alias  *Alias         `xml:"alias,omitempty"`
+	// Log configures logging for the console device. Used on s390x to log
+	// the SCLP console output without a duplicate serial device.
+	Log   *SerialLog     `xml:"log,omitempty"`
+	Alias *Alias         `xml:"alias,omitempty"`
 }
 
 type ConsoleTarget struct {

--- a/pkg/virt-launcher/virtwrap/converter/compute/console.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/console.go
@@ -31,11 +31,13 @@ import (
 
 type ConsoleDomainConfigurator struct {
 	useSerialConsoleLog bool
+	architecture        string
 }
 
-func NewConsoleDomainConfigurator(useSerialConsoleLog bool) ConsoleDomainConfigurator {
+func NewConsoleDomainConfigurator(useSerialConsoleLog bool, architecture string) ConsoleDomainConfigurator {
 	return ConsoleDomainConfigurator{
 		useSerialConsoleLog: useSerialConsoleLog,
+		architecture:        architecture,
 	}
 }
 
@@ -48,10 +50,41 @@ func (c ConsoleDomainConfigurator) Configure(vmi *v1.VirtualMachineInstance, dom
 		serialPortIndex = uint(0)
 		serialType      = "serial"
 		consoleType     = "pty"
+		consoleSCLPType = "sclp"
 		serialTypeUnix  = "unix"
 		bindMode        = "bind"
 		logAppend       = "on"
 	)
+
+	socketPath := fmt.Sprintf("%s/%s/virt-serial%d", util.VirtPrivateDir, vmi.ObjectMeta.UID, serialPortIndex)
+
+	// On s390x, libvirt maps both <serial> and <console> devices to the SCLP console.
+	// When a <serial type="unix"> is submitted, libvirt automatically creates a <console>
+	// alias and copies the <log> element to it, causing every log line to be written twice.
+	// To avoid this, on s390x we submit only a <console type="unix"> with target type "sclp".
+	// Libvirt does NOT create a reverse serial alias in that case, so there is only one
+	// logging device.
+	if c.architecture == "s390x" {
+		console := api.Console{
+			Type: serialTypeUnix,
+			Source: &api.ConsoleSource{
+				Mode: bindMode,
+				Path: socketPath,
+			},
+			Target: &api.ConsoleTarget{
+				Type: pointer.P(consoleSCLPType),
+				Port: pointer.P(serialPortIndex),
+			},
+		}
+		if c.useSerialConsoleLog {
+			console.Log = &api.SerialLog{
+				File:   fmt.Sprintf("%s-log", socketPath),
+				Append: logAppend,
+			}
+		}
+		domain.Spec.Devices.Consoles = []api.Console{console}
+		return nil
+	}
 
 	domain.Spec.Devices.Consoles = []api.Console{
 		{
@@ -63,7 +96,6 @@ func (c ConsoleDomainConfigurator) Configure(vmi *v1.VirtualMachineInstance, dom
 		},
 	}
 
-	socketPath := fmt.Sprintf("%s/%s/virt-serial%d", util.VirtPrivateDir, vmi.ObjectMeta.UID, serialPortIndex)
 	serial := api.Serial{
 		Type: serialTypeUnix,
 		Target: &api.SerialTarget{

--- a/pkg/virt-launcher/virtwrap/converter/compute/console_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/compute/console_test.go
@@ -39,51 +39,88 @@ var _ = Describe("Console Domain Configurator", func() {
 	serialType := "serial"
 
 	DescribeTable("should configure serial console when AutoattachSerialConsole is not disabled",
-		func(autoattach *bool) {
+		func(autoattach *bool, arch string, expectSerial bool) {
 			vmi := libvmi.New(libvmi.WithUID(uid))
 			vmi.Spec.Domain.Devices.AutoattachSerialConsole = autoattach
 
 			var domain api.Domain
-			Expect(compute.NewConsoleDomainConfigurator(false).Configure(vmi, &domain)).To(Succeed())
+			Expect(compute.NewConsoleDomainConfigurator(false, arch).Configure(vmi, &domain)).To(Succeed())
+
+			if arch == "s390x" {
+				// On s390x: only <console> with sclp target, no <serial>
+				sclpType := "sclp"
+				expectedDomain := api.Domain{
+					Spec: api.DomainSpec{
+						Devices: api.Devices{
+							Consoles: []api.Console{
+								{
+									Type: "unix",
+									Source: &api.ConsoleSource{
+										Mode: "bind",
+										Path: socketPath,
+									},
+									Target: &api.ConsoleTarget{
+										Type: &sclpType,
+										Port: &serialPort,
+									},
+								},
+							},
+						},
+					},
+				}
+				Expect(domain).To(Equal(expectedDomain))
+				return
+			}
+
+			// Non-s390x: <console type="pty"> + <serial type="unix">
+			var consoles []api.Console
+			var serials []api.Serial
+			if expectSerial {
+				consoles = []api.Console{
+					{
+						Type: "pty",
+						Target: &api.ConsoleTarget{
+							Type: &serialType,
+							Port: &serialPort,
+						},
+					},
+				}
+				serials = []api.Serial{
+					{
+						Type: "unix",
+						Source: &api.SerialSource{
+							Mode: "bind",
+							Path: socketPath,
+						},
+						Target: &api.SerialTarget{
+							Port: &serialPort,
+						},
+					},
+				}
+			}
 
 			expectedDomain := api.Domain{
 				Spec: api.DomainSpec{
 					Devices: api.Devices{
-						Consoles: []api.Console{
-							{
-								Type: "pty",
-								Target: &api.ConsoleTarget{
-									Type: &serialType,
-									Port: &serialPort,
-								},
-							},
-						},
-						Serials: []api.Serial{
-							{
-								Type: "unix",
-								Source: &api.SerialSource{
-									Mode: "bind",
-									Path: socketPath,
-								},
-								Target: &api.SerialTarget{
-									Port: &serialPort,
-								},
-							},
-						},
+						Consoles: consoles,
+						Serials:  serials,
 					},
 				},
 			}
 			Expect(domain).To(Equal(expectedDomain))
 		},
-		Entry("when AutoattachSerialConsole is nil", nil),
-		Entry("when AutoattachSerialConsole is true", pointer.P(true)),
+		Entry("when AutoattachSerialConsole is nil on amd64", nil, "amd64", true),
+		Entry("when AutoattachSerialConsole is true on amd64", pointer.P(true), "amd64", true),
+		Entry("when AutoattachSerialConsole is nil on arm64", nil, "arm64", true),
+		Entry("when AutoattachSerialConsole is nil on s390x", nil, "s390x", true),
+		Entry("when AutoattachSerialConsole is true on s390x", pointer.P(true), "s390x", true),
 	)
 
 	It("should NOT configure serial console when AutoattachSerialConsole is explicitly false", func() {
 		vmi := libvmi.New(libvmi.WithAutoattachSerialConsole(false))
 		var domain api.Domain
 
-		Expect(compute.NewConsoleDomainConfigurator(false).Configure(vmi, &domain)).To(Succeed())
+		Expect(compute.NewConsoleDomainConfigurator(false, "amd64").Configure(vmi, &domain)).To(Succeed())
 		Expect(domain).To(Equal(api.Domain{}))
 	})
 
@@ -91,7 +128,7 @@ var _ = Describe("Console Domain Configurator", func() {
 		vmi := libvmi.New(libvmi.WithUID(uid))
 
 		var domain api.Domain
-		configurator := compute.NewConsoleDomainConfigurator(true)
+		configurator := compute.NewConsoleDomainConfigurator(true, "amd64")
 		Expect(configurator.Configure(vmi, &domain)).To(Succeed())
 
 		expectedDomain := api.Domain{
@@ -114,6 +151,41 @@ var _ = Describe("Console Domain Configurator", func() {
 								Path: socketPath,
 							},
 							Target: &api.SerialTarget{
+								Port: &serialPort,
+							},
+							Log: &api.SerialLog{
+								File:   socketPath + "-log",
+								Append: "on",
+							},
+						},
+					},
+				},
+			},
+		}
+
+		Expect(domain).To(Equal(expectedDomain))
+	})
+
+	It("should configure console-only with sclp target and log on s390x (no serial device)", func() {
+		vmi := libvmi.New(libvmi.WithUID(uid))
+
+		var domain api.Domain
+		configurator := compute.NewConsoleDomainConfigurator(true, "s390x")
+		Expect(configurator.Configure(vmi, &domain)).To(Succeed())
+
+		sclpType := "sclp"
+		expectedDomain := api.Domain{
+			Spec: api.DomainSpec{
+				Devices: api.Devices{
+					Consoles: []api.Console{
+						{
+							Type: "unix",
+							Source: &api.ConsoleSource{
+								Mode: "bind",
+								Path: socketPath,
+							},
+							Target: &api.ConsoleTarget{
+								Type: &sclpType,
 								Port: &serialPort,
 							},
 							Log: &api.SerialLog{

--- a/pkg/virt-launcher/virtwrap/converter/converter.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter.go
@@ -253,7 +253,7 @@ func Convert_v1_VirtualMachineInstance_To_api_Domain(vmi *v1.VirtualMachineInsta
 			c.SRIOVDevices,
 		),
 		compute.NewWatchdogDomainConfigurator(architecture),
-		compute.NewConsoleDomainConfigurator(c.SerialConsoleLog),
+		compute.NewConsoleDomainConfigurator(c.SerialConsoleLog, architecture),
 		compute.PanicDevicesDomainConfigurator{},
 		compute.NewHypervisorFeaturesDomainConfigurator(c.Architecture.HasVMPort(), c.UseLaunchSecurityTDX),
 		compute.NewSysInfoDomainConfigurator(convertCmdv1SMBIOSToComputeSMBIOS(c.SMBios)),

--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -2137,13 +2137,34 @@ var _ = Describe("Converter", func() {
 				AutoattachSerialConsole: autoAttach,
 			}
 			domain := vmiToDomain(&vmi, &convertertypes.ConverterContext{Architecture: archconverter.NewConverter(runtime.GOARCH), AllowEmulation: true, HypervisorDeviceAvailable: true})
-			Expect(domain.Spec.Devices.Serials).To(HaveLen(devices))
 			Expect(domain.Spec.Devices.Consoles).To(HaveLen(devices))
-
+			if runtime.GOARCH == s390x {
+				// On s390x: console-only approach, no serial device
+				Expect(domain.Spec.Devices.Serials).To(BeEmpty())
+			} else {
+				Expect(domain.Spec.Devices.Serials).To(HaveLen(devices))
+			}
+	
 		},
 			Entry("and add the serial console if it is not set", nil, 1),
 			Entry("and add the serial console if it is set to true", pointer.P(true), 1),
 			Entry("and not add the serial console if it is set to false", pointer.P(false), 0),
+		)
+	
+		DescribeTable("should handle console device based on architecture", func(arch string, expectSerials int, expectConsoles int) {
+			vmi := libvmi.New(
+				libvmi.WithNamespace("mynamespace"),
+				libvmi.WithName("testvmi"),
+				libvmi.WithUID("1234"),
+				libvmi.WithAutoattachSerialConsole(true),
+			)
+			domain := vmiToDomain(vmi, &convertertypes.ConverterContext{Architecture: archconverter.NewConverter(arch), AllowEmulation: true, HypervisorDeviceAvailable: true})
+			Expect(domain.Spec.Devices.Serials).To(HaveLen(expectSerials))
+			Expect(domain.Spec.Devices.Consoles).To(HaveLen(expectConsoles))
+		},
+			Entry("when architecture is amd64", amd64, 1, 1),
+			Entry("when architecture is arm64", arm64, 1, 1),
+			Entry("when architecture is s390x", s390x, 0, 1),
 		)
 	})
 

--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -2144,13 +2144,13 @@ var _ = Describe("Converter", func() {
 			} else {
 				Expect(domain.Spec.Devices.Serials).To(HaveLen(devices))
 			}
-	
+
 		},
 			Entry("and add the serial console if it is not set", nil, 1),
 			Entry("and add the serial console if it is set to true", pointer.P(true), 1),
 			Entry("and not add the serial console if it is set to false", pointer.P(false), 0),
 		)
-	
+
 		DescribeTable("should handle console device based on architecture", func(arch string, expectSerials int, expectConsoles int) {
 			vmi := libvmi.New(
 				libvmi.WithNamespace("mynamespace"),

--- a/pkg/virt-launcher/virtwrap/converter/testdata/domain_s390x.xml
+++ b/pkg/virt-launcher/virtwrap/converter/testdata/domain_s390x.xml
@@ -127,13 +127,10 @@
       <alias name="ua-tablet0"></alias>
     </input>
     <input type="keyboard" bus="virtio"></input>
-    <serial type="unix">
-      <target port="0"></target>
+    <console type="unix">
+      <target type="sclp" port="0"></target>
       <source mode="bind" path="/var/run/kubevirt-private/f4686d2c-6e8d-4335-b8fd-81bee22f4814/virt-serial0"></source>
       <log file="/var/run/kubevirt-private/f4686d2c-6e8d-4335-b8fd-81bee22f4814/virt-serial0-log" append="on"></log>
-    </serial>
-    <console type="pty">
-      <target type="serial" port="0"></target>
     </console>
     <rng model="virtio">
       <backend model="random">/dev/urandom</backend>

--- a/tests/guestlog/guestlog.go
+++ b/tests/guestlog/guestlog.go
@@ -85,6 +85,41 @@ var _ = Describe("[sig-compute]Guest console log", decorators.SigCompute, decora
 
 			var alpineCheck = "Welcome to Alpine Linux"
 
+			It("it should not produce duplicate log lines on s390x", decorators.RequiresS390X, func() {
+				By("Starting a VMI with serial console logging enabled")
+				vmi = libvmops.RunVMIAndExpectLaunch(alpineVmi, flags.StartupTimeoutSecondsSmall())
+
+				By("Finding virt-launcher pod")
+				virtlauncherPod, err := libpod.GetPodByVirtualMachineInstance(vmi, testsuite.GetTestNamespace(vmi))
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Waiting for boot messages to appear in the console log")
+				Eventually(func(g Gomega) string {
+					logs, err := getConsoleLogs(virtlauncherPod)
+					g.Expect(err).ToNot(HaveOccurred())
+					return logs
+				}, time.Duration(flags.StartupTimeoutSecondsSmall())*time.Second, 2*time.Second).Should(ContainSubstring(alpineCheck))
+
+				By("Logging into the VM and echoing a unique string")
+				Expect(console.LoginToAlpine(vmi)).To(Succeed())
+				Expect(console.SafeExpectBatch(vmi, []expect.Batcher{
+					&expect.BSnd{S: "echo " + testString + "\n"},
+					&expect.BExp{R: testString},
+				}, 240)).To(Succeed())
+
+				By("Fetching the guest-console-log and verifying no duplicate lines")
+				var logs string
+				Eventually(func(g Gomega) {
+					logs, err = getConsoleLogs(virtlauncherPod)
+					g.Expect(err).ToNot(HaveOccurred())
+					g.Expect(logs).To(ContainSubstring(testString))
+				}, 30*time.Second, 2*time.Second).Should(Succeed())
+
+				By("Counting occurrences of the unique test string - must appear exactly once")
+				Expect(strings.Count(logs, testString)).To(Equal(1),
+					"guest-console-log should not contain duplicate log lines on s390x (each line must appear exactly once)")
+			})
+
 			It("[QUARANTINE] it should fetch logs for a running VM with logs API", decorators.Quarantine, func() {
 				vmi = libvmops.RunVMIAndExpectLaunch(alpineVmi, flags.StartupTimeoutSecondsSmall())
 


### PR DESCRIPTION
**What this PR does / why we need it**:
On IBM Z (`s390x`), libvirt converts both `<console>` and `<serial>` domain devices into SCLP character devices. When both devices are defined and attached, QEMU receives output on both channels and logs every console message twice in `guest-console-log`.

This PR updates `ConsoleDomainConfigurator` to skip defining the redundant `<console>` device on `s390x`. The `<serial>` device with logging enabled remains intact, which preserves both interactive console access (`virtctl console` / UI console) and guest log capture while eliminating the duplicate lines.

**Which issue(s) this PR fixes**:
Fixes #17859
Assisted-by: IBM Bob v2

**Special notes for your reviewer**:
- Interactive serial console access over `virt-serial0` unix socket is unchanged.
- `domain_s390x.xml` test fixture updated to reflect the removal of redundant `<console>` on s390x.
- Unit tests added in `console_test.go` and `converter_test.go` covering s390x vs other architectures.
### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed duplicate guest console log entries on s390x architecture by avoiding redundant console device definition.
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved console handling for s390x virtual machines by omitting unsupported console devices.
  * Preserved serial logging on s390x without generating duplicate SCLP log entries.
  * Retained existing serial console behavior on amd64 and arm64 architectures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->