### PR TITLE
virt-controller: fail migration when target lands on source node

### DIFF
--- a/pkg/virt-controller/watch/migration/migration.go
+++ b/pkg/virt-controller/watch/migration/migration.go
@@ -517,6 +517,14 @@ func (c *Controller) failMigration(migration *virtv1.VirtualMachineInstanceMigra
 	return nil
 }
 
+// isLocalTargetOnSourceNode reports whether a local migration's target pod was
+// scheduled onto the node already running the VMI (the source), which can never
+// succeed. Decentralized migrations are excluded: their nodes may live in
+// different clusters and can share a name.
+func isLocalTargetOnSourceNode(migration *virtv1.VirtualMachineInstanceMigration, pod *k8sv1.Pod, vmi *virtv1.VirtualMachineInstance) bool {
+	return !migration.IsDecentralized() && pod != nil && pod.Spec.NodeName != "" && pod.Spec.NodeName == vmi.Status.NodeName
+}
+
 func (c *Controller) interruptMigration(migration *virtv1.VirtualMachineInstanceMigration, vmi *virtv1.VirtualMachineInstance) error {
 	if vmi == nil || !backendstorage.IsBackendStorageNeeded(vmi) {
 		return c.failMigration(migration)
@@ -586,6 +594,21 @@ func (c *Controller) updateStatus(migration *virtv1.VirtualMachineInstanceMigrat
 		if err != nil {
 			return err
 		}
+	} else if podExists && isLocalTargetOnSourceNode(migration, pod, vmi) {
+		// The target pod landed on the source node, normally prevented by the
+		// target pod's required anti-affinity but possible when its placement does
+		// not honor that constraint (e.g. a non-conformant scheduler or external
+		// binder). Fail with a clear reason instead of stalling in PreparingTarget
+		// and reporting the generic "target pod shutdown" below. sync() skips the
+		// handoff for the same condition, so the target was never prepared.
+		err := c.failMigration(migrationCopy)
+		if err != nil {
+			return err
+		}
+		c.recorder.Eventf(migration, k8sv1.EventTypeWarning, controller.FailedMigrationReason,
+			"Migration failed because target pod %s was scheduled onto the source node %q; a live migration cannot target the node already running the VMI",
+			pod.Name, vmi.Status.NodeName)
+		log.Log.Object(migration).Errorf("target pod %s/%s was scheduled onto source node %s; failing migration", pod.Namespace, pod.Name, vmi.Status.NodeName)
 	} else if podExists && controller.PodIsDown(pod) {
 		err := c.interruptMigration(migrationCopy, vmi)
 		if err != nil {
@@ -1887,7 +1910,9 @@ func (c *Controller) sync(key string, migration *virtv1.VirtualMachineInstanceMi
 
 		// once target pod is running, then alert the VMI of the migration by
 		// setting the target and source nodes. This kicks off the preparation stage.
-		if targetPodExists && controller.IsPodReady(pod) {
+		// Skip the handoff if the target landed on the source node: that migration
+		// can never succeed, and updateStatus() fails it below.
+		if targetPodExists && controller.IsPodReady(pod) && !isLocalTargetOnSourceNode(migration, pod, vmi) {
 			if err := c.updateTargetPodNetworkInfo(vmi, pod); err != nil {
 				return err
 			}

--- a/pkg/virt-controller/watch/migration/migration_test.go
+++ b/pkg/virt-controller/watch/migration/migration_test.go
@@ -1655,6 +1655,33 @@ var _ = Describe("Migration watcher", func() {
 			Entry("in scheduling state", v1.MigrationScheduling),
 			Entry("in target ready state", v1.MigrationTargetReady),
 		)
+
+		DescribeTable("the target pod was scheduled onto the source node", func(phase v1.VirtualMachineInstanceMigrationPhase) {
+			vmi := newVirtualMachine("testvmi", v1.Running)
+			addNodeNameToVMI(vmi, "node01")
+			migration := newMigration("testmigration", vmi.Name, phase)
+			// MigrationState is left nil to exercise the pre-handoff path; a non-nil
+			// value makes handleTargetPodHandoff() early-return and hides whether the
+			// handoff was skipped.
+			targetPod := newTargetPodForVirtualMachine(vmi, migration, k8sv1.PodRunning)
+			targetPod.Spec.NodeName = "node01" // same node as the source
+
+			addMigration(migration)
+			addVirtualMachineInstance(vmi)
+			addPod(newSourcePodForVirtualMachine(vmi))
+			addPod(targetPod)
+
+			sanityExecute()
+
+			testutils.ExpectEvent(recorder, virtcontroller.FailedMigrationReason)
+			expectMigrationFailedState(migration.Namespace, migration.Name)
+			// never handed off: the target-node label (set only during handoff) is absent
+			expectVirtualMachineInstanceLabels(vmi.Namespace, vmi.Name, Not(HaveKey(v1.MigrationTargetNodeNameLabel)))
+		},
+			Entry("in pending state", v1.MigrationPending),
+			Entry("in scheduling state", v1.MigrationScheduling),
+			Entry("in scheduled state", v1.MigrationScheduled),
+		)
 	})
 
 	Context("Migration object ", func() {


### PR DESCRIPTION
**What this PR does / why we need it**:

A live migration can never succeed when its target pod is scheduled onto the node already running the VMI. Today the target pod is handed off to virt-handler, the migration stalls in `PreparingTarget` until it times out (~5 min), and then fails with the misleading `target pod shutdown during migration` event, which reports a symptom rather than the placement.

The target pod carries a required anti-affinity against the source pod, so a conformant scheduler prevents this. It can still happen when placement does not honor that constraint: a non-conformant scheduler (`spec.schedulerName`), a scheduler profile with the `InterPodAffinity` plugin disabled, an external binder, or mislabeled node topology.

For local (non-decentralized) migrations, this detects when the scheduled target pod is on the source node and fails fast with a clear reason. `sync()` skips the `MigrationScheduled` handoff for the same condition so the target pod is never prepared, and `updateStatus()` fails the migration before reaching the generic "target pod shutdown" branch.

**Which issue(s) this PR fixes**:

Fixes #18946

**Special notes for your reviewer**:

Unit tests cover the pending/scheduling/scheduled cases, asserting the migration fails fast and that no handoff occurs (the target-node label stays absent). Also verified end-to-end on v1.9.0.

**Release note**:

```release-note
virt-controller: fail a live migration fast with a clear reason when the target pod is scheduled onto the source node, instead of stalling in PreparingTarget and reporting a misleading "target pod shutdown" error.
```
