### PR TITLE
[release-1.8] Fix VMs restarting

### DIFF
--- a/cmd/virt-launcher/virt-launcher.go
+++ b/cmd/virt-launcher/virt-launcher.go
@@ -157,7 +157,10 @@ func startDomainEventMonitoring(
 		}
 	}()
 
-	err := notifier.StartDomainNotifier(domainConn, deleteNotificationSent, vmi, domainName, agentStore, qemuAgentSysInterval, qemuAgentFileInterval, qemuAgentUserInterval, qemuAgentVersionInterval, qemuAgentFSFreezeStatusInterval, metadataCache, nonRoot)
+	err := notifier.StartDomainNotifier(domainConn, deleteNotificationSent, vmi, domainName, agentStore,
+		qemuAgentSysInterval, qemuAgentFileInterval, qemuAgentUserInterval,
+		qemuAgentVersionInterval, qemuAgentFSFreezeStatusInterval,
+		metadataCache, nonRoot, make(chan notifyclient.LibvirtEvent, 10))
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/virt-handler/cache/domain-watcher.go
+++ b/pkg/virt-handler/cache/domain-watcher.go
@@ -295,53 +295,10 @@ func (d *domainWatcher) handleStaleSocketConnections() error {
 func (d *domainWatcher) listAllKnownDomains() ([]*api.Domain, error) {
 	var domains []*api.Domain
 
-	socketFiles, err := listSockets(GhostRecordGlobalStore.list())
-	if err != nil {
-		return nil, err
-	}
-	for _, socketFile := range socketFiles {
+	ghostRecords := GhostRecordGlobalStore.list()
 
-		exists, err := diskutils.FileExists(socketFile)
-		if err != nil {
-			log.Log.Reason(err).Error("failed access cmd client socket")
-			continue
-		}
-
-		if !exists {
-			record, recordExists := GhostRecordGlobalStore.findBySocket(socketFile)
-			if recordExists {
-				domain := api.NewMinimalDomainWithNS(record.Namespace, record.Name)
-				domain.ObjectMeta.UID = record.UID
-				now := metav1.Now()
-				domain.ObjectMeta.DeletionTimestamp = &now
-				log.Log.Object(domain).Warning("detected stale domain from ghost record")
-				domains = append(domains, domain)
-			}
-			continue
-		}
-
-		log.Log.V(3).Infof("List domains from sock %s", socketFile)
-		client, err := cmdclient.NewClient(socketFile)
-		if err != nil {
-			log.Log.Reason(err).Error("failed to connect to cmd client socket")
-			// Ignore failure to connect to client.
-			// These are all local connections via unix socket.
-			// A failure to connect means there's nothing on the other
-			// end listening.
-			continue
-		}
-		defer client.Close()
-
-		domain, exists, err := client.GetDomain()
-		if err != nil {
-			log.Log.Reason(err).Error("failed to list domains on cmd client socket")
-			// Failure to get domain list means that client
-			// was unable to contact libvirt. As soon as the connection
-			// is restored on the client's end, a domain notification will
-			// be sent.
-			continue
-		}
-		if exists {
+	for _, record := range ghostRecords {
+		if domain := getDomainFromRecord(record); domain != nil {
 			domains = append(domains, domain)
 		}
 	}
@@ -406,4 +363,49 @@ func listSockets(ghostRecords []ghostRecord) ([]string, error) {
 	}
 
 	return sockets, nil
+}
+
+func newDomainFromGhostRecord(record ghostRecord, status api.DomainStatus) *api.Domain {
+	domain := api.NewMinimalDomainWithNS(record.Namespace, record.Name)
+	domain.ObjectMeta.UID = record.UID
+	domain.Spec.Metadata.KubeVirt.UID = record.UID
+	domain.Status = status
+
+	return domain
+}
+
+func getDomainFromRecord(record ghostRecord) *api.Domain {
+	socketFile := record.SocketFile
+
+	exists, err := diskutils.FileExists(socketFile)
+	if err != nil {
+		log.Log.Reason(err).Error("failed access cmd client socket")
+		return nil
+	}
+
+	if !exists {
+		domain := newDomainFromGhostRecord(record, api.DomainStatus{})
+		now := metav1.Now()
+		domain.DeletionTimestamp = &now
+		log.Log.Object(domain).Warning("detected stale domain from ghost record")
+		return domain
+	}
+
+	log.Log.V(3).Infof("List domains from sock %s", socketFile)
+	client, err := cmdclient.NewClient(socketFile)
+	if err != nil {
+		log.Log.Reason(err).Warningf("failed to connect to cmd client socket %s, preserving domain with Unknown status", socketFile)
+		return newDomainFromGhostRecord(record, api.DomainStatus{Status: api.Unknown})
+	}
+	defer client.Close()
+
+	domain, exists, err := client.GetDomain()
+	if err != nil {
+		log.Log.Reason(err).Warningf("failed to list domains on cmd client socket %s, preserving domain with Unknown status", socketFile)
+		return newDomainFromGhostRecord(record, api.DomainStatus{Status: api.Unknown})
+	}
+	if !exists {
+		return nil
+	}
+	return domain
 }

--- a/pkg/virt-handler/cache/domain-watcher_test.go
+++ b/pkg/virt-handler/cache/domain-watcher_test.go
@@ -21,6 +21,8 @@ package cache
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -28,6 +30,8 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	k8scache "k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
+
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 )
 
 var _ = Describe("Domain Watcher", func() {
@@ -101,6 +105,86 @@ var _ = Describe("Domain Watcher", func() {
 
 			Expect(func() { d.Stop() }).ShouldNot(Panic())
 			Expect(func() { d.Stop() }).ShouldNot(Panic())
+		})
+	})
+
+	Context("listAllKnownDomains", func() {
+		var ghostCacheDir string
+
+		BeforeEach(func() {
+			ghostCacheDir = GinkgoT().TempDir()
+			InitializeGhostRecordCache(NewIterableCheckpointManager(ghostCacheDir))
+		})
+
+		It("should return domain with Unknown status when socket exists but connection fails", func() {
+			socketDir := GinkgoT().TempDir()
+			socketPath := filepath.Join(socketDir, "cmd.sock")
+
+			err := os.WriteFile(socketPath, []byte{}, 0600)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = GhostRecordGlobalStore.Add("test-ns", "test-vmi", socketPath, "uid-1234")
+			Expect(err).ToNot(HaveOccurred())
+
+			d := &domainWatcher{}
+			domains, err := d.listAllKnownDomains()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(domains).To(HaveLen(1))
+			Expect(domains[0].ObjectMeta.Namespace).To(Equal("test-ns"))
+			Expect(domains[0].ObjectMeta.Name).To(Equal("test-vmi"))
+			Expect(domains[0].ObjectMeta.UID).To(BeEquivalentTo("uid-1234"))
+			Expect(domains[0].Status.Status).To(Equal(api.Unknown))
+			Expect(domains[0].ObjectMeta.DeletionTimestamp).To(BeNil())
+		})
+
+		It("should return domain with DeletionTimestamp when socket file does not exist", func() {
+			socketPath := "/nonexistent/path/cmd.sock"
+
+			err := GhostRecordGlobalStore.Add("test-ns", "test-vmi", socketPath, "uid-1234")
+			Expect(err).ToNot(HaveOccurred())
+
+			d := &domainWatcher{}
+			domains, err := d.listAllKnownDomains()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(domains).To(HaveLen(1))
+			Expect(domains[0].ObjectMeta.Namespace).To(Equal("test-ns"))
+			Expect(domains[0].ObjectMeta.Name).To(Equal("test-vmi"))
+			Expect(domains[0].ObjectMeta.DeletionTimestamp).ToNot(BeNil())
+		})
+
+		It("should handle mix of reachable, unreachable, and missing sockets", func() {
+			socketDir := GinkgoT().TempDir()
+
+			unreachablePath := filepath.Join(socketDir, "unreachable.sock")
+			err := os.WriteFile(unreachablePath, []byte{}, 0600)
+			Expect(err).ToNot(HaveOccurred())
+			err = GhostRecordGlobalStore.Add("ns1", "unreachable-vmi", unreachablePath, "uid-1")
+			Expect(err).ToNot(HaveOccurred())
+
+			missingPath := filepath.Join(socketDir, "missing.sock")
+			err = GhostRecordGlobalStore.Add("ns2", "missing-vmi", missingPath, "uid-2")
+			Expect(err).ToNot(HaveOccurred())
+
+			d := &domainWatcher{}
+			domains, err := d.listAllKnownDomains()
+			Expect(err).ToNot(HaveOccurred())
+			Expect(domains).To(HaveLen(2))
+
+			var unknownDomain, deletedDomain *api.Domain
+			for _, d := range domains {
+				if d.Status.Status == api.Unknown {
+					unknownDomain = d
+				}
+				if d.ObjectMeta.DeletionTimestamp != nil {
+					deletedDomain = d
+				}
+			}
+
+			Expect(unknownDomain).ToNot(BeNil())
+			Expect(unknownDomain.ObjectMeta.Name).To(Equal("unreachable-vmi"))
+
+			Expect(deletedDomain).ToNot(BeNil())
+			Expect(deletedDomain.ObjectMeta.Name).To(Equal("missing-vmi"))
 		})
 	})
 })

