### PR TITLE
Add VMI GPU usage recording rules correlating DCGM metrics

### DIFF
--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -156,6 +156,9 @@
 | pvc:kubevirt_vmsnapshot_labels:info | Recording rule | Gauge | Returns the labels of the persistent volume claims that are used for restoring virtual machines. |
 | vm:kubevirt_vmsnapshot_disks_restored:sum | Recording rule | Gauge | Returns the total number of virtual machine disks restored from the source virtual machine. |
 | vm:kubevirt_vmsnapshot_restored_bytes:sum | Recording rule | Gauge | Returns the amount of space in bytes restored from the source virtual machine. |
+| vmi:kubevirt_vmi_gpu_fb_free:sum | Recording rule | Gauge | Framebuffer memory free (in bytes) of the GPU passed through to a virtual machine instance. |
+| vmi:kubevirt_vmi_gpu_fb_used:sum | Recording rule | Gauge | Framebuffer memory used (in bytes) of the GPU passed through to a virtual machine instance. |
+| vmi:kubevirt_vmi_gpu_mem_copy_util:sum | Recording rule | Gauge | Memory utilization (ratio, 0-1) of the GPU passed through to a virtual machine instance. |
 | vmi:kubevirt_vmi_guest_queue_length:sum | Recording rule | Gauge | Guest queue length. |
 | vmi:kubevirt_vmi_memory_available_bytes:sum | Recording rule | Gauge | Sum of available memory bytes per VMI (aggregated by name, namespace). |
 | vmi:kubevirt_vmi_memory_headroom_ratio:sum | Recording rule | Gauge | Usable memory to available memory ratio per VMI (aggregated by name, namespace). |

--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -1059,6 +1059,47 @@ tests:
           - labels: 'vmi:kubevirt_vmi_memory_used_bytes:sum{container="virt-handler", name="vm-example-2", namespace="default", node="node-1"}'
             value: 234329980
 
+  - interval: 1m
+    input_series:
+      - series: 'kubevirt_vmi_gpu_info{node="node-1", namespace="default", pod="virt-launcher-vm-gpu-1", name="vm-gpu-1", resource="nvidia.com/GA100", uuid="GPU-owned-by-vmi"}'
+        values: "1 1 1"
+      - series: 'DCGM_FI_DEV_MEM_COPY_UTIL{UUID="GPU-owned-by-vmi", gpu="0", device="nvidia0", modelName="NVIDIA A100", Hostname="node-1", pci_bus_id="00000000:07:00.0"}'
+        values: "42 42 42"
+      - series: 'DCGM_FI_DEV_FB_FREE{UUID="GPU-owned-by-vmi", gpu="0", device="nvidia0", modelName="NVIDIA A100", Hostname="node-1", pci_bus_id="00000000:07:00.0"}'
+        values: "30000 30000 30000"
+      - series: 'DCGM_FI_DEV_FB_USED{UUID="GPU-owned-by-vmi", gpu="0", device="nvidia0", modelName="NVIDIA A100", Hostname="node-1", pci_bus_id="00000000:07:00.0"}'
+        values: "10000 10000 10000"
+      # Duplicate scrape of the same GPU (same UUID, different exporter-specific labels).
+      # max by(UUID) must collapse these so the recording rules do not silently double the value.
+      - series: 'DCGM_FI_DEV_MEM_COPY_UTIL{UUID="GPU-owned-by-vmi", gpu="0", device="nvidia0", modelName="NVIDIA A100", Hostname="node-2", pci_bus_id="00000000:07:00.0"}'
+        values: "42 42 42"
+      - series: 'DCGM_FI_DEV_FB_FREE{UUID="GPU-owned-by-vmi", gpu="0", device="nvidia0", modelName="NVIDIA A100", Hostname="node-2", pci_bus_id="00000000:07:00.0"}'
+        values: "30000 30000 30000"
+      - series: 'DCGM_FI_DEV_FB_USED{UUID="GPU-owned-by-vmi", gpu="0", device="nvidia0", modelName="NVIDIA A100", Hostname="node-2", pci_bus_id="00000000:07:00.0"}'
+        values: "10000 10000 10000"
+      - series: 'DCGM_FI_DEV_MEM_COPY_UTIL{UUID="GPU-unused", gpu="1", device="nvidia1", modelName="NVIDIA A100", Hostname="node-1", pci_bus_id="00000000:08:00.0"}'
+        values: "99 99 99"
+      - series: 'DCGM_FI_DEV_FB_FREE{UUID="GPU-unused", gpu="1", device="nvidia1", modelName="NVIDIA A100", Hostname="node-1", pci_bus_id="00000000:08:00.0"}'
+        values: "99 99 99"
+      - series: 'DCGM_FI_DEV_FB_USED{UUID="GPU-unused", gpu="1", device="nvidia1", modelName="NVIDIA A100", Hostname="node-1", pci_bus_id="00000000:08:00.0"}'
+        values: "99 99 99"
+    promql_expr_test:
+      - expr: 'vmi:kubevirt_vmi_gpu_mem_copy_util:sum'
+        eval_time: 1m
+        exp_samples:
+          - labels: 'vmi:kubevirt_vmi_gpu_mem_copy_util:sum{namespace="default", name="vm-gpu-1", node="node-1", uuid="GPU-owned-by-vmi", resource="nvidia.com/GA100"}'
+            value: 0.42
+      - expr: 'vmi:kubevirt_vmi_gpu_fb_free:sum'
+        eval_time: 1m
+        exp_samples:
+          - labels: 'vmi:kubevirt_vmi_gpu_fb_free:sum{namespace="default", name="vm-gpu-1", node="node-1", uuid="GPU-owned-by-vmi", resource="nvidia.com/GA100"}'
+            value: 31457280000
+      - expr: 'vmi:kubevirt_vmi_gpu_fb_used:sum'
+        eval_time: 1m
+        exp_samples:
+          - labels: 'vmi:kubevirt_vmi_gpu_fb_used:sum{namespace="default", name="vm-gpu-1", node="node-1", uuid="GPU-owned-by-vmi", resource="nvidia.com/GA100"}'
+            value: 10485760000
+
   # Mass Failed virt-launcher pods should trigger critical alert after 10m
   - interval: 1m
     input_series:

