### PR TITLE
[release-1.7] fix(virt-handler): remove incorrect ghost record deletions

### DIFF
--- a/pkg/virt-handler/migration-target.go
+++ b/pkg/virt-handler/migration-target.go
@@ -384,11 +384,13 @@ func (c *MigrationTargetController) updateVMI(vmi *v1.VirtualMachineInstance, ol
 
 // finalCleanup is the last thing we run on finished migrations.
 // If the function completes successfully:
-// - On failure, virt-launcher will be notified and the virt-handler-managed volumes will be unmounted
-// - All caches related to the VMI and domain will be dropped
-// - The VMI will be removed from our informer
-// - The migration proxy for the VMI will be stopped
-// - The key will not be re-enqueued
+//   - On failure, virt-launcher will be notified on a best-effort basis, the virt-handler-managed volumes
+//     will be unmounted, VMI will be removed from store and launcher client will be closed
+//   - On success, the launcher client and its ghost record are retained until the
+//     VM controller takes over and performs domain teardown
+//   - Migration-target bookkeeping is removed and the VMI is updated in the informer
+//   - The migration proxy for the VMI will be stopped
+//   - The key will not be re-enqueued
 func (c *MigrationTargetController) finalCleanup(vmi *v1.VirtualMachineInstance, oldSpec *v1.VirtualMachineInstanceSpec, oldStatus *v1.VirtualMachineInstanceStatus, oldLabels map[string]string, domain *api.Domain) error {
 	if domainPausedFailedPostCopy(domain) {
 		if vmi.Status.Phase == v1.Running {
@@ -408,7 +410,6 @@ func (c *MigrationTargetController) finalCleanup(vmi *v1.VirtualMachineInstance,
 	}
 
 	defer c.migrationProxy.StopTargetListener(string(vmi.UID))
-	defer c.launcherClients.CloseLauncherClient(vmi)
 	client, err := c.launcherClients.GetLauncherClient(vmi)
 	if err != nil {
 		return err
@@ -434,6 +435,7 @@ func (c *MigrationTargetController) finalCleanup(vmi *v1.VirtualMachineInstance,
 		if err = c.domainStore.Delete(vmi); err != nil {
 			return err
 		}
+		c.launcherClients.CloseLauncherClient(vmi)
 	} else {
 		options := &cmdv1.VirtualMachineOptions{}
 		options.InterfaceMigration = domainspec.BindingMigrationByInterfaceName(vmi.Spec.Domain.Devices.Interfaces, c.clusterConfig.GetNetworkBindings())

--- a/pkg/virt-handler/migration-target_test.go
+++ b/pkg/virt-handler/migration-target_test.go
@@ -743,6 +743,70 @@ var _ = Describe("VirtualMachineInstance migration target", func() {
 		Expect(updatedVMI.Spec.Volumes).To(Equal(originalVMI.Spec.Volumes))
 		Expect(updatedVMI.Labels).To(Not(HaveKey(v1.MigrationTargetNodeNameLabel)))
 	})
+
+	It("should preserve ghost record on successful migration cleanup", func() {
+		vmi := api2.NewMinimalVMI("testvmi")
+		vmi.UID = vmiTestUUID
+		vmi.ObjectMeta.ResourceVersion = "1"
+		vmi.Status.Phase = v1.Running
+		vmi.Labels = make(map[string]string)
+		vmi.Status.NodeName = host
+		vmi.Labels[v1.MigrationTargetNodeNameLabel] = host
+		pastTime := metav1.NewTime(metav1.Now().Add(time.Duration(-10) * time.Second))
+		vmi.Status.MigrationState = &v1.VirtualMachineInstanceMigrationState{
+			TargetNode:               host,
+			TargetNodeAddress:        "127.0.0.1:12345",
+			SourceNode:               "othernode",
+			MigrationUID:             "123",
+			TargetNodeDomainDetected: true,
+			StartTimestamp:           &pastTime,
+			EndTimestamp:             pointer.P(metav1.Now()),
+			Completed:                true,
+		}
+
+		domain := api.NewMinimalDomainWithUUID("testvmi", vmiTestUUID)
+		domain.Status.Status = api.Running
+		domain.Spec.Metadata.KubeVirt.Migration = &api.MigrationMetadata{
+			UID:            "123",
+			StartTimestamp: &pastTime,
+			EndTimestamp:   pointer.P(metav1.Now()),
+		}
+
+		Expect(virtcache.GhostRecordGlobalStore.Add(vmi.Namespace, vmi.Name, sockFile, vmi.UID)).To(Succeed())
+		addVMI(vmi, domain)
+
+		client.EXPECT().FinalizeVirtualMachineMigration(gomock.Any(), gomock.Any()).Return(nil)
+		sanityExecute()
+
+		Expect(virtcache.GhostRecordGlobalStore.Exists(vmi.Namespace, vmi.Name)).To(BeTrue())
+	})
+
+	It("should remove ghost record on failed migration cleanup", func() {
+		vmi := api2.NewMinimalVMI("testvmi")
+		vmi.UID = vmiTestUUID
+		vmi.ObjectMeta.ResourceVersion = "1"
+		vmi.Status.Phase = v1.Running
+		vmi.Labels = make(map[string]string)
+		vmi.Status.NodeName = "othernode"
+		vmi.Labels[v1.MigrationTargetNodeNameLabel] = host
+		vmi.Status.MigrationState = &v1.VirtualMachineInstanceMigrationState{
+			TargetNode:   host,
+			SourceNode:   "othernode",
+			MigrationUID: "123",
+			Failed:       true,
+			Completed:    true,
+			EndTimestamp: pointer.P(metav1.Now()),
+		}
+		vmi = addActivePods(vmi, podTestUUID, host)
+
+		Expect(virtcache.GhostRecordGlobalStore.Add(vmi.Namespace, vmi.Name, sockFile, vmi.UID)).To(Succeed())
+		createVMI(vmi)
+
+		client.EXPECT().SignalTargetPodCleanup(vmi)
+		sanityExecute()
+
+		Expect(virtcache.GhostRecordGlobalStore.Exists(vmi.Namespace, vmi.Name)).To(BeFalse())
+	})
 })
 
 type stubTargetPasstRepairHandler struct {


### PR DESCRIPTION
This is a manual backport of #18917 

* [The first commit](https://github.com/kubevirt/kubevirt/pull/18953/changes/23003e4ad25e273bbfc584ab4ad8b4d3382b0944) conflicted with non existing `migrationProxyKey` function.
* [The second commit](https://github.com/kubevirt/kubevirt/pull/18953/changes/47fe2f3004e09dee4f9b7c91070f03651f3ac657) was omitted because its a fix for #17798, which exists only since release-1.8 and wasn't backported to release-1.7


**Release Note**
```release-note
NONE
```

