### PR TITLE
Accept a per-VMI VMStatsRequest body in virt-handler GetVMStats

### DIFF
--- a/cmd/virt-handler/virt-handler.go
+++ b/cmd/virt-handler/virt-handler.go
@@ -698,7 +698,7 @@ func (app *virtHandlerApp) runVMStatsServer(vmStatsHandler *rest.VMStatsHandler)
 	mux := restful.NewContainer()
 	webService := new(restful.WebService)
 	webService.Path("/").Consumes(restful.MIME_JSON).Produces(restful.MIME_JSON)
-	webService.Route(webService.GET("/v1/vmstats").
+	webService.Route(webService.POST("/v1/vmstats").
 		To(vmStatsHandler.GetVMStats).
 		Produces(restful.MIME_JSON).
 		Consumes(restful.MIME_JSON).

--- a/pkg/virt-handler/rest/vmstats.go
+++ b/pkg/virt-handler/rest/vmstats.go
@@ -48,7 +48,7 @@ var _ collector.MetricsScraper = &VMStatsScraper{}
 type VMStatsScraper struct {
 	ch        chan *vmStatsChannelResult
 	newClient func(string) (cmdclient.LauncherClient, error)
-	request   *cmdv1.VMStatsRequest
+	requests  map[string]*cmdv1.VMStatsRequest
 }
 
 type vmStatsChannelResult struct {
@@ -57,17 +57,23 @@ type vmStatsChannelResult struct {
 	errMsg string
 }
 
-func NewVMStatsScraper(channelLength int, newClient func(string) (cmdclient.LauncherClient, error), request *cmdv1.VMStatsRequest) *VMStatsScraper {
+func NewVMStatsScraper(channelLength int, newClient func(string) (cmdclient.LauncherClient, error), requests map[string]*cmdv1.VMStatsRequest) *VMStatsScraper {
 	return &VMStatsScraper{
 		ch:        make(chan *vmStatsChannelResult, channelLength),
 		newClient: newClient,
-		request:   request,
+		requests:  requests,
 	}
 }
 
 func (s *VMStatsScraper) Scrape(socketFile string, vmi *v1.VirtualMachineInstance) {
 	ts := time.Now()
 	key := fmt.Sprintf("%s/%s", vmi.Namespace, vmi.Name)
+
+	req, ok := s.requests[key]
+	if !ok {
+		s.ch <- &vmStatsChannelResult{key: key, errMsg: "no stats request configured for VMI"}
+		return
+	}
 
 	cli, err := s.newClient(socketFile)
 	if err != nil {
@@ -77,7 +83,7 @@ func (s *VMStatsScraper) Scrape(socketFile string, vmi *v1.VirtualMachineInstanc
 	}
 	defer cli.Close()
 
-	vmStats, err := cli.GetVMStats(s.request)
+	vmStats, err := cli.GetVMStats(req)
 	if err != nil {
 		log.Log.Object(vmi).Reason(err).Error("Failed to get VM stats")
 		s.ch <- &vmStatsChannelResult{key: key, errMsg: err.Error()}

--- a/pkg/virt-handler/rest/vmstats.go
+++ b/pkg/virt-handler/rest/vmstats.go
@@ -21,6 +21,7 @@ package rest
 
 import (
 	"fmt"
+	"maps"
 	"net/http"
 	"time"
 
@@ -139,24 +140,43 @@ func (h *VMStatsHandler) GetVMStats(request *restful.Request, response *restful.
 		return
 	}
 
-	statsRequest := buildVMStatsRequestFromQuery(request)
-	if *statsRequest == (cmdv1.VMStatsRequest{}) {
-		response.WriteError(http.StatusBadRequest, fmt.Errorf("at least one stats category must be requested via query parameters"))
+	requests, err := parseVMStatsRequests(request)
+	if err != nil {
+		response.WriteError(http.StatusBadRequest, fmt.Errorf("failed to parse request body: %v", err))
 		return
 	}
-
-	items := h.vmiStore.List()
-	vmis := make([]*v1.VirtualMachineInstance, 0, len(items))
-	for _, obj := range items {
-		if vmi, ok := obj.(*v1.VirtualMachineInstance); ok {
-			vmis = append(vmis, vmi)
+	if len(requests) == 0 {
+		response.WriteError(http.StatusBadRequest, fmt.Errorf("at least one VMI must be requested"))
+		return
+	}
+	for key, req := range requests {
+		if req == nil || *req == (cmdv1.VMStatsRequest{}) {
+			response.WriteError(http.StatusBadRequest, fmt.Errorf("at least one stats category must be requested for %q", key))
+			return
 		}
 	}
 
-	scraper := NewVMStatsScraper(len(vmis), cmdclient.NewClient, statsRequest)
+	onNode := make(map[string]*v1.VirtualMachineInstance)
+	for _, obj := range h.vmiStore.List() {
+		if vmi, ok := obj.(*v1.VirtualMachineInstance); ok {
+			onNode[fmt.Sprintf("%s/%s", vmi.Namespace, vmi.Name)] = vmi
+		}
+	}
+
+	results := make(map[string]*VMStatsResult)
+	vmis := make([]*v1.VirtualMachineInstance, 0, len(requests))
+	for key := range requests {
+		if vmi, ok := onNode[key]; ok {
+			vmis = append(vmis, vmi)
+		} else {
+			results[key] = &VMStatsResult{Error: "VMI not found on node"}
+		}
+	}
+
+	scraper := NewVMStatsScraper(len(vmis), cmdclient.NewClient, requests)
 	h.collector.Collect(vmis, scraper, collector.CollectionTimeout)
 
-	results := scraper.GetValues()
+	maps.Copy(results, scraper.GetValues())
 
 	for _, vmi := range vmis {
 		key := fmt.Sprintf("%s/%s", vmi.Namespace, vmi.Name)
@@ -168,64 +188,12 @@ func (h *VMStatsHandler) GetVMStats(request *restful.Request, response *restful.
 	response.WriteEntity(results)
 }
 
-func buildVMStatsRequestFromQuery(request *restful.Request) *cmdv1.VMStatsRequest {
-	query := request.Request.URL.Query()
-	req := &cmdv1.VMStatsRequest{}
-
-	if query.Get("domainStats") == "true" {
-		req.DomainStats = &cmdv1.DomainStatsRequest{}
+func parseVMStatsRequests(request *restful.Request) (map[string]*cmdv1.VMStatsRequest, error) {
+	body := struct {
+		VMIs map[string]*cmdv1.VMStatsRequest `json:"vmis"`
+	}{}
+	if err := request.ReadEntity(&body); err != nil {
+		return nil, err
 	}
-	if query.Get("dirtyRate") == "true" {
-		req.DirtyRate = &cmdv1.DirtyRateRequest{}
-	}
-	if query.Get("guestGetLoad") == "true" {
-		req.GuestGetLoad = &cmdv1.AgentLoadRequest{}
-	}
-	if query.Get("guestGetCpuStats") == "true" {
-		req.GuestGetCpuStats = &cmdv1.AgentCpuStatsRequest{}
-	}
-	if query.Get("guestGetDiskStats") == "true" {
-		req.GuestGetDiskStats = &cmdv1.AgentDiskStatsRequest{}
-	}
-	if query.Get("guestGetTime") == "true" {
-		req.GuestGetTime = &cmdv1.AgentTimeRequest{}
-	}
-	if query.Get("guestGetVcpus") == "true" {
-		req.GuestGetVcpus = &cmdv1.AgentVcpusRequest{}
-	}
-	if query.Get("guestGetMemoryBlockInfo") == "true" {
-		req.GuestGetMemoryBlockInfo = &cmdv1.AgentMemoryBlockInfoRequest{}
-	}
-	if query.Get("guestGetUsers") == "true" {
-		req.GuestGetUsers = &cmdv1.AgentUsersRequest{}
-	}
-	if query.Get("guestGetOsInfo") == "true" {
-		req.GuestGetOsInfo = &cmdv1.AgentOsInfoRequest{}
-	}
-	if query.Get("guestGetDisks") == "true" {
-		req.GuestGetDisks = &cmdv1.AgentDisksRequest{}
-	}
-	if query.Get("guestGetHostName") == "true" {
-		req.GuestGetHostName = &cmdv1.AgentHostNameRequest{}
-	}
-	if query.Get("guestGetTimezone") == "true" {
-		req.GuestGetTimezone = &cmdv1.AgentTimezoneRequest{}
-	}
-	if query.Get("guestNetworkGetRoute") == "true" {
-		req.GuestNetworkGetRoute = &cmdv1.AgentNetworkRouteRequest{}
-	}
-	if query.Get("guestNetworkGetInterfaces") == "true" {
-		req.GuestNetworkGetInterfaces = &cmdv1.AgentNetworkInterfacesRequest{}
-	}
-	if query.Get("guestGetMemoryBlocks") == "true" {
-		req.GuestGetMemoryBlocks = &cmdv1.AgentMemoryBlocksRequest{}
-	}
-	if query.Get("guestGetFsInfo") == "true" {
-		req.GuestGetFsInfo = &cmdv1.AgentFsInfoRequest{}
-	}
-	if query.Get("guestGetDevices") == "true" {
-		req.GuestGetDevices = &cmdv1.AgentDevicesRequest{}
-	}
-
-	return req
+	return body.VMIs, nil
 }

--- a/pkg/virt-handler/rest/vmstats_test.go
+++ b/pkg/virt-handler/rest/vmstats_test.go
@@ -144,6 +144,33 @@ var _ = Describe("VMStats handler", func() {
 		Expect(recorder.Body.String()).To(MatchJSON(
 			`{"default/test-vm":{"error":"stats not available: VMI socket not found or busy"}}`))
 	})
+
+	It("should only report the VMI named in the body when others are in the store", func() {
+		enableFeatureGate()
+		Expect(vmiStore.Add(&v1.VirtualMachineInstance{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "vm1"},
+		})).To(Succeed())
+		Expect(vmiStore.Add(&v1.VirtualMachineInstance{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "vm2"},
+		})).To(Succeed())
+
+		recorder := makeRequest(`{"vmis":{"default/vm1":{"domainStats":{}}}}`)
+		Expect(recorder.Code).To(Equal(http.StatusOK))
+		Expect(recorder.Body.String()).To(MatchJSON(
+			`{"default/vm1":{"error":"stats not available: VMI socket not found or busy"}}`))
+	})
+
+	It("should report per-VMI results when one requested VMI is on-node and another is not", func() {
+		enableFeatureGate()
+		Expect(vmiStore.Add(&v1.VirtualMachineInstance{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "on-node-vm"},
+		})).To(Succeed())
+
+		recorder := makeRequest(`{"vmis":{"default/on-node-vm":{"domainStats":{}},"default/missing-vm":{"domainStats":{}}}}`)
+		Expect(recorder.Code).To(Equal(http.StatusOK))
+		Expect(recorder.Body.String()).To(MatchJSON(
+			`{"default/on-node-vm":{"error":"stats not available: VMI socket not found or busy"},"default/missing-vm":{"error":"VMI not found on node"}}`))
+	})
 })
 
 var _ = Describe("parseVMStatsRequests", func() {

--- a/pkg/virt-handler/rest/vmstats_test.go
+++ b/pkg/virt-handler/rest/vmstats_test.go
@@ -219,7 +219,7 @@ var _ = Describe("VMStatsScraper", func() {
 		ctrl.Finish()
 	})
 
-	It("should collect stats using the provided request", func() {
+	It("should collect stats using the request configured for the VMI", func() {
 		expectedStats := &stats.VMStats{
 			DomainStats: stats.DomainStats{
 				Name: "default_test-vm",
@@ -237,13 +237,14 @@ var _ = Describe("VMStatsScraper", func() {
 		)
 		mockClient.EXPECT().Close()
 
-		request := &cmdv1.VMStatsRequest{DomainStats: &cmdv1.DomainStatsRequest{}}
+		requests := map[string]*cmdv1.VMStatsRequest{
+			"default/test-vm": {DomainStats: &cmdv1.DomainStatsRequest{}},
+		}
 		scraper := NewVMStatsScraper(1, func(socketFile string) (cmdclient.LauncherClient, error) {
 			return mockClient, nil
-		}, request)
+		}, requests)
 
-		vmi := newVMI("default", "test-vm")
-		scraper.Scrape("/some/socket", vmi)
+		scraper.Scrape("/some/socket", newVMI("default", "test-vm"))
 		scraper.Complete()
 
 		results := scraper.GetValues()
@@ -253,16 +254,79 @@ var _ = Describe("VMStatsScraper", func() {
 		Expect(results["default/test-vm"].Error).To(BeEmpty())
 	})
 
+	It("should send each VMI its own request", func() {
+		ctrl2 := gomock.NewController(GinkgoT())
+		mockClient2 := cmdclient.NewMockLauncherClient(ctrl2)
+
+		mockClient.EXPECT().GetVMStats(gomock.Any()).DoAndReturn(
+			func(req *cmdv1.VMStatsRequest) (*stats.VMStats, error) {
+				Expect(req.DomainStats).ToNot(BeNil())
+				Expect(req.DirtyRate).To(BeNil())
+				return &stats.VMStats{DomainStats: stats.DomainStats{Name: "default_vm1"}}, nil
+			},
+		)
+		mockClient.EXPECT().Close()
+		mockClient2.EXPECT().GetVMStats(gomock.Any()).DoAndReturn(
+			func(req *cmdv1.VMStatsRequest) (*stats.VMStats, error) {
+				Expect(req.DirtyRate).ToNot(BeNil())
+				Expect(req.DomainStats).To(BeNil())
+				return &stats.VMStats{DomainStats: stats.DomainStats{Name: "default_vm2"}}, nil
+			},
+		)
+		mockClient2.EXPECT().Close()
+
+		requests := map[string]*cmdv1.VMStatsRequest{
+			"default/vm1": {DomainStats: &cmdv1.DomainStatsRequest{}},
+			"default/vm2": {DirtyRate: &cmdv1.DirtyRateRequest{}},
+		}
+		callCount := 0
+		scraper := NewVMStatsScraper(2, func(socketFile string) (cmdclient.LauncherClient, error) {
+			callCount++
+			if socketFile == "/socket/1" {
+				return mockClient, nil
+			}
+			return mockClient2, nil
+		}, requests)
+
+		scraper.Scrape("/socket/1", newVMI("default", "vm1"))
+		scraper.Scrape("/socket/2", newVMI("default", "vm2"))
+		scraper.Complete()
+
+		results := scraper.GetValues()
+		Expect(results).To(HaveLen(2))
+		Expect(results["default/vm1"].Error).To(BeEmpty())
+		Expect(results["default/vm2"].Error).To(BeEmpty())
+
+		ctrl2.Finish()
+	})
+
+	It("should report an error when no request is configured for the VMI", func() {
+		scraper := NewVMStatsScraper(1, func(socketFile string) (cmdclient.LauncherClient, error) {
+			Fail("newClient should not be called when no request is configured")
+			return nil, nil
+		}, map[string]*cmdv1.VMStatsRequest{})
+
+		scraper.Scrape("/some/socket", newVMI("default", "test-vm"))
+		scraper.Complete()
+
+		results := scraper.GetValues()
+		Expect(results).To(HaveLen(1))
+		Expect(results["default/test-vm"].Stats).To(BeNil())
+		Expect(results["default/test-vm"].Error).To(Equal("no stats request configured for VMI"))
+	})
+
 	It("should report error when gRPC call fails", func() {
 		mockClient.EXPECT().GetVMStats(gomock.Any()).Return(nil, fmt.Errorf("gRPC connection failed"))
 		mockClient.EXPECT().Close()
 
+		requests := map[string]*cmdv1.VMStatsRequest{
+			"default/test-vm": {DomainStats: &cmdv1.DomainStatsRequest{}},
+		}
 		scraper := NewVMStatsScraper(1, func(socketFile string) (cmdclient.LauncherClient, error) {
 			return mockClient, nil
-		}, &cmdv1.VMStatsRequest{DomainStats: &cmdv1.DomainStatsRequest{}})
+		}, requests)
 
-		vmi := newVMI("default", "test-vm")
-		scraper.Scrape("/some/socket", vmi)
+		scraper.Scrape("/some/socket", newVMI("default", "test-vm"))
 		scraper.Complete()
 
 		results := scraper.GetValues()
@@ -272,56 +336,19 @@ var _ = Describe("VMStatsScraper", func() {
 	})
 
 	It("should report error when client creation fails", func() {
+		requests := map[string]*cmdv1.VMStatsRequest{
+			"default/test-vm": {DomainStats: &cmdv1.DomainStatsRequest{}},
+		}
 		scraper := NewVMStatsScraper(1, func(socketFile string) (cmdclient.LauncherClient, error) {
 			return nil, fmt.Errorf("socket not found")
-		}, &cmdv1.VMStatsRequest{DomainStats: &cmdv1.DomainStatsRequest{}})
+		}, requests)
 
-		vmi := newVMI("default", "test-vm")
-		scraper.Scrape("/some/socket", vmi)
+		scraper.Scrape("/some/socket", newVMI("default", "test-vm"))
 		scraper.Complete()
 
 		results := scraper.GetValues()
 		Expect(results).To(HaveLen(1))
 		Expect(results["default/test-vm"].Stats).To(BeNil())
 		Expect(results["default/test-vm"].Error).To(Equal("socket not found"))
-	})
-
-	It("should collect stats from multiple VMIs with partial failure", func() {
-		successStats := &stats.VMStats{
-			DomainStats: stats.DomainStats{Name: "default_vm1"},
-		}
-
-		ctrl2 := gomock.NewController(GinkgoT())
-		mockClient2 := cmdclient.NewMockLauncherClient(ctrl2)
-
-		mockClient.EXPECT().GetVMStats(gomock.Any()).Return(successStats, nil)
-		mockClient.EXPECT().Close()
-		mockClient2.EXPECT().GetVMStats(gomock.Any()).Return(nil, fmt.Errorf("vmi shutting down"))
-		mockClient2.EXPECT().Close()
-
-		callCount := 0
-		scraper := NewVMStatsScraper(2, func(socketFile string) (cmdclient.LauncherClient, error) {
-			callCount++
-			if callCount == 1 {
-				return mockClient, nil
-			}
-			return mockClient2, nil
-		}, &cmdv1.VMStatsRequest{DomainStats: &cmdv1.DomainStatsRequest{}})
-
-		scraper.Scrape("/socket/1", newVMI("default", "vm1"))
-		scraper.Scrape("/socket/2", newVMI("default", "vm2"))
-		scraper.Complete()
-
-		results := scraper.GetValues()
-		Expect(results).To(HaveLen(2))
-
-		Expect(results["default/vm1"].Stats).ToNot(BeNil())
-		Expect(results["default/vm1"].Stats.DomainStats.Name).To(Equal("default_vm1"))
-		Expect(results["default/vm1"].Error).To(BeEmpty())
-
-		Expect(results["default/vm2"].Stats).To(BeNil())
-		Expect(results["default/vm2"].Error).To(Equal("vmi shutting down"))
-
-		ctrl2.Finish()
 	})
 })

--- a/pkg/virt-handler/rest/vmstats_test.go
+++ b/pkg/virt-handler/rest/vmstats_test.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 
 	"github.com/emicklei/go-restful/v3"
 	. "github.com/onsi/ginkgo/v2"
@@ -50,18 +51,16 @@ var _ = Describe("VMStats handler", func() {
 		handler  *VMStatsHandler
 	)
 
-	makeRequest := func(queryString ...string) *httptest.ResponseRecorder {
-		url := "/v1/vmstats"
-		if len(queryString) > 0 {
-			url += queryString[0]
-		}
-		httpReq, _ := http.NewRequest("GET", url, nil)
+	makeRequest := func(body string) *httptest.ResponseRecorder {
+		httpReq, _ := http.NewRequest("POST", "/v1/vmstats", strings.NewReader(body))
+		httpReq.Header.Set("Content-Type", "application/json")
 		httpReq.Header.Set("Accept", "application/json")
 
 		recorder := httptest.NewRecorder()
 
 		ws := new(restful.WebService)
-		ws.Route(ws.GET("/v1/vmstats").To(handler.GetVMStats).Produces(restful.MIME_JSON))
+		ws.Route(ws.POST("/v1/vmstats").To(handler.GetVMStats).
+			Consumes(restful.MIME_JSON).Produces(restful.MIME_JSON))
 
 		container := restful.NewContainer()
 		container.Add(ws)
@@ -110,87 +109,69 @@ var _ = Describe("VMStats handler", func() {
 
 	It("should return 403 when feature gate is disabled", func() {
 		disableFeatureGate()
-		recorder := makeRequest()
+		recorder := makeRequest(`{"vmis":{"default/test-vm":{"domainStats":{}}}}`)
 		Expect(recorder.Code).To(Equal(http.StatusForbidden))
 	})
 
-	It("should return 400 when no stats categories are requested", func() {
+	It("should return 400 when the body has no VMIs", func() {
 		enableFeatureGate()
-		recorder := makeRequest()
+		recorder := makeRequest(`{"vmis":{}}`)
 		Expect(recorder.Code).To(Equal(http.StatusBadRequest))
 	})
 
-	It("should return 200 when valid query params are provided", func() {
+	It("should return 400 when a VMI requests no stats categories", func() {
 		enableFeatureGate()
-		recorder := makeRequest("?domainStats=true")
-		Expect(recorder.Code).To(Equal(http.StatusOK))
-		Expect(recorder.Body.String()).To(MatchJSON(`{}`))
+		recorder := makeRequest(`{"vmis":{"default/test-vm":{}}}`)
+		Expect(recorder.Code).To(Equal(http.StatusBadRequest))
 	})
 
+	It("should report VMI not found on node for keys absent from the store", func() {
+		enableFeatureGate()
+		recorder := makeRequest(`{"vmis":{"default/missing-vm":{"domainStats":{}}}}`)
+		Expect(recorder.Code).To(Equal(http.StatusOK))
+		Expect(recorder.Body.String()).To(MatchJSON(
+			`{"default/missing-vm":{"error":"VMI not found on node"}}`))
+	})
+
+	It("should report stats not available for an on-node VMI with no socket", func() {
+		enableFeatureGate()
+		Expect(vmiStore.Add(&v1.VirtualMachineInstance{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "test-vm"},
+		})).To(Succeed())
+
+		recorder := makeRequest(`{"vmis":{"default/test-vm":{"domainStats":{}}}}`)
+		Expect(recorder.Code).To(Equal(http.StatusOK))
+		Expect(recorder.Body.String()).To(MatchJSON(
+			`{"default/test-vm":{"error":"stats not available: VMI socket not found or busy"}}`))
+	})
 })
 
-var _ = Describe("buildVMStatsRequestFromQuery", func() {
-	buildRequest := func(queryString string) *cmdv1.VMStatsRequest {
-		httpReq, _ := http.NewRequest("GET", "/v1/vmstats"+queryString, nil)
-		restReq := restful.NewRequest(httpReq)
-		return buildVMStatsRequestFromQuery(restReq)
+var _ = Describe("parseVMStatsRequests", func() {
+	parse := func(body string) (map[string]*cmdv1.VMStatsRequest, error) {
+		httpReq, _ := http.NewRequest("POST", "/v1/vmstats", strings.NewReader(body))
+		httpReq.Header.Set("Content-Type", "application/json")
+		return parseVMStatsRequests(restful.NewRequest(httpReq))
 	}
 
-	It("should return empty request when no query params are provided", func() {
-		req := buildRequest("")
-		Expect(req.DomainStats).To(BeNil())
-		Expect(req.DirtyRate).To(BeNil())
-		Expect(req.GuestGetLoad).To(BeNil())
+	It("should decode a per-VMI request map", func() {
+		requests, err := parse(`{"vmis":{"default/vm1":{"domainStats":{}},"default/vm2":{"dirtyRate":{}}}}`)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(requests).To(HaveLen(2))
+		Expect(requests["default/vm1"].DomainStats).ToNot(BeNil())
+		Expect(requests["default/vm1"].DirtyRate).To(BeNil())
+		Expect(requests["default/vm2"].DirtyRate).ToNot(BeNil())
+		Expect(requests["default/vm2"].DomainStats).To(BeNil())
 	})
 
-	It("should return only requested fields", func() {
-		req := buildRequest("?domainStats=true&guestGetLoad=true")
-		Expect(req.DomainStats).ToNot(BeNil())
-		Expect(req.GuestGetLoad).ToNot(BeNil())
-
-		Expect(req.DirtyRate).To(BeNil())
-		Expect(req.GuestGetCpuStats).To(BeNil())
-		Expect(req.GuestGetDiskStats).To(BeNil())
-		Expect(req.GuestGetTime).To(BeNil())
-		Expect(req.GuestGetVcpus).To(BeNil())
-		Expect(req.GuestGetMemoryBlockInfo).To(BeNil())
-		Expect(req.GuestGetUsers).To(BeNil())
-		Expect(req.GuestGetOsInfo).To(BeNil())
-		Expect(req.GuestGetDisks).To(BeNil())
-		Expect(req.GuestGetHostName).To(BeNil())
-		Expect(req.GuestGetTimezone).To(BeNil())
-		Expect(req.GuestNetworkGetRoute).To(BeNil())
-		Expect(req.GuestNetworkGetInterfaces).To(BeNil())
-		Expect(req.GuestGetMemoryBlocks).To(BeNil())
-		Expect(req.GuestGetFsInfo).To(BeNil())
-		Expect(req.GuestGetDevices).To(BeNil())
+	It("should return an empty map when no vmis are provided", func() {
+		requests, err := parse(`{"vmis":{}}`)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(requests).To(BeEmpty())
 	})
 
-	It("should enable guestGetFsInfo", func() {
-		req := buildRequest("?guestGetFsInfo=true")
-		Expect(req.GuestGetFsInfo).ToNot(BeNil())
-		Expect(req.DomainStats).To(BeNil())
-		Expect(req.GuestGetLoad).To(BeNil())
-	})
-
-	It("should enable guestGetDevices", func() {
-		req := buildRequest("?guestGetDevices=true")
-		Expect(req.GuestGetDevices).ToNot(BeNil())
-		Expect(req.DomainStats).To(BeNil())
-		Expect(req.GuestGetLoad).To(BeNil())
-	})
-
-	It("should ignore params with non-true values", func() {
-		req := buildRequest("?domainStats=false&guestGetLoad=yes")
-		Expect(req.DomainStats).To(BeNil())
-		Expect(req.GuestGetLoad).To(BeNil())
-	})
-
-	It("should enable a single field", func() {
-		req := buildRequest("?dirtyRate=true")
-		Expect(req.DirtyRate).ToNot(BeNil())
-		Expect(req.DomainStats).To(BeNil())
-		Expect(req.GuestGetLoad).To(BeNil())
+	It("should return an error for malformed JSON", func() {
+		_, err := parse(`{"vmis":`)
+		Expect(err).To(HaveOccurred())
 	})
 })
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:

Single VMStatsRequest for all VMIs in the virt-handler node

#### After this PR:

virt-handler GetVMStats accepts a per-VMI VMStatsRequest body, allowing the caller to filter which VMIs to collect from and specify the stats categories it needs on a per-VMI basis, rather than one set applied to every VMI on the node, so it can collect different data for different VMIs in a single call.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/143


### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Accept a per-VMI VMStatsRequest body in virt-handler GetVMStats
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Changed the `/v1/vmstats` endpoint from `GET` to `POST`.
  * VM stats requests must now be provided as JSON, specifying request categories for each VMI.
  * Empty requests or requests without stats categories are rejected.
* **Bug Fixes**
  * VMIs can now receive individualized stats requests.
  * Requests for VMIs not present on the node return clear per-VMI errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->