### PR TITLE
Fix getVcpuMask using pid/awk

### DIFF
--- a/tests/vmi_configuration_test.go
+++ b/tests/vmi_configuration_test.go
@@ -1261,7 +1261,7 @@ var _ = Describe("[sig-compute]Configurations", decorators.SigCompute, func() {
 				kvmpitmask, err := getKvmPitMask(strings.TrimSpace(qemuPid), node)
 				Expect(err).ToNot(HaveOccurred())
 
-				vcpuzeromask, err := getVcpuMask(readyPod, emulator, "0")
+				vcpuzeromask, err := getVcpuMask(readyPod, strings.TrimSpace(qemuPid), "0")
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(kvmpitmask).To(Equal(vcpuzeromask))
@@ -1762,8 +1762,8 @@ func getProcessName(pod *k8sv1.Pod, pid string) (output string, err error) {
 	return
 }
 
-func getVcpuMask(pod *k8sv1.Pod, emulator, cpu string) (output string, err error) {
-	pscmd := `ps -LC ` + emulator + ` -o lwp,comm | grep "CPU ` + cpu + `"  | cut -f1 -dC`
+func getVcpuMask(pod *k8sv1.Pod, emulatorPid, cpu string) (output string, err error) {
+	pscmd := `ps -L -o lwp=,comm= -p ` + emulatorPid + ` | grep "CPU ` + cpu + `/KVM" | awk '{print $1}'`
 	args := []string{"/bin/bash", "-c", pscmd}
 	Eventually(func() error {
 		output, err = exec.ExecuteCommandOnPod(pod, "compute", args)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
In CentOS Stream 10, the output format of `ps` or the process naming/path
structure for QEMU/KVM has subtle differences, and using fixed
field cutting with `cut -f1 -dC` relies heavily on exact space alignments
that can easily break between versions.

In CentOS 10, QEMU binaries are named or invoked via qemu-kvm directly without
requiring the full /usr/libexec/ binary match, or the process thread
name may format slightly differently.

Switch using awk to parse white spaces cleanly, match the exact process,
and strip any header line.
Also switch using the emulatorPid(already retrieved).
This makes the function compatible with both cs9 and cs10

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.

- Fixes #
- Partially addresses #
-->
Failures observed in https://github.com/kubevirt/project-infra/pull/5394#issuecomment-5424694917
and periodics https://testgrid.k8s.io/kubevirt-periodics#periodic-kubevirt-e2e-k8s-1.37-sig-compute&width=20
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```

/cc @0xFelix @jean-edouard 