### PR TITLE
workload-updater: steer update migrations to updated-handler nodes

### DIFF
--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -192,6 +192,8 @@ type VirtControllerApp struct {
 	migrationController *migration.Controller
 	migrationInformer   cache.SharedIndexInformer
 
+	daemonSetInformer cache.SharedIndexInformer
+
 	workloadUpdateController *workloadupdater.WorkloadUpdateController
 
 	caExportConfigMapInformer    cache.SharedIndexInformer
@@ -402,6 +404,8 @@ func Execute() {
 	app.vmInformer = app.informerFactory.VirtualMachine()
 
 	app.migrationInformer = app.informerFactory.VirtualMachineInstanceMigration()
+
+	app.daemonSetInformer = app.informerFactory.OperatorDaemonSet()
 
 	app.controllerRevisionInformer = app.informerFactory.ControllerRevision()
 
@@ -877,6 +881,7 @@ func (vca *VirtControllerApp) initWorkloadUpdaterController() {
 		vca.kvPodInformer,
 		vca.migrationInformer,
 		vca.kubeVirtInformer,
+		vca.daemonSetInformer,
 		recorder,
 		vca.clientSet,
 		vca.clusterConfig)

--- a/pkg/virt-controller/watch/workload-updater/workload-updater.go
+++ b/pkg/virt-controller/watch/workload-updater/workload-updater.go
@@ -10,6 +10,7 @@ import (
 
 	"golang.org/x/time/rate"
 
+	appsv1 "k8s.io/api/apps/v1"
 	k8sv1 "k8s.io/api/core/v1"
 	policy "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -60,12 +61,16 @@ const defaultThrottleInterval = 5 * time.Second
 const defaultBatchDeletionIntervalSeconds = 60
 const defaultBatchDeletionCount = 10
 
+// name of the virt-handler DaemonSet, used to look up its rollout status
+const virtHandlerDaemonSetName = "virt-handler"
+
 type WorkloadUpdateController struct {
 	clientset             kubecli.KubevirtClient
 	queue                 workqueue.TypedRateLimitingInterface[string]
 	vmiStore              cache.Store
 	podIndexer            cache.Indexer
 	migrationIndexer      cache.Indexer
+	daemonSetStore        cache.Store
 	recorder              record.EventRecorder
 	migrationExpectations *controller.UIDTrackingControllerExpectations
 	kubeVirtStore         cache.Store
@@ -92,6 +97,7 @@ func NewWorkloadUpdateController(
 	podInformer cache.SharedIndexInformer,
 	migrationInformer cache.SharedIndexInformer,
 	kubeVirtInformer cache.SharedIndexInformer,
+	daemonSetInformer cache.SharedIndexInformer,
 	recorder record.EventRecorder,
 	clientset kubecli.KubevirtClient,
 	clusterConfig *virtconfig.ClusterConfig,
@@ -110,6 +116,7 @@ func NewWorkloadUpdateController(
 		vmiStore:              vmiInformer.GetStore(),
 		podIndexer:            podInformer.GetIndexer(),
 		migrationIndexer:      migrationInformer.GetIndexer(),
+		daemonSetStore:        daemonSetInformer.GetStore(),
 		kubeVirtStore:         kubeVirtInformer.GetStore(),
 		recorder:              recorder,
 		clientset:             clientset,
@@ -117,7 +124,7 @@ func NewWorkloadUpdateController(
 		migrationExpectations: controller.NewUIDTrackingControllerExpectations(controller.NewControllerExpectations()),
 		clusterConfig:         clusterConfig,
 		hasSynced: func() bool {
-			return migrationInformer.HasSynced() && vmiInformer.HasSynced() && podInformer.HasSynced() && kubeVirtInformer.HasSynced()
+			return migrationInformer.HasSynced() && vmiInformer.HasSynced() && podInformer.HasSynced() && kubeVirtInformer.HasSynced() && daemonSetInformer.HasSynced()
 		},
 	}
 
@@ -146,7 +153,37 @@ func NewWorkloadUpdateController(
 		return nil, err
 	}
 
+	// Re-reconcile as the virt-handler DaemonSet rolls out so newly updated
+	// nodes become eligible migration targets as soon as they appear.
+	_, err = daemonSetInformer.AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    c.addDaemonSet,
+		UpdateFunc: c.updateDaemonSet,
+	})
+	if err != nil {
+		return nil, err
+	}
+
 	return c, nil
+}
+
+func (c *WorkloadUpdateController) addDaemonSet(obj interface{}) {
+	c.enqueueDaemonSet(obj)
+}
+
+func (c *WorkloadUpdateController) updateDaemonSet(_, curr interface{}) {
+	c.enqueueDaemonSet(curr)
+}
+
+func (c *WorkloadUpdateController) enqueueDaemonSet(obj interface{}) {
+	ds, ok := obj.(*appsv1.DaemonSet)
+	if !ok || ds.Name != virtHandlerDaemonSetName {
+		return
+	}
+	key, err := c.getKubeVirtKey()
+	if key == "" || err != nil {
+		return
+	}
+	c.queue.AddAfter(key, defaultThrottleInterval)
 }
 
 func (c *WorkloadUpdateController) getKubeVirtKey() (string, error) {
@@ -161,6 +198,31 @@ func (c *WorkloadUpdateController) getKubeVirtKey() (string, error) {
 		return controller.KeyFunc(kv)
 	}
 	return "", nil
+}
+
+// updatedHandlerNodesAvailable reports whether at least one node has already
+// been rolled out to the target virt-handler. Workload-update migrations are
+// steered towards these nodes (via AddedNodeSelector), so creating them before
+// any node is updated would only produce unschedulable target pods. Returns
+// true (fail-open) if the DaemonSet can't be inspected, preserving the previous
+// behaviour rather than blocking updates on a lookup failure.
+func (c *WorkloadUpdateController) updatedHandlerNodesAvailable(namespace string) bool {
+	key := namespace + "/" + virtHandlerDaemonSetName
+	obj, exists, err := c.daemonSetStore.GetByKey(key)
+	if err != nil || !exists {
+		return true
+	}
+	ds, ok := obj.(*appsv1.DaemonSet)
+	if !ok {
+		return true
+	}
+	// Only trust the rollout counters once the DaemonSet controller has
+	// observed the current spec, otherwise UpdatedNumberScheduled may still
+	// refer to the previous pod template.
+	if ds.Status.ObservedGeneration < ds.Generation {
+		return false
+	}
+	return ds.Status.UpdatedNumberScheduled > 0
 }
 
 func (c *WorkloadUpdateController) addMigration(obj interface{}) {
@@ -539,6 +601,15 @@ func (c *WorkloadUpdateController) sync(kv *virtv1.KubeVirt) error {
 	}
 
 	migrateCount := int(math.Min(float64(maxNewMigrations), float64(len(data.migratableOutdatedVMIs))))
+	// Don't create workload-update migrations until at least one node has been
+	// rolled out to the target virt-handler. The migrations target updated
+	// nodes only (see AddedNodeSelector below), so creating them earlier would
+	// only pile up unschedulable target pods. The periodic re-enqueue and the
+	// DaemonSet event handlers ensure we retry once a node becomes available.
+	if migrateCount > 0 && !c.updatedHandlerNodesAvailable(kv.Namespace) {
+		log.Log.V(2).Infof("Deferring %d workload-update migration(s): no node has been updated to the target virt-handler yet", migrateCount)
+		migrateCount = 0
+	}
 	var migrationCandidates []*virtv1.VirtualMachineInstance
 	if migrateCount > 0 {
 		migrationCandidates = data.migratableOutdatedVMIs[0:migrateCount]
@@ -578,6 +649,15 @@ func (c *WorkloadUpdateController) sync(kv *virtv1.KubeVirt) error {
 				Spec: virtv1.VirtualMachineInstanceMigrationSpec{
 					VMIName: vmi.Name,
 				},
+			}
+			// Steer the migration towards a node whose virt-handler has already
+			// been rolled out to the current deployment, so the target launcher
+			// is never older than the source. At this point ObservedDeploymentID
+			// equals TargetDeploymentID (enforced in execute()).
+			if kv.Status.ObservedDeploymentID != "" {
+				wuMigration.Spec.AddedNodeSelector = map[string]string{
+					virtv1.VirtHandlerDeploymentIDLabel: kv.Status.ObservedDeploymentID,
+				}
 			}
 			// default is upgrade
 			priority := v1.PrioritySystemCritical

--- a/pkg/virt-controller/watch/workload-updater/workload-updater_test.go
+++ b/pkg/virt-controller/watch/workload-updater/workload-updater_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/onsi/gomega/gstruct"
 	"go.uber.org/mock/gomock"
 
+	appsv1 "k8s.io/api/apps/v1"
 	k8sv1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -43,10 +44,15 @@ var _ = Describe("Workload Updater", func() {
 		fakeVirtClient *kubevirtfake.Clientset
 		kubeClient     *fake.Clientset
 
-		controller *WorkloadUpdateController
+		controller        *WorkloadUpdateController
+		daemonSetInformer cache.SharedIndexInformer
 
 		expectedImage string
 	)
+
+	addDaemonSet := func(ds *appsv1.DaemonSet) {
+		Expect(daemonSetInformer.GetStore().Add(ds)).To(Succeed())
+	}
 
 	addKubeVirt := func(kv *v1.KubeVirt) {
 		key, err := virtcontroller.KeyFunc(kv)
@@ -97,8 +103,9 @@ var _ = Describe("Workload Updater", func() {
 		config, _, _ := testutils.NewFakeClusterConfigUsingKVConfig(&v1.KubeVirtConfiguration{})
 
 		kubeVirtInformer, _ := testutils.NewFakeInformerFor(&v1.KubeVirt{})
+		daemonSetInformer, _ = testutils.NewFakeInformerFor(&appsv1.DaemonSet{})
 
-		controller, _ = NewWorkloadUpdateController(expectedImage, vmiInformer, podInformer, migrationInformer, kubeVirtInformer, recorder, virtClient, config)
+		controller, _ = NewWorkloadUpdateController(expectedImage, vmiInformer, podInformer, migrationInformer, kubeVirtInformer, daemonSetInformer, recorder, virtClient, config)
 
 		// Set up mock client
 		virtClient.EXPECT().VirtualMachineInstanceMigration(k8sv1.NamespaceDefault).Return(fakeVirtClient.KubevirtV1().VirtualMachineInstanceMigrations(k8sv1.NamespaceDefault)).AnyTimes()
@@ -136,6 +143,48 @@ var _ = Describe("Workload Updater", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(migrations.Items).To(HaveLen(1))
 			Expect(migrations.Items[0].Spec.VMIName).To(Equal("testvm"))
+		})
+
+		It("should target the migration at nodes running the updated virt-handler", func() {
+			vmi := newVirtualMachineInstance("testvm", true, "madeup")
+			pod := newLauncherPodForVMI(vmi)
+			kv := newKubeVirt(1)
+			kv.Spec.WorkloadUpdateStrategy.WorkloadUpdateMethods = []v1.WorkloadUpdateMethod{v1.WorkloadUpdateMethodLiveMigrate}
+			kv.Status.ObservedDeploymentID = "v2"
+			kv.Status.TargetDeploymentID = "v2"
+
+			addKubeVirt(kv)
+			addDaemonSet(newVirtHandlerDaemonSet(1))
+			controller.vmiStore.Add(vmi)
+			controller.podIndexer.Add(pod)
+			waitForNumberOfInstancesOnVMIInformerCache(controller, 1)
+
+			sanityExecute()
+			testutils.ExpectEvent(recorder, SuccessfulCreateVirtualMachineInstanceMigrationReason)
+			migrations, err := fakeVirtClient.KubevirtV1().VirtualMachineInstanceMigrations(k8sv1.NamespaceDefault).List(context.Background(), metav1.ListOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(migrations.Items).To(HaveLen(1))
+			Expect(migrations.Items[0].Spec.AddedNodeSelector).To(HaveKeyWithValue(v1.VirtHandlerDeploymentIDLabel, "v2"))
+		})
+
+		It("should defer the migration until at least one node runs the updated virt-handler", func() {
+			vmi := newVirtualMachineInstance("testvm", true, "madeup")
+			pod := newLauncherPodForVMI(vmi)
+			kv := newKubeVirt(1)
+			kv.Spec.WorkloadUpdateStrategy.WorkloadUpdateMethods = []v1.WorkloadUpdateMethod{v1.WorkloadUpdateMethodLiveMigrate}
+			kv.Status.ObservedDeploymentID = "v2"
+			kv.Status.TargetDeploymentID = "v2"
+
+			addKubeVirt(kv)
+			addDaemonSet(newVirtHandlerDaemonSet(0))
+			controller.vmiStore.Add(vmi)
+			controller.podIndexer.Add(pod)
+			waitForNumberOfInstancesOnVMIInformerCache(controller, 1)
+
+			sanityExecute()
+			migrations, err := fakeVirtClient.KubevirtV1().VirtualMachineInstanceMigrations(k8sv1.NamespaceDefault).List(context.Background(), metav1.ListOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(migrations.Items).To(BeEmpty())
 		})
 
 		It("should do nothing if deployment is updating", func() {
@@ -743,6 +792,18 @@ func newKubeVirt(expectedNumOutdated int) *v1.KubeVirt {
 		Status: v1.KubeVirtStatus{
 			Phase:                                   v1.KubeVirtPhaseDeployed,
 			OutdatedVirtualMachineInstanceWorkloads: &expectedNumOutdated,
+		},
+	}
+}
+
+func newVirtHandlerDaemonSet(updatedNumberScheduled int32) *appsv1.DaemonSet {
+	return &appsv1.DaemonSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      virtHandlerDaemonSetName,
+			Namespace: k8sv1.NamespaceDefault,
+		},
+		Status: appsv1.DaemonSetStatus{
+			UpdatedNumberScheduled: updatedNumberScheduled,
 		},
 	}
 }

--- a/pkg/virt-handler/heartbeat/heartbeat.go
+++ b/pkg/virt-handler/heartbeat/heartbeat.go
@@ -48,12 +48,13 @@ type HeartBeat struct {
 	deviceManagerController   device_manager.DeviceControllerInterface
 	clusterConfig             *virtconfig.ClusterConfig
 	host                      string
+	deploymentID              string
 	cpuManagerPaths           []string
 	devicePluginPollIntervall time.Duration
 	devicePluginWaitTimeout   time.Duration
 }
 
-func NewHeartBeat(clientset k8scli.CoreV1Interface, deviceManager device_manager.DeviceControllerInterface, clusterConfig *virtconfig.ClusterConfig, host string) *HeartBeat {
+func NewHeartBeat(clientset k8scli.CoreV1Interface, deviceManager device_manager.DeviceControllerInterface, clusterConfig *virtconfig.ClusterConfig, host, deploymentID string) *HeartBeat {
 	const cpuManagerOS3Path = virtutil.HostRootMount + "var/lib/origin/openshift.local.volumes/cpu_manager_state"
 	const cpuManagerPath = virtutil.KubeletRoot + "/cpu_manager_state"
 	return &HeartBeat{
@@ -61,6 +62,7 @@ func NewHeartBeat(clientset k8scli.CoreV1Interface, deviceManager device_manager
 		deviceManagerController: deviceManager,
 		clusterConfig:           clusterConfig,
 		host:                    host,
+		deploymentID:            deploymentID,
 		// This is a temporary workaround until k8s bug #66525 is resolved
 		cpuManagerPaths:           []string{cpuManagerPath, cpuManagerOS3Path},
 		devicePluginPollIntervall: 1 * time.Second,
@@ -157,10 +159,15 @@ func (h *HeartBeat) do() {
 		cpuManagerEnabled = h.isCPUManagerEnabled(h.cpuManagerPaths)
 	}
 
-	data = []byte(fmt.Sprintf(`{"metadata": { "labels": {"%s": "%s", "%s": "%t", "%s": "%t"}, "annotations": {"%s": %s}}}`,
+	deploymentIDLabel := ""
+	if h.deploymentID != "" {
+		deploymentIDLabel = fmt.Sprintf(`, "%s": "%s"`, v1.VirtHandlerDeploymentIDLabel, h.deploymentID)
+	}
+	data = []byte(fmt.Sprintf(`{"metadata": { "labels": {"%s": "%s", "%s": "%t", "%s": "%t"%s}, "annotations": {"%s": %s}}}`,
 		v1.NodeSchedulable, kubevirtSchedulable,
 		v1.DeprecatedCPUManager, cpuManagerEnabled,
 		v1.CPUManager, cpuManagerEnabled,
+		deploymentIDLabel,
 		v1.VirtHandlerHeartbeat, string(now),
 	))
 	_, err = h.clientset.Nodes().Patch(context.Background(), h.host, types.StrategicMergePatchType, data, metav1.PatchOptions{})

--- a/pkg/virt-handler/heartbeat/heartbeat_test.go
+++ b/pkg/virt-handler/heartbeat/heartbeat_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Heartbeat", func() {
 	})
 	Context("upon finishing", func() {
 		It("should set the node to not schedulable", func() {
-			heartbeat := NewHeartBeat(fakeClient.CoreV1(), deviceController(true), config(), "mynode")
+			heartbeat := NewHeartBeat(fakeClient.CoreV1(), deviceController(true), config(), "mynode", "deployment-1")
 			stopChan := make(chan struct{})
 			done := heartbeat.Run(30*time.Second, stopChan)
 			Eventually(func() map[string]string {
@@ -67,6 +67,7 @@ var _ = Describe("Heartbeat", func() {
 				return node.Labels
 			}).Should(And(
 				HaveKeyWithValue(virtv1.NodeSchedulable, "true"),
+				HaveKeyWithValue(virtv1.VirtHandlerDeploymentIDLabel, "deployment-1"),
 			))
 			close(stopChan)
 			<-done
@@ -77,7 +78,7 @@ var _ = Describe("Heartbeat", func() {
 	})
 
 	DescribeTable("with cpumanager featuregate should set the node to", func(deviceController device_manager.DeviceControllerInterface, cpuManagerPaths []string, schedulable string, cpumanager string) {
-		heartbeat := NewHeartBeat(fakeClient.CoreV1(), deviceController, config(featuregate.CPUManager), "mynode")
+		heartbeat := NewHeartBeat(fakeClient.CoreV1(), deviceController, config(featuregate.CPUManager), "mynode", "")
 		heartbeat.cpuManagerPaths = cpuManagerPaths
 		heartbeat.do()
 		node, err := fakeClient.CoreV1().Nodes().Get(context.Background(), "mynode", metav1.GetOptions{})
@@ -113,7 +114,7 @@ var _ = Describe("Heartbeat", func() {
 	)
 
 	DescribeTable("without cpumanager featuregate should set the node to", func(deviceController device_manager.DeviceControllerInterface, schedulable string) {
-		heartbeat := NewHeartBeat(fakeClient.CoreV1(), deviceController, config(), "mynode")
+		heartbeat := NewHeartBeat(fakeClient.CoreV1(), deviceController, config(), "mynode", "")
 		heartbeat.do()
 		node, err := fakeClient.CoreV1().Nodes().Get(context.Background(), "mynode", metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
@@ -132,7 +133,7 @@ var _ = Describe("Heartbeat", func() {
 	)
 
 	DescribeTable("without deviceplugin and", func(deviceController device_manager.DeviceControllerInterface, initiallySchedulable string, finallySchedulable string) {
-		heartbeat := NewHeartBeat(fakeClient.CoreV1(), deviceController, config(), "mynode")
+		heartbeat := NewHeartBeat(fakeClient.CoreV1(), deviceController, config(), "mynode", "")
 		heartbeat.devicePluginWaitTimeout = 2 * time.Second
 		heartbeat.devicePluginPollIntervall = 10 * time.Millisecond
 		stopChan := make(chan struct{})

--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -72,6 +72,7 @@ import (
 	storagetypes "kubevirt.io/kubevirt/pkg/storage/types"
 	"kubevirt.io/kubevirt/pkg/util"
 	"kubevirt.io/kubevirt/pkg/util/migrations"
+	operatorutil "kubevirt.io/kubevirt/pkg/virt-operator/util"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
 	"kubevirt.io/kubevirt/pkg/virt-controller/watch/topology"
@@ -240,7 +241,7 @@ func NewVirtualMachineController(
 		deviceManager.PermanentHostDevicePlugins(c.hypervisorNodeInfo.GetHypervisorDevice(), maxDevices, permissions),
 		clusterConfig,
 		nodeStore)
-	c.heartBeat = heartbeat.NewHeartBeat(k8sClient.CoreV1(), c.deviceManagerController, clusterConfig, host)
+	c.heartBeat = heartbeat.NewHeartBeat(k8sClient.CoreV1(), c.deviceManagerController, clusterConfig, host, os.Getenv(operatorutil.DeploymentIDEnvName))
 
 	return c, nil
 }

--- a/pkg/virt-operator/resource/generate/components/daemonsets.go
+++ b/pkg/virt-operator/resource/generate/components/daemonsets.go
@@ -266,6 +266,13 @@ func NewHandlerDaemonSet(config *operatorutil.KubeVirtDeploymentConfig, productN
 				},
 			},
 		},
+		{
+			// Advertised as a node label by virt-handler so workload-update
+			// migrations can be steered towards nodes whose handler has
+			// already rolled out to this deployment.
+			Name:  operatorutil.DeploymentIDEnvName,
+			Value: config.GetDeploymentID(),
+		},
 	}
 
 	container.Env = append(container.Env, containerEnv...)

--- a/pkg/virt-operator/resource/generate/rbac/controller.go
+++ b/pkg/virt-operator/resource/generate/rbac/controller.go
@@ -280,7 +280,9 @@ func baseControllerClusterRole() *rbacv1.ClusterRole {
 					"daemonsets",
 				},
 				Verbs: []string{
+					"get",
 					"list",
+					"watch",
 				},
 			},
 			{

--- a/pkg/virt-operator/util/config.go
+++ b/pkg/virt-operator/util/config.go
@@ -62,6 +62,9 @@ const (
 	RunbookURLTemplate                        = "RUNBOOK_URL_TEMPLATE"
 
 	KubeVirtVersionEnvName = "KUBEVIRT_VERSION"
+	// DeploymentIDEnvName carries the KubeVirt deployment ID into the
+	// virt-handler container so it can advertise it as a node label.
+	DeploymentIDEnvName = "KUBEVIRT_DEPLOYMENT_ID"
 	// Deprecated, use TargetDeploymentConfig instead
 	TargetInstallNamespace = "TARGET_INSTALL_NAMESPACE"
 	// Deprecated, use TargetDeploymentConfig instead

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -1201,6 +1201,12 @@ const (
 	VirtHandlerHeartbeat string = "kubevirt.io/heartbeat"
 	// This label indicates what launcher image a VMI is currently running with.
 	OutdatedLauncherImageLabel string = "kubevirt.io/outdatedLauncherImage"
+	// This label is set by virt-handler on the node it runs on and advertises
+	// the KubeVirt deployment ID of the virt-handler currently active on that
+	// node. It is used to steer workload-update migrations towards nodes whose
+	// virt-handler has already been rolled out to the target deployment. Used
+	// on Node.
+	VirtHandlerDeploymentIDLabel string = "kubevirt.io/handler-deployment-id"
 	// Namespace recommended by Kubernetes for commonly recognized labels
 	AppLabelPrefix = "app.kubernetes.io"
 	// This label is commonly used by 3rd party management tools to identify


### PR DESCRIPTION
### What this PR does
#### Before this PR:

Workload-update auto-migrations are created as soon as the KubeVirt CR reaches the `Deployed` phase and `ObservedDeploymentID == TargetDeploymentID`. This can happen while the virt-handler DaemonSet is still rolling out, so an outdated VMI can be migrated onto a node whose virt-handler (and therefore virt-launcher) has **not** yet been updated.

During a rollout this means the target launcher can end up *older* than the source. When migration-completion ownership sits on the target (1.6+), an older target that doesn't set the end timestamp can deadlock the migration.

#### After this PR:

Rather than blocking all workload-update migrations until the handler rollout completes, their targets are constrained to nodes that already run the updated handler:

- virt-handler advertises its KubeVirt deployment ID as a node label (`kubevirt.io/handler-deployment-id`) via the heartbeat. The operator injects the deployment ID into the handler container environment.
- the workload-update controller sets `AddedNodeSelector` on the migrations it creates so they only schedule onto nodes whose handler matches the current deployment ID, and defers creating them until at least one node has been rolled out (observed via the virt-handler DaemonSet), avoiding a pile-up of unschedulable target pods.

The deployment ID changes on every install round, so this also steers migrations correctly when a rollout is re-rolled mid-flight.

### References

Alternative to #18397, which instead blocks *all* workload-update migrations until the virt-handler DaemonSet has fully rolled out. This PR is the finer-grained approach: allow migrations as soon as one node is updated, but pin each migration's target to an already-updated node.

### Why we need it and why it was done in this way
The following tradeoffs were made:

- Keying the node label on the **deployment ID** rather than a version string means it changes every install round, so re-rolled rollouts are handled correctly too.
- The "at least one updated node" guard is cluster-global. Residual edge case: if the only updated node is a VMI's own source node, that VMI waits until a second node is updated. This is safe (better to wait than migrate onto an older handler).

The following alternatives were considered:

- #18397 — block all workload-update migrations until the handler DaemonSet is fully rolled out. Simpler, but pauses all workload updates for the duration of the rollout instead of making progress node-by-node.

### Special notes for your reviewer

Best reviewed against #18397 side by side.

### Release note
```release-note
Workload-update migrations are now steered towards nodes whose virt-handler has already been updated, avoiding migrations onto not-yet-updated nodes during a rollout.
```