--- a/pkg/virt-launcher/notify-client/BUILD.bazel
+++ b/pkg/virt-launcher/notify-client/BUILD.bazel
@@ -46,6 +46,7 @@ go_test(
         "//pkg/testutils:go_default_library",
         "//pkg/virt-handler/notify-server:go_default_library",
         "//pkg/virt-launcher/metadata:go_default_library",
+        "//pkg/virt-launcher/virtwrap/agent-poller:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//pkg/virt-launcher/virtwrap/testing:go_default_library",
         "//pkg/virt-launcher/virtwrap/util:go_default_library",

--- a/pkg/virt-launcher/notify-client/client.go
+++ b/pkg/virt-launcher/notify-client/client.go
@@ -62,7 +62,7 @@ type Notifier struct {
 	firstDelete *sync.Once
 }
 
-type libvirtEvent struct {
+type LibvirtEvent struct {
 	Domain            string
 	Event             *libvirt.DomainEventLifecycle
 	AgentEvent        *libvirt.DomainEventAgentLifecycle
@@ -238,10 +238,6 @@ func (n *Notifier) updateEvents(event watch.Event, domain *api.Domain, events ch
 	}
 }
 
-func newWatchEventError(err error) watch.Event {
-	return watch.Event{Type: watch.Error, Object: &metav1.Status{Status: metav1.StatusFailure, Message: err.Error()}}
-}
-
 type eventCaller struct {
 	domainStatus             api.LifeCycle
 	domainStatusChangeReason api.StateChangeReason
@@ -322,7 +318,7 @@ func (e *eventCaller) handleGuestPanicEvent(client *Notifier, vmi *v1.VirtualMac
 	return panicInfo
 }
 
-func (e *eventCaller) eventCallback(c cli.Connection, domain *api.Domain, libvirtEvent libvirtEvent, client *Notifier, events chan watch.Event,
+func (e *eventCaller) eventCallback(c cli.Connection, domain *api.Domain, libvirtEvent LibvirtEvent, client *Notifier, events chan watch.Event,
 	interfaceStatus []api.InterfaceStatus, osInfo *api.GuestOSInfo, vmi *v1.VirtualMachineInstance, fsFreezeStatus *api.FSFreeze,
 	metadataCache *metadata.Cache, nonRoot bool) {
 	// Handle guest panic event early, before domain lookup which may fail if VM is already gone
@@ -450,9 +446,8 @@ func (n *Notifier) StartDomainNotifier(
 	qemuAgentFSFreezeStatusInterval time.Duration,
 	metadataCache *metadata.Cache,
 	nonRoot bool,
+	eventChan chan LibvirtEvent,
 ) error {
-
-	eventChan := make(chan libvirtEvent, 10)
 
 	reconnectChan := make(chan bool, 10)
 
@@ -501,11 +496,14 @@ func (n *Notifier) StartDomainNotifier(
 				guestOsInfo = agentUpdate.DomainInfo.OSInfo
 				fsFreezeStatus = agentUpdate.DomainInfo.FSFreezeStatus
 
-				eventCaller.eventCallback(domainConn, domainCache, libvirtEvent{}, n, deleteNotificationSent,
+				eventCaller.eventCallback(domainConn, domainCache, LibvirtEvent{}, n, deleteNotificationSent,
 					interfaceStatuses, guestOsInfo, vmi, fsFreezeStatus, metadataCache, nonRoot)
 			case <-reconnectChan:
-				n.SendDomainEvent(newWatchEventError(fmt.Errorf("Libvirt reconnect, domain %s", domainName)))
-
+				log.Log.Infof("Libvirt reconnected, domain %s. Event callbacks re-registered, triggering immediate reconciliation.", domainName)
+				if domainCache != nil {
+					eventCaller.eventCallback(domainConn, domainCache, LibvirtEvent{}, n, deleteNotificationSent,
+						interfaceStatuses, guestOsInfo, vmi, fsFreezeStatus, metadataCache, nonRoot)
+				}
 			case <-metadataCache.Listen():
 				// Metadata cache updates should be processed only *after* at least one
 				// libvirt event arrived (which creates the first domainCache).
@@ -521,7 +519,7 @@ func (n *Notifier) StartDomainNotifier(
 					eventCaller.eventCallback(
 						domainConn,
 						domainCache,
-						libvirtEvent{},
+						LibvirtEvent{},
 						n,
 						deleteNotificationSent,
 						interfaceStatuses,
@@ -544,7 +542,7 @@ func (n *Notifier) StartDomainNotifier(
 			log.Log.Reason(err).Info(cantDetermineLibvirtDomainName)
 		}
 		select {
-		case eventChan <- libvirtEvent{Event: event, Domain: name}:
+		case eventChan <- LibvirtEvent{Event: event, Domain: name}:
 		default:
 			log.Log.Infof(libvirtEventChannelFull)
 		}
@@ -557,7 +555,7 @@ func (n *Notifier) StartDomainNotifier(
 			log.Log.Reason(err).Info(cantDetermineLibvirtDomainName)
 		}
 		select {
-		case eventChan <- libvirtEvent{Domain: name}:
+		case eventChan <- LibvirtEvent{Domain: name}:
 		default:
 			log.Log.Infof(libvirtEventChannelFull)
 		}
@@ -571,7 +569,7 @@ func (n *Notifier) StartDomainNotifier(
 		}
 
 		select {
-		case eventChan <- libvirtEvent{Domain: name}:
+		case eventChan <- LibvirtEvent{Domain: name}:
 		default:
 			log.Log.Infof(libvirtEventChannelFull)
 		}
@@ -585,7 +583,7 @@ func (n *Notifier) StartDomainNotifier(
 		}
 
 		select {
-		case eventChan <- libvirtEvent{Domain: name}:
+		case eventChan <- LibvirtEvent{Domain: name}:
 		default:
 			log.Log.Infof(libvirtEventChannelFull)
 		}
@@ -597,7 +595,7 @@ func (n *Notifier) StartDomainNotifier(
 			log.Log.Reason(err).Info(cantDetermineLibvirtDomainName)
 		}
 		select {
-		case eventChan <- libvirtEvent{JobCompletedEvent: event, Domain: name}:
+		case eventChan <- LibvirtEvent{JobCompletedEvent: event, Domain: name}:
 		default:
 			log.Log.Infof(libvirtEventChannelFull)
 		}
@@ -637,7 +635,7 @@ func (n *Notifier) StartDomainNotifier(
 			log.Log.Reason(err).Info(cantDetermineLibvirtDomainName)
 		}
 		select {
-		case eventChan <- libvirtEvent{AgentEvent: event, Domain: name}:
+		case eventChan <- LibvirtEvent{AgentEvent: event, Domain: name}:
 		default:
 			log.Log.Infof(libvirtEventChannelFull)
 		}

--- a/pkg/virt-launcher/notify-client/notify_test.go
+++ b/pkg/virt-launcher/notify-client/notify_test.go
@@ -44,6 +44,7 @@ import (
 	"kubevirt.io/kubevirt/pkg/testutils"
 	notifyserver "kubevirt.io/kubevirt/pkg/virt-handler/notify-server"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/metadata"
+	agentpoller "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/agent-poller"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/testing"
 	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/util"
@@ -79,9 +80,9 @@ var _ = Describe("Notify", func() {
 			vmiStore = vmiInformer.GetStore()
 			e = &eventCaller{}
 
-			go func() {
-				notifyserver.RunServer(shareDir, stop, eventChan, recorder, vmiStore)
-			}()
+			go func(ec chan watch.Event, rec *record.FakeRecorder, vs cache.Store) {
+				notifyserver.RunServer(shareDir, stop, ec, rec, vs)
+			}(eventChan, recorder, vmiStore)
 			// mimic pipe
 			notifyServer := filepath.Join(shareDir, "domain-notify.sock")
 			pipePath := filepath.Join(shareDir, "domain-notify-pipe.sock")
@@ -113,7 +114,7 @@ var _ = Describe("Notify", func() {
 				mockLibvirt.DomainEXPECT().GetName().Return("test", nil).AnyTimes()
 				mockLibvirt.DomainEXPECT().GetXMLDesc(gomock.Eq(libvirt.DomainXMLFlags(0))).Return(string(x), nil)
 
-				e.eventCallback(mockLibvirt.VirtConnection, util.NewDomainFromName("test", "1234"), libvirtEvent{Event: &libvirt.DomainEventLifecycle{Event: event}}, client, deleteNotificationSent, nil, nil, nil, nil, metadataCache(), false)
+				e.eventCallback(mockLibvirt.VirtConnection, util.NewDomainFromName("test", "1234"), LibvirtEvent{Event: &libvirt.DomainEventLifecycle{Event: event}}, client, deleteNotificationSent, nil, nil, nil, nil, metadataCache(), false)
 
 				timedOut := false
 				timeout := time.After(2 * time.Second)
@@ -135,6 +136,132 @@ var _ = Describe("Notify", func() {
 				Entry("modified for running VMIs", libvirt.DOMAIN_RUNNING, libvirt.DOMAIN_EVENT_STARTED, api.Running, watch.Modified),
 				Entry("added for defined VMIs", libvirt.DOMAIN_SHUTOFF, libvirt.DOMAIN_EVENT_DEFINED, api.Shutoff, watch.Added),
 			)
+
+			It("should not send watch.Error event on libvirt reconnect", func() {
+				By("Setting up StartDomainNotifier with a mock connection")
+				mockConn := testing.NewLibvirt(gomock.NewController(GinkgoT()))
+
+				var reconnectChan chan bool
+				mockConn.ConnectionEXPECT().SetReconnectChan(gomock.Any()).Do(func(ch chan bool) {
+					reconnectChan = ch
+				})
+				mockConn.ConnectionEXPECT().DomainEventLifecycleRegister(gomock.Any()).Return(nil)
+				mockConn.ConnectionEXPECT().DomainEventDeviceAddedRegister(gomock.Any()).Return(nil)
+				mockConn.ConnectionEXPECT().DomainEventDeviceRemovedRegister(gomock.Any()).Return(nil)
+				mockConn.ConnectionEXPECT().DomainEventMemoryDeviceSizeChangeRegister(gomock.Any()).Return(nil)
+				mockConn.ConnectionEXPECT().DomainEventJobCompletedRegister(gomock.Any()).Return(nil)
+				mockConn.ConnectionEXPECT().AgentEventLifecycleRegister(gomock.Any()).Return(nil)
+
+				vmi := api2.NewMinimalVMI("test-vmi")
+				vmi.UID = "1234"
+				agentStore := agentpoller.NewAsyncAgentStore()
+
+				err := client.StartDomainNotifier(
+					mockConn.VirtConnection,
+					deleteNotificationSent,
+					vmi,
+					"test_domain",
+					&agentStore,
+					10*time.Second,
+					10*time.Second,
+					10*time.Second,
+					10*time.Second,
+					10*time.Second,
+					metadataCache(),
+					false,
+					make(chan LibvirtEvent),
+				)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Triggering a libvirt reconnect")
+				Expect(reconnectChan).ToNot(BeNil())
+				reconnectChan <- true
+
+				By("Verifying no watch.Error event is sent to virt-handler")
+				Consistently(eventChan, 1*time.Second).ShouldNot(Receive())
+			})
+
+			It("should send watch.Modified event on libvirt reconnect when domain cache is populated", func() {
+				domain := api.NewMinimalDomain("test")
+				x, err := xml.Marshal(domain.Spec)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Setting up StartDomainNotifier with a mock connection")
+				mockConn := testing.NewLibvirt(gomock.NewController(GinkgoT()))
+
+				// The domain state is fetched twice: once for the initial
+				// lifecycle event that populates the domain cache, and once
+				// again for the reconnect-triggered reconciliation. The domain
+				// is looked up via the notifier's connection (mockConn), so the
+				// per-connection call-stack accounting must live on mockConn.
+				mockConn.ConnectionEXPECT().LookupDomainByName(gomock.Any()).Return(mockConn.VirtDomain, nil).AnyTimes()
+				mockConn.DomainEXPECT().GetState().Return(libvirt.DOMAIN_RUNNING, -1, nil).Times(2)
+				mockConn.DomainEXPECT().Free().Times(2)
+				mockConn.DomainEXPECT().GetName().Return("test", nil).AnyTimes()
+				mockConn.DomainEXPECT().GetXMLDesc(gomock.Eq(libvirt.DomainXMLFlags(0))).Return(string(x), nil).Times(2)
+
+				var reconnectChan chan bool
+				mockConn.ConnectionEXPECT().SetReconnectChan(gomock.Any()).Do(func(ch chan bool) {
+					reconnectChan = ch
+				})
+				mockConn.ConnectionEXPECT().DomainEventLifecycleRegister(gomock.Any()).Return(nil)
+				mockConn.ConnectionEXPECT().DomainEventDeviceAddedRegister(gomock.Any()).Return(nil)
+				mockConn.ConnectionEXPECT().DomainEventDeviceRemovedRegister(gomock.Any()).Return(nil)
+				mockConn.ConnectionEXPECT().DomainEventMemoryDeviceSizeChangeRegister(gomock.Any()).Return(nil)
+				mockConn.ConnectionEXPECT().DomainEventJobCompletedRegister(gomock.Any()).Return(nil)
+				mockConn.ConnectionEXPECT().AgentEventLifecycleRegister(gomock.Any()).Return(nil)
+
+				agentStore := agentpoller.NewAsyncAgentStore()
+				vmi := api2.NewMinimalVMI("test-vmi")
+				vmi.UID = "1234"
+
+				libvirtEventChan := make(chan LibvirtEvent)
+				err = client.StartDomainNotifier(
+					mockConn.VirtConnection,
+					deleteNotificationSent,
+					vmi,
+					"test_domain",
+					&agentStore,
+					10*time.Second,
+					10*time.Second,
+					10*time.Second,
+					10*time.Second,
+					10*time.Second,
+					metadataCache(),
+					false,
+					libvirtEventChan,
+				)
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Populating the domain cache with an initial libvirt lifecycle event")
+				libvirtEventChan <- LibvirtEvent{Event: &libvirt.DomainEventLifecycle{Event: libvirt.DOMAIN_EVENT_STARTED}, Domain: "test_domain"}
+
+				// Wait for (and drain) the event triggered by the initial
+				// lifecycle event to guarantee the cache is populated before the
+				// reconnect is triggered.
+				var initialEvent watch.Event
+				Eventually(eventChan, 2*time.Second).Should(Receive(&initialEvent))
+				Expect(initialEvent.Type).To(Equal(watch.Modified))
+
+				By("Triggering a libvirt reconnect")
+				Expect(reconnectChan).ToNot(BeNil())
+				reconnectChan <- true
+
+				By("Verifying a reconciliation event is sent to virt-handler")
+				var event watch.Event
+				Eventually(eventChan, 2*time.Second).Should(Receive(&event))
+				Expect(event.Type).To(Equal(watch.Modified))
+				newDomain, ok := event.Object.(*api.Domain)
+				Expect(ok).To(BeTrue())
+				Expect(newDomain.Status.Status).To(Equal(api.Running))
+
+				By("Verifying the reconnect event carries the same domain as the initial event")
+				initialDomain, ok := initialEvent.Object.(*api.Domain)
+				Expect(ok).To(BeTrue())
+				Expect(initialEvent.Type).To(Equal(event.Type))
+				Expect(equality.Semantic.DeepEqual(initialDomain, newDomain)).To(BeTrue(),
+					"reconnect reconciliation should re-send the cached domain unchanged")
+			})
 		})
 
 		It("should receive a delete event when a VirtualMachineInstance is undefined",
@@ -144,7 +271,7 @@ var _ = Describe("Notify", func() {
 				mockLibvirt.DomainEXPECT().GetState().Return(libvirt.DOMAIN_NOSTATE, -1, libvirt.Error{Code: libvirt.ERR_NO_DOMAIN})
 				mockLibvirt.DomainEXPECT().GetName().Return("test", nil).AnyTimes()
 
-				e.eventCallback(mockLibvirt.VirtConnection, util.NewDomainFromName("test", "1234"), libvirtEvent{Event: &libvirt.DomainEventLifecycle{Event: libvirt.DOMAIN_EVENT_UNDEFINED}}, client, deleteNotificationSent, nil, nil, nil, nil, metadataCache(), false)
+				e.eventCallback(mockLibvirt.VirtConnection, util.NewDomainFromName("test", "1234"), LibvirtEvent{Event: &libvirt.DomainEventLifecycle{Event: libvirt.DOMAIN_EVENT_UNDEFINED}}, client, deleteNotificationSent, nil, nil, nil, nil, metadataCache(), false)
 
 				timedOut := false
 				timeout := time.After(2 * time.Second)
@@ -184,7 +311,7 @@ var _ = Describe("Notify", func() {
 					},
 				}
 
-				e.eventCallback(mockLibvirt.VirtConnection, util.NewDomainFromName("test", "1234"), libvirtEvent{}, client, deleteNotificationSent, interfaceStatus, nil, nil, nil, metadataCache(), false)
+				e.eventCallback(mockLibvirt.VirtConnection, util.NewDomainFromName("test", "1234"), LibvirtEvent{}, client, deleteNotificationSent, interfaceStatus, nil, nil, nil, metadataCache(), false)
 
 				timedOut := false
 				timeout := time.After(2 * time.Second)
@@ -215,7 +342,7 @@ var _ = Describe("Notify", func() {
 					Name: guestOsName,
 				}
 
-				e.eventCallback(mockLibvirt.VirtConnection, util.NewDomainFromName("test", "1234"), libvirtEvent{}, client, deleteNotificationSent, nil, &osInfoStatus, nil, nil, metadataCache(), false)
+				e.eventCallback(mockLibvirt.VirtConnection, util.NewDomainFromName("test", "1234"), LibvirtEvent{}, client, deleteNotificationSent, nil, &osInfoStatus, nil, nil, metadataCache(), false)
 
 				timedOut := false
 				timeout := time.After(2 * time.Second)
@@ -245,7 +372,7 @@ var _ = Describe("Notify", func() {
 					Status: fsFrozenStatus,
 				}
 
-				e.eventCallback(mockLibvirt.VirtConnection, util.NewDomainFromName("test", "1234"), libvirtEvent{}, client, deleteNotificationSent, nil, nil, nil, &fsFreezeStatus, metadataCache(), false)
+				e.eventCallback(mockLibvirt.VirtConnection, util.NewDomainFromName("test", "1234"), LibvirtEvent{}, client, deleteNotificationSent, nil, nil, nil, &fsFreezeStatus, metadataCache(), false)
 
 				timedOut := false
 				timeout := time.After(2 * time.Second)
@@ -286,7 +413,7 @@ var _ = Describe("Notify", func() {
 
 			metadataCache := metadata.NewCache()
 			interfaceStatus := []api.InterfaceStatus{{Ip: "10.0.0.1", InterfaceName: "eth0"}}
-			e.eventCallback(mockLibvirt.VirtConnection, domain, libvirtEvent{}, client, deleteNotificationSent, interfaceStatus, nil, vmi, nil, metadataCache, false)
+			e.eventCallback(mockLibvirt.VirtConnection, domain, LibvirtEvent{}, client, deleteNotificationSent, interfaceStatus, nil, vmi, nil, metadataCache, false)
 
 			var event watch.Event
 			Eventually(eventChan, 2*time.Second).Should(Receive(&event))
@@ -325,7 +452,7 @@ var _ = Describe("Notify", func() {
 
 			metadataCache := metadata.NewCache()
 			metadataCache.Backup.Store(api.BackupMetadata{})
-			libvirtEvent := libvirtEvent{
+			libvirtEvent := LibvirtEvent{
 				JobCompletedEvent: &libvirt.DomainEventJobCompleted{
 					Info: domainJobInfo,
 				},
@@ -432,7 +559,7 @@ var _ = Describe("Notify", func() {
 			eventReason := "IOerror"
 			eventMessage := "VM Paused due to not enough space on volume: "
 			metadataCache := metadata.NewCache()
-			e.eventCallback(mockLibvirt.VirtConnection, domain, libvirtEvent{}, client, deleteNotificationSent, nil, nil, vmi, nil, metadataCache, false)
+			e.eventCallback(mockLibvirt.VirtConnection, domain, LibvirtEvent{}, client, deleteNotificationSent, nil, nil, vmi, nil, metadataCache, false)
 			event := <-recorder.Events
 			Expect(event).To(Equal(fmt.Sprintf("%s %s %s involvedObject{kind=VirtualMachineInstance,apiVersion=kubevirt.io/v1}", eventType, eventReason, eventMessage)))
 		})

--- a/pkg/virt-launcher/virtwrap/api/schema.go
+++ b/pkg/virt-launcher/virtwrap/api/schema.go
@@ -54,6 +54,10 @@ const (
 	Shutoff     LifeCycle = "Shutoff"
 	Crashed     LifeCycle = "Crashed"
 	PMSuspended LifeCycle = "PMSuspended"
+	// Unknown indicates the domain exists but its virt-launcher is
+	// unreachable (e.g. during NFS failover). Prevents spurious deletions
+	// during informer re-lists.
+	Unknown LifeCycle = "Unknown"
 
 	// Common reasons
 	ReasonUnknown StateChangeReason = "Unknown"

--- a/pkg/virt-launcher/virtwrap/cli/libvirt.go
+++ b/pkg/virt-launcher/virtwrap/cli/libvirt.go
@@ -596,8 +596,8 @@ func (l *LibvirtConnection) reconnectIfNecessary() (err error) {
 
 	if l.reconnect != nil {
 		// Notify the callback about the reconnect through channel.
-		// This way we give the callback a chance to emit an error to the watcher
-		// ListWatcher will re-register automatically afterwards
+		// The callback triggers an immediate domain state reconciliation
+		// via eventCallback, sending a watch.Modified event to virt-handler.
 		l.reconnect <- true
 	}
 	return nil


### PR DESCRIPTION
### What this PR does
This is manual cherry-pick of https://github.com/kubevirt/kubevirt/pull/17752 & https://github.com/kubevirt/kubevirt/pull/18813. 

There are couple of deviations from the original 17752:
1. Wording of first commit, the issue is general, therefore the commit message was reworded 
2. First commit, the test "should send watch.Modified event on libvirt reconnect when domain cache is populated" now exercise the e2e path rather than calling the callback.
3. First commit, the test "should not send watch.Error event on libvirt reconnect" is using shorter timeout
4. The second commit doesn't include `The sync function in vm.go is updated to skip processing for domains
with Unknown status, letting the existing handleResync and
handleStaleSocketConnections mechanisms handle convergence when the
launcher becomes reachable again or is confirmed dead.
`
5. The second commit contains simplification from #18813 
6. The second commit contains fix from #18813 that closes client right away

### Special notes for your reviewer

<!-- optional -->


### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Bug fix: VMs are no longer incorrectly restarted during temporary unavailability of virt-launcher or libvirt restart( e.g., NFS server failover).
```

