### PR TITLE
Fix(hotplug): Apply bus preferences to hotplugged disks

### DIFF
--- a/pkg/instancetype/controller/disk/BUILD.bazel
+++ b/pkg/instancetype/controller/disk/BUILD.bazel
@@ -1,0 +1,39 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["controller.go"],
+    importpath = "kubevirt.io/kubevirt/pkg/instancetype/controller/disk",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/instancetype/preference/apply:go_default_library",
+        "//pkg/instancetype/preference/find:go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/api/instancetype/v1beta1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//vendor/k8s.io/client-go/tools/cache:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "controller_suite_test.go",
+        "controller_test.go",
+    ],
+    race = "on",
+    deps = [
+        ":go_default_library",
+        "//pkg/libvmi:go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/api/instancetype/v1beta1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
+        "//staging/src/kubevirt.io/client-go/kubevirt/fake:go_default_library",
+        "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+        "//vendor/go.uber.org/mock/gomock:go_default_library",
+        "//vendor/k8s.io/api/core/v1:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
+    ],
+)

--- a/pkg/instancetype/controller/disk/controller.go
+++ b/pkg/instancetype/controller/disk/controller.go
@@ -1,0 +1,59 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ */
+
+package disk
+
+import (
+	"k8s.io/client-go/tools/cache"
+
+	v1 "kubevirt.io/api/core/v1"
+	"kubevirt.io/client-go/kubecli"
+
+	instancetypev1beta1 "kubevirt.io/api/instancetype/v1beta1"
+
+	"kubevirt.io/kubevirt/pkg/instancetype/preference/apply"
+	"kubevirt.io/kubevirt/pkg/instancetype/preference/find"
+)
+
+type preferenceFinder interface {
+	FindPreference(vm *v1.VirtualMachine) (*instancetypev1beta1.VirtualMachinePreferenceSpec, error)
+}
+
+type controller struct {
+	finder preferenceFinder
+}
+
+func New(store, clusterStore, revisionStore cache.Store, clientSet kubecli.KubevirtClient) *controller {
+	return &controller{
+		finder: find.NewSpecFinder(store, clusterStore, revisionStore, clientSet),
+	}
+}
+
+func (c *controller) ApplyDiskPreferences(vm *v1.VirtualMachine, vmiSpec *v1.VirtualMachineInstanceSpec) error {
+	if vm.Spec.Preference == nil || len(vmiSpec.Domain.Devices.Disks) == 0 {
+		return nil
+	}
+	preferenceSpec, err := c.finder.FindPreference(vm)
+	if err != nil {
+		return err
+	}
+	if preferenceSpec != nil {
+		apply.ApplyDiskPreferences(preferenceSpec, vmiSpec)
+	}
+	return nil
+}

--- a/pkg/instancetype/controller/disk/controller_suite_test.go
+++ b/pkg/instancetype/controller/disk/controller_suite_test.go
@@ -1,0 +1,29 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ */
+
+package disk_test
+
+import (
+	"testing"
+
+	"kubevirt.io/client-go/testutils"
+)
+
+func TestDisk(t *testing.T) {
+	testutils.KubeVirtTestSuiteSetup(t)
+}

