### PR TITLE
[release-1.8] virt-operator: fix DeploymentInProgress after toggling optional feature gates

### DIFF
--- a/pkg/virt-operator/kubevirt.go
+++ b/pkg/virt-operator/kubevirt.go
@@ -1094,15 +1094,18 @@ func (c *KubeVirtController) syncInstallation(kv *v1.KubeVirt) error {
 	// the entire sync can't always occur within a single control loop execution.
 	// when synced==true that means SyncAll() has completed and has nothing left to wait on.
 	if synced {
-		// record the version that has been completely installed
-		config.SetObservedDeploymentConfig(kv)
-
 		// update conditions
 		util.UpdateConditionsCreated(kv)
 		logger.Info("All KubeVirt resources created")
 
 		// check if components are ready
 		if c.isReady(kv) {
+			// record the version that has been completely installed only once all
+			// components are ready. This ensures isUpdating() returns true while
+			// optional feature deployments (e.g. virt-template) are still starting,
+			// keeping Available=True during the transition instead of flipping to
+			// Available=False (DeploymentInProgress).
+			config.SetObservedDeploymentConfig(kv)
 			logger.Info("All KubeVirt components ready")
 			kv.Status.Phase = v1.KubeVirtPhaseDeployed
 			util.UpdateConditionsAvailable(kv)

--- a/pkg/virt-operator/kubevirt_test.go
+++ b/pkg/virt-operator/kubevirt_test.go
@@ -2192,6 +2192,95 @@ var _ = Describe("KubeVirt Operator", func() {
 			kvTestData.controller.Execute()
 		})
 
+		It("should advance ObservedDeploymentID only once all pods are ready when toggling an optional feature gate", func() {
+			kvTestData := KubeVirtTestData{}
+			kvTestData.BeforeTest()
+			defer kvTestData.AfterTest()
+
+			// Start with KubeVirt deployed without any optional feature gates.
+			kv := &v1.KubeVirt{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-install",
+					Namespace:  NAMESPACE,
+					Finalizers: []string{util.KubeVirtFinalizer},
+					Generation: int64(1),
+				},
+				Spec: v1.KubeVirtSpec{
+					Configuration: v1.KubeVirtConfiguration{
+						// Disable to avoid instancetype create/update noise across both Execute cycles.
+						CommonInstancetypesDeployment: &v1.CommonInstancetypesDeployment{
+							Enabled: pointer.P(false),
+						},
+					},
+				},
+				Status: v1.KubeVirtStatus{
+					Phase:              v1.KubeVirtPhaseDeployed,
+					OperatorVersion:    version.Get().String(),
+					ObservedGeneration: pointer.P(int64(1)),
+				},
+			}
+			oldConfig := util.GetTargetConfigFromKVWithEnvVarManager(kv, kvTestData.mockEnvVarManager)
+			oldConfig.SetTargetDeploymentConfig(kv)
+			oldConfig.SetObservedDeploymentConfig(kv)
+			util.UpdateConditionsCreated(kv)
+			util.UpdateConditionsAvailable(kv)
+
+			// Toggle the Template feature gate — changes TargetDeploymentID but not version/registry.
+			enableTemplateFeatureGate(kv)
+			initialObservedID := kv.Status.ObservedDeploymentID
+
+			newConfig := util.GetTargetConfigFromKVWithEnvVarManager(kv, kvTestData.mockEnvVarManager)
+
+			// kvNoFG: a minimal KV without the Template FG, used to restrict
+			// makeDeploymentsReady and addPodsWithOptionalPodDisruptionBudgets to
+			// non-virt-template components only (simulating pods still starting).
+			kvNoFG := &v1.KubeVirt{}
+
+			kubecontroller.SetLatestApiVersionAnnotation(kv)
+			kvTestData.addKubeVirt(kv)
+			kvTestData.addInstallStrategy(newConfig)
+			kvTestData.addAll(newConfig, kv)
+			kvTestData.addPodsWithOptionalPodDisruptionBudgets(newConfig, true, kvNoFG)
+			kvTestData.makeDeploymentsReady(kvNoFG)
+			kvTestData.makeHandlerReady()
+
+			kvTestData.fakeNamespaceModificationEvent()
+			kvTestData.shouldExpectNamespacePatch()
+			kvTestData.shouldExpectPatchesAndUpdates(kv)
+			kvTestData.shouldExpectKubeVirtUpdateStatus(1)
+
+			kvTestData.controller.Execute()
+			kv = kvTestData.getLatestKubeVirt(kv)
+
+			// ObservedDeploymentID must not advance: SetObservedDeploymentConfig must only
+			// be called once isReady() returns true (virt-template pods are still starting).
+			Expect(kv.Status.ObservedDeploymentID).To(Equal(initialObservedID))
+			// isUpdating() stayed true throughout, so Available remains True.
+			shouldExpectHCOConditions(kv, k8sv1.ConditionTrue, k8sv1.ConditionTrue, k8sv1.ConditionTrue)
+
+			// Second cycle: mark all pods ready (including virt-template) and verify
+			// that ObservedDeploymentID is now advanced to the new config's ID.
+			// Drain pending queue items left over from the first cycle so the
+			// KubeVirt key can lead the queue for the second Execute().
+			for kvTestData.mockQueue.Len() > 0 {
+				key, quit := kvTestData.mockQueue.Get()
+				if quit {
+					break
+				}
+				kvTestData.mockQueue.Done(key)
+			}
+			kvTestData.addKubeVirt(kv)
+			kvTestData.addPodsWithOptionalPodDisruptionBudgets(newConfig, true, kv)
+			kvTestData.makeDeploymentsReady(kv)
+			kvTestData.shouldExpectPatchesAndUpdates(kv)
+			kvTestData.shouldExpectKubeVirtUpdateStatus(1)
+
+			kvTestData.controller.Execute()
+			kv = kvTestData.getLatestKubeVirt(kv)
+			Expect(kv.Status.ObservedDeploymentID).NotTo(Equal(initialObservedID))
+			Expect(kv.Status.ObservedDeploymentID).To(Equal(kv.Status.TargetDeploymentID))
+		})
+
 		It("should update KubeVirt object if generation IDs do not match", func() {
 			kvTestData := KubeVirtTestData{}
 			kvTestData.BeforeTest()


### PR DESCRIPTION
### What this PR does

Backport of #17996 (commit `f85a9748c7`) to `release-1.8`.

#### Before this PR:

On an in-place KubeVirt CR change that alters the computed deployment ID without a version/registry change (e.g. toggling an optional feature gate), `virt-operator` recorded the new `Status.ObservedDeploymentID` on `synced` — i.e. before all components (notably the `virt-handler` DaemonSet) were actually `Ready`. This caused the CR to get stuck reporting `Available=False` / `DeploymentInProgress`, and — because `Status.Phase` stays `Deployed` during an in-place change — let the `WorkloadUpdateController` begin auto-migrating workloads before `virt-handler` had finished rolling out across nodes.

#### After this PR:

`config.SetObservedDeploymentConfig(kv)` is called inside the `if c.isReady(kv)` block, so `ObservedDeploymentID` only advances once every Deployment and DaemonSet passes `DeploymentIsReady`/`DaemonsetIsReady`. The premature-`ObservedDeploymentID` window for same-version / config changes is closed at the source.

### References

- Partially addresses #18919
- Backport of #17996 (`f85a9748c7`)

### Why we need it and why it was done in this way

Straight cherry-pick from `main`/`release-1.9`; the fix applies cleanly (source + unit tests) to this branch with no conflicts.

### Special notes for your reviewer

Clean cherry-pick, no manual conflict resolution required. See #18919 for the full description of the defect and the two observable symptoms (condition flapping and premature workload updates).

### Release note

```release-note
virt-operator: only record a deployment as observed once all components have finished rolling out, preventing premature Available=False/DeploymentInProgress reporting and premature workload-update migrations on in-place KubeVirt CR changes.
```
