### PR TITLE
Simplify error message when referencing a DVTemplate disk image from another running VM

### DIFF
--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -2043,9 +2043,26 @@ func (c *VirtualMachineController) syncVirtualMachine(client cmdclient.LauncherC
 		if strings.Contains(err.Error(), "EFI OVMF rom missing") {
 			return &virtLauncherCriticalSecurebootError{fmt.Sprintf("mismatch of Secure Boot setting and bootloaders: %v", err)}
 		}
+		if msg, ok := c.detectDiskWriteLockError(err, vmi); ok {
+			return fmt.Errorf("%s", msg)
+		}
 	}
 
 	return err
+}
+
+func (c *VirtualMachineController) detectDiskWriteLockError(err error, vmi *v1.VirtualMachineInstance) (string, bool) {
+	errMsg := err.Error()
+	if !strings.Contains(errMsg, `Failed to get "write" lock`) &&
+		!strings.Contains(errMsg, "Is another process using the image") {
+		return "", false
+	}
+
+	msg := fmt.Sprintf("failed to start VM %q: a disk image is locked by another process. "+
+		"The PVC may be in use by another VirtualMachine. "+
+		"Each VM needs its own PVC, or the disk must be marked as shareable.", vmi.Name)
+
+	return msg, true
 }
 
 func (c *VirtualMachineController) getPreallocatedVolumes(vmi *v1.VirtualMachineInstance) []string {

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -3875,3 +3875,42 @@ func withFilesystemDevice(deviceName string) libvmi.Option {
 		})
 	}
 }
+
+var _ = Describe("detectDiskWriteLockError", func() {
+	var controller *VirtualMachineController
+	const expectedSubstr = "a disk image is locked by another process"
+
+	BeforeEach(func() {
+		controller = &VirtualMachineController{
+			vmiGlobalStore: cache.NewStore(cache.MetaNamespaceKeyFunc),
+		}
+	})
+
+	It("should not match an empty error", func() {
+		vmi := api2.NewMinimalVMI("testvmi")
+		_, ok := controller.detectDiskWriteLockError(fmt.Errorf(""), vmi)
+		Expect(ok).To(BeFalse())
+	})
+
+	It("should not match an unrelated error", func() {
+		vmi := api2.NewMinimalVMI("testvmi")
+		_, ok := controller.detectDiskWriteLockError(fmt.Errorf("some other error"), vmi)
+		Expect(ok).To(BeFalse())
+	})
+
+	It("should return a generic message when there is a write lock", func() {
+		err := fmt.Errorf(`Failed to get "write" lock on /some/unknown/path`)
+		vmi := api2.NewMinimalVMI("testvmi")
+		msg, ok := controller.detectDiskWriteLockError(err, vmi)
+		Expect(ok).To(BeTrue())
+		Expect(msg).To(ContainSubstring(expectedSubstr))
+	})
+
+	It("should return a generic message when another process is using the image", func() {
+		err := fmt.Errorf("Is another process using the image")
+		vmi := api2.NewMinimalVMI("testvmi")
+		msg, ok := controller.detectDiskWriteLockError(err, vmi)
+		Expect(ok).To(BeTrue())
+		Expect(msg).To(ContainSubstring(expectedSubstr))
+	})
+})

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -1092,8 +1092,6 @@ var _ = Describe(SIG("Storage", func() {
 				createAndWaitForVMIReady(vmi2, dv, 500)
 			})
 		})