--- a/pkg/instancetype/controller/disk/controller_test.go
+++ b/pkg/instancetype/controller/disk/controller_test.go
@@ -1,0 +1,155 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ */
+
+package disk_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/mock/gomock"
+
+	k8sv1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "kubevirt.io/api/core/v1"
+	instancetypev1beta1 "kubevirt.io/api/instancetype/v1beta1"
+	"kubevirt.io/client-go/kubecli"
+	"kubevirt.io/client-go/kubevirt/fake"
+
+	"kubevirt.io/kubevirt/pkg/instancetype/controller/disk"
+	"kubevirt.io/kubevirt/pkg/libvmi"
+)
+
+var _ = Describe("Disk Controller", func() {
+	const (
+		preferredBus   = v1.DiskBusVirtio
+		preferenceName = "test-preference"
+	)
+
+	type diskController interface {
+		ApplyDiskPreferences(*v1.VirtualMachine, *v1.VirtualMachineInstanceSpec) error
+	}
+
+	var (
+		ctrl          diskController
+		fakeClientset *fake.Clientset
+		virtClient    *kubecli.MockKubevirtClient
+	)
+
+	BeforeEach(func() {
+		mockCtrl := gomock.NewController(GinkgoT())
+		virtClient = kubecli.NewMockKubevirtClient(mockCtrl)
+		fakeClientset = fake.NewSimpleClientset()
+
+		virtClient.EXPECT().VirtualMachinePreference(metav1.NamespaceDefault).Return(
+			fakeClientset.InstancetypeV1beta1().VirtualMachinePreferences(metav1.NamespaceDefault)).AnyTimes()
+		virtClient.EXPECT().VirtualMachineClusterPreference().Return(
+			fakeClientset.InstancetypeV1beta1().VirtualMachineClusterPreferences()).AnyTimes()
+
+		preference := &instancetypev1beta1.VirtualMachinePreference{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      preferenceName,
+				Namespace: metav1.NamespaceDefault,
+			},
+			Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{
+				Devices: &instancetypev1beta1.DevicePreferences{
+					PreferredDiskBus: preferredBus,
+				},
+			},
+		}
+		_, err := fakeClientset.InstancetypeV1beta1().VirtualMachinePreferences(metav1.NamespaceDefault).
+			Create(context.Background(), preference, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		ctrl = disk.New(nil, nil, nil, virtClient)
+	})
+
+	DescribeTable("ApplyDiskPreferences does nothing when", func(vm *v1.VirtualMachine) {
+		originalSpec := vm.Spec.Template.Spec.DeepCopy()
+		Expect(ctrl.ApplyDiskPreferences(vm, &vm.Spec.Template.Spec)).To(Succeed())
+		Expect(vm.Spec.Template.Spec.Domain.Devices.Disks).To(Equal(originalSpec.Domain.Devices.Disks))
+	},
+		Entry("the VM has no preference reference",
+			libvmi.NewVirtualMachine(libvmi.New(
+				libvmi.WithDisk("disk1", v1.DiskBusVirtio))),
+		),
+		Entry("the VMI spec has no disks",
+			libvmi.NewVirtualMachine(libvmi.New(
+				libvmi.WithNamespace(k8sv1.NamespaceDefault)),
+				libvmi.WithPreference(preferenceName)),
+		),
+	)
+
+	It("should apply the preferred disk bus to disks without a bus", func() {
+		vm := libvmi.NewVirtualMachine(libvmi.New(
+			libvmi.WithNamespace(k8sv1.NamespaceDefault),
+			libvmi.WithDisk("disk1", ""),
+			libvmi.WithDisk("disk2", ""),
+		), libvmi.WithPreference(preferenceName))
+
+		Expect(ctrl.ApplyDiskPreferences(vm, &vm.Spec.Template.Spec)).To(Succeed())
+
+		for _, d := range vm.Spec.Template.Spec.Domain.Devices.Disks {
+			Expect(d.DiskDevice.Disk.Bus).To(Equal(preferredBus), "disk %q should have the preferred bus", d.Name)
+		}
+	})
+
+	It("should not override a disk bus that is already set", func() {
+		const existingBus = v1.DiskBusSCSI
+		vm := libvmi.NewVirtualMachine(libvmi.New(
+			libvmi.WithNamespace(k8sv1.NamespaceDefault),
+			libvmi.WithDisk("disk1", ""),
+			libvmi.WithDisk("disk2", ""),
+		), libvmi.WithPreference(preferenceName))
+		// Set bus after VM creation because WithPreference clears all disk buses
+		vm.Spec.Template.Spec.Domain.Devices.Disks[0].DiskDevice.Disk.Bus = existingBus
+
+		Expect(ctrl.ApplyDiskPreferences(vm, &vm.Spec.Template.Spec)).To(Succeed())
+
+		Expect(vm.Spec.Template.Spec.Domain.Devices.Disks[0].DiskDevice.Disk.Bus).To(Equal(existingBus),
+			"existing bus should not be overridden")
+		Expect(vm.Spec.Template.Spec.Domain.Devices.Disks[1].DiskDevice.Disk.Bus).To(Equal(preferredBus),
+			"empty bus should get the preferred bus")
+	})
+
+	It("should do nothing when the preference has no device preferences", func() {
+		noDevicePreference := &instancetypev1beta1.VirtualMachinePreference{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "no-device-preference",
+				Namespace: metav1.NamespaceDefault,
+			},
+			Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{},
+		}
+		_, err := fakeClientset.InstancetypeV1beta1().VirtualMachinePreferences(metav1.NamespaceDefault).
+			Create(context.Background(), noDevicePreference, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		vm := libvmi.NewVirtualMachine(libvmi.New(
+			libvmi.WithNamespace(k8sv1.NamespaceDefault),
+			libvmi.WithDisk("disk1", ""),
+		), libvmi.WithPreference(noDevicePreference.Name))
+
+		Expect(ctrl.ApplyDiskPreferences(vm, &vm.Spec.Template.Spec)).To(Succeed())
+
+		for _, d := range vm.Spec.Template.Spec.Domain.Devices.Disks {
+			Expect(d.DiskDevice.Disk.Bus).To(BeEmpty(), "disk %q should have empty bus", d.Name)
+		}
+	})
+})

--- a/pkg/instancetype/preference/apply/device.go
+++ b/pkg/instancetype/preference/apply/device.go
@@ -98,7 +98,7 @@ func ApplyDevicePreferences(preferenceSpec *v1beta1.VirtualMachinePreferenceSpec
 	}
 
 	ApplyAutoAttachPreferences(preferenceSpec, vmiSpec)
-	applyDiskPreferences(preferenceSpec, vmiSpec)
+	ApplyDiskPreferences(preferenceSpec, vmiSpec)
 	applyInterfacePreferences(preferenceSpec, vmiSpec)
 	applyInputPreferences(preferenceSpec, vmiSpec)
 	applyPanicDevicePreferences(preferenceSpec, vmiSpec)

--- a/pkg/instancetype/preference/apply/disk.go
+++ b/pkg/instancetype/preference/apply/disk.go
@@ -26,7 +26,10 @@ import (
 	"kubevirt.io/kubevirt/pkg/pointer"
 )
 
