### PR TITLE
virt-launcher: Remove the VirtualMachine field from ConverterContext

### DIFF
--- a/cmd/sidecars/smbios/smbios_test.go
+++ b/cmd/sidecars/smbios/smbios_test.go
@@ -50,7 +50,6 @@ var _ = Describe("SMBios sidecar", func() {
 
 		c := &convertertypes.ConverterContext{
 			Architecture:   archconverter.NewConverter(runtime.GOARCH),
-			VirtualMachine: vmi,
 			AllowEmulation: true,
 		}
 

--- a/pkg/virt-launcher/premigration-hook-server/hook_server.go
+++ b/pkg/virt-launcher/premigration-hook-server/hook_server.go
@@ -39,6 +39,7 @@ type HookFunc func(c *convertertypes.ConverterContext, vmi *v1.VirtualMachineIns
 // PreMigrationHookServer handles libvirt premigration hook communication via unix socket
 type PreMigrationHookServer struct {
 	c         *convertertypes.ConverterContext
+	vmi       *v1.VirtualMachineInstance
 	hooks     []HookFunc
 	stopChan  chan struct{}
 	done      chan struct{}
@@ -56,9 +57,10 @@ func NewPreMigrationHookServer(stopChan chan struct{}, hooks ...HookFunc) *PreMi
 	return server
 }
 
-func (h *PreMigrationHookServer) Start(c *convertertypes.ConverterContext) error {
+func (h *PreMigrationHookServer) Start(c *convertertypes.ConverterContext, vmi *v1.VirtualMachineInstance) error {
 	h.c = c
-	log.Log.Object(c.VirtualMachine).Info("Hook server updated with VMI")
+	h.vmi = vmi
+	log.Log.Object(vmi).Info("Hook server updated with VMI")
 
 	var startErr error
 	h.startOnce.Do(func() {
@@ -106,6 +108,7 @@ func (h *PreMigrationHookServer) Start(c *convertertypes.ConverterContext) error
 				log.Log.Errorf("Failed to close connection: %v", err.Error())
 			}
 			h.c = nil // Release ConverterContext reference after processing
+			h.vmi = nil
 		}()
 
 		log.Log.Infof("Started premigration hook server on %s", socketPath)
@@ -141,7 +144,7 @@ func (h *PreMigrationHookServer) processHook(conn net.Conn) error {
 	}
 
 	for _, hook := range h.hooks {
-		if err := hook(h.c, h.c.VirtualMachine, &domain); err != nil {
+		if err := hook(h.c, h.vmi, &domain); err != nil {
 			return err
 		}
 	}

--- a/pkg/virt-launcher/virtwrap/access-credentials/access_credentials_test.go
+++ b/pkg/virt-launcher/virtwrap/access-credentials/access_credentials_test.go
@@ -81,7 +81,6 @@ var _ = Describe("AccessCredentials", func() {
 		domain := &api.Domain{}
 		c := &convertertypes.ConverterContext{
 			Architecture:   arch.NewConverter(runtime.GOARCH),
-			VirtualMachine: vmi,
 			AllowEmulation: true,
 			SMBios:         &cmdv1.SMBios{},
 		}

--- a/pkg/virt-launcher/virtwrap/converter/converter_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/converter_test.go
@@ -557,7 +557,6 @@ var _ = Describe("Converter", func() {
 		BeforeEach(func() {
 			c = &convertertypes.ConverterContext{
 				Architecture:                    archconverter.NewConverter(runtime.GOARCH),
-				VirtualMachine:                  vmi,
 				AllowEmulation:                  true,
 				HypervisorDeviceAvailable:       true,
 				IsBlockPVC:                      isBlockPVCMap,
@@ -1595,7 +1594,6 @@ var _ = Describe("Converter", func() {
 
 			c = &convertertypes.ConverterContext{
 				Architecture:   archconverter.NewConverter(runtime.GOARCH),
-				VirtualMachine: vmi,
 				AllowEmulation: true,
 				Topology: &cmdv1.Topology{
 					NumaCells: []*cmdv1.Cell{
@@ -1751,7 +1749,6 @@ var _ = Describe("Converter", func() {
 
 			c = &convertertypes.ConverterContext{
 				Architecture:   archconverter.NewConverter(runtime.GOARCH),
-				VirtualMachine: vmi,
 				AllowEmulation: true,
 				SMBios:         TestSmbios,
 				DomainAttachmentByInterfaceName: map[string]string{
@@ -3218,7 +3215,6 @@ var _ = Describe("Converter", func() {
 
 			c = &convertertypes.ConverterContext{
 				Architecture:   archconverter.NewConverter(runtime.GOARCH),
-				VirtualMachine: vmi,
 				AllowEmulation: true,
 			}
 		})
@@ -3342,7 +3338,6 @@ var _ = Describe("Converter", func() {
 			c = &convertertypes.ConverterContext{
 				Architecture:      archconverter.NewConverter(arch),
 				BochsForEFIGuests: enableFG,
-				VirtualMachine:    vmi,
 				AllowEmulation:    true,
 				EFIConfiguration:  &convertertypes.EFIConfiguration{},
 			}
@@ -3388,7 +3383,6 @@ var _ = Describe("Converter", func() {
 
 			c = &convertertypes.ConverterContext{
 				Architecture:   archconverter.NewConverter(runtime.GOARCH),
-				VirtualMachine: vmi,
 				AllowEmulation: true,
 			}
 
@@ -3484,7 +3478,6 @@ var _ = Describe("Converter", func() {
 
 			c = &convertertypes.ConverterContext{
 				Architecture:   archconverter.NewConverter(runtime.GOARCH),
-				VirtualMachine: vmi,
 				AllowEmulation: true,
 			}
 		})
@@ -3544,7 +3537,6 @@ var _ = Describe("Converter", func() {
 
 				c = &convertertypes.ConverterContext{
 					Architecture:   archconverter.NewConverter(runtime.GOARCH),
-					VirtualMachine: vmi,
 					AllowEmulation: true,
 					IsBlockPVC: map[string]bool{
 						"test-block-pvc": true,

--- a/pkg/virt-launcher/virtwrap/converter/types/converter-context.go
+++ b/pkg/virt-launcher/virtwrap/converter/types/converter-context.go
@@ -41,7 +41,6 @@ type ConverterContext struct {
 	Architecture                    arch.Converter
 	AllowEmulation                  bool
 	HypervisorDeviceAvailable       bool
-	VirtualMachine                  *v1.VirtualMachineInstance
 	CPUSet                          []int
 	IsBlockPVC                      map[string]bool
 	IsBlockDV                       map[string]bool

--- a/pkg/virt-launcher/virtwrap/live-migration-target.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-target.go
@@ -176,7 +176,7 @@ func (l *LibvirtDomainManager) prepareMigrationTarget(
 	}
 
 	if l.hookServer != nil {
-		if err := l.hookServer.Start(c); err != nil {
+		if err := l.hookServer.Start(c, vmi); err != nil {
 			return err
 		}
 	}

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -1304,7 +1304,6 @@ func (l *LibvirtDomainManager) generateConverterContext(vmi *v1.VirtualMachineIn
 
 	c := &convertertypes.ConverterContext{
 		Architecture:              l.selectConverterArch(vmi.Spec.Architecture),
-		VirtualMachine:            vmi,
 		AllowEmulation:            allowEmulation,
 		AllowCrossArchEmulation:   l.allowCrossArchEmulation && vmi.Spec.Architecture != "" && vmi.Spec.Architecture != runtime.GOARCH,
 		HostArchitecture:          runtime.GOARCH,

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -422,7 +422,6 @@ var _ = Describe("Manager", func() {
 
 		c := &convertertypes.ConverterContext{
 			Architecture:      arch.NewConverter(runtime.GOARCH),
-			VirtualMachine:    vmi,
 			AllowEmulation:    true,
 			SMBios:            &cmdv1.SMBios{},
 			HotplugVolumes:    hotplugVolumes,
@@ -1709,7 +1708,6 @@ var _ = Describe("Manager", func() {
 
 				c := &convertertypes.ConverterContext{
 					Architecture:      arch.NewConverter(runtime.GOARCH),
-					VirtualMachine:    vmi,
 					AllowEmulation:    true,
 					SMBios:            &cmdv1.SMBios{},
 					HotplugVolumes:    hotplugVolumes,

--- a/pkg/virt-launcher/virtwrap/util/libvirt_helper_test.go
+++ b/pkg/virt-launcher/virtwrap/util/libvirt_helper_test.go
@@ -221,7 +221,6 @@ var _ = Describe("LibvirtHelper", func() {
 		domain := &api.Domain{}
 		c := &convertertypes.ConverterContext{
 			Architecture:     arch.NewConverter(runtime.GOARCH),
-			VirtualMachine:   vmi,
 			AllowEmulation:   true,
 			SMBios:           &cmdv1.SMBios{},
 			HotplugVolumes:   make(map[string]v1.VolumeStatus),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
The hook server was the only code reading the VMI from the converter context; every other converter and hook already takes it as a parameter. Passing it directly makes the dependency explicit. 

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

