### PR TITLE
export: reconcile manifest ConfigMap after CA rotation

### DIFF
--- a/pkg/storage/export/export/BUILD.bazel
+++ b/pkg/storage/export/export/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/apimachinery:go_default_library",
+        "//pkg/apimachinery/patch:go_default_library",
         "//pkg/certificates/bootstrap:go_default_library",
         "//pkg/certificates/triple:go_default_library",
         "//pkg/certificates/triple/cert:go_default_library",
@@ -51,6 +52,7 @@ go_library(
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1/unstructured:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/runtime/schema:go_default_library",
+        "//vendor/k8s.io/apimachinery/pkg/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/intstr:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/rand:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/runtime:go_default_library",
@@ -107,6 +109,7 @@ go_test(
         "//vendor/github.com/onsi/gomega/gstruct:go_default_library",
         "//vendor/github.com/openshift/api/route/v1:go_default_library",
         "//vendor/go.uber.org/mock/gomock:go_default_library",
+        "//vendor/gopkg.in/evanphx/json-patch.v4:go_default_library",
         "//vendor/k8s.io/api/apps/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/networking/v1:go_default_library",

--- a/pkg/storage/export/export/export.go
+++ b/pkg/storage/export/export/export.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8stypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/rand"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -50,6 +51,7 @@ import (
 	"kubevirt.io/client-go/log"
 	cdiv1 "kubevirt.io/containerized-data-importer-api/pkg/apis/core/v1beta1"
 
+	"kubevirt.io/kubevirt/pkg/apimachinery/patch"
 	"kubevirt.io/kubevirt/pkg/certificates/bootstrap"
 	"kubevirt.io/kubevirt/pkg/certificates/triple"
 	"kubevirt.io/kubevirt/pkg/certificates/triple/cert"
@@ -121,6 +123,7 @@ const (
 	serviceCreatedEvent                   = "ServiceCreated"
 	certParamsChangedEvent                = "CertificateParametersChanged"
 	exporterManifestConfigMapCreatedEvent = "DataManifestCreated"
+	exporterManifestConfigMapUpdatedEvent = "DataManifestUpdated"
 
 	kvm = 107
 
@@ -1292,6 +1295,25 @@ func (ctrl *VMExportController) createManifestAndAddToPod(vmExport *exportv1.Vir
 	if err != nil {
 		if !errors.IsAlreadyExists(err) {
 			return err
+		}
+		cm, err = ctrl.Client.CoreV1().ConfigMaps(vmExport.Namespace).Get(context.Background(), manifestConfigMap.Name, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		// Do not adopt a ConfigMap left by a previous VMExport.
+		if !metav1.IsControlledBy(cm, vmExport) {
+			return fmt.Errorf("exporter data manifest %s/%s is not controlled by the current VMExport", cm.Namespace, cm.Name)
+		}
+		if !equality.Semantic.DeepEqual(cm.Data, manifestConfigMap.Data) {
+			patchBytes, err := patch.New(patch.WithAdd("/data", manifestConfigMap.Data)).GeneratePayload()
+			if err != nil {
+				return err
+			}
+			cm, err = ctrl.Client.CoreV1().ConfigMaps(vmExport.Namespace).Patch(context.Background(), manifestConfigMap.Name, k8stypes.JSONPatchType, patchBytes, metav1.PatchOptions{})
+			if err != nil {
+				return err
+			}
+			ctrl.Recorder.Eventf(vmExport, corev1.EventTypeNormal, exporterManifestConfigMapUpdatedEvent, "Updated exporter data manifest %s/%s", cm.Namespace, cm.Name)
 		}
 	} else {
 		ctrl.Recorder.Eventf(vmExport, corev1.EventTypeNormal, exporterManifestConfigMapCreatedEvent, "Created exporter data manifest %s/%s", cm.Namespace, cm.Name)

--- a/pkg/storage/export/export/export.go
+++ b/pkg/storage/export/export/export.go
@@ -39,7 +39,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/rand"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	validation "k8s.io/apimachinery/pkg/util/validation"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/record"
@@ -1280,26 +1280,28 @@ func (ctrl *VMExportController) configureSourceManifest(vmExport *exportv1.Virtu
 	}
 
 	if key != "" {
-		return ctrl.createManifestAndAddToPod(vmExport, key, data, podManifest, service, extra)
+		return ctrl.reconcileManifestAndAddToPod(vmExport, key, data, podManifest, service, extra)
 	}
 
 	return nil
 }
 
-func (ctrl *VMExportController) createManifestAndAddToPod(vmExport *exportv1.VirtualMachineExport, manifestKey string, manifestBytes []byte, podManifest *corev1.Pod, service *corev1.Service, extraData map[string]string) error {
+func (ctrl *VMExportController) reconcileManifestAndAddToPod(vmExport *exportv1.VirtualMachineExport, manifestKey string, manifestBytes []byte, podManifest *corev1.Pod, service *corev1.Service, extraData map[string]string) error {
 	manifestConfigMap, err := ctrl.createManifestConfigMap(vmExport, manifestKey, manifestBytes, service, extraData)
 	if err != nil {
 		return err
 	}
-	cm, err := ctrl.Client.CoreV1().ConfigMaps(vmExport.Namespace).Create(context.Background(), manifestConfigMap, metav1.CreateOptions{})
+	cm, err := ctrl.Client.CoreV1().ConfigMaps(vmExport.Namespace).Get(context.Background(), manifestConfigMap.Name, metav1.GetOptions{})
 	if err != nil {
-		if !errors.IsAlreadyExists(err) {
+		if !errors.IsNotFound(err) {
 			return err
 		}
-		cm, err = ctrl.Client.CoreV1().ConfigMaps(vmExport.Namespace).Get(context.Background(), manifestConfigMap.Name, metav1.GetOptions{})
+		cm, err = ctrl.Client.CoreV1().ConfigMaps(vmExport.Namespace).Create(context.Background(), manifestConfigMap, metav1.CreateOptions{})
 		if err != nil {
 			return err
 		}
+		ctrl.Recorder.Eventf(vmExport, corev1.EventTypeNormal, exporterManifestConfigMapCreatedEvent, "Created exporter data manifest %s/%s", cm.Namespace, cm.Name)
+	} else {
 		// Do not adopt a ConfigMap left by a previous VMExport.
 		if !metav1.IsControlledBy(cm, vmExport) {
 			return fmt.Errorf("exporter data manifest %s/%s is not controlled by the current VMExport", cm.Namespace, cm.Name)
@@ -1315,8 +1317,6 @@ func (ctrl *VMExportController) createManifestAndAddToPod(vmExport *exportv1.Vir
 			}
 			ctrl.Recorder.Eventf(vmExport, corev1.EventTypeNormal, exporterManifestConfigMapUpdatedEvent, "Updated exporter data manifest %s/%s", cm.Namespace, cm.Name)
 		}
-	} else {
-		ctrl.Recorder.Eventf(vmExport, corev1.EventTypeNormal, exporterManifestConfigMapCreatedEvent, "Created exporter data manifest %s/%s", cm.Namespace, cm.Name)
 	}
 
 	podManifest.Spec.Containers[0].VolumeMounts = append(podManifest.Spec.Containers[0].VolumeMounts, corev1.VolumeMount{

--- a/pkg/storage/export/export/export_test.go
+++ b/pkg/storage/export/export/export_test.go
@@ -1617,7 +1617,7 @@ var _ = Describe("Export controller", func() {
 		})
 		extra, err := controller.extraVMData(vm)
 		Expect(err).ToNot(HaveOccurred())
-		err = controller.createManifestAndAddToPod(testVMExport, vmManifest, vmBytes, testPod, service, extra)
+		err = controller.reconcileManifestAndAddToPod(testVMExport, vmManifest, vmBytes, testPod, service, extra)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(testVMExport.Status).ToNot(BeNil())
 	})
@@ -1653,7 +1653,7 @@ var _ = Describe("Export controller", func() {
 		extra, err := controller.extraVMData(vm)
 		Expect(err).ToNot(HaveOccurred())
 
-		Expect(controller.createManifestAndAddToPod(testVMExport, vmManifest, vmBytes, newPod(), service, extra)).To(Succeed())
+		Expect(controller.reconcileManifestAndAddToPod(testVMExport, vmManifest, vmBytes, newPod(), service, extra)).To(Succeed())
 		testutils.ExpectEvent(recorder, exporterManifestConfigMapCreatedEvent)
 
 		Expect(cmInformer.GetStore().Update(&k8sv1.ConfigMap{
@@ -1694,11 +1694,11 @@ var _ = Describe("Export controller", func() {
 			return false, nil, nil
 		})
 
-		Expect(controller.createManifestAndAddToPod(testVMExport, vmManifest, vmBytes, newPod(), service, extra)).To(Succeed())
+		Expect(controller.reconcileManifestAndAddToPod(testVMExport, vmManifest, vmBytes, newPod(), service, extra)).To(Succeed())
 		Expect(patchCalls).To(Equal(1))
 		testutils.ExpectEvent(recorder, exporterManifestConfigMapUpdatedEvent)
 
-		Expect(controller.createManifestAndAddToPod(testVMExport, vmManifest, vmBytes, newPod(), service, extra)).To(Succeed())
+		Expect(controller.reconcileManifestAndAddToPod(testVMExport, vmManifest, vmBytes, newPod(), service, extra)).To(Succeed())
 		Expect(patchCalls).To(Equal(1))
 		Expect(recorder.Events).To(BeEmpty())
 	})
@@ -1743,7 +1743,7 @@ var _ = Describe("Export controller", func() {
 			return false, nil, nil
 		})
 
-		Expect(controller.createManifestAndAddToPod(testVMExport, vmManifest, vmBytes, pod, service, extra)).To(MatchError(ContainSubstring("is not controlled by the current VMExport")))
+		Expect(controller.reconcileManifestAndAddToPod(testVMExport, vmManifest, vmBytes, pod, service, extra)).To(MatchError(ContainSubstring("is not controlled by the current VMExport")))
 		Expect(patchCalls).To(BeZero())
 		Expect(pod.Spec.Containers[0].VolumeMounts).To(BeEmpty())
 		Expect(pod.Spec.Volumes).To(BeEmpty())
@@ -1789,7 +1789,7 @@ var _ = Describe("Export controller", func() {
 			return true, nil, patchErr
 		})
 
-		Expect(controller.createManifestAndAddToPod(testVMExport, vmManifest, vmBytes, pod, service, extra)).To(MatchError(patchErr))
+		Expect(controller.reconcileManifestAndAddToPod(testVMExport, vmManifest, vmBytes, pod, service, extra)).To(MatchError(patchErr))
 		Expect(pod.Spec.Containers[0].VolumeMounts).To(BeEmpty())
 		Expect(pod.Spec.Volumes).To(BeEmpty())
 		Expect(recorder.Events).To(BeEmpty())
@@ -1855,7 +1855,7 @@ var _ = Describe("Export controller", func() {
 			return true, cm, nil
 		})
 
-		err = controller.createManifestAndAddToPod(testVMExport, vmTemplateManifest, tplBytes, testPod, service, extra)
+		err = controller.reconcileManifestAndAddToPod(testVMExport, vmTemplateManifest, tplBytes, testPod, service, extra)
 		Expect(err).ToNot(HaveOccurred())
 	})
 

--- a/pkg/storage/export/export/export_test.go
+++ b/pkg/storage/export/export/export_test.go
@@ -19,6 +19,7 @@
 package export
 
 import (
+	"context"
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
@@ -28,6 +29,7 @@ import (
 	"strings"
 	"time"
 
+	jsonpatch "gopkg.in/evanphx/json-patch.v4"
 	"k8s.io/apimachinery/pkg/util/uuid"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -1618,6 +1620,179 @@ var _ = Describe("Export controller", func() {
 		err = controller.createManifestAndAddToPod(testVMExport, vmManifest, vmBytes, testPod, service, extra)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(testVMExport.Status).ToNot(BeNil())
+	})
+
+	It("should patch an existing datamanifest after the internal CA rotates", func() {
+		testVMExport := createVMVMExport()
+		vm := &virtv1.VirtualMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testVmName,
+				Namespace: testNamespace,
+			},
+			Spec: virtv1.VirtualMachineSpec{
+				Template: &virtv1.VirtualMachineInstanceTemplateSpec{
+					Spec: virtv1.VirtualMachineInstanceSpec{},
+				},
+			},
+		}
+		service := &k8sv1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      controller.getExportServiceName(testVMExport),
+				Namespace: testVMExport.Namespace,
+			},
+		}
+		newPod := func() *k8sv1.Pod {
+			return &k8sv1.Pod{
+				Spec: k8sv1.PodSpec{
+					Containers: []k8sv1.Container{{}},
+				},
+			}
+		}
+		vmBytes, err := controller.generateVMDefinitionFromVm(vm)
+		Expect(err).ToNot(HaveOccurred())
+		extra, err := controller.extraVMData(vm)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(controller.createManifestAndAddToPod(testVMExport, vmManifest, vmBytes, newPod(), service, extra)).To(Succeed())
+		testutils.ExpectEvent(recorder, exporterManifestConfigMapCreatedEvent)
+
+		Expect(cmInformer.GetStore().Update(&k8sv1.ConfigMap{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: controller.KubevirtNamespace,
+				Name:      components.KubeVirtExportCASecretName,
+			},
+			Data: map[string]string{
+				"ca-bundle": "rotated ca cert",
+			},
+		})).To(Succeed())
+
+		originalManifest, err := k8sClient.CoreV1().ConfigMaps(testNamespace).Get(context.Background(), controller.getVmManifestConfigMapName(testVMExport), metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		originalManifestBytes, err := json.Marshal(originalManifest)
+		Expect(err).ToNot(HaveOccurred())
+
+		patchCalls := 0
+		k8sClient.Fake.PrependReactor("patch", "configmaps", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+			patchAction, ok := action.(testing.PatchActionImpl)
+			Expect(ok).To(BeTrue())
+
+			manifestPatch, err := jsonpatch.DecodePatch(patchAction.Patch)
+			Expect(err).ToNot(HaveOccurred())
+
+			patchedManifestBytes, err := manifestPatch.Apply(originalManifestBytes)
+			Expect(err).ToNot(HaveOccurred())
+
+			patchedManifest := &k8sv1.ConfigMap{}
+			Expect(json.Unmarshal(patchedManifestBytes, patchedManifest)).To(Succeed())
+
+			embeddedCA := &k8sv1.ConfigMap{}
+			Expect(json.Unmarshal([]byte(patchedManifest.Data[internalCaConfigMapKey]), embeddedCA)).To(Succeed())
+			Expect(embeddedCA.Data["ca.pem"]).To(Equal("rotated ca cert"))
+
+			patchCalls++
+			return false, nil, nil
+		})
+
+		Expect(controller.createManifestAndAddToPod(testVMExport, vmManifest, vmBytes, newPod(), service, extra)).To(Succeed())
+		Expect(patchCalls).To(Equal(1))
+		testutils.ExpectEvent(recorder, exporterManifestConfigMapUpdatedEvent)
+
+		Expect(controller.createManifestAndAddToPod(testVMExport, vmManifest, vmBytes, newPod(), service, extra)).To(Succeed())
+		Expect(patchCalls).To(Equal(1))
+		Expect(recorder.Events).To(BeEmpty())
+	})
+
+	It("should not patch a datamanifest owned by a previous VMExport", func() {
+		testVMExport := createVMVMExport()
+		vm := &virtv1.VirtualMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testVmName,
+				Namespace: testNamespace,
+			},
+			Spec: virtv1.VirtualMachineSpec{
+				Template: &virtv1.VirtualMachineInstanceTemplateSpec{
+					Spec: virtv1.VirtualMachineInstanceSpec{},
+				},
+			},
+		}
+		service := &k8sv1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      controller.getExportServiceName(testVMExport),
+				Namespace: testVMExport.Namespace,
+			},
+		}
+		pod := &k8sv1.Pod{
+			Spec: k8sv1.PodSpec{
+				Containers: []k8sv1.Container{{}},
+			},
+		}
+		vmBytes, err := controller.generateVMDefinitionFromVm(vm)
+		Expect(err).ToNot(HaveOccurred())
+		extra, err := controller.extraVMData(vm)
+		Expect(err).ToNot(HaveOccurred())
+		manifest, err := controller.createManifestConfigMap(testVMExport, vmManifest, vmBytes, service, extra)
+		Expect(err).ToNot(HaveOccurred())
+		manifest.OwnerReferences[0].UID = uuid.NewUUID()
+		_, err = k8sClient.CoreV1().ConfigMaps(testNamespace).Create(context.Background(), manifest, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		patchCalls := 0
+		k8sClient.Fake.PrependReactor("patch", "configmaps", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+			patchCalls++
+			return false, nil, nil
+		})
+
+		Expect(controller.createManifestAndAddToPod(testVMExport, vmManifest, vmBytes, pod, service, extra)).To(MatchError(ContainSubstring("is not controlled by the current VMExport")))
+		Expect(patchCalls).To(BeZero())
+		Expect(pod.Spec.Containers[0].VolumeMounts).To(BeEmpty())
+		Expect(pod.Spec.Volumes).To(BeEmpty())
+		Expect(recorder.Events).To(BeEmpty())
+	})
+
+	It("should return an error when patching an existing datamanifest fails", func() {
+		testVMExport := createVMVMExport()
+		vm := &virtv1.VirtualMachine{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      testVmName,
+				Namespace: testNamespace,
+			},
+			Spec: virtv1.VirtualMachineSpec{
+				Template: &virtv1.VirtualMachineInstanceTemplateSpec{
+					Spec: virtv1.VirtualMachineInstanceSpec{},
+				},
+			},
+		}
+		service := &k8sv1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      controller.getExportServiceName(testVMExport),
+				Namespace: testVMExport.Namespace,
+			},
+		}
+		pod := &k8sv1.Pod{
+			Spec: k8sv1.PodSpec{
+				Containers: []k8sv1.Container{{}},
+			},
+		}
+		vmBytes, err := controller.generateVMDefinitionFromVm(vm)
+		Expect(err).ToNot(HaveOccurred())
+		extra, err := controller.extraVMData(vm)
+		Expect(err).ToNot(HaveOccurred())
+		manifest, err := controller.createManifestConfigMap(testVMExport, vmManifest, vmBytes, service, extra)
+		Expect(err).ToNot(HaveOccurred())
+		manifest.Data[internalHostKey] = "stale host"
+		_, err = k8sClient.CoreV1().ConfigMaps(testNamespace).Create(context.Background(), manifest, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		patchErr := fmt.Errorf("patch failed")
+		k8sClient.Fake.PrependReactor("patch", "configmaps", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+			return true, nil, patchErr
+		})
+
+		Expect(controller.createManifestAndAddToPod(testVMExport, vmManifest, vmBytes, pod, service, extra)).To(MatchError(patchErr))
+		Expect(pod.Spec.Containers[0].VolumeMounts).To(BeEmpty())
+		Expect(pod.Spec.Volumes).To(BeEmpty())
+		Expect(recorder.Events).To(BeEmpty())
 	})
 
 	It("should create template manifest and add it to the pod spec", func() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:

When the manifest ConfigMap already existed, the controller ignored the `AlreadyExists` error and continued without validating or updating it.

After export CA rotation, a recreated exporter Pod could use a certificate signed by the new CA while the manifest ConfigMap still contained the old CA. CDI imports using that manifest then failed TLS verification.

#### After this PR:

When the ConfigMap already exists, the controller patches ConfigMap with new CA.

### References

 - Fixes #18964

### Why we need it and why it was done in this way
The following tradeoffs were made:

- An additional GET request is made when ConfigMap creation returns `AlreadyExists`.
- Reconciliation waits and retries when the existing ConfigMap belongs to another `VirtualMachineExport`.
- Only `data` is reconciled; metadata remains unchanged.

The following alternatives were considered:

- Deleting and recreating the ConfigMap: introduces a period when the ConfigMap is missing.
- Making the exporter Pod the ConfigMap owner: the Pod UID is not available when the ConfigMap must be created and introduces an additional failure window.

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed VirtualMachineExport manifests retaining stale CA certificates when exporter Pods are recreated after CA rotation, which could cause CDI disk imports to fail TLS verification
```

