### PR TITLE
tests: Drop v1alpha1 from VMT/VMTR namespace cleanup

### DIFF
--- a/tests/testsuite/namespace.go
+++ b/tests/testsuite/namespace.go
@@ -276,17 +276,13 @@ func CleanNamespaces() {
 		Expect(virtCli.VirtualMachineExport(namespace).DeleteCollection(context.Background(), metav1.DeleteOptions{}, metav1.ListOptions{})).To(Succeed())
 
 		// Remove VirtualMachineTemplateRequests and strip finalizers
-		for _, version := range []string{"v1alpha1", "v1beta1"} {
-			vmtrGVR := schema.GroupVersionResource{Group: "template.kubevirt.io", Version: version, Resource: "virtualmachinetemplaterequests"}
-			Expect(removeAllGroupVersionResourceFromNamespace(vmtrGVR, namespace)).To(Succeed())
-			Expect(stripFinalizersFromGVR(vmtrGVR, namespace)).To(Succeed())
-		}
+		vmtrGVR := schema.GroupVersionResource{Group: "template.kubevirt.io", Version: "v1beta1", Resource: "virtualmachinetemplaterequests"}
+		Expect(removeAllGroupVersionResourceFromNamespace(vmtrGVR, namespace)).To(Succeed())
+		Expect(stripFinalizersFromGVR(vmtrGVR, namespace)).To(Succeed())
 
 		// Remove VirtualMachineTemplates
-		for _, version := range []string{"v1alpha1", "v1beta1"} {
-			vmtGVR := schema.GroupVersionResource{Group: "template.kubevirt.io", Version: version, Resource: "virtualmachinetemplates"}
-			Expect(removeAllGroupVersionResourceFromNamespace(vmtGVR, namespace)).To(Succeed())
-		}
+		vmtGVR := schema.GroupVersionResource{Group: "template.kubevirt.io", Version: "v1beta1", Resource: "virtualmachinetemplates"}
+		Expect(removeAllGroupVersionResourceFromNamespace(vmtGVR, namespace)).To(Succeed())
 
 	}
 }


### PR DESCRIPTION
### What this PR does
#### Before this PR:
`CleanNamespaces()` iterated over both `v1alpha1` and `v1beta1` of `template.kubevirt.io` when removing `VirtualMachineTemplates` and `VirtualMachineTemplateRequests`. Touching the deprecated `v1alpha1` version made the API server emit deprecation warnings on every namespace cleanup, cluttering the test output.

#### After this PR:
Only `v1beta1` is used, so no deprecation warnings are emitted. Deleting through one served version already removes every object of that kind, so the `v1alpha1` pass was redundant.

### Why we need it and why it was done in this way
Removes unnecessary warnings from the test suite output. No behavior change.

### Special notes for your reviewer
Test-only change.

### Checklist

- [x] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
NONE
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