-func applyDiskPreferences(preferenceSpec *v1beta1.VirtualMachinePreferenceSpec, vmiSpec *virtv1.VirtualMachineInstanceSpec) {
+func ApplyDiskPreferences(preferenceSpec *v1beta1.VirtualMachinePreferenceSpec, vmiSpec *virtv1.VirtualMachineInstanceSpec) {
+	if preferenceSpec.Devices == nil || len(vmiSpec.Domain.Devices.Disks) == 0 {
+		return
+	}
 	for diskIndex := range vmiSpec.Domain.Devices.Disks {
 		vmiDisk := &vmiSpec.Domain.Devices.Disks[diskIndex]
 		// If we don't have a target device defined default to a DiskTarget so we can apply preferences

--- a/pkg/storage/hotplug/hotplug.go
+++ b/pkg/storage/hotplug/hotplug.go
@@ -34,13 +34,17 @@ import (
 	storagetypes "kubevirt.io/kubevirt/pkg/storage/types"
 )
 
-func HandleDeclarativeVolumes(client kubecli.KubevirtClient, vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance) error {
+type DiskPreferenceApplier interface {
+	ApplyDiskPreferences(vm *virtv1.VirtualMachine, vmiSpec *virtv1.VirtualMachineInstanceSpec) error
+}
+
+func HandleDeclarativeVolumes(client kubecli.KubevirtClient, vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance, prefApplier DiskPreferenceApplier) error {
 	if vm.Spec.UpdateVolumesStrategy != nil && *vm.Spec.UpdateVolumesStrategy == virtv1.UpdateVolumesStrategyMigration {
 		// Are there some cases we can proceed?
 		return nil
 	}
 
-	if err := patchHotplugVolumes(client, vm, vmi); err != nil {
+	if err := patchHotplugVolumes(client, vm, vmi, prefApplier); err != nil {
 		log.Log.Object(vm).Errorf("failed to update hotplug volumes for vmi:%v", err)
 		return err
 	}
@@ -48,13 +52,22 @@ func HandleDeclarativeVolumes(client kubecli.KubevirtClient, vm *virtv1.VirtualM
 	return nil
 }
 
-func patchHotplugVolumes(client kubecli.KubevirtClient, vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance) error {
+func patchHotplugVolumes(client kubecli.KubevirtClient, vm *virtv1.VirtualMachine, vmi *virtv1.VirtualMachineInstance, prefApplier DiskPreferenceApplier) error {
 	if vmi == nil || !vmi.IsRunning() {
 		return nil
 	}
 
 	newVmiVolumes := append(filterHotplugVMIVolumes(vm, vmi), getNewHotplugVMVolumes(vm, vmi)...)
 	newVmiDisks := append(filterHotplugVMIDisks(vm, vmi, newVmiVolumes), getNewHotplugVMDisks(vm, vmi, newVmiVolumes)...)
+
+	if prefApplier != nil {
+		tempSpec := &virtv1.VirtualMachineInstanceSpec{
+			Domain: virtv1.DomainSpec{Devices: virtv1.Devices{Disks: newVmiDisks}},
+		}
+		if err := prefApplier.ApplyDiskPreferences(vm, tempSpec); err != nil {
+			log.Log.Object(vm).Warningf("Failed to apply disk preferences during declarative hotplug: %v", err)
+		}
+	}
 
 	if equality.Semantic.DeepEqual(vmi.Spec.Volumes, newVmiVolumes) &&
 		equality.Semantic.DeepEqual(vmi.Spec.Domain.Devices.Disks, newVmiDisks) {

--- a/pkg/storage/hotplug/hotplug_test.go
+++ b/pkg/storage/hotplug/hotplug_test.go
@@ -43,6 +43,21 @@ var _ = Describe("Volume Hotplug", func() {
 	var virtClient *kubecli.MockKubevirtClient
 	var virtFakeClient *fake.Clientset
 
+	handle := func(vm *v1.VirtualMachine, vmi *v1.VirtualMachineInstance, applier DiskPreferenceApplier) *v1.VirtualMachineInstance {
+		vm, err := virtFakeClient.KubevirtV1().VirtualMachines(metav1.NamespaceDefault).Create(context.TODO(), vm, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		vmi, err = virtFakeClient.KubevirtV1().VirtualMachineInstances(metav1.NamespaceDefault).Create(context.Background(), vmi, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(HandleDeclarativeVolumes(virtClient, vm, vmi, applier)).To(Succeed())
+
+		vmi, err = virtFakeClient.KubevirtV1().VirtualMachineInstances(metav1.NamespaceDefault).Get(context.TODO(), vm.Name, metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		return vmi
+	}
+
 	BeforeEach(func() {
 		virtClient = kubecli.NewMockKubevirtClient(gomock.NewController(GinkgoT()))
 		virtFakeClient = fake.NewSimpleClientset()
@@ -57,21 +72,6 @@ var _ = Describe("Volume Hotplug", func() {
 	})
 
 	Context("declarative volume hotplug", func() {
-		handle := func(vm *v1.VirtualMachine, vmi *v1.VirtualMachineInstance) *v1.VirtualMachineInstance {
-			vm, err := virtFakeClient.KubevirtV1().VirtualMachines(metav1.NamespaceDefault).Create(context.TODO(), vm, metav1.CreateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-
-			vmi, err = virtFakeClient.KubevirtV1().VirtualMachineInstances(metav1.NamespaceDefault).Create(context.Background(), vmi, metav1.CreateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-
-			Expect(HandleDeclarativeVolumes(virtClient, vm, vmi)).To(Succeed())
-
-			vmi, err = virtFakeClient.KubevirtV1().VirtualMachineInstances(metav1.NamespaceDefault).Get(context.TODO(), vm.Name, metav1.GetOptions{})
-			Expect(err).ToNot(HaveOccurred())
-
-			return vmi
-		}
-
 		It("should do nothing if VMI not running", func() {
 			opts := []libvmi.Option{
 				libvmi.WithDataVolume("perm", "perm"),
@@ -80,7 +80,7 @@ var _ = Describe("Volume Hotplug", func() {
 			origVMI := libvmi.New(opts...)
 			postVMI := libvmi.New(append(allOpts, libvmi.WithName(origVMI.Name))...)
 			vm := libvmi.NewVirtualMachine(postVMI)
-			result := handle(vm, origVMI)
+			result := handle(vm, origVMI, nil)
 			Expect(result.Spec).To(Equal(origVMI.Spec))
 			Expect(result.Spec.Domain.Devices.Disks).To(HaveLen(1))
 			Expect(result.Spec.Volumes).To(HaveLen(1))
@@ -95,7 +95,7 @@ var _ = Describe("Volume Hotplug", func() {
 			origVMI := libvmi.New(opts...)
 			postVMI := libvmi.New(append(allOpts, libvmi.WithName(origVMI.Name))...)
 			vm := libvmi.NewVirtualMachine(postVMI)
-			result := handle(vm, origVMI)
+			result := handle(vm, origVMI, nil)
 			Expect(result.Spec).To(Equal(origVMI.Spec))
 			Expect(result.Spec.Domain.Devices.Disks).To(HaveLen(1))
 			Expect(result.Spec.Volumes).To(HaveLen(1))
@@ -113,7 +113,7 @@ var _ = Describe("Volume Hotplug", func() {
 			origVMI := libvmi.New(opts...)
 			postVMI := libvmi.New(append(allOpts, libvmi.WithName(origVMI.Name))...)
 			vm := libvmi.NewVirtualMachine(postVMI)
-			result := handle(vm, origVMI)
+			result := handle(vm, origVMI, nil)
 			Expect(result.Spec).To(Equal(postVMI.Spec))
 			Expect(result.Spec.Domain.Devices.Disks).To(HaveLen(numDisks + 1)) // +1 for the existing disk
 			Expect(result.Spec.Volumes).To(HaveLen(numDisks + 1))              // +1 for the existing volume
@@ -137,7 +137,7 @@ var _ = Describe("Volume Hotplug", func() {
 			postVMI.Spec.Domain.Devices.Disks = slices.Delete(postVMI.Spec.Domain.Devices.Disks, index+1, index+2)
 			postVMI.Spec.Volumes = slices.Delete(postVMI.Spec.Volumes, index+1, index+2)
 			vm := libvmi.NewVirtualMachine(postVMI)
-			result := handle(vm, origVMI)
+			result := handle(vm, origVMI, nil)
 			Expect(result.Spec).To(Equal(postVMI.Spec))
 			Expect(result.Spec.Domain.Devices.Disks).To(HaveLen(numDisks))
 			Expect(result.Spec.Volumes).To(HaveLen(numDisks))
@@ -164,7 +164,7 @@ var _ = Describe("Volume Hotplug", func() {
 			postVMI.Spec.Volumes = slices.Delete(postVMI.Spec.Volumes, 1, 2)
 			postVMI.Spec.Domain.Devices.Disks = slices.Delete(postVMI.Spec.Domain.Devices.Disks, 1, 2)
 			vm := libvmi.NewVirtualMachine(postVMI)
-			result := handle(vm, origVMI)
+			result := handle(vm, origVMI, nil)
 			Expect(result.Spec).To(Equal(origVMI.Spec))
 			Expect(result.Spec.Domain.Devices.Disks).To(HaveLen(3))
 			Expect(result.Spec.Volumes).To(HaveLen(3))
@@ -188,7 +188,7 @@ var _ = Describe("Volume Hotplug", func() {
 			origVMI := libvmi.New(opts...)
 			postVMI := libvmi.New(append(allOpts, libvmi.WithName(origVMI.Name))...)
 			vm := libvmi.NewVirtualMachine(postVMI)
-			result := handle(vm, origVMI)
+			result := handle(vm, origVMI, nil)
 			Expect(result.Spec).To(Equal(origVMI.Spec))
 			Expect(result.Spec.Domain.Devices.Disks).To(HaveLen(1))
 			Expect(result.Spec.Volumes).To(HaveLen(1))
@@ -204,7 +204,7 @@ var _ = Describe("Volume Hotplug", func() {
 			postVMI := origVMI.DeepCopy()
 			postVMI.Spec.Volumes[1].VolumeSource.DataVolume.Name = "changed"
 			vm := libvmi.NewVirtualMachine(postVMI)
-			result := handle(vm, origVMI)
+			result := handle(vm, origVMI, nil)
 			Expect(result.Spec.Domain.Devices.Disks).To(HaveLen(1))
 			Expect(result.Spec.Domain.Devices.Disks[0].Name).To(Equal("perm"))
 			Expect(result.Spec.Volumes).To(HaveLen(1))
@@ -220,7 +220,7 @@ var _ = Describe("Volume Hotplug", func() {
 			origVMI := libvmi.New(opts...)
 			postVMI := libvmi.New(append(allOpts, libvmi.WithName(origVMI.Name))...)
 			vm := libvmi.NewVirtualMachine(postVMI, libvmi.WithUpdateVolumeStrategy(v1.UpdateVolumesStrategyMigration))
-			result := handle(vm, origVMI)
+			result := handle(vm, origVMI, nil)
 			Expect(result.Spec).To(Equal(origVMI.Spec))
 			Expect(result.Spec.Domain.Devices.Disks).To(HaveLen(1))
 			Expect(result.Spec.Volumes).To(HaveLen(1))
@@ -250,7 +250,7 @@ var _ = Describe("Volume Hotplug", func() {
 			origVMI := libvmi.New(origOpts...)
 			postVMI := libvmi.New(append(postOpts, libvmi.WithName(origVMI.Name))...)
 			vm := libvmi.NewVirtualMachine(postVMI)
-			result := handle(vm, origVMI)
+			result := handle(vm, origVMI, nil)
 			Expect(result.Spec).To(Equal(postVMI.Spec))
 			Expect(result.Spec.Domain.Devices.Disks).To(HaveLen(numDisks + 1)) // +1 for the existing disk
 			Expect(result.Spec.Volumes).To(HaveLen(numDisks + 1))              // +1 for the existing volume
@@ -280,7 +280,7 @@ var _ = Describe("Volume Hotplug", func() {
 			postVMI := origVMI.DeepCopy()
 			postVMI.Spec.Volumes = slices.Delete(postVMI.Spec.Volumes, index+1, index+2)
 			vm := libvmi.NewVirtualMachine(postVMI)
-			result := handle(vm, origVMI)
+			result := handle(vm, origVMI, nil)
 			Expect(result.Spec).To(Equal(postVMI.Spec))
 			Expect(result.Spec.Domain.Devices.Disks).To(HaveLen(numDisks + 1))
 			Expect(result.Spec.Volumes).To(HaveLen(numDisks))
@@ -310,10 +310,77 @@ var _ = Describe("Volume Hotplug", func() {
 			origVMI := libvmi.New(origOpts...)
 			postVMI := libvmi.New(append(postOpts, libvmi.WithName(origVMI.Name))...)
 			vm := libvmi.NewVirtualMachine(postVMI)
-			result := handle(vm, origVMI)
+			result := handle(vm, origVMI, nil)
 			Expect(result.Spec).To(Equal(origVMI.Spec))
 			Expect(result.Spec.Domain.Devices.Disks).To(HaveLen(2))
 			Expect(result.Spec.Volumes).To(HaveLen(1))
 		})
 	})
+
+	Context("declarative volume hotplug with disk preferences", func() {
+		vmWithHotplugDataVolumeNoBus := func(diskName string) (*v1.VirtualMachine, *v1.VirtualMachineInstance) {
+			opts := []libvmi.Option{
+				libvmi.WithDataVolume("perm", "perm"),
+				libvmistatus.WithStatus(libvmistatus.New(libvmistatus.WithPhase(v1.Running))),
+			}
+			origVMI := libvmi.New(opts...)
+
+			postVMI := libvmi.New(append(opts, libvmi.WithName(origVMI.Name))...)
+			postVMI.Spec.Domain.Devices.Disks = append(postVMI.Spec.Domain.Devices.Disks, v1.Disk{
+				Name:       "hotplugdisk_1",
+				DiskDevice: v1.DiskDevice{Disk: &v1.DiskTarget{}},
+			})
+			postVMI.Spec.Volumes = append(postVMI.Spec.Volumes, v1.Volume{
+				Name: "hotplugdisk_1",
+				VolumeSource: v1.VolumeSource{
+					DataVolume: &v1.DataVolumeSource{Name: "hotplugvolume_1", Hotpluggable: true},
+				},
+			})
+			vm := libvmi.NewVirtualMachine(postVMI)
+			return vm, origVMI
+		}
+
+		It("should apply disk preferences to hotplugged volumes", func() {
+			const preferredBus = v1.DiskBusVirtio
+
+			applier := &stubDiskPreferenceApplier{bus: preferredBus}
+
+			vm, origVMI := vmWithHotplugDataVolumeNoBus("hotplugdisk_1")
+
+			result := handle(vm, origVMI, applier)
+
+			Expect(result.Spec.Domain.Devices.Disks).To(HaveLen(2))
+			for _, d := range result.Spec.Domain.Devices.Disks {
+				Expect(d.DiskDevice.Disk.Bus).To(Equal(preferredBus), "disk %q should have the preferred bus from preferences", d.Name)
+			}
+		})
+
+		It("should not fail when disk preference applier returns an error", func() {
+			applier := &stubDiskPreferenceApplier{err: fmt.Errorf("preference not found")}
+
+			vm, origVMI := vmWithHotplugDataVolumeNoBus("hotplugdisk_1")
+
+			result := handle(vm, origVMI, applier)
+
+			Expect(result.Spec.Domain.Devices.Disks).To(HaveLen(2),
+				"hotplug should succeed even when preference applier fails")
+		})
+	})
 })
+
+type stubDiskPreferenceApplier struct {
+	bus v1.DiskBus
+	err error
+}
+
+func (s *stubDiskPreferenceApplier) ApplyDiskPreferences(_ *v1.VirtualMachine, vmiSpec *v1.VirtualMachineInstanceSpec) error {
+	if s.err != nil {
+		return s.err
+	}
+	for i := range vmiSpec.Domain.Devices.Disks {
+		if vmiSpec.Domain.Devices.Disks[i].DiskDevice.Disk != nil && vmiSpec.Domain.Devices.Disks[i].DiskDevice.Disk.Bus == "" {
+			vmiSpec.Domain.Devices.Disks[i].DiskDevice.Disk.Bus = s.bus
+		}
+	}
+	return nil
+}

--- a/pkg/virt-controller/watch/BUILD.bazel
+++ b/pkg/virt-controller/watch/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "//pkg/controller:go_default_library",
         "//pkg/healthz:go_default_library",
         "//pkg/hooks:go_default_library",
+        "//pkg/instancetype/controller/disk:go_default_library",
         "//pkg/instancetype/controller/vm:go_default_library",
         "//pkg/monitoring/metrics/common/client:go_default_library",
         "//pkg/monitoring/metrics/virt-controller:go_default_library",

--- a/pkg/virt-controller/watch/application.go
+++ b/pkg/virt-controller/watch/application.go
@@ -82,6 +82,7 @@ import (
 	netresources "kubevirt.io/kubevirt/pkg/network/resources"
 	clusterutil "kubevirt.io/kubevirt/pkg/util/cluster"
 
+	diskcontroller "kubevirt.io/kubevirt/pkg/instancetype/controller/disk"
 	instancetypecontroller "kubevirt.io/kubevirt/pkg/instancetype/controller/vm"
 	clientmetrics "kubevirt.io/kubevirt/pkg/monitoring/metrics/common/client"
 	metrics "kubevirt.io/kubevirt/pkg/monitoring/metrics/virt-controller"
@@ -843,6 +844,12 @@ func (vca *VirtControllerApp) initVirtualMachines() {
 			vca.clientSet,
 			vca.clusterConfig,
 			recorder,
+		),
+		diskcontroller.New(
+			vca.preferenceInformer.GetStore(),
+			vca.clusterPreferenceInformer.GetStore(),
+			vca.controllerRevisionInformer.GetStore(),
+			vca.clientSet,
 		),
 		vca.additionalLauncherAnnotationsSync,
 		vca.additionalLauncherLabelsSync,

--- a/pkg/virt-controller/watch/application_test.go
+++ b/pkg/virt-controller/watch/application_test.go
@@ -182,6 +182,7 @@ var _ = Describe("Application", func() {
 			nil,
 			nil,
 			instancetypecontroller.NewControllerStub(),
+			nil,
 			[]string{},
 			[]string{},
 		)

--- a/pkg/virt-controller/watch/vm/vm.go
+++ b/pkg/virt-controller/watch/vm/vm.go
@@ -145,6 +145,7 @@ func NewController(vmiInformer cache.SharedIndexInformer,
 	netSynchronizer synchronizer,
 	firmwareSynchronizer synchronizer,
 	instancetypeController instancetypeHandler,
+	diskPreferenceApplier diskPreferenceApplier,
 	additionalLauncherAnnotationsSync []string,
 	additionalLauncherLabelsSync []string,
 ) (*Controller, error) {
@@ -173,6 +174,7 @@ func NewController(vmiInformer cache.SharedIndexInformer,
 		clusterConfig:                     clusterConfig,
 		netSynchronizer:                   netSynchronizer,
 		firmwareSynchronizer:              firmwareSynchronizer,
+		diskPreferenceApplier:             diskPreferenceApplier,
 		additionalLauncherAnnotationsSync: additionalLauncherAnnotationsSync,
 		additionalLauncherLabelsSync:      additionalLauncherLabelsSync,
 	}
@@ -273,6 +275,10 @@ type synchronizer interface {
 	Sync(*virtv1.VirtualMachine, *virtv1.VirtualMachineInstance) (*virtv1.VirtualMachine, error)
 }
 
+type diskPreferenceApplier interface {
+	ApplyDiskPreferences(vm *virtv1.VirtualMachine, vmiSpec *virtv1.VirtualMachineInstanceSpec) error
+}
+
 type instancetypeHandler interface {
 	synchronizer
 	ApplyToVM(*virtv1.VirtualMachine) error
@@ -300,6 +306,8 @@ type Controller struct {
 
 	netSynchronizer      synchronizer
 	firmwareSynchronizer synchronizer
+
+	diskPreferenceApplier diskPreferenceApplier
 
 	additionalLauncherAnnotationsSync []string
 	additionalLauncherLabelsSync      []string
@@ -3571,7 +3579,7 @@ func (c *Controller) handleDeclarativeVolumeHotplug(vm *virtv1.VirtualMachine, v
 		return nil
 	}
 
-	return storagehotplug.HandleDeclarativeVolumes(c.clientset, vm, vmi)
+	return storagehotplug.HandleDeclarativeVolumes(c.clientset, vm, vmi, c.diskPreferenceApplier)
 }
 
 func (c *Controller) handleKubeVirtUpdate(oldObj, newObj interface{}) {

--- a/pkg/virt-controller/watch/vm/vm_test.go
+++ b/pkg/virt-controller/watch/vm/vm_test.go
@@ -151,6 +151,7 @@ var _ = Describe("VirtualMachine", func() {
 				nil,
 				nil,
 				instancetypecontroller.NewControllerStub(),
+				nil,
 				[]string{},
 				[]string{},
 			)
@@ -7480,6 +7481,7 @@ var _ = Describe("VirtualMachine", func() {
 				record.NewFakeRecorder(100),
 				virtClient,
 				config,
+				nil,
 				nil,
 				nil,
 				nil,

--- a/tests/libstorage/hotplug.go
+++ b/tests/libstorage/hotplug.go
@@ -174,6 +174,10 @@ func WaitForHotplugToComplete(virtClient kubecli.KubevirtClient, vm *v1.VirtualM
 }
 
 func AddHotplugDiskAndVolume(virtClient kubecli.KubevirtClient, vm *v1.VirtualMachine, volumeName, dvName string) *v1.VirtualMachine {
+	return AddHotplugDiskAndVolumeWithBus(virtClient, vm, volumeName, dvName, v1.DiskBusSCSI)
+}
+
+func AddHotplugDiskAndVolumeWithBus(virtClient kubecli.KubevirtClient, vm *v1.VirtualMachine, volumeName, dvName string, bus v1.DiskBus) *v1.VirtualMachine {
 	vm, err := virtClient.VirtualMachine(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
 	Expect(err).ToNot(HaveOccurred())
 	vmCpy := vm.DeepCopy()
@@ -183,7 +187,7 @@ func AddHotplugDiskAndVolume(virtClient kubecli.KubevirtClient, vm *v1.VirtualMa
 		Name: volumeName,
 		DiskDevice: v1.DiskDevice{
 			Disk: &v1.DiskTarget{
-				Bus: v1.DiskBusSCSI,
+				Bus: bus,
 			},
 		},
 	})

--- a/tests/storage/BUILD.bazel
+++ b/tests/storage/BUILD.bazel
@@ -67,6 +67,7 @@ go_library(
         "//tests/libdomain:go_default_library",
         "//tests/libinfra:go_default_library",
         "//tests/libinstancetype:go_default_library",
+        "//tests/libinstancetype/builder:go_default_library",
         "//tests/libkubevirt:go_default_library",
         "//tests/libkubevirt/config:go_default_library",
         "//tests/libmigration:go_default_library",

--- a/tests/storage/declarative-hotplug.go
+++ b/tests/storage/declarative-hotplug.go
@@ -41,6 +41,7 @@ import (
 	cd "kubevirt.io/kubevirt/tests/containerdisk"
 	"kubevirt.io/kubevirt/tests/framework/kubevirt"
 	"kubevirt.io/kubevirt/tests/framework/matcher"
+	"kubevirt.io/kubevirt/tests/libinstancetype/builder"
 	"kubevirt.io/kubevirt/tests/libstorage"
 	"kubevirt.io/kubevirt/tests/libvmifact"
 	"kubevirt.io/kubevirt/tests/testsuite"
@@ -59,14 +60,19 @@ var _ = Describe(SIG("Declarative Hotplug", func() {
 		virtClient = kubevirt.Client()
 	})
 
-	createVM := func(options ...libvmi.Option) *v1.VirtualMachine {
+	createVMWithVMOptions := func(vmiOptions []libvmi.Option, vmOptions ...libvmi.VMOption) *v1.VirtualMachine {
+		allVMOptions := append([]libvmi.VMOption{libvmi.WithRunStrategy(v1.RunStrategyAlways)}, vmOptions...)
 		vm := libvmi.NewVirtualMachine(
-			libvmifact.NewAlpineWithTestTooling(options...),
-			libvmi.WithRunStrategy(v1.RunStrategyAlways))
+			libvmifact.NewAlpineWithTestTooling(vmiOptions...),
+			allVMOptions...)
 		vm, err := virtClient.VirtualMachine(testsuite.GetTestNamespace(nil)).Create(context.Background(), vm, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred(), "failed to create VirtualMachine")
 		Eventually(matcher.ThisVM(vm)).WithTimeout(300*time.Second).WithPolling(time.Second).Should(matcher.BeReady(), "VM %s did not become ready in time", vm.Name)
 		return vm
+	}
+
+	createVM := func(options ...libvmi.Option) *v1.VirtualMachine {
+		return createVMWithVMOptions(options)
 	}
 
 	createAndStartVMWithEmptyCDRom := func() *v1.VirtualMachine {
@@ -339,15 +345,39 @@ var _ = Describe(SIG("Declarative Hotplug", func() {
 	})
 
 	Context("Hotplug disks", func() {
-		It("Should add and remove a hotplug disk", func() {
-			By("Creating a VM")
-			vm := createVM()
+		const preferredBus = v1.DiskBusVirtio
 
-			By("Hotplugging a disk")
+		It("Should add and remove a hotplug disk", func() {
+			By("Creating a preference with PreferredDiskBus")
+			preference := builder.NewPreference(
+				builder.WithPreferredDiskBus(preferredBus),
+			)
+			preference, err := virtClient.VirtualMachinePreference(testsuite.GetTestNamespace(nil)).
+				Create(context.Background(), preference, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Creating a VM with the preference")
+			vm := createVMWithVMOptions(nil, libvmi.WithPreference(preference.Name))
+
+			By("Hotplugging a disk with empty bus")
 			dv1 := createBlankVolume(vm.Namespace)
-			vm = libstorage.AddHotplugDiskAndVolume(virtClient, vm, hotplugDiskName, dv1.Name)
+			vm = libstorage.AddHotplugDiskAndVolumeWithBus(virtClient, vm, hotplugDiskName, dv1.Name, "")
 			libstorage.WaitForHotplugToComplete(virtClient, vm, hotplugDiskName, dv1.Name, true)
 			libstorage.EventuallyDV(dv1, 240, matcher.HaveSucceeded())
+
+			By("Verifying the hotplugged disk has the preferred bus")
+			vmi, err := virtClient.VirtualMachineInstance(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			var hotplugDisk *v1.Disk
+			for i := range vmi.Spec.Domain.Devices.Disks {
+				if vmi.Spec.Domain.Devices.Disks[i].Name == hotplugDiskName {
+					hotplugDisk = &vmi.Spec.Domain.Devices.Disks[i]
+					break
+				}
+			}
+			Expect(hotplugDisk).NotTo(BeNil(), "hotplugged disk should exist in VMI spec")
+			Expect(hotplugDisk.DiskDevice.Disk.Bus).To(Equal(preferredBus),
+				"hotplugged disk should have the preferred bus from the preference")
 
 			By("Unplug the disk")
 			vm = libstorage.RemoveHotplugDiskAndVolume(virtClient, vm, hotplugDiskName)


### PR DESCRIPTION
### What this PR does
#### Before this PR:

When a disk was declaratively hotplugged to a VM referencing a `VirtualMachinePreference` with `PreferredDiskBus`, the preference was not applied to the new disk. The disk was copied from the VM template to the VMI without consulting the preference, causing the admission webhook to reject the VMI patch with "bus is not permitted" — effectively breaking
declarative disk hotplug for VMs using preferences or forcing the user to specify a bus.

#### After this PR:

Disk preferences are applied to declaratively hotplugged disks before the VMI is patched. The fix exports `applyDiskPreferences`, introduces a lightweight disk preference controller under `pkg/instancetype/controller/disk`, and injects it into the declarative hotplug path via a `DiskPreferenceApplier` interface.

Note: The imperative hotplug path, i.e., `virtctl addvolume` is not addressed here because both virtctl and the API admission webhook enforce a bus value before the controller runs, so the preference can never fill an
empty bus. That path requires changes at the virtctl or admission layer.

### Why we need it and why it was done in this way
The following tradeoffs were made:
- A separate disk controller `pkg/instancetype/controller/disk` was created rather than adding `ApplyDiskPreferences` to the main instancetype controller. This avoids passing the full instancetype controller where only disk preference application is needed.
- When preference resolution fails during hotplug, a warning is logged instead of blocking the operation, since the VM is already running and the hotplug should not fail due to a missing preference.

The following alternatives were considered:
- Adding `ApplyDiskPreferences` directly to the instancetype VM controller and composing instancetypeHandler to keep single responsibility.
- Fixing the imperative path (virtctl addvolume / handleVolumeRequests). Not possible without changes to virtctl or the admission webhook, since they enforce a bus value before our code runs.

### Special notes for your reviewer

The fix only covers Path 2 (declarative hotplug viaHandleDeclarativeVolumes). Path 1 (imperative AddVolume API via virtctl) hardcodes the bus to scsi in virtctl and the admission webhook rejects empty bus — so the preference can never be applied at the controller level. That would need a separate fix in virtctl/admission.

### Checklist

- [ ] Design: A VEP was considered and is not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New unit tests and e2e test added
- [ ] Documentation: A user-guide update was considered and is not required
- [ ] Community: Announcement to kubevirt-dev was considered
- [x] AI Contributions: The PR abides by the KubeVirt AI Contribution Policy.

### Release note
```release-note
fix: Disk preferences (e.g. PreferredDiskBus) are now correctly applied to declaratively hotplugged disks
```