--- a/pkg/monitoring/rules/recordingrules/BUILD.bazel
+++ b/pkg/monitoring/rules/recordingrules/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "api.go",
         "deprecated_recordingrules.go",
+        "gpu.go",
         "nodes.go",
         "operator.go",
         "pvc.go",

--- a/pkg/monitoring/rules/recordingrules/gpu.go
+++ b/pkg/monitoring/rules/recordingrules/gpu.go
@@ -1,0 +1,61 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ */
+
+package recordingrules
+
+import (
+	"github.com/rhobs/operator-observability-toolkit/pkg/operatormetrics"
+	"github.com/rhobs/operator-observability-toolkit/pkg/operatorrules"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+var gpuRecordingRules = []operatorrules.RecordingRule{
+	{
+		MetricsOpts: operatormetrics.MetricOpts{
+			Name: "vmi:kubevirt_vmi_gpu_mem_copy_util:sum",
+			Help: "Memory utilization (ratio, 0-1) of the GPU passed through to a virtual machine instance.",
+		},
+		MetricType: operatormetrics.GaugeType,
+		Expr: intstr.FromString(
+			"sum by(namespace, name, node, uuid, resource) (" +
+				"label_replace(max by (UUID) (DCGM_FI_DEV_MEM_COPY_UTIL), 'uuid', '$1', 'UUID', '(.*)') * " +
+				"on(uuid) group_left(namespace, name, node, resource) kubevirt_vmi_gpu_info) / 100"),
+	},
+	{
+		MetricsOpts: operatormetrics.MetricOpts{
+			Name: "vmi:kubevirt_vmi_gpu_fb_free:sum",
+			Help: "Framebuffer memory free (in bytes) of the GPU passed through to a virtual machine instance.",
+		},
+		MetricType: operatormetrics.GaugeType,
+		Expr: intstr.FromString(
+			"sum by(namespace, name, node, uuid, resource) (" +
+				"label_replace(max by (UUID) (DCGM_FI_DEV_FB_FREE), 'uuid', '$1', 'UUID', '(.*)') * " +
+				"on(uuid) group_left(namespace, name, node, resource) kubevirt_vmi_gpu_info) * 1024 * 1024"),
+	},
+	{
+		MetricsOpts: operatormetrics.MetricOpts{
+			Name: "vmi:kubevirt_vmi_gpu_fb_used:sum",
+			Help: "Framebuffer memory used (in bytes) of the GPU passed through to a virtual machine instance.",
+		},
+		MetricType: operatormetrics.GaugeType,
+		Expr: intstr.FromString(
+			"sum by(namespace, name, node, uuid, resource) (" +
+				"label_replace(max by (UUID) (DCGM_FI_DEV_FB_USED), 'uuid', '$1', 'UUID', '(.*)') * " +
+				"on(uuid) group_left(namespace, name, node, resource) kubevirt_vmi_gpu_info) * 1024 * 1024"),
+	},
+}

--- a/pkg/monitoring/rules/recordingrules/recordingrules.go
+++ b/pkg/monitoring/rules/recordingrules/recordingrules.go
@@ -23,6 +23,7 @@ import "github.com/rhobs/operator-observability-toolkit/pkg/operatorrules"
 func Register(registry *operatorrules.Registry, namespace string) error {
 	return registry.RegisterRecordingRules(
 		apiRecordingRules,
+		gpuRecordingRules,
 		nodesRecordingRules,
 		operatorRecordingRules,
 		virtRecordingRules(namespace),


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:

No correlation between vmi gpu metrics and dcgm exporter metrics

#### After this PR:

vmi gpu mempry related recording rules

### References

jira-ticket: https://redhat.atlassian.net/browse/CNV-51522

<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add VMI GPU usage recording rules correlating DCGM metrics
```

