### PR TITLE
Fix no ready alerts to fire only when pods are running but not ready

### DIFF
--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -82,6 +82,16 @@ tests:
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
               namespace: "ci"
+      # NoReady must not overlap with Down when there are no running pods
+      - eval_time: 10m
+        alertname: NoReadyVirtAPI
+        exp_alerts: []
+      - eval_time: 10m
+        alertname: NoReadyVirtController
+        exp_alerts: [ ]
+      - eval_time: 10m
+        alertname: NoReadyVirtHandler
+        exp_alerts: [ ]
       # it must trigger when operators are not healthy
       - eval_time: 16m
         alertname: VirtAPIDown
@@ -131,6 +141,15 @@ tests:
               kubernetes_operator_part_of: "kubevirt"
               kubernetes_operator_component: "kubevirt"
               namespace: "ci"
+      - eval_time: 16m
+        alertname: NoReadyVirtAPI
+        exp_alerts: []
+      - eval_time: 16m
+        alertname: NoReadyVirtController
+        exp_alerts: [ ]
+      - eval_time: 16m
+        alertname: NoReadyVirtHandler
+        exp_alerts: [ ]
       # it must not trigger when operators are healthy
       - eval_time: 17m
         alertname: VirtAPIDown
@@ -394,6 +413,9 @@ tests:
               kubernetes_operator_component: "kubevirt"
               namespace: "ci"
       - eval_time: 10m
+        alertname: VirtAPIDown
+        exp_alerts: [ ]
+      - eval_time: 10m
         alertname: LowReadyVirtAPICount
         exp_alerts: [ ]
 
@@ -454,6 +476,9 @@ tests:
               kubernetes_operator_component: "kubevirt"
               namespace: "ci"
       - eval_time: 10m
+        alertname: VirtHandlerDown
+        exp_alerts: [ ]
+      - eval_time: 10m
         alertname: LowReadyVirtHandlerCount
         exp_alerts: [ ]
 
@@ -485,26 +510,34 @@ tests:
               kubernetes_operator_component: "kubevirt"
               namespace: "ci"
       - eval_time: 10m
+        alertname: VirtControllerDown
+        exp_alerts: [ ]
+      - eval_time: 10m
         alertname: LowReadyVirtControllersCount
         exp_alerts: [ ]
 
-  # All virt controllers are not ready (ImagePullBackOff)
+  # ImagePullBackOff: no running pods is Down, not NoReady
   - interval: 1m
     input_series:
       - series: 'kubevirt_virt_controller_ready_status{namespace="ci", pod="virt-controller-1"}'
         values: "stale stale stale stale stale stale stale stale stale stale"
 
     alert_rule_test:
-      # no alert before 10 minutes
       - eval_time: 9m
         alertname: NoReadyVirtController
         exp_alerts: [ ]
+      - eval_time: 9m
+        alertname: VirtControllerDown
+        exp_alerts: [ ]
       - eval_time: 10m
         alertname: NoReadyVirtController
+        exp_alerts: [ ]
+      - eval_time: 10m
+        alertname: VirtControllerDown
         exp_alerts:
           - exp_annotations:
-              summary: "No ready virt-controller was detected for the last 10 min."
-              runbook_url: "https://kubevirt.io/monitoring/runbooks/NoReadyVirtController"
+              summary: "No running virt-controller was detected for the last 10 min."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/VirtControllerDown"
             exp_labels:
               severity: "critical"
               operator_health_impact: "critical"