-<<<<<<< Updated upstream
-=======
 		Context("non-shareable disk conflict", func() {
 			It("should report a clear error when two VMs use the same DataVolume without shareable", decorators.RequiresRWXFilesystemStorage, func() {
 				sc, exists := libstorage.GetRWXFileSystemStorageClass()
@@ -1143,7 +1141,6 @@ var _ = Describe(SIG("Storage", func() {
 				}, time.Second*120, time.Second*5).Should(Succeed())
 			})
 		})
->>>>>>> Stashed changes
 		Context("write and read data from a shared disk", func() {
 			It("should successfully write and read data", decorators.RequiresBlockStorage, func() {
 				const diskName = "disk1"

--- a/tests/storage/storage.go
+++ b/tests/storage/storage.go
@@ -1092,6 +1092,58 @@ var _ = Describe(SIG("Storage", func() {
 				createAndWaitForVMIReady(vmi2, dv, 500)
 			})
 		})
+<<<<<<< Updated upstream
+=======
+		Context("non-shareable disk conflict", func() {
+			It("should report a clear error when two VMs use the same DataVolume without shareable", decorators.RequiresRWXFilesystemStorage, func() {
+				sc, exists := libstorage.GetRWXFileSystemStorageClass()
+				if !exists {
+					Skip("Skip when RWX filesystem storage class is not present")
+				}
+
+				By("Creating a DataVolume")
+				dv := libdv.NewDataVolume(
+					libdv.WithNamespace(testsuite.GetTestNamespace(nil)),
+					libdv.WithRegistryURLSource(cd.DataVolumeImportUrlForContainerDisk(cd.ContainerDiskAlpineTestTooling)),
+					libdv.WithStorage(
+						libdv.StorageWithStorageClass(sc),
+						libdv.StorageWithAccessMode(k8sv1.ReadWriteMany),
+					),
+				)
+
+				By("Creating VM1 that owns the DataVolume via dataVolumeTemplates")
+				vm1 := libstorage.RenderVMWithDataVolumeTemplate(dv, libvmi.WithRunStrategy(v1.RunStrategyAlways))
+				vm1, err = virtClient.VirtualMachine(vm1.Namespace).Create(context.Background(), vm1, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Waiting for VM1's VMI to be running")
+				Eventually(matcher.ThisVMIWith(vm1.Namespace, vm1.Name), time.Second*250, time.Second*5).Should(matcher.BeRunning())
+
+				By("Creating VM2 referencing the same DataVolume by name")
+				vmi2 := libstorage.RenderVMIWithDataVolume(dv.Name, vm1.Namespace)
+				vm2 := libvmi.NewVirtualMachine(vmi2, libvmi.WithRunStrategy(v1.RunStrategyAlways))
+				vm2, err = virtClient.VirtualMachine(vm2.Namespace).Create(context.Background(), vm2, metav1.CreateOptions{})
+				Expect(err).ToNot(HaveOccurred())
+
+				By("Checking VM2's VMI gets a clear disk local error in its Synchronized condition")
+				Eventually(func(g Gomega) {
+					vmi, err := virtClient.VirtualMachineInstance(vm2.Namespace).Get(context.Background(), vm2.Name, metav1.GetOptions{})
+					g.Expect(err).ToNot(HaveOccurred())
+
+					var syncCond *v1.VirtualMachineInstanceCondition
+					for i := range vmi.Status.Conditions {
+						if vmi.Status.Conditions[i].Type == v1.VirtualMachineInstanceSynchronized {
+							syncCond = &vmi.Status.Conditions[i]
+							break
+						}
+					}
+					g.Expect(syncCond).ToNot(BeNil())
+					g.Expect(syncCond.Status).To(Equal(k8sv1.ConditionFalse))
+					g.Expect(syncCond.Message).To(ContainSubstring("is locked by another process"))
+				}, time.Second*120, time.Second*5).Should(Succeed())
+			})
+		})
+>>>>>>> Stashed changes
 		Context("write and read data from a shared disk", func() {
 			It("should successfully write and read data", decorators.RequiresBlockStorage, func() {
 				const diskName = "disk1"

--- a/tests/vmlogchecker/checker.go
+++ b/tests/vmlogchecker/checker.go
@@ -563,6 +563,11 @@ var VirtLauncherErrorAllowlist = []AllowlistEntry{
 		Regex: regexp.MustCompile(`"level":"error","msg":"internal error: unable to execute QEMU command 'block-job-cancel': Job '[^']+' in state 'concluded' cannot accept command verb 'cancel'"`),
 		SIGs:  SIGCompute | SIGStorage,
 	},
+	{
+		ID:    107,
+		Regex: regexp.MustCompile(`"level":"error","msg":".*QEMU unexpectedly closed the monitor.*Failed to get .*write.* lock.*"`),
+		SIGs:  SIGStorage,
+	},
 }
 
 // errorKeywordPatterns provides broad keyword-based error detection for the


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
This PR simplifies the error message when creating a second VM that references the first VM's DV Template spec name (the same disk image) when using NFS storage class. 

#### Before this PR:
Users would receive a long, unclear error message stating that QEMU is experiencing a write lock.

#### After this PR:
This now appends a simpler error message to the Conditions and Events field in the VMI and VM.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:
- The searching algorithm for the other VMI's name using the original VMI's claim name uses quadratic time complexity.

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->
With my mentor in person

### Special notes for your reviewer
Intern looking for feedback

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
 Users will now receive a simplified error message than what QEMU reports when two VMs share the same disk image when an NFS storage class is uitilized in the 'Conditions' field in the faulty VM/VMI. The complicated QEMU error can still be found in the 'virt-handler' pod.
```

