### PR TITLE
storage: Enable gating for unexpected virt launcher errors

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -106,6 +106,7 @@ case "$TARGET" in
     export KUBEVIRT_STORAGE="rook-ceph-default"
     export KUBEVIRT_DEPLOY_NFS_CSI=true
     export KUBEVIRT_WITH_ETC_CAPACITY="1G"
+    export FAIL_ON_VM_LOG_ERRORS=true
     ;;
   *sig-compute-realtime*)
     export KUBEVIRT_PROVIDER=${TARGET/-sig-compute-realtime/}


### PR DESCRIPTION
### What this PR does

Enable assert unexpected virt-launcher errors gating for sig-storage lanes.
This switches for collect only to gating,
i.e in case an unexpected virt-launcher error is detected, on a passed test,
the test will marked as a failure, and artifacts would be collected, as any error.

This will allow avoiding regression of newly introduced errors, keeping the logs healthy,
improving SnR and potentially help finding new issues.

Mechanism:  https://github.com/kubevirt/kubevirt/pull/16815

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