--- a/pkg/monitoring/rules/alerts/virt-api.go
+++ b/pkg/monitoring/rules/alerts/virt-api.go
@@ -57,8 +57,11 @@ func virtAPIAlerts(namespace string) []promv1.Rule {
 		},
 		{
 			Alert: "NoReadyVirtAPI",
-			Expr:  intstr.FromString("cluster:kubevirt_virt_api_ready:sum == 0"),
-			For:   ptr.To(promv1.Duration("10m")),
+			Expr: intstr.FromString(
+				"cluster:kubevirt_virt_api_ready:sum == 0 " +
+					"and cluster:kubevirt_virt_api_pods_running:count > 0",
+			),
+			For: ptr.To(promv1.Duration("10m")),
 			Annotations: map[string]string{
 				summaryAnnotationKey: "No ready virt-api was detected for the last 10 min.",
 			},

--- a/pkg/monitoring/rules/alerts/virt-controller.go
+++ b/pkg/monitoring/rules/alerts/virt-controller.go
@@ -45,8 +45,11 @@ func virtControllerAlerts(namespace string) []promv1.Rule {
 		},
 		{
 			Alert: "NoReadyVirtController",
-			Expr:  intstr.FromString("cluster:kubevirt_virt_controller_ready:sum == 0"),
-			For:   ptr.To(promv1.Duration("10m")),
+			Expr: intstr.FromString(
+				"cluster:kubevirt_virt_controller_ready:sum == 0 " +
+					"and cluster:kubevirt_virt_controller_pods_running:count > 0",
+			),
+			For: ptr.To(promv1.Duration("10m")),
 			Annotations: map[string]string{
 				summaryAnnotationKey: "No ready virt-controller was detected for the last 10 min.",
 			},

--- a/pkg/monitoring/rules/alerts/virt-handler.go
+++ b/pkg/monitoring/rules/alerts/virt-handler.go
@@ -57,8 +57,11 @@ func virtHandlerAlerts(namespace string) []promv1.Rule {
 		},
 		{
 			Alert: "NoReadyVirtHandler",
-			Expr:  intstr.FromString("cluster:kubevirt_virt_handler_ready:sum == 0"),
-			For:   ptr.To(promv1.Duration("10m")),
+			Expr: intstr.FromString(
+				"cluster:kubevirt_virt_handler_ready:sum == 0 " +
+					"and cluster:kubevirt_virt_handler_pods_running:count > 0",
+			),
+			For: ptr.To(promv1.Duration("10m")),
 			Annotations: map[string]string{
 				summaryAnnotationKey: "No ready virt-handler was detected for the last 10 min.",
 			},

--- a/tests/monitoring/component_monitoring.go
+++ b/tests/monitoring/component_monitoring.go
@@ -157,12 +157,19 @@ var _ = Describe("[sig-monitoring]Component Monitoring", Serial, Ordered, decora
 			libmonitoring.VerifyAlertExist(virtClient, virtController.downAlert)
 		})
 
-		It("NoReadyVirtController should be triggered when virt-controller is down", func() {
-			By("Scaling down the controller")
-			scales.UpdateScale(virtController.deploymentName, int32(0))
+		It("NoReadyVirtController should be triggered when virt-controller is not ready", func() {
+			original := makeDeploymentNotReady(virtClient, virtController.deploymentName)
+			defer restoreImageAndWaitForAlert(
+				virtClient, virtController.noReadyAlert,
+				"Restoring the virt-controller deployment to the correct image",
+				restoreDeploymentFirstContainer(virtClient, original),
+			)
 
-			By("Waiting for the controller to be down")
-			libmonitoring.WaitForMetricValue(virtClient, "cluster:kubevirt_virt_controller_ready:sum", 0)
+			waitForRunningButNotReady(
+				virtClient,
+				"cluster:kubevirt_virt_controller_ready:sum",
+				"cluster:kubevirt_virt_controller_pods_running:count",
+			)
 
 			By("Verifying the alert exists")
 			libmonitoring.VerifyAlertExist(virtClient, virtController.noReadyAlert)
@@ -179,12 +186,19 @@ var _ = Describe("[sig-monitoring]Component Monitoring", Serial, Ordered, decora
 			libmonitoring.VerifyAlertExist(virtClient, virtAPI.downAlert)
 		})
 
-		It("NoReadyVirtAPI should be triggered when virt-api is down", func() {
-			By("Scaling down the api")
-			scales.UpdateScale(virtAPI.deploymentName, int32(0))
+		It("NoReadyVirtAPI should be triggered when virt-api is not ready", func() {
+			original := makeDeploymentNotReady(virtClient, virtAPI.deploymentName)
+			defer restoreImageAndWaitForAlert(
+				virtClient, virtAPI.noReadyAlert,
+				"Restoring the virt-api deployment to the correct image",
+				restoreDeploymentFirstContainer(virtClient, original),
+			)
 
-			By("Waiting for the api ready metric to be zero")
-			libmonitoring.WaitForMetricValue(virtClient, "cluster:kubevirt_virt_api_ready:sum", 0)
+			waitForRunningButNotReady(
+				virtClient,
+				"cluster:kubevirt_virt_api_ready:sum",
+				"cluster:kubevirt_virt_api_pods_running:count",
+			)
 
 			By("Verifying the alert exists")
 			libmonitoring.VerifyAlertExist(virtClient, virtAPI.noReadyAlert)
@@ -232,18 +246,19 @@ var _ = Describe("[sig-monitoring]Component Monitoring", Serial, Ordered, decora
 				)
 			}()
 
-			badContainer := daemonSet.Spec.Template.Spec.Containers[0]
-			badContainer.Image = libregistry.GetUtilityImageFromRegistry("vm-killer")
-			badContainer.Command = []string{"tail", "-f", "/dev/null"}
-			badContainer.Args = []string{}
-			badContainer.ReadinessProbe = nil
-			badContainer.LivenessProbe = nil
-
+			badContainer := makeContainerNotReady(daemonSet.Spec.Template.Spec.Containers[0])
 			err = patchDaemonSetFirstContainer(virtClient, daemonSet.Name, badContainer)
 			Expect(err).ToNot(HaveOccurred())
 
-			By("Waiting for virt-handler ready metric to be zero")
-			libmonitoring.WaitForMetricValue(virtClient, "cluster:kubevirt_virt_handler_ready:sum", 0)
+			By("Waiting for virt-handler pods to be running but not ready")
+			Eventually(func(g Gomega) {
+				ready, errReady := libmonitoring.GetMetricValueWithLabels(virtClient, "cluster:kubevirt_virt_handler_ready:sum", nil)
+				running, errRunning := libmonitoring.GetMetricValueWithLabels(virtClient, "cluster:kubevirt_virt_handler_pods_running:count", nil)
+				g.Expect(errReady).ToNot(HaveOccurred())
+				g.Expect(errRunning).ToNot(HaveOccurred())
+				g.Expect(ready).To(BeNumerically("==", 0))
+				g.Expect(running).To(BeNumerically(">", 0))
+			}, 5*time.Minute, 2*time.Second).Should(Succeed())
 
 			By("Verifying the alert exists")
 			libmonitoring.VerifyAlertExist(virtClient, virtHandler.noReadyAlert)
@@ -570,6 +585,87 @@ func restoreImageAndWaitForAlert(
 	Expect(doRestore()).ToNot(HaveOccurred())
 	By("Waiting for the low ready alert to not be firing anymore")
 	libmonitoring.WaitUntilAlertDoesNotExist(virtClient, alertName)
+}
+
+func makeDeploymentNotReady(virtClient kubecli.KubevirtClient, deploymentName string) *appsv1.Deployment {
+	ns := flags.KubeVirtInstallNamespace
+	ctx := context.Background()
+
+	deployment, getErr := virtClient.AppsV1().Deployments(ns).Get(ctx, deploymentName, metav1.GetOptions{})
+	Expect(getErr).ToNot(HaveOccurred())
+
+	originalDeployment := deployment.DeepCopy()
+	Expect(patchDeploymentFirstContainer(
+		virtClient,
+		deployment.Name,
+		makeContainerNotReady(deployment.Spec.Template.Spec.Containers[0]),
+	)).To(Succeed())
+
+	return originalDeployment
+}
+
+func waitForRunningButNotReady(virtClient kubecli.KubevirtClient, readyMetric, runningMetric string) {
+	By("Waiting for pods to be running but not ready")
+	Eventually(func(g Gomega) {
+		ready, errReady := libmonitoring.GetMetricValueWithLabels(virtClient, readyMetric, nil)
+		running, errRunning := libmonitoring.GetMetricValueWithLabels(virtClient, runningMetric, nil)
+		g.Expect(errReady).ToNot(HaveOccurred())
+		g.Expect(errRunning).ToNot(HaveOccurred())
+		g.Expect(ready).To(BeNumerically("==", 0))
+		g.Expect(running).To(BeNumerically(">", 0))
+	}, 5*time.Minute, 2*time.Second).Should(Succeed())
+}
+
+func makeContainerNotReady(container corev1.Container) corev1.Container {
+	container.Image = libregistry.GetUtilityImageFromRegistry("vm-killer")
+	container.Command = []string{"tail", "-f", "/dev/null"}
+	container.Args = []string{}
+	container.ReadinessProbe = nil
+	container.LivenessProbe = nil
+	container.StartupProbe = nil
+	return container
+}
+
+func restoreDeploymentFirstContainer(virtClient kubecli.KubevirtClient, original *appsv1.Deployment) func() error {
+	return func() error {
+		return patchDeploymentFirstContainer(
+			virtClient,
+			original.Name,
+			original.Spec.Template.Spec.Containers[0],
+		)
+	}
+}
+
+func patchDeploymentFirstContainer(virtClient kubecli.KubevirtClient, deploymentName string, container corev1.Container) error {
+	ns := flags.KubeVirtInstallNamespace
+	ctx := context.Background()
+
+	deployment, err := virtClient.AppsV1().Deployments(ns).Get(ctx, deploymentName, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+
+	deployment.Spec.Template.Spec.Containers[0] = container
+
+	return mergePatchDeployment(ctx, virtClient, ns, deployment)
+}
+
+func mergePatchDeployment(
+	ctx context.Context,
+	virtClient kubecli.KubevirtClient,
+	ns string,
+	deployment *appsv1.Deployment,
+) error {
+	patchBytes, err := json.Marshal(deployment)
+	if err != nil {
+		return err
+	}
+
+	_, err = virtClient.AppsV1().Deployments(ns).Patch(
+		ctx, deployment.Name, types.MergePatchType, patchBytes, metav1.PatchOptions{},
+	)
+
+	return err
 }
 
 func restoreDaemonSetImage(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
VirtController/Handler/API Down and NoReady alerts fire simultaneously
#### After this PR:
No ready alerts fire only when pods are running but not ready 
### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://redhat.atlassian.net/browse/CNV-95562
``

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix no ready alerts
```

