### PR TITLE
hack: add a go fix modernization gate and roll it out across pkg/network

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -242,6 +242,7 @@ lint:
 	hack/dockerized "hack/golangci-lint.sh"
 	hack/dockerized "monitoringlinter ./pkg/..."
 	hack/dockerized "hack/license-header-check.sh"
+	hack/dockerized "hack/go-fix.sh --diff"
 
 lint-metrics:
 	hack/dockerized "./hack/prom-metric-linter/metrics_collector.sh > metrics.json"
@@ -250,6 +251,9 @@ lint-metrics:
 
 gofumpt:
 	./hack/dockerized "hack/gofumpt.sh"
+
+gofix:
+	./hack/dockerized "hack/go-fix.sh"
 
 update-generated-api-testdata:
 	./hack/update-generated-api-testdata.sh

--- a/hack/go-fix.sh
+++ b/hack/go-fix.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+#
+# This file is part of the KubeVirt project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Copyright The KubeVirt Authors.
+#
+
+set -e
+
+paths=""
+while IFS= read -r line; do
+    # read directory from the file and append a wildcard
+    [[ -n "${line}" ]] && paths+="./${line}/... "
+done <hack/linter/go-fix-paths.txt
+
+# Nothing opted in yet: go fix with no packages would default to '.', so bail out.
+if [[ -z "${paths}" ]]; then
+    exit 0
+fi
+
+if [[ "${1:-}" == "--diff" ]]; then
+    # go fix -diff exits 0 even when fixes are pending, so fail on non-empty
+    # output instead of the exit code. '|| true' keeps a conflict-skip exit
+    # (which does return non-zero) from aborting the capture under 'set -e'.
+    diff="$(go fix -diff ${paths} || true)"
+    if [[ -n "${diff}" ]]; then
+        echo "${diff}"
+        echo "go fix found unapplied fixes; run 'make gofix' and commit the result." >&2
+        exit 1
+    fi
+else
+    # A single 'go fix' pass applies only non-overlapping fixes and then
+    # exits non-zero asking to "Re-run the command to apply more". Loop until
+    # no fixes remain (the -diff gate is empty) so one 'make gofix' converges
+    # instead of leaving pending fixes behind. '|| true' keeps that partial
+    # exit from aborting under 'set -e'.
+    for _ in $(seq 1 5); do
+        go fix ${paths} || true
+        [[ -z "$(go fix -diff ${paths} || true)" ]] && break
+    done
+fi

--- a/hack/linter/go-fix-paths.txt
+++ b/hack/linter/go-fix-paths.txt
@@ -1,7 +1,1 @@
-pkg/network/admitter
-pkg/network/cache
-pkg/network/dhcp
-pkg/network/dns
-pkg/network/driver
-pkg/network/multus
-pkg/network/setup
+pkg/network

--- a/hack/linter/go-fix-paths.txt
+++ b/hack/linter/go-fix-paths.txt
@@ -1,0 +1,1 @@
+pkg/network/admitter

--- a/hack/linter/go-fix-paths.txt
+++ b/hack/linter/go-fix-paths.txt
@@ -3,3 +3,4 @@ pkg/network/cache
 pkg/network/dhcp
 pkg/network/dns
 pkg/network/driver
+pkg/network/multus

--- a/hack/linter/go-fix-paths.txt
+++ b/hack/linter/go-fix-paths.txt
@@ -4,3 +4,4 @@ pkg/network/dhcp
 pkg/network/dns
 pkg/network/driver
 pkg/network/multus
+pkg/network/setup

--- a/hack/linter/go-fix-paths.txt
+++ b/hack/linter/go-fix-paths.txt
@@ -2,3 +2,4 @@ pkg/network/admitter
 pkg/network/cache
 pkg/network/dhcp
 pkg/network/dns
+pkg/network/driver

--- a/hack/linter/go-fix-paths.txt
+++ b/hack/linter/go-fix-paths.txt
@@ -1,3 +1,4 @@
 pkg/network/admitter
 pkg/network/cache
 pkg/network/dhcp
+pkg/network/dns

--- a/hack/linter/go-fix-paths.txt
+++ b/hack/linter/go-fix-paths.txt
@@ -1,2 +1,3 @@
 pkg/network/admitter
 pkg/network/cache
+pkg/network/dhcp

--- a/hack/linter/go-fix-paths.txt
+++ b/hack/linter/go-fix-paths.txt
@@ -1,1 +1,2 @@
 pkg/network/admitter
+pkg/network/cache

--- a/pkg/network/admitter/BUILD.bazel
+++ b/pkg/network/admitter/BUILD.bazel
@@ -49,6 +49,5 @@ go_test(
         "//vendor/github.com/onsi/gomega/types:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/util/validation/field:go_default_library",
-        "//vendor/k8s.io/utils/ptr:go_default_library",
     ],
 )

--- a/pkg/network/admitter/dra_test.go
+++ b/pkg/network/admitter/dra_test.go
@@ -25,7 +25,6 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/ptr"
 
 	v1 "kubevirt.io/api/core/v1"
 
@@ -241,7 +240,7 @@ func newDRASpec() *v1.VirtualMachineInstanceSpec {
 			},
 		},
 		ResourceClaims: []v1.VirtualMachineInstanceResourceClaim{
-			{Name: "claim1", ResourceClaimName: ptr.To("claim1")},
+			{Name: "claim1", ResourceClaimName: new("claim1")},
 		},
 	}
 }

--- a/pkg/network/admitter/netsource_test.go
+++ b/pkg/network/admitter/netsource_test.go
@@ -24,7 +24,6 @@ import (
 	. "github.com/onsi/gomega"
 
 	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/utils/ptr"
 
 	v1 "kubevirt.io/api/core/v1"
 
@@ -92,7 +91,7 @@ var _ = Describe("Validate network source", func() {
 		spec.Domain.Devices.Interfaces = []v1.Interface{
 			{Name: draNetName, Binding: &v1.PluginBinding{Name: "netbinding"}},
 		}
-		spec.ResourceClaims = []v1.VirtualMachineInstanceResourceClaim{{Name: "claim1", ResourceClaimName: ptr.To("claim1")}}
+		spec.ResourceClaims = []v1.VirtualMachineInstanceResourceClaim{{Name: "claim1", ResourceClaimName: new("claim1")}}
 		spec.Networks = []v1.Network{
 			{
 				Name: draNetName,
@@ -115,7 +114,7 @@ var _ = Describe("Validate network source", func() {
 			spec.Domain.Devices.Interfaces = []v1.Interface{
 				{Name: "default", Binding: &v1.PluginBinding{Name: "netbinding"}},
 			}
-			spec.ResourceClaims = []v1.VirtualMachineInstanceResourceClaim{{Name: "claim1", ResourceClaimName: ptr.To("claim1")}}
+			spec.ResourceClaims = []v1.VirtualMachineInstanceResourceClaim{{Name: "claim1", ResourceClaimName: new("claim1")}}
 			spec.Networks = []v1.Network{
 				{
 					Name: "default",

--- a/pkg/network/cache/cache.go
+++ b/pkg/network/cache/cache.go
@@ -70,12 +70,12 @@ func (c Cache) Entry(path string) (Cache, error) {
 	}, nil
 }
 
-func (c Cache) Read(data interface{}) (interface{}, error) {
+func (c Cache) Read(data any) (any, error) {
 	err := readFromCachedFile(c.fs, data, c.path)
 	return data, err
 }
 
-func (c Cache) Write(data interface{}) error {
+func (c Cache) Write(data any) error {
 	return writeToCachedFile(c.fs, data, c.path)
 }
 
@@ -87,7 +87,7 @@ type cacheCreator interface {
 	New(filePath string) *Cache
 }
 
-func writeToCachedFile(fs cacheFS, obj interface{}, fileName string) error {
+func writeToCachedFile(fs cacheFS, obj any, fileName string) error {
 	if err := fs.MkdirAll(filepath.Dir(fileName), 0750); err != nil {
 		return err
 	}
@@ -103,7 +103,7 @@ func writeToCachedFile(fs cacheFS, obj interface{}, fileName string) error {
 	return dutils.DefaultOwnershipManager.UnsafeSetFileOwnership(fileName)
 }
 
-func readFromCachedFile(fs cacheFS, obj interface{}, fileName string) error {
+func readFromCachedFile(fs cacheFS, obj any, fileName string) error {
 	buf, err := fs.ReadFile(fileName)
 	if err != nil {
 		return err

--- a/pkg/network/dhcp/server/server.go
+++ b/pkg/network/dhcp/server/server.go
@@ -299,8 +299,8 @@ func convertSearchDomainsToBytes(searchDomainStrings []string) ([]byte, error) {
 	var searchDomainBytes []byte
 	for _, domain := range searchDomainStrings {
 		if isValidSearchDomain(domain) {
-			labels := strings.Split(domain, ".")
-			for _, label := range labels {
+			labels := strings.SplitSeq(domain, ".")
+			for label := range labels {
 				searchDomainBytes = append(searchDomainBytes, byte(len(label)))
 				searchDomainBytes = append(searchDomainBytes, []byte(label)...)
 			}

--- a/pkg/network/dns/resolveconf.go
+++ b/pkg/network/dns/resolveconf.go
@@ -92,9 +92,9 @@ func ParseSearchDomains(content string) ([]string, error) {
 
 	for scanner.Scan() {
 		line := scanner.Text()
-		if strings.HasPrefix(line, domainSearchPrefix) {
-			doms := strings.Fields(strings.TrimPrefix(line, domainSearchPrefix))
-			for _, dom := range doms {
+		if after, ok := strings.CutPrefix(line, domainSearchPrefix); ok {
+			doms := strings.FieldsSeq(after)
+			for dom := range doms {
 				// domain names are case insensitive but kubernetes allows only lower-case
 				searchDomains = append(searchDomains, strings.ToLower(dom))
 			}

--- a/pkg/network/driver/nmstate/BUILD.bazel
+++ b/pkg/network/driver/nmstate/BUILD.bazel
@@ -13,7 +13,6 @@ go_library(
         "//pkg/network/driver/netlink:go_default_library",
         "//pkg/network/driver/procsys:go_default_library",
         "//pkg/network/driver/virtchroot:go_default_library",
-        "//pkg/pointer:go_default_library",
         "//vendor/github.com/vishvananda/netlink:go_default_library",
         "//vendor/golang.org/x/sys/unix:go_default_library",
     ],

--- a/pkg/network/driver/nmstate/integration_test.go
+++ b/pkg/network/driver/nmstate/integration_test.go
@@ -90,11 +90,11 @@ var _ = Describe("NMState", integrationLabel, func() {
 			TypeName:   nmstate.TypeBridge,
 			MacAddress: bridgeMac,
 			MTU:        bridgeMTU,
-			IPv4:       nmstate.IP{Enabled: pointer.P(false)},
-			IPv6:       nmstate.IP{Enabled: pointer.P(false)},
+			IPv4:       nmstate.IP{Enabled: new(false)},
+			IPv6:       nmstate.IP{Enabled: new(false)},
 			LinuxStack: nmstate.LinuxIfaceStack{
-				IP4RouteLocalNet: pointer.P(false),
-				PortLearning:     pointer.P(false),
+				IP4RouteLocalNet: new(false),
+				PortLearning:     new(false),
 			},
 		}))
 	})
@@ -129,7 +129,7 @@ var _ = Describe("NMState", integrationLabel, func() {
 
 		It("add IP to the bridge", func() {
 			spec.Interfaces[0].IPv4 = nmstate.IP{
-				Enabled: pointer.P(true),
+				Enabled: new(true),
 				Address: []nmstate.IPAddress{primaryIP4Address()},
 			}
 			Expect(nmState.Apply(&spec)).To(Succeed())
@@ -145,20 +145,20 @@ var _ = Describe("NMState", integrationLabel, func() {
 				MacAddress: bridgeMac,
 				MTU:        bridgeMTU,
 				IPv4: nmstate.IP{
-					Enabled: pointer.P(true),
+					Enabled: new(true),
 					Address: []nmstate.IPAddress{primaryIP4Address()},
 				},
-				IPv6: nmstate.IP{Enabled: pointer.P(false)},
+				IPv6: nmstate.IP{Enabled: new(false)},
 				LinuxStack: nmstate.LinuxIfaceStack{
-					IP4RouteLocalNet: pointer.P(false),
-					PortLearning:     pointer.P(false),
+					IP4RouteLocalNet: new(false),
+					PortLearning:     new(false),
 				},
 			}))
 		})
 
 		It("add a secondary IP to the bridge", func() {
 			spec.Interfaces[0].IPv4 = nmstate.IP{
-				Enabled: pointer.P(true),
+				Enabled: new(true),
 				Address: []nmstate.IPAddress{primaryIP4Address()},
 			}
 			Expect(nmState.Apply(&spec)).To(Succeed())
@@ -177,20 +177,20 @@ var _ = Describe("NMState", integrationLabel, func() {
 				MacAddress: bridgeMac,
 				MTU:        bridgeMTU,
 				IPv4: nmstate.IP{
-					Enabled: pointer.P(true),
+					Enabled: new(true),
 					Address: []nmstate.IPAddress{primaryIP4Address(), secondaryIP4Address()},
 				},
-				IPv6: nmstate.IP{Enabled: pointer.P(false)},
+				IPv6: nmstate.IP{Enabled: new(false)},
 				LinuxStack: nmstate.LinuxIfaceStack{
-					IP4RouteLocalNet: pointer.P(false),
-					PortLearning:     pointer.P(false),
+					IP4RouteLocalNet: new(false),
+					PortLearning:     new(false),
 				},
 			}))
 		})
 
 		It("remove a secondary IP from the bridge", func() {
 			spec.Interfaces[0].IPv4 = nmstate.IP{
-				Enabled: pointer.P(true),
+				Enabled: new(true),
 				Address: []nmstate.IPAddress{primaryIP4Address(), secondaryIP4Address()},
 			}
 			Expect(nmState.Apply(&spec)).To(Succeed())
@@ -209,13 +209,13 @@ var _ = Describe("NMState", integrationLabel, func() {
 				MacAddress: bridgeMac,
 				MTU:        bridgeMTU,
 				IPv4: nmstate.IP{
-					Enabled: pointer.P(true),
+					Enabled: new(true),
 					Address: []nmstate.IPAddress{primaryIP4Address()},
 				},
-				IPv6: nmstate.IP{Enabled: pointer.P(false)},
+				IPv6: nmstate.IP{Enabled: new(false)},
 				LinuxStack: nmstate.LinuxIfaceStack{
-					IP4RouteLocalNet: pointer.P(false),
-					PortLearning:     pointer.P(false),
+					IP4RouteLocalNet: new(false),
+					PortLearning:     new(false),
 				},
 			}))
 		})
@@ -254,8 +254,8 @@ var _ = Describe("NMState", integrationLabel, func() {
 			vethIface := lookupIface(status.Interfaces, vethName)
 			Expect(vethIface.Controller).To(Equal(bridgeIface.Name))
 			Expect(vethIface.LinuxStack).To(Equal(nmstate.LinuxIfaceStack{
-				IP4RouteLocalNet: pointer.P(false),
-				PortLearning:     pointer.P(true),
+				IP4RouteLocalNet: new(false),
+				PortLearning:     new(true),
 			}))
 		})
 
@@ -280,7 +280,7 @@ var _ = Describe("NMState", integrationLabel, func() {
 						GID:    ownerID,
 					},
 					LinuxStack: nmstate.LinuxIfaceStack{
-						PortLearning: pointer.P(false),
+						PortLearning: new(false),
 					},
 				},
 			}})
@@ -299,8 +299,8 @@ var _ = Describe("NMState", integrationLabel, func() {
 			Expect(tapIface.TypeName).To(Equal(nmstate.TypeTap))
 			Expect(tapIface.Controller).To(Equal(bridgeIface.Name))
 			Expect(tapIface.LinuxStack).To(Equal(nmstate.LinuxIfaceStack{
-				IP4RouteLocalNet: pointer.P(false),
-				PortLearning:     pointer.P(false),
+				IP4RouteLocalNet: new(false),
+				PortLearning:     new(false),
 			}))
 		})
 	})
@@ -365,19 +365,19 @@ var _ = Describe("NMState", integrationLabel, func() {
 					State:      nmstate.IfaceStateUp,
 					Controller: bridgeName,
 					LinuxStack: nmstate.LinuxIfaceStack{
-						IP4RouteLocalNet: pointer.P(true),
-						PortLearning:     pointer.P(false),
+						IP4RouteLocalNet: new(true),
+						PortLearning:     new(false),
 					},
 				},
 			},
 			LinuxStack: nmstate.LinuxStack{
 				IPv4: nmstate.LinuxStackIP4{
 					ArpIgnore:             pointer.P(procsys.ARPReplyMode1),
-					Forwarding:            pointer.P(true),
+					Forwarding:            new(true),
 					PingGroupRange:        []int{pingGroupRangeFrom, pingGroupRangeTo},
 					UnprivilegedPortStart: pointer.P(unprivilegedPortStart),
 				},
-				IPv6: nmstate.LinuxStackIP6{Forwarding: pointer.P(true)},
+				IPv6: nmstate.LinuxStackIP6{Forwarding: new(true)},
 			},
 		}
 
@@ -401,17 +401,17 @@ var _ = Describe("NMState", integrationLabel, func() {
 
 		dummyIface := lookupIface(status.Interfaces, dummyName)
 		Expect(dummyIface.LinuxStack).To(Equal(nmstate.LinuxIfaceStack{
-			IP4RouteLocalNet: pointer.P(true),
-			PortLearning:     pointer.P(false),
+			IP4RouteLocalNet: new(true),
+			PortLearning:     new(false),
 		}))
 		Expect(status.LinuxStack).To(Equal(nmstate.LinuxStack{
 			IPv4: nmstate.LinuxStackIP4{
 				ArpIgnore:             pointer.P(procsys.ARPReplyMode1),
-				Forwarding:            pointer.P(true),
+				Forwarding:            new(true),
 				PingGroupRange:        []int{pingGroupRangeFrom, pingGroupRangeTo},
 				UnprivilegedPortStart: pointer.P(unprivilegedPortStart),
 			},
-			IPv6: nmstate.LinuxStackIP6{Forwarding: pointer.P(true)},
+			IPv6: nmstate.LinuxStackIP6{Forwarding: new(true)},
 		}))
 	})
 

--- a/pkg/network/driver/nmstate/spec_test.go
+++ b/pkg/network/driver/nmstate/spec_test.go
@@ -79,27 +79,27 @@ var _ = Describe("NMState Spec interfaces", func() {
 				IPv4:       ipv4,
 				IPv6:       ipv6,
 				LinuxStack: nmstate.LinuxIfaceStack{
-					IP4RouteLocalNet: pointer.P(false),
-					PortLearning:     pointer.P(false),
+					IP4RouteLocalNet: new(false),
+					PortLearning:     new(false),
 				},
 			},
 		}))
 	},
-		Entry("no IP", nmstate.IP{Enabled: pointer.P(false)}, nmstate.IP{Enabled: pointer.P(false)}),
+		Entry("no IP", nmstate.IP{Enabled: new(false)}, nmstate.IP{Enabled: new(false)}),
 		Entry("IPv4 (only)",
 			nmstate.IP{
-				Enabled: pointer.P(true),
+				Enabled: new(true),
 				Address: []nmstate.IPAddress{{
 					IP:        ip4Addr0,
 					PrefixLen: ip4Prefix0,
 				}},
 			},
-			nmstate.IP{Enabled: pointer.P(false)},
+			nmstate.IP{Enabled: new(false)},
 		),
 		Entry("IPv6 (only)",
-			nmstate.IP{Enabled: pointer.P(false)},
+			nmstate.IP{Enabled: new(false)},
 			nmstate.IP{
-				Enabled: pointer.P(true),
+				Enabled: new(true),
 				Address: []nmstate.IPAddress{{
 					IP:        ip6Addr0,
 					PrefixLen: ip6Prefix0,
@@ -108,14 +108,14 @@ var _ = Describe("NMState Spec interfaces", func() {
 		),
 		Entry("IPv4 & IPv6",
 			nmstate.IP{
-				Enabled: pointer.P(true),
+				Enabled: new(true),
 				Address: []nmstate.IPAddress{{
 					IP:        ip4Addr0,
 					PrefixLen: ip4Prefix0,
 				}},
 			},
 			nmstate.IP{
-				Enabled: pointer.P(true),
+				Enabled: new(true),
 				Address: []nmstate.IPAddress{{
 					IP:        ip6Addr0,
 					PrefixLen: ip6Prefix0,
@@ -134,14 +134,14 @@ var _ = Describe("NMState Spec interfaces", func() {
 					MacAddress: macAddress0,
 					MTU:        defaultMTU,
 					IPv4: nmstate.IP{
-						Enabled: pointer.P(true),
+						Enabled: new(true),
 						Address: []nmstate.IPAddress{{
 							IP:        ip4Addr0,
 							PrefixLen: ip4Prefix0,
 						}},
 					},
 					IPv6: nmstate.IP{
-						Enabled: pointer.P(true),
+						Enabled: new(true),
 						Address: []nmstate.IPAddress{{
 							IP:        ip6Addr0,
 							PrefixLen: ip6Prefix0,
@@ -189,18 +189,18 @@ var _ = Describe("NMState Spec interfaces", func() {
 					MacAddress: macAddress0,
 					MTU:        defaultMTU,
 					LinuxStack: nmstate.LinuxIfaceStack{
-						IP4RouteLocalNet: pointer.P(false),
-						PortLearning:     pointer.P(false),
+						IP4RouteLocalNet: new(false),
+						PortLearning:     new(false),
 					},
 					IPv4: nmstate.IP{
-						Enabled: pointer.P(true),
+						Enabled: new(true),
 						Address: []nmstate.IPAddress{{
 							IP:        ip4Addr0,
 							PrefixLen: ip4Prefix0,
 						}},
 					},
 					IPv6: nmstate.IP{
-						Enabled: pointer.P(true),
+						Enabled: new(true),
 						Address: []nmstate.IPAddress{{
 							IP:        ip6Addr0,
 							PrefixLen: ip6Prefix0,
@@ -215,11 +215,11 @@ var _ = Describe("NMState Spec interfaces", func() {
 					MacAddress: macAddress0,
 					MTU:        defaultMTU,
 					LinuxStack: nmstate.LinuxIfaceStack{
-						IP4RouteLocalNet: pointer.P(false),
-						PortLearning:     pointer.P(false),
+						IP4RouteLocalNet: new(false),
+						PortLearning:     new(false),
 					},
-					IPv4: nmstate.IP{Enabled: pointer.P(false)},
-					IPv6: nmstate.IP{Enabled: pointer.P(false)},
+					IPv4: nmstate.IP{Enabled: new(false)},
+					IPv6: nmstate.IP{Enabled: new(false)},
 				},
 			}))
 		})
@@ -228,8 +228,8 @@ var _ = Describe("NMState Spec interfaces", func() {
 			err := nmState.Apply(&nmstate.Spec{Interfaces: []nmstate.Interface{
 				{
 					Name: dummyName,
-					IPv4: nmstate.IP{Enabled: pointer.P(false)},
-					IPv6: nmstate.IP{Enabled: pointer.P(false)},
+					IPv4: nmstate.IP{Enabled: new(false)},
+					IPv6: nmstate.IP{Enabled: new(false)},
 				},
 			}})
 			Expect(err).NotTo(HaveOccurred())
@@ -245,11 +245,11 @@ var _ = Describe("NMState Spec interfaces", func() {
 					MacAddress: macAddress0,
 					MTU:        defaultMTU,
 					LinuxStack: nmstate.LinuxIfaceStack{
-						IP4RouteLocalNet: pointer.P(false),
-						PortLearning:     pointer.P(false),
+						IP4RouteLocalNet: new(false),
+						PortLearning:     new(false),
 					},
-					IPv4: nmstate.IP{Enabled: pointer.P(false)},
-					IPv6: nmstate.IP{Enabled: pointer.P(false)},
+					IPv4: nmstate.IP{Enabled: new(false)},
+					IPv6: nmstate.IP{Enabled: new(false)},
 				},
 			}))
 		})
@@ -265,14 +265,14 @@ var _ = Describe("NMState Spec interfaces", func() {
 				{
 					Name: dummyName,
 					IPv4: nmstate.IP{
-						Enabled: pointer.P(true),
+						Enabled: new(true),
 						Address: []nmstate.IPAddress{{
 							IP:        ip4Addr1,
 							PrefixLen: ip4Prefix1,
 						}},
 					},
 					IPv6: nmstate.IP{
-						Enabled: pointer.P(true),
+						Enabled: new(true),
 						Address: []nmstate.IPAddress{{
 							IP:        ip6Addr1,
 							PrefixLen: ip6Prefix1,
@@ -293,18 +293,18 @@ var _ = Describe("NMState Spec interfaces", func() {
 					MacAddress: macAddress0,
 					MTU:        defaultMTU,
 					LinuxStack: nmstate.LinuxIfaceStack{
-						IP4RouteLocalNet: pointer.P(false),
-						PortLearning:     pointer.P(false),
+						IP4RouteLocalNet: new(false),
+						PortLearning:     new(false),
 					},
 					IPv4: nmstate.IP{
-						Enabled: pointer.P(true),
+						Enabled: new(true),
 						Address: []nmstate.IPAddress{{
 							IP:        ip4Addr1,
 							PrefixLen: ip4Prefix1,
 						}},
 					},
 					IPv6: nmstate.IP{
-						Enabled: pointer.P(true),
+						Enabled: new(true),
 						Address: []nmstate.IPAddress{{
 							IP:        ip6Addr1,
 							PrefixLen: ip6Prefix1,
@@ -320,8 +320,8 @@ var _ = Describe("NMState Spec interfaces", func() {
 				{
 					Name:  newDummyName,
 					Index: 1,
-					IPv4:  nmstate.IP{Enabled: pointer.P(false)},
-					IPv6:  nmstate.IP{Enabled: pointer.P(false)},
+					IPv4:  nmstate.IP{Enabled: new(false)},
+					IPv6:  nmstate.IP{Enabled: new(false)},
 				},
 			}})
 			Expect(err).NotTo(HaveOccurred())
@@ -337,11 +337,11 @@ var _ = Describe("NMState Spec interfaces", func() {
 					MacAddress: macAddress0,
 					MTU:        defaultMTU,
 					LinuxStack: nmstate.LinuxIfaceStack{
-						IP4RouteLocalNet: pointer.P(false),
-						PortLearning:     pointer.P(false),
+						IP4RouteLocalNet: new(false),
+						PortLearning:     new(false),
 					},
-					IPv4: nmstate.IP{Enabled: pointer.P(false)},
-					IPv6: nmstate.IP{Enabled: pointer.P(false)},
+					IPv4: nmstate.IP{Enabled: new(false)},
+					IPv6: nmstate.IP{Enabled: new(false)},
 				},
 			}))
 		})
@@ -358,8 +358,8 @@ var _ = Describe("NMState Spec interfaces", func() {
 				{
 					Name:       dummyName,
 					Controller: bridgeName,
-					IPv4:       nmstate.IP{Enabled: pointer.P(false)},
-					IPv6:       nmstate.IP{Enabled: pointer.P(false)},
+					IPv4:       nmstate.IP{Enabled: new(false)},
+					IPv6:       nmstate.IP{Enabled: new(false)},
 				},
 			}})
 			Expect(err).NotTo(HaveOccurred())
@@ -376,11 +376,11 @@ var _ = Describe("NMState Spec interfaces", func() {
 					MacAddress: macAddress0,
 					MTU:        defaultMTU,
 					LinuxStack: nmstate.LinuxIfaceStack{
-						IP4RouteLocalNet: pointer.P(false),
-						PortLearning:     pointer.P(false),
+						IP4RouteLocalNet: new(false),
+						PortLearning:     new(false),
 					},
-					IPv4: nmstate.IP{Enabled: pointer.P(false)},
-					IPv6: nmstate.IP{Enabled: pointer.P(false)},
+					IPv4: nmstate.IP{Enabled: new(false)},
+					IPv6: nmstate.IP{Enabled: new(false)},
 				},
 				{
 					Name:       bridgeName,
@@ -390,11 +390,11 @@ var _ = Describe("NMState Spec interfaces", func() {
 					MacAddress: macAddress0,
 					MTU:        defaultMTU,
 					LinuxStack: nmstate.LinuxIfaceStack{
-						IP4RouteLocalNet: pointer.P(false),
-						PortLearning:     pointer.P(false),
+						IP4RouteLocalNet: new(false),
+						PortLearning:     new(false),
 					},
-					IPv4: nmstate.IP{Enabled: pointer.P(false)},
-					IPv6: nmstate.IP{Enabled: pointer.P(false)},
+					IPv4: nmstate.IP{Enabled: new(false)},
+					IPv6: nmstate.IP{Enabled: new(false)},
 				},
 			}))
 		})
@@ -403,11 +403,11 @@ var _ = Describe("NMState Spec interfaces", func() {
 			Expect(nmState.Apply(&nmstate.Spec{Interfaces: []nmstate.Interface{
 				{
 					Name: dummyName,
-					IPv4: nmstate.IP{Enabled: pointer.P(false)},
-					IPv6: nmstate.IP{Enabled: pointer.P(false)},
+					IPv4: nmstate.IP{Enabled: new(false)},
+					IPv6: nmstate.IP{Enabled: new(false)},
 					LinuxStack: nmstate.LinuxIfaceStack{
-						IP4RouteLocalNet: pointer.P(true),
-						PortLearning:     pointer.P(false),
+						IP4RouteLocalNet: new(true),
+						PortLearning:     new(false),
 					},
 				},
 			}})).To(Succeed())
@@ -423,11 +423,11 @@ var _ = Describe("NMState Spec interfaces", func() {
 					MacAddress: macAddress0,
 					MTU:        defaultMTU,
 					LinuxStack: nmstate.LinuxIfaceStack{
-						IP4RouteLocalNet: pointer.P(true),
-						PortLearning:     pointer.P(false),
+						IP4RouteLocalNet: new(true),
+						PortLearning:     new(false),
 					},
-					IPv4: nmstate.IP{Enabled: pointer.P(false)},
-					IPv6: nmstate.IP{Enabled: pointer.P(false)},
+					IPv4: nmstate.IP{Enabled: new(false)},
+					IPv6: nmstate.IP{Enabled: new(false)},
 				},
 			}))
 		})
@@ -455,26 +455,26 @@ var _ = Describe("NMState Spec Linux Stack", func() {
 			nmstate.LinuxStack{
 				IPv4: nmstate.LinuxStackIP4{
 					ArpIgnore:             pointer.P(procsys.ARPReplyMode1),
-					Forwarding:            pointer.P(false),
+					Forwarding:            new(false),
 					PingGroupRange:        []int{0, 0},
-					UnprivilegedPortStart: pointer.P(0),
+					UnprivilegedPortStart: new(0),
 				},
-				IPv6: nmstate.LinuxStackIP6{Forwarding: pointer.P(false)},
+				IPv6: nmstate.LinuxStackIP6{Forwarding: new(false)},
 			},
 		),
 		Entry("IPv4 & IPv6 forwarding enabled",
 			nmstate.LinuxStack{
-				IPv4: nmstate.LinuxStackIP4{Forwarding: pointer.P(true)},
-				IPv6: nmstate.LinuxStackIP6{Forwarding: pointer.P(true)},
+				IPv4: nmstate.LinuxStackIP4{Forwarding: new(true)},
+				IPv6: nmstate.LinuxStackIP6{Forwarding: new(true)},
 			},
 			nmstate.LinuxStack{
 				IPv4: nmstate.LinuxStackIP4{
 					ArpIgnore:             pointer.P(procsys.ARPReplyMode0),
-					Forwarding:            pointer.P(true),
+					Forwarding:            new(true),
 					PingGroupRange:        []int{0, 0},
-					UnprivilegedPortStart: pointer.P(0),
+					UnprivilegedPortStart: new(0),
 				},
-				IPv6: nmstate.LinuxStackIP6{Forwarding: pointer.P(true)},
+				IPv6: nmstate.LinuxStackIP6{Forwarding: new(true)},
 			},
 		),
 		Entry("ping group range",
@@ -484,25 +484,25 @@ var _ = Describe("NMState Spec Linux Stack", func() {
 			nmstate.LinuxStack{
 				IPv4: nmstate.LinuxStackIP4{
 					ArpIgnore:             pointer.P(procsys.ARPReplyMode0),
-					Forwarding:            pointer.P(false),
+					Forwarding:            new(false),
 					PingGroupRange:        []int{123, 321},
-					UnprivilegedPortStart: pointer.P(0),
+					UnprivilegedPortStart: new(0),
 				},
-				IPv6: nmstate.LinuxStackIP6{Forwarding: pointer.P(false)},
+				IPv6: nmstate.LinuxStackIP6{Forwarding: new(false)},
 			},
 		),
 		Entry("unprivileged port start",
 			nmstate.LinuxStack{
-				IPv4: nmstate.LinuxStackIP4{UnprivilegedPortStart: pointer.P(1000)},
+				IPv4: nmstate.LinuxStackIP4{UnprivilegedPortStart: new(1000)},
 			},
 			nmstate.LinuxStack{
 				IPv4: nmstate.LinuxStackIP4{
 					ArpIgnore:             pointer.P(procsys.ARPReplyMode0),
-					Forwarding:            pointer.P(false),
+					Forwarding:            new(false),
 					PingGroupRange:        []int{0, 0},
-					UnprivilegedPortStart: pointer.P(1000),
+					UnprivilegedPortStart: new(1000),
 				},
-				IPv6: nmstate.LinuxStackIP6{Forwarding: pointer.P(false)},
+				IPv6: nmstate.LinuxStackIP6{Forwarding: new(false)},
 			},
 		),
 	)

--- a/pkg/network/driver/nmstate/status.go
+++ b/pkg/network/driver/nmstate/status.go
@@ -23,8 +23,6 @@ import (
 	"net"
 	"strings"
 
-	"kubevirt.io/kubevirt/pkg/pointer"
-
 	vishnetlink "github.com/vishvananda/netlink"
 )
 
@@ -62,10 +60,10 @@ func (n NMState) readInterfaces(links []vishnetlink.Link) ([]Interface, error) {
 			MacAddress: link.Attrs().HardwareAddr.String(),
 			MTU:        link.Attrs().MTU,
 			IPv4: IP{
-				Enabled: pointer.P(false),
+				Enabled: new(false),
 			},
 			IPv6: IP{
-				Enabled: pointer.P(false),
+				Enabled: new(false),
 			},
 		}
 		if index := link.Attrs().MasterIndex; index > 0 {
@@ -81,7 +79,7 @@ func (n NMState) readInterfaces(links []vishnetlink.Link) ([]Interface, error) {
 			return nil, err
 		}
 		if len(addresses) > 0 {
-			iface.IPv4.Enabled = pointer.P(true)
+			iface.IPv4.Enabled = new(true)
 			iface.IPv4.Address = addresses
 		}
 
@@ -90,7 +88,7 @@ func (n NMState) readInterfaces(links []vishnetlink.Link) ([]Interface, error) {
 			return nil, err
 		}
 		if len(addresses) > 0 {
-			iface.IPv6.Enabled = pointer.P(true)
+			iface.IPv6.Enabled = new(true)
 			iface.IPv6.Address = addresses
 		}
 

--- a/pkg/network/driver/nmstate/status_test.go
+++ b/pkg/network/driver/nmstate/status_test.go
@@ -74,11 +74,11 @@ var _ = Describe("NMState Status interfaces", func() {
 				State:      nmstate.IfaceStateUp,
 				MacAddress: macAddress0,
 				MTU:        defaultMTU,
-				IPv4:       nmstate.IP{Enabled: pointer.P(false)},
-				IPv6:       nmstate.IP{Enabled: pointer.P(false)},
+				IPv4:       nmstate.IP{Enabled: new(false)},
+				IPv6:       nmstate.IP{Enabled: new(false)},
 				LinuxStack: nmstate.LinuxIfaceStack{
-					IP4RouteLocalNet: pointer.P(false),
-					PortLearning:     pointer.P(false),
+					IP4RouteLocalNet: new(false),
+					PortLearning:     new(false),
 				},
 			},
 			{
@@ -88,11 +88,11 @@ var _ = Describe("NMState Status interfaces", func() {
 				State:      nmstate.IfaceStateUp,
 				MacAddress: macAddress0,
 				MTU:        defaultMTU,
-				IPv4:       nmstate.IP{Enabled: pointer.P(false)},
-				IPv6:       nmstate.IP{Enabled: pointer.P(false)},
+				IPv4:       nmstate.IP{Enabled: new(false)},
+				IPv6:       nmstate.IP{Enabled: new(false)},
 				LinuxStack: nmstate.LinuxIfaceStack{
-					IP4RouteLocalNet: pointer.P(false),
-					PortLearning:     pointer.P(false),
+					IP4RouteLocalNet: new(false),
+					PortLearning:     new(false),
 				},
 			},
 		}))
@@ -118,11 +118,11 @@ var _ = Describe("NMState Status interfaces", func() {
 				MacAddress: macAddress0,
 				MTU:        defaultMTU,
 				Controller: bridgeName,
-				IPv4:       nmstate.IP{Enabled: pointer.P(false)},
-				IPv6:       nmstate.IP{Enabled: pointer.P(false)},
+				IPv4:       nmstate.IP{Enabled: new(false)},
+				IPv6:       nmstate.IP{Enabled: new(false)},
 				LinuxStack: nmstate.LinuxIfaceStack{
-					IP4RouteLocalNet: pointer.P(false),
-					PortLearning:     pointer.P(false),
+					IP4RouteLocalNet: new(false),
+					PortLearning:     new(false),
 				},
 			},
 			{
@@ -132,11 +132,11 @@ var _ = Describe("NMState Status interfaces", func() {
 				State:      nmstate.IfaceStateUp,
 				MacAddress: macAddress0,
 				MTU:        defaultMTU,
-				IPv4:       nmstate.IP{Enabled: pointer.P(false)},
-				IPv6:       nmstate.IP{Enabled: pointer.P(false)},
+				IPv4:       nmstate.IP{Enabled: new(false)},
+				IPv6:       nmstate.IP{Enabled: new(false)},
 				LinuxStack: nmstate.LinuxIfaceStack{
-					IP4RouteLocalNet: pointer.P(false),
-					PortLearning:     pointer.P(false),
+					IP4RouteLocalNet: new(false),
+					PortLearning:     new(false),
 				},
 			},
 		}))
@@ -160,16 +160,16 @@ var _ = Describe("NMState Status interfaces", func() {
 				MacAddress: macAddress0,
 				MTU:        defaultMTU,
 				IPv4: nmstate.IP{
-					Enabled: pointer.P(true),
+					Enabled: new(true),
 					Address: []nmstate.IPAddress{{IP: ip4, PrefixLen: prefix4}},
 				},
 				IPv6: nmstate.IP{
-					Enabled: pointer.P(true),
+					Enabled: new(true),
 					Address: []nmstate.IPAddress{{IP: ip6, PrefixLen: prefix6}},
 				},
 				LinuxStack: nmstate.LinuxIfaceStack{
-					IP4RouteLocalNet: pointer.P(false),
-					PortLearning:     pointer.P(false),
+					IP4RouteLocalNet: new(false),
+					PortLearning:     new(false),
 				},
 			},
 			{
@@ -179,11 +179,11 @@ var _ = Describe("NMState Status interfaces", func() {
 				State:      nmstate.IfaceStateUp,
 				MacAddress: macAddress0,
 				MTU:        defaultMTU,
-				IPv4:       nmstate.IP{Enabled: pointer.P(false)},
-				IPv6:       nmstate.IP{Enabled: pointer.P(false)},
+				IPv4:       nmstate.IP{Enabled: new(false)},
+				IPv6:       nmstate.IP{Enabled: new(false)},
 				LinuxStack: nmstate.LinuxIfaceStack{
-					IP4RouteLocalNet: pointer.P(false),
-					PortLearning:     pointer.P(false),
+					IP4RouteLocalNet: new(false),
+					PortLearning:     new(false),
 				},
 			},
 		}))
@@ -208,11 +208,11 @@ var _ = Describe("NMState Status interfaces", func() {
 			State:      nmstate.IfaceStateUp,
 			MacAddress: macAddress0,
 			MTU:        defaultMTU,
-			IPv4:       nmstate.IP{Enabled: pointer.P(false)},
-			IPv6:       nmstate.IP{Enabled: pointer.P(false)},
+			IPv4:       nmstate.IP{Enabled: new(false)},
+			IPv6:       nmstate.IP{Enabled: new(false)},
 			LinuxStack: nmstate.LinuxIfaceStack{
-				IP4RouteLocalNet: pointer.P(true),
-				PortLearning:     pointer.P(true),
+				IP4RouteLocalNet: new(true),
+				PortLearning:     new(true),
 			},
 		}))
 	})
@@ -235,11 +235,11 @@ var _ = Describe("NMState Status Linux Stack", func() {
 		Expect(status.LinuxStack).To(Equal(nmstate.LinuxStack{
 			IPv4: nmstate.LinuxStackIP4{
 				ArpIgnore:             pointer.P(procsys.ARPReplyMode1),
-				Forwarding:            pointer.P(false),
+				Forwarding:            new(false),
 				PingGroupRange:        []int{0, 0},
-				UnprivilegedPortStart: pointer.P(0),
+				UnprivilegedPortStart: new(0),
 			},
-			IPv6: nmstate.LinuxStackIP6{Forwarding: pointer.P(false)},
+			IPv6: nmstate.LinuxStackIP6{Forwarding: new(false)},
 		}))
 	})
 
@@ -251,11 +251,11 @@ var _ = Describe("NMState Status Linux Stack", func() {
 		Expect(status.LinuxStack).To(Equal(nmstate.LinuxStack{
 			IPv4: nmstate.LinuxStackIP4{
 				ArpIgnore:             pointer.P(procsys.ARPReplyMode0),
-				Forwarding:            pointer.P(true),
+				Forwarding:            new(true),
 				PingGroupRange:        []int{0, 0},
-				UnprivilegedPortStart: pointer.P(0),
+				UnprivilegedPortStart: new(0),
 			},
-			IPv6: nmstate.LinuxStackIP6{Forwarding: pointer.P(false)},
+			IPv6: nmstate.LinuxStackIP6{Forwarding: new(false)},
 		}))
 	})
 
@@ -267,11 +267,11 @@ var _ = Describe("NMState Status Linux Stack", func() {
 		Expect(status.LinuxStack).To(Equal(nmstate.LinuxStack{
 			IPv4: nmstate.LinuxStackIP4{
 				ArpIgnore:             pointer.P(procsys.ARPReplyMode0),
-				Forwarding:            pointer.P(false),
+				Forwarding:            new(false),
 				PingGroupRange:        []int{0, 0},
-				UnprivilegedPortStart: pointer.P(0),
+				UnprivilegedPortStart: new(0),
 			},
-			IPv6: nmstate.LinuxStackIP6{Forwarding: pointer.P(true)},
+			IPv6: nmstate.LinuxStackIP6{Forwarding: new(true)},
 		}))
 	})
 
@@ -284,11 +284,11 @@ var _ = Describe("NMState Status Linux Stack", func() {
 		Expect(status.LinuxStack).To(Equal(nmstate.LinuxStack{
 			IPv4: nmstate.LinuxStackIP4{
 				ArpIgnore:             pointer.P(procsys.ARPReplyMode0),
-				Forwarding:            pointer.P(false),
+				Forwarding:            new(false),
 				PingGroupRange:        []int{groupID, groupID},
-				UnprivilegedPortStart: pointer.P(0),
+				UnprivilegedPortStart: new(0),
 			},
-			IPv6: nmstate.LinuxStackIP6{Forwarding: pointer.P(false)},
+			IPv6: nmstate.LinuxStackIP6{Forwarding: new(false)},
 		}))
 	})
 
@@ -301,11 +301,11 @@ var _ = Describe("NMState Status Linux Stack", func() {
 		Expect(status.LinuxStack).To(Equal(nmstate.LinuxStack{
 			IPv4: nmstate.LinuxStackIP4{
 				ArpIgnore:             pointer.P(procsys.ARPReplyMode0),
-				Forwarding:            pointer.P(false),
+				Forwarding:            new(false),
 				PingGroupRange:        []int{0, 0},
 				UnprivilegedPortStart: pointer.P(unprivPortStart),
 			},
-			IPv6: nmstate.LinuxStackIP6{Forwarding: pointer.P(false)},
+			IPv6: nmstate.LinuxStackIP6{Forwarding: new(false)},
 		}))
 	})
 })

--- a/pkg/network/driver/nmstate/types.go
+++ b/pkg/network/driver/nmstate/types.go
@@ -31,13 +31,13 @@ import (
 
 type Spec struct {
 	Interfaces []Interface `json:"interfaces,omitempty"`
-	LinuxStack LinuxStack  `json:"linux-stack,omitempty"`
+	LinuxStack LinuxStack  `json:"linux-stack"`
 }
 
 type Status struct {
 	Interfaces []Interface `json:"interfaces"`
 	Routes     Routes      `json:"routes"`
-	LinuxStack LinuxStack  `json:"linux-stack,omitempty"`
+	LinuxStack LinuxStack  `json:"linux-stack"`
 }
 
 type Interface struct {
@@ -52,10 +52,10 @@ type Interface struct {
 
 	Tap *TapDevice `json:"tap,omitempty"`
 
-	IPv4 IP `json:"IPv4,omitempty"`
-	IPv6 IP `json:"IPv6,omitempty"`
+	IPv4 IP `json:"IPv4"`
+	IPv6 IP `json:"IPv6"`
 
-	LinuxStack LinuxIfaceStack `json:"linux-stack,omitempty"`
+	LinuxStack LinuxIfaceStack `json:"linux-stack"`
 
 	Metadata *IfaceMetadata
 }
@@ -93,8 +93,8 @@ type LinuxIfaceStack struct {
 }
 
 type LinuxStack struct {
-	IPv4 LinuxStackIP4 `json:"ipv4,omitempty"`
-	IPv6 LinuxStackIP6 `json:"ipv6,omitempty"`
+	IPv4 LinuxStackIP4 `json:"ipv4"`
+	IPv6 LinuxStackIP6 `json:"ipv6"`
 }
 
 type LinuxStackIP4 struct {

--- a/pkg/network/multus/annotation.go
+++ b/pkg/network/multus/annotation.go
@@ -143,7 +143,7 @@ func newBindingPluginAnnotationData(
 	return &networkv1.NetworkSelectionElement{
 		Namespace: nadNamespacedName.Namespace,
 		Name:      nadNamespacedName.Name,
-		CNIArgs: &map[string]interface{}{
+		CNIArgs: &map[string]any{
 			cniArgNetworkName: networkName,
 		},
 	}, nil

--- a/pkg/network/setup/netpod/masquerade/BUILD.bazel
+++ b/pkg/network/setup/netpod/masquerade/BUILD.bazel
@@ -26,7 +26,6 @@ go_test(
         ":go_default_library",
         "//pkg/network/driver/nft:go_default_library",
         "//pkg/network/driver/nmstate:go_default_library",
-        "//pkg/pointer:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",

--- a/pkg/network/setup/netpod/masquerade/masquerade_test.go
+++ b/pkg/network/setup/netpod/masquerade/masquerade_test.go
@@ -22,6 +22,7 @@ package masquerade_test
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -31,7 +32,6 @@ import (
 	"kubevirt.io/kubevirt/pkg/network/driver/nft"
 	"kubevirt.io/kubevirt/pkg/network/driver/nmstate"
 	"kubevirt.io/kubevirt/pkg/network/setup/netpod/masquerade"
-	"kubevirt.io/kubevirt/pkg/pointer"
 )
 
 var _ = Describe("masquerade (NAT)", func() {
@@ -41,7 +41,7 @@ var _ = Describe("masquerade (NAT)", func() {
 			addTableErr: testErr,
 		}))
 
-		ifaceSpec := nmstate.Interface{IPv4: nmstate.IP{Enabled: pointer.P(true)}}
+		ifaceSpec := nmstate.Interface{IPv4: nmstate.IP{Enabled: new(true)}}
 		Expect(masqPod.Setup(&ifaceSpec, &ifaceSpec, v1.Interface{})).To(MatchError(testErr))
 	})
 
@@ -57,7 +57,7 @@ var _ = Describe("masquerade (NAT)", func() {
 				State:      nmstate.IfaceStateUp,
 				MacAddress: "bb:bb:bb:bb:bb:bb",
 				IPv4: nmstate.IP{
-					Enabled: pointer.P(true),
+					Enabled: new(true),
 					Address: []nmstate.IPAddress{{IP: "10.0.2.1", PrefixLen: 24}},
 				},
 				Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: "default"},
@@ -70,7 +70,7 @@ var _ = Describe("masquerade (NAT)", func() {
 				MacAddress: "aa:aa:aa:aa:aa:aa",
 				MTU:        1500,
 				IPv4: nmstate.IP{
-					Enabled: pointer.P(true),
+					Enabled: new(true),
 					Address: []nmstate.IPAddress{{
 						IP:        "10.222.222.1",
 						PrefixLen: 30,
@@ -116,7 +116,7 @@ family ip table nat chain output rulespec [ip daddr { 127.0.0.1 } counter dnat t
 				State:      nmstate.IfaceStateUp,
 				MacAddress: "bb:bb:bb:bb:bb:bb",
 				IPv6: nmstate.IP{
-					Enabled: pointer.P(true),
+					Enabled: new(true),
 					Address: []nmstate.IPAddress{{IP: "fd10:0:2::1", PrefixLen: 120}},
 				},
 				Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: "default"},
@@ -129,7 +129,7 @@ family ip table nat chain output rulespec [ip daddr { 127.0.0.1 } counter dnat t
 				MacAddress: "aa:aa:aa:aa:aa:aa",
 				MTU:        1500,
 				IPv6: nmstate.IP{
-					Enabled: pointer.P(true),
+					Enabled: new(true),
 					Address: []nmstate.IPAddress{{
 						IP:        "2001::1",
 						PrefixLen: 64,
@@ -175,11 +175,11 @@ family ip6 table nat chain output rulespec [ip6 daddr { ::1 } counter dnat to fd
 				State:      nmstate.IfaceStateUp,
 				MacAddress: "bb:bb:bb:bb:bb:bb",
 				IPv4: nmstate.IP{
-					Enabled: pointer.P(true),
+					Enabled: new(true),
 					Address: []nmstate.IPAddress{{IP: "10.0.2.1", PrefixLen: 24}},
 				},
 				IPv6: nmstate.IP{
-					Enabled: pointer.P(true),
+					Enabled: new(true),
 					Address: []nmstate.IPAddress{{IP: "fd10:0:2::1", PrefixLen: 120}},
 				},
 				Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: "default"},
@@ -192,14 +192,14 @@ family ip6 table nat chain output rulespec [ip6 daddr { ::1 } counter dnat to fd
 				MacAddress: "aa:aa:aa:aa:aa:aa",
 				MTU:        1500,
 				IPv4: nmstate.IP{
-					Enabled: pointer.P(true),
+					Enabled: new(true),
 					Address: []nmstate.IPAddress{{
 						IP:        "10.222.222.1",
 						PrefixLen: 30,
 					}},
 				},
 				IPv6: nmstate.IP{
-					Enabled: pointer.P(true),
+					Enabled: new(true),
 					Address: []nmstate.IPAddress{{
 						IP:        "2001::1",
 						PrefixLen: 64,
@@ -258,11 +258,11 @@ family ip6 table nat chain output rulespec [ip6 daddr { ::1 } counter dnat to fd
 				State:      nmstate.IfaceStateUp,
 				MacAddress: "bb:bb:bb:bb:bb:bb",
 				IPv4: nmstate.IP{
-					Enabled: pointer.P(true),
+					Enabled: new(true),
 					Address: []nmstate.IPAddress{{IP: "10.0.2.1", PrefixLen: 24}},
 				},
 				IPv6: nmstate.IP{
-					Enabled: pointer.P(true),
+					Enabled: new(true),
 					Address: []nmstate.IPAddress{{IP: "fd10:0:2::1", PrefixLen: 120}},
 				},
 				Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: "default"},
@@ -275,14 +275,14 @@ family ip6 table nat chain output rulespec [ip6 daddr { ::1 } counter dnat to fd
 				MacAddress: "aa:aa:aa:aa:aa:aa",
 				MTU:        1500,
 				IPv4: nmstate.IP{
-					Enabled: pointer.P(true),
+					Enabled: new(true),
 					Address: []nmstate.IPAddress{{
 						IP:        "10.222.222.1",
 						PrefixLen: 30,
 					}},
 				},
 				IPv6: nmstate.IP{
-					Enabled: pointer.P(true),
+					Enabled: new(true),
 					Address: []nmstate.IPAddress{{
 						IP:        "2001::1",
 						PrefixLen: 64,
@@ -351,7 +351,7 @@ family ip6 table nat chain output rulespec [ip6 daddr { ::1 } tcp dport 8080 cou
 				State:      nmstate.IfaceStateUp,
 				MacAddress: "bb:bb:bb:bb:bb:bb",
 				IPv4: nmstate.IP{
-					Enabled: pointer.P(true),
+					Enabled: new(true),
 					Address: []nmstate.IPAddress{{IP: "10.0.2.1", PrefixLen: 24}},
 				},
 				Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: "default"},
@@ -364,7 +364,7 @@ family ip6 table nat chain output rulespec [ip6 daddr { ::1 } tcp dport 8080 cou
 				MacAddress: "aa:aa:aa:aa:aa:aa",
 				MTU:        1500,
 				IPv4: nmstate.IP{
-					Enabled: pointer.P(true),
+					Enabled: new(true),
 					Address: []nmstate.IPAddress{{
 						IP:        "10.222.222.1",
 						PrefixLen: 30,
@@ -416,11 +416,11 @@ family ip table nat chain output rulespec [ip daddr { 127.0.0.1 } counter dnat t
 				State:      nmstate.IfaceStateUp,
 				MacAddress: "bb:bb:bb:bb:bb:bb",
 				IPv4: nmstate.IP{
-					Enabled: pointer.P(true),
+					Enabled: new(true),
 					Address: []nmstate.IPAddress{{IP: "10.0.2.1", PrefixLen: 24}},
 				},
 				IPv6: nmstate.IP{
-					Enabled: pointer.P(true),
+					Enabled: new(true),
 					Address: []nmstate.IPAddress{{IP: "fd10:0:2::1", PrefixLen: 120}},
 				},
 				Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: "default"},
@@ -433,14 +433,14 @@ family ip table nat chain output rulespec [ip daddr { 127.0.0.1 } counter dnat t
 				MacAddress: "aa:aa:aa:aa:aa:aa",
 				MTU:        1500,
 				IPv4: nmstate.IP{
-					Enabled: pointer.P(true),
+					Enabled: new(true),
 					Address: []nmstate.IPAddress{{
 						IP:        "10.222.222.1",
 						PrefixLen: 30,
 					}},
 				},
 				IPv6: nmstate.IP{
-					Enabled: pointer.P(true),
+					Enabled: new(true),
 					Address: []nmstate.IPAddress{{
 						IP:        "2001::1",
 						PrefixLen: 64,
@@ -511,11 +511,11 @@ family ip6 table nat chain output rulespec [ip6 daddr { ::1 } tcp dport 443-444 
 				State:      nmstate.IfaceStateUp,
 				MacAddress: "bb:bb:bb:bb:bb:bb",
 				IPv4: nmstate.IP{
-					Enabled: pointer.P(true),
+					Enabled: new(true),
 					Address: []nmstate.IPAddress{{IP: "10.0.2.1", PrefixLen: 24}},
 				},
 				IPv6: nmstate.IP{
-					Enabled: pointer.P(true),
+					Enabled: new(true),
 					Address: []nmstate.IPAddress{{IP: "fd10:0:2::1", PrefixLen: 120}},
 				},
 			},
@@ -527,14 +527,14 @@ family ip6 table nat chain output rulespec [ip6 daddr { ::1 } tcp dport 443-444 
 				MacAddress: "aa:aa:aa:aa:aa:aa",
 				MTU:        1500,
 				IPv4: nmstate.IP{
-					Enabled: pointer.P(true),
+					Enabled: new(true),
 					Address: []nmstate.IPAddress{{
 						IP:        "10.222.222.1",
 						PrefixLen: 30,
 					}},
 				},
 				IPv6: nmstate.IP{
-					Enabled: pointer.P(true),
+					Enabled: new(true),
 					Address: []nmstate.IPAddress{{
 						IP:        "2001::1",
 						PrefixLen: 64,
@@ -603,11 +603,11 @@ family ip6 table nat chain output rulespec [ip6 daddr { ::1 } udp dport 1500-250
 					State:      nmstate.IfaceStateUp,
 					MacAddress: "bb:bb:bb:bb:bb:bb",
 					IPv4: nmstate.IP{
-						Enabled: pointer.P(true),
+						Enabled: new(true),
 						Address: []nmstate.IPAddress{{IP: "10.0.2.1", PrefixLen: 24}},
 					},
 					IPv6: nmstate.IP{
-						Enabled: pointer.P(true),
+						Enabled: new(true),
 						Address: []nmstate.IPAddress{{IP: "fd10:0:2::1", PrefixLen: 120}},
 					},
 					Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: "default"},
@@ -620,14 +620,14 @@ family ip6 table nat chain output rulespec [ip6 daddr { ::1 } udp dport 1500-250
 					MacAddress: "aa:aa:aa:aa:aa:aa",
 					MTU:        1500,
 					IPv4: nmstate.IP{
-						Enabled: pointer.P(true),
+						Enabled: new(true),
 						Address: []nmstate.IPAddress{{
 							IP:        "10.222.222.1",
 							PrefixLen: 30,
 						}},
 					},
 					IPv6: nmstate.IP{
-						Enabled: pointer.P(true),
+						Enabled: new(true),
 						Address: []nmstate.IPAddress{{
 							IP:        "2001::1",
 							PrefixLen: 64,
@@ -694,11 +694,11 @@ family ip6 table nat chain output rulespec [ip6 daddr { ::1 } counter dnat to fd
 					State:      nmstate.IfaceStateUp,
 					MacAddress: "bb:bb:bb:bb:bb:bb",
 					IPv4: nmstate.IP{
-						Enabled: pointer.P(true),
+						Enabled: new(true),
 						Address: []nmstate.IPAddress{{IP: "10.0.2.1", PrefixLen: 24}},
 					},
 					IPv6: nmstate.IP{
-						Enabled: pointer.P(true),
+						Enabled: new(true),
 						Address: []nmstate.IPAddress{{IP: "fd10:0:2::1", PrefixLen: 120}},
 					},
 					Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: "default"},
@@ -711,14 +711,14 @@ family ip6 table nat chain output rulespec [ip6 daddr { ::1 } counter dnat to fd
 					MacAddress: "aa:aa:aa:aa:aa:aa",
 					MTU:        1500,
 					IPv4: nmstate.IP{
-						Enabled: pointer.P(true),
+						Enabled: new(true),
 						Address: []nmstate.IPAddress{{
 							IP:        "10.222.222.1",
 							PrefixLen: 30,
 						}},
 					},
 					IPv6: nmstate.IP{
-						Enabled: pointer.P(true),
+						Enabled: new(true),
 						Address: []nmstate.IPAddress{{
 							IP:        "2001::1",
 							PrefixLen: 64,
@@ -790,11 +790,11 @@ family ip6 table nat chain output rulespec [ip6 daddr { ::1 } tcp dport 8080 cou
 					State:      nmstate.IfaceStateUp,
 					MacAddress: "bb:bb:bb:bb:bb:bb",
 					IPv4: nmstate.IP{
-						Enabled: pointer.P(true),
+						Enabled: new(true),
 						Address: []nmstate.IPAddress{{IP: "10.0.2.1", PrefixLen: 24}},
 					},
 					IPv6: nmstate.IP{
-						Enabled: pointer.P(true),
+						Enabled: new(true),
 						Address: []nmstate.IPAddress{{IP: "fd10:0:2::1", PrefixLen: 120}},
 					},
 					Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: "default"},
@@ -807,14 +807,14 @@ family ip6 table nat chain output rulespec [ip6 daddr { ::1 } tcp dport 8080 cou
 					MacAddress: "aa:aa:aa:aa:aa:aa",
 					MTU:        1500,
 					IPv4: nmstate.IP{
-						Enabled: pointer.P(true),
+						Enabled: new(true),
 						Address: []nmstate.IPAddress{{
 							IP:        "10.222.222.1",
 							PrefixLen: 30,
 						}},
 					},
 					IPv6: nmstate.IP{
-						Enabled: pointer.P(true),
+						Enabled: new(true),
 						Address: []nmstate.IPAddress{{
 							IP:        "2001::1",
 							PrefixLen: 64,
@@ -882,11 +882,11 @@ family ip6 table nat chain output rulespec [ip6 daddr { ::1 } tcp dport 8080 cou
 					State:      nmstate.IfaceStateUp,
 					MacAddress: "bb:bb:bb:bb:bb:bb",
 					IPv4: nmstate.IP{
-						Enabled: pointer.P(true),
+						Enabled: new(true),
 						Address: []nmstate.IPAddress{{IP: "10.0.2.1", PrefixLen: 24}},
 					},
 					IPv6: nmstate.IP{
-						Enabled: pointer.P(true),
+						Enabled: new(true),
 						Address: []nmstate.IPAddress{{IP: "fd10:0:2::1", PrefixLen: 120}},
 					},
 					Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: "default"},
@@ -899,14 +899,14 @@ family ip6 table nat chain output rulespec [ip6 daddr { ::1 } tcp dport 8080 cou
 					MacAddress: "aa:aa:aa:aa:aa:aa",
 					MTU:        1500,
 					IPv4: nmstate.IP{
-						Enabled: pointer.P(true),
+						Enabled: new(true),
 						Address: []nmstate.IPAddress{{
 							IP:        "10.222.222.1",
 							PrefixLen: 30,
 						}},
 					},
 					IPv6: nmstate.IP{
-						Enabled: pointer.P(true),
+						Enabled: new(true),
 						Address: []nmstate.IPAddress{{
 							IP:        "2001::1",
 							PrefixLen: 64,
@@ -976,11 +976,11 @@ family ip6 table nat chain output rulespec [ip6 daddr { ::1 } tcp dport 8080 cou
 					State:      nmstate.IfaceStateUp,
 					MacAddress: "bb:bb:bb:bb:bb:bb",
 					IPv4: nmstate.IP{
-						Enabled: pointer.P(true),
+						Enabled: new(true),
 						Address: []nmstate.IPAddress{{IP: "10.0.2.1", PrefixLen: 24}},
 					},
 					IPv6: nmstate.IP{
-						Enabled: pointer.P(true),
+						Enabled: new(true),
 						Address: []nmstate.IPAddress{{IP: "fd10:0:2::1", PrefixLen: 120}},
 					},
 					Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: "default"},
@@ -993,14 +993,14 @@ family ip6 table nat chain output rulespec [ip6 daddr { ::1 } tcp dport 8080 cou
 					MacAddress: "aa:aa:aa:aa:aa:aa",
 					MTU:        1500,
 					IPv4: nmstate.IP{
-						Enabled: pointer.P(true),
+						Enabled: new(true),
 						Address: []nmstate.IPAddress{{
 							IP:        "10.222.222.1",
 							PrefixLen: 30,
 						}},
 					},
 					IPv6: nmstate.IP{
-						Enabled: pointer.P(true),
+						Enabled: new(true),
 						Address: []nmstate.IPAddress{{
 							IP:        "2001::1",
 							PrefixLen: 64,
@@ -1064,11 +1064,11 @@ family ip6 table nat chain output rulespec [ip6 daddr { ::1 } tcp dport 15000 co
 					State:      nmstate.IfaceStateUp,
 					MacAddress: "bb:bb:bb:bb:bb:bb",
 					IPv4: nmstate.IP{
-						Enabled: pointer.P(true),
+						Enabled: new(true),
 						Address: []nmstate.IPAddress{{IP: "10.0.2.1", PrefixLen: 24}},
 					},
 					IPv6: nmstate.IP{
-						Enabled: pointer.P(true),
+						Enabled: new(true),
 						Address: []nmstate.IPAddress{{IP: "fd10:0:2::1", PrefixLen: 120}},
 					},
 					Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: "default"},
@@ -1081,14 +1081,14 @@ family ip6 table nat chain output rulespec [ip6 daddr { ::1 } tcp dport 15000 co
 					MacAddress: "aa:aa:aa:aa:aa:aa",
 					MTU:        1500,
 					IPv4: nmstate.IP{
-						Enabled: pointer.P(true),
+						Enabled: new(true),
 						Address: []nmstate.IPAddress{{
 							IP:        "10.222.222.1",
 							PrefixLen: 30,
 						}},
 					},
 					IPv6: nmstate.IP{
-						Enabled: pointer.P(true),
+						Enabled: new(true),
 						Address: []nmstate.IPAddress{{
 							IP:        "2001::1",
 							PrefixLen: 64,
@@ -1152,11 +1152,11 @@ family ip6 table nat chain output rulespec [ip6 daddr { ::1 } tcp dport 1000-150
 					State:      nmstate.IfaceStateUp,
 					MacAddress: "bb:bb:bb:bb:bb:bb",
 					IPv4: nmstate.IP{
-						Enabled: pointer.P(true),
+						Enabled: new(true),
 						Address: []nmstate.IPAddress{{IP: "10.0.2.1", PrefixLen: 24}},
 					},
 					IPv6: nmstate.IP{
-						Enabled: pointer.P(true),
+						Enabled: new(true),
 						Address: []nmstate.IPAddress{{IP: "fd10:0:2::1", PrefixLen: 120}},
 					},
 					Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: "default"},
@@ -1169,14 +1169,14 @@ family ip6 table nat chain output rulespec [ip6 daddr { ::1 } tcp dport 1000-150
 					MacAddress: "aa:aa:aa:aa:aa:aa",
 					MTU:        1500,
 					IPv4: nmstate.IP{
-						Enabled: pointer.P(true),
+						Enabled: new(true),
 						Address: []nmstate.IPAddress{{
 							IP:        "10.222.222.1",
 							PrefixLen: 30,
 						}},
 					},
 					IPv6: nmstate.IP{
-						Enabled: pointer.P(true),
+						Enabled: new(true),
 						Address: []nmstate.IPAddress{{
 							IP:        "2001::1",
 							PrefixLen: 64,
@@ -1242,11 +1242,11 @@ family ip6 table nat chain output rulespec [ip6 daddr { ::1 } tcp dport 20-25 co
 					State:      nmstate.IfaceStateUp,
 					MacAddress: "bb:bb:bb:bb:bb:bb",
 					IPv4: nmstate.IP{
-						Enabled: pointer.P(true),
+						Enabled: new(true),
 						Address: []nmstate.IPAddress{{IP: "10.0.2.1", PrefixLen: 24}},
 					},
 					IPv6: nmstate.IP{
-						Enabled: pointer.P(true),
+						Enabled: new(true),
 						Address: []nmstate.IPAddress{{IP: "fd10:0:2::1", PrefixLen: 120}},
 					},
 					Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: "default"},
@@ -1259,14 +1259,14 @@ family ip6 table nat chain output rulespec [ip6 daddr { ::1 } tcp dport 20-25 co
 					MacAddress: "aa:aa:aa:aa:aa:aa",
 					MTU:        1500,
 					IPv4: nmstate.IP{
-						Enabled: pointer.P(true),
+						Enabled: new(true),
 						Address: []nmstate.IPAddress{{
 							IP:        "10.222.222.1",
 							PrefixLen: 30,
 						}},
 					},
 					IPv6: nmstate.IP{
-						Enabled: pointer.P(true),
+						Enabled: new(true),
 						Address: []nmstate.IPAddress{{
 							IP:        "2001::1",
 							PrefixLen: 64,
@@ -1368,19 +1368,19 @@ func (n *nftableStub) AddRule(family nft.IPFamily, table string, chain string, r
 }
 
 func (n *nftableStub) String() string {
-	var out string
+	var out strings.Builder
 
-	out += "tables:\n"
+	out.WriteString("tables:\n")
 	for _, t := range n.Tables {
-		out += fmt.Sprintf("family %s name %s\n", t.Family, t.Name)
+		out.WriteString(fmt.Sprintf("family %s name %s\n", t.Family, t.Name))
 	}
-	out += "chains:\n"
+	out.WriteString("chains:\n")
 	for _, c := range n.Chains {
-		out += fmt.Sprintf("family %s table %s name %s chainspec %s\n", c.Table.Family, c.Table.Name, c.Name, c.Chainspec)
+		out.WriteString(fmt.Sprintf("family %s table %s name %s chainspec %s\n", c.Table.Family, c.Table.Name, c.Name, c.Chainspec))
 	}
-	out += "rules:\n"
+	out.WriteString("rules:\n")
 	for _, r := range n.Rules {
-		out += fmt.Sprintf("family %s table %s chain %s rulespec %s\n", r.Chain.Table.Family, r.Chain.Table.Name, r.Chain.Name, r.Rulespec)
+		out.WriteString(fmt.Sprintf("family %s table %s chain %s rulespec %s\n", r.Chain.Table.Family, r.Chain.Table.Name, r.Chain.Name, r.Rulespec))
 	}
-	return out
+	return out.String()
 }

--- a/pkg/network/setup/netpod/netpod.go
+++ b/pkg/network/setup/netpod/netpod.go
@@ -297,14 +297,14 @@ func (n NetPod) composeDesiredSpec(currentStatus *nmstate.Status) (*nmstate.Spec
 			ifacesSpec, err = n.masqueradeBindingSpec(podIfaceName, ifIndex, podIfaceStatusByName)
 
 			if nmstate.AnyInterface(ifacesSpec, hasIP4GlobalUnicast) {
-				spec.LinuxStack.IPv4.Forwarding = pointer.P(true)
+				spec.LinuxStack.IPv4.Forwarding = new(true)
 			}
 			if nmstate.AnyInterface(ifacesSpec, hasIP6GlobalUnicast) {
-				spec.LinuxStack.IPv6.Forwarding = pointer.P(true)
+				spec.LinuxStack.IPv6.Forwarding = new(true)
 			}
 		case iface.PasstBinding != nil:
 			spec.LinuxStack.IPv4.PingGroupRange = []int{107, 107}
-			spec.LinuxStack.IPv4.UnprivilegedPortStart = pointer.P(0)
+			spec.LinuxStack.IPv4.UnprivilegedPortStart = new(0)
 
 		case iface.SRIOV != nil:
 		case iface.Binding != nil:
@@ -354,7 +354,7 @@ func (n NetPod) bridgeBindingSpec(podIfaceName string, vmiIfaceIndex int, ifaceS
 
 	if hasIPGlobalUnicast(podStatusIface.IPv4) {
 		bridgeIface.IPv4 = nmstate.IP{
-			Enabled: pointer.P(true),
+			Enabled: new(true),
 			Address: []nmstate.IPAddress{
 				{
 					IP:        bridgeFakeIPBase + strconv.Itoa(vmiIfaceIndex),
@@ -370,9 +370,9 @@ func (n NetPod) bridgeBindingSpec(podIfaceName string, vmiIfaceIndex int, ifaceS
 		State:       nmstate.IfaceStateUp,
 		CopyMacFrom: bridgeIface.Name,
 		Controller:  bridgeIface.Name,
-		IPv4:        nmstate.IP{Enabled: pointer.P(false)},
-		IPv6:        nmstate.IP{Enabled: pointer.P(false)},
-		LinuxStack:  nmstate.LinuxIfaceStack{PortLearning: pointer.P(false)},
+		IPv4:        nmstate.IP{Enabled: new(false)},
+		IPv6:        nmstate.IP{Enabled: new(false)},
+		LinuxStack:  nmstate.LinuxIfaceStack{PortLearning: new(false)},
 		Metadata:    &nmstate.IfaceMetadata{NetworkName: vmiNetworkName},
 	}
 
@@ -424,8 +424,8 @@ func (n NetPod) masqueradeBindingSpec(podIfaceName string, vmiIfaceIndex int, if
 		State:      nmstate.IfaceStateUp,
 		MacAddress: link.StaticMasqueradeBridgeMAC,
 		MTU:        podIface.MTU,
-		IPv4:       nmstate.IP{Enabled: pointer.P(false)},
-		IPv6:       nmstate.IP{Enabled: pointer.P(false)},
+		IPv4:       nmstate.IP{Enabled: new(false)},
+		IPv6:       nmstate.IP{Enabled: new(false)},
 		Metadata:   &nmstate.IfaceMetadata{NetworkName: vmiNetwork.Name},
 	}
 
@@ -435,10 +435,10 @@ func (n NetPod) masqueradeBindingSpec(podIfaceName string, vmiIfaceIndex int, if
 			return nil, err
 		}
 		bridgeIface.IPv4 = nmstate.IP{
-			Enabled: pointer.P(true),
+			Enabled: new(true),
 			Address: []nmstate.IPAddress{ip4GatewayAddress},
 		}
-		bridgeIface.LinuxStack.IP4RouteLocalNet = pointer.P(true)
+		bridgeIface.LinuxStack.IP4RouteLocalNet = new(true)
 	}
 
 	if hasIPGlobalUnicast(podIface.IPv6) {
@@ -447,7 +447,7 @@ func (n NetPod) masqueradeBindingSpec(podIfaceName string, vmiIfaceIndex int, if
 			return nil, err
 		}
 		bridgeIface.IPv6 = nmstate.IP{
-			Enabled: pointer.P(true),
+			Enabled: new(true),
 			Address: []nmstate.IPAddress{ip6GatewayAddress},
 		}
 	}
@@ -493,9 +493,9 @@ func (n NetPod) managedTapSpec(podIfaceName string, vmiIfaceIndex int, ifaceStat
 		State:       nmstate.IfaceStateUp,
 		CopyMacFrom: bridgeIface.Name,
 		Controller:  bridgeIface.Name,
-		IPv4:        nmstate.IP{Enabled: pointer.P(false)},
-		IPv6:        nmstate.IP{Enabled: pointer.P(false)},
-		LinuxStack:  nmstate.LinuxIfaceStack{PortLearning: pointer.P(false)},
+		IPv4:        nmstate.IP{Enabled: new(false)},
+		IPv6:        nmstate.IP{Enabled: new(false)},
+		LinuxStack:  nmstate.LinuxIfaceStack{PortLearning: new(false)},
 		Metadata:    &nmstate.IfaceMetadata{NetworkName: vmiNetworkName},
 	}
 

--- a/pkg/network/setup/netpod/netpod_test.go
+++ b/pkg/network/setup/netpod/netpod_test.go
@@ -55,7 +55,7 @@ const (
 )
 
 var (
-	ipDisabled = nmstate.IP{Enabled: pointer.P(false)}
+	ipDisabled = nmstate.IP{Enabled: new(false)}
 )
 
 var _ = Describe("netpod", func() {
@@ -198,14 +198,14 @@ var _ = Describe("netpod", func() {
 				MacAddress: "12:34:56:78:90:ab",
 				MTU:        1500,
 				IPv4: nmstate.IP{
-					Enabled: pointer.P(true),
+					Enabled: new(true),
 					Address: []nmstate.IPAddress{{
 						IP:        primaryIPv4Address,
 						PrefixLen: 30,
 					}},
 				},
 				IPv6: nmstate.IP{
-					Enabled: pointer.P(true),
+					Enabled: new(true),
 					Address: []nmstate.IPAddress{{
 						IP:        primaryIPv6Address,
 						PrefixLen: 64,
@@ -238,14 +238,14 @@ var _ = Describe("netpod", func() {
 						MacAddress: "02:00:00:00:00:00",
 						MTU:        1500,
 						IPv4: nmstate.IP{
-							Enabled: pointer.P(true),
+							Enabled: new(true),
 							Address: []nmstate.IPAddress{{IP: "10.0.2.1", PrefixLen: 24}},
 						},
 						IPv6: nmstate.IP{
-							Enabled: pointer.P(true),
+							Enabled: new(true),
 							Address: []nmstate.IPAddress{{IP: "fd10:0:2::1", PrefixLen: 120}},
 						},
-						LinuxStack: nmstate.LinuxIfaceStack{IP4RouteLocalNet: pointer.P(true)},
+						LinuxStack: nmstate.LinuxIfaceStack{IP4RouteLocalNet: new(true)},
 						Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 					},
 					{
@@ -259,8 +259,8 @@ var _ = Describe("netpod", func() {
 					},
 				},
 				LinuxStack: nmstate.LinuxStack{
-					IPv4: nmstate.LinuxStackIP4{Forwarding: pointer.P(true)},
-					IPv6: nmstate.LinuxStackIP6{Forwarding: pointer.P(true)},
+					IPv4: nmstate.LinuxStackIP4{Forwarding: new(true)},
+					IPv6: nmstate.LinuxStackIP6{Forwarding: new(true)},
 				},
 			}),
 		)
@@ -289,14 +289,14 @@ var _ = Describe("netpod", func() {
 				MacAddress: podIfaceOrignalMAC,
 				MTU:        1500,
 				IPv4: nmstate.IP{
-					Enabled: pointer.P(true),
+					Enabled: new(true),
 					Address: []nmstate.IPAddress{{
 						IP:        primaryIPv4Address,
 						PrefixLen: 30,
 					}},
 				},
 				IPv6: nmstate.IP{
-					Enabled: pointer.P(true),
+					Enabled: new(true),
 					Address: []nmstate.IPAddress{{
 						IP:        primaryIPv6Address,
 						PrefixLen: 64,
@@ -354,7 +354,7 @@ var _ = Describe("netpod", func() {
 						TypeName: nmstate.TypeBridge,
 						State:    nmstate.IfaceStateUp,
 						IPv4: nmstate.IP{
-							Enabled: pointer.P(true),
+							Enabled: new(true),
 							Address: []nmstate.IPAddress{{IP: "169.254.75.10", PrefixLen: 32}},
 						},
 						Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
@@ -367,7 +367,7 @@ var _ = Describe("netpod", func() {
 						State:       nmstate.IfaceStateUp,
 						IPv4:        ipDisabled,
 						IPv6:        ipDisabled,
-						LinuxStack:  nmstate.LinuxIfaceStack{PortLearning: pointer.P(false)},
+						LinuxStack:  nmstate.LinuxIfaceStack{PortLearning: new(false)},
 						Metadata:    &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 					},
 					{
@@ -385,14 +385,14 @@ var _ = Describe("netpod", func() {
 						MacAddress: podIfaceOrignalMAC,
 						MTU:        1500,
 						IPv4: nmstate.IP{
-							Enabled: pointer.P(true),
+							Enabled: new(true),
 							Address: []nmstate.IPAddress{{
 								IP:        primaryIPv4Address,
 								PrefixLen: 30,
 							}},
 						},
 						IPv6: nmstate.IP{
-							Enabled: pointer.P(true),
+							Enabled: new(true),
 							Address: []nmstate.IPAddress{{
 								IP:        primaryIPv6Address,
 								PrefixLen: 64,
@@ -438,14 +438,14 @@ var _ = Describe("netpod", func() {
 				MacAddress: podIfaceOrignalMAC,
 				MTU:        1500,
 				IPv4: nmstate.IP{
-					Enabled: pointer.P(true),
+					Enabled: new(true),
 					Address: []nmstate.IPAddress{{
 						IP:        primaryIPv4Address,
 						PrefixLen: 30,
 					}},
 				},
 				IPv6: nmstate.IP{
-					Enabled: pointer.P(true),
+					Enabled: new(true),
 					Address: []nmstate.IPAddress{{
 						IP:        primaryIPv6Address,
 						PrefixLen: 64,
@@ -507,7 +507,7 @@ var _ = Describe("netpod", func() {
 						TypeName: nmstate.TypeBridge,
 						State:    nmstate.IfaceStateUp,
 						IPv4: nmstate.IP{
-							Enabled: pointer.P(true),
+							Enabled: new(true),
 							Address: []nmstate.IPAddress{{IP: "169.254.75.10", PrefixLen: 32}},
 						},
 						Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
@@ -520,7 +520,7 @@ var _ = Describe("netpod", func() {
 						State:       nmstate.IfaceStateUp,
 						IPv4:        ipDisabled,
 						IPv6:        ipDisabled,
-						LinuxStack:  nmstate.LinuxIfaceStack{PortLearning: pointer.P(false)},
+						LinuxStack:  nmstate.LinuxIfaceStack{PortLearning: new(false)},
 						Metadata:    &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 					},
 					{
@@ -538,14 +538,14 @@ var _ = Describe("netpod", func() {
 						MacAddress: podIfaceOrignalMAC,
 						MTU:        1500,
 						IPv4: nmstate.IP{
-							Enabled: pointer.P(true),
+							Enabled: new(true),
 							Address: []nmstate.IPAddress{{
 								IP:        primaryIPv4Address,
 								PrefixLen: 30,
 							}},
 						},
 						IPv6: nmstate.IP{
-							Enabled: pointer.P(true),
+							Enabled: new(true),
 							Address: []nmstate.IPAddress{{
 								IP:        primaryIPv6Address,
 								PrefixLen: 64,
@@ -589,7 +589,7 @@ var _ = Describe("netpod", func() {
 				MTU:        1500,
 				IPv4:       ipDisabled,
 				IPv6: nmstate.IP{
-					Enabled: pointer.P(true),
+					Enabled: new(true),
 					Address: []nmstate.IPAddress{{
 						IP:        linklocalIPv6Address,
 						PrefixLen: 64,
@@ -626,7 +626,7 @@ var _ = Describe("netpod", func() {
 						State:       nmstate.IfaceStateUp,
 						IPv4:        ipDisabled,
 						IPv6:        ipDisabled,
-						LinuxStack:  nmstate.LinuxIfaceStack{PortLearning: pointer.P(false)},
+						LinuxStack:  nmstate.LinuxIfaceStack{PortLearning: new(false)},
 						Metadata:    &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 					},
 					{
@@ -645,7 +645,7 @@ var _ = Describe("netpod", func() {
 						MTU:        1500,
 						IPv4:       ipDisabled,
 						IPv6: nmstate.IP{
-							Enabled: pointer.P(true),
+							Enabled: new(true),
 							Address: []nmstate.IPAddress{{
 								IP:        linklocalIPv6Address,
 								PrefixLen: 64,
@@ -687,7 +687,7 @@ var _ = Describe("netpod", func() {
 				LinuxStack: nmstate.LinuxStack{
 					IPv4: nmstate.LinuxStackIP4{
 						PingGroupRange:        []int{107, 107},
-						UnprivilegedPortStart: pointer.P(0),
+						UnprivilegedPortStart: new(0),
 					},
 				},
 			}),
@@ -726,14 +726,14 @@ var _ = Describe("netpod", func() {
 						MacAddress: "12:34:56:78:90:ab",
 						MTU:        1500,
 						IPv4: nmstate.IP{
-							Enabled: pointer.P(true),
+							Enabled: new(true),
 							Address: []nmstate.IPAddress{{
 								IP:        primaryIPv4Address,
 								PrefixLen: 30,
 							}},
 						},
 						IPv6: nmstate.IP{
-							Enabled: pointer.P(true),
+							Enabled: new(true),
 							Address: []nmstate.IPAddress{{
 								IP:        primaryIPv6Address,
 								PrefixLen: 64,
@@ -797,14 +797,14 @@ var _ = Describe("netpod", func() {
 					MacAddress: "02:00:00:00:00:00",
 					MTU:        1500,
 					IPv4: nmstate.IP{
-						Enabled: pointer.P(true),
+						Enabled: new(true),
 						Address: []nmstate.IPAddress{{IP: "10.0.2.1", PrefixLen: 24}},
 					},
 					IPv6: nmstate.IP{
-						Enabled: pointer.P(true),
+						Enabled: new(true),
 						Address: []nmstate.IPAddress{{IP: "fd10:0:2::1", PrefixLen: 120}},
 					},
-					LinuxStack: nmstate.LinuxIfaceStack{IP4RouteLocalNet: pointer.P(true)},
+					LinuxStack: nmstate.LinuxIfaceStack{IP4RouteLocalNet: new(true)},
 					Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 				},
 				{
@@ -822,8 +822,8 @@ var _ = Describe("netpod", func() {
 					nmstate.Spec{
 						Interfaces: expectedPrimaryNetIfaces,
 						LinuxStack: nmstate.LinuxStack{
-							IPv4: nmstate.LinuxStackIP4{Forwarding: pointer.P(true)},
-							IPv6: nmstate.LinuxStackIP6{Forwarding: pointer.P(true)},
+							IPv4: nmstate.LinuxStackIP4{Forwarding: new(true)},
+							IPv6: nmstate.LinuxStackIP6{Forwarding: new(true)},
 						},
 					},
 				))
@@ -859,7 +859,7 @@ var _ = Describe("netpod", func() {
 							State:       nmstate.IfaceStateUp,
 							IPv4:        ipDisabled,
 							IPv6:        ipDisabled,
-							LinuxStack:  nmstate.LinuxIfaceStack{PortLearning: pointer.P(false)},
+							LinuxStack:  nmstate.LinuxIfaceStack{PortLearning: new(false)},
 							Metadata:    &nmstate.IfaceMetadata{Pid: 0, NetworkName: secondaryNetworkName},
 						},
 						{
@@ -882,8 +882,8 @@ var _ = Describe("netpod", func() {
 						},
 					},
 					LinuxStack: nmstate.LinuxStack{
-						IPv4: nmstate.LinuxStackIP4{Forwarding: pointer.P(true)},
-						IPv6: nmstate.LinuxStackIP6{Forwarding: pointer.P(true)},
+						IPv4: nmstate.LinuxStackIP4{Forwarding: new(true)},
+						IPv6: nmstate.LinuxStackIP6{Forwarding: new(true)},
 					},
 				}),
 			)
@@ -925,14 +925,14 @@ var _ = Describe("netpod", func() {
 							MacAddress: "02:00:00:00:00:00",
 							MTU:        1500,
 							IPv4: nmstate.IP{
-								Enabled: pointer.P(true),
+								Enabled: new(true),
 								Address: []nmstate.IPAddress{{IP: "10.0.2.1", PrefixLen: 24}},
 							},
 							IPv6: nmstate.IP{
-								Enabled: pointer.P(true),
+								Enabled: new(true),
 								Address: []nmstate.IPAddress{{IP: "fd10:0:2::1", PrefixLen: 120}},
 							},
-							LinuxStack: nmstate.LinuxIfaceStack{IP4RouteLocalNet: pointer.P(true)},
+							LinuxStack: nmstate.LinuxIfaceStack{IP4RouteLocalNet: new(true)},
 							Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 						},
 						{
@@ -972,8 +972,8 @@ var _ = Describe("netpod", func() {
 						},
 					},
 					LinuxStack: nmstate.LinuxStack{
-						IPv4: nmstate.LinuxStackIP4{Forwarding: pointer.P(true)},
-						IPv6: nmstate.LinuxStackIP6{Forwarding: pointer.P(true)},
+						IPv4: nmstate.LinuxStackIP4{Forwarding: new(true)},
+						IPv6: nmstate.LinuxStackIP6{Forwarding: new(true)},
 					},
 				}),
 			)
@@ -1004,14 +1004,14 @@ var _ = Describe("netpod", func() {
 							MacAddress: "02:00:00:00:00:00",
 							MTU:        1500,
 							IPv4: nmstate.IP{
-								Enabled: pointer.P(true),
+								Enabled: new(true),
 								Address: []nmstate.IPAddress{{IP: "10.0.2.1", PrefixLen: 24}},
 							},
 							IPv6: nmstate.IP{
-								Enabled: pointer.P(true),
+								Enabled: new(true),
 								Address: []nmstate.IPAddress{{IP: "fd10:0:2::1", PrefixLen: 120}},
 							},
-							LinuxStack: nmstate.LinuxIfaceStack{IP4RouteLocalNet: pointer.P(true)},
+							LinuxStack: nmstate.LinuxIfaceStack{IP4RouteLocalNet: new(true)},
 							Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 						},
 						{
@@ -1038,7 +1038,7 @@ var _ = Describe("netpod", func() {
 							State:       nmstate.IfaceStateUp,
 							IPv4:        ipDisabled,
 							IPv6:        ipDisabled,
-							LinuxStack:  nmstate.LinuxIfaceStack{PortLearning: pointer.P(false)},
+							LinuxStack:  nmstate.LinuxIfaceStack{PortLearning: new(false)},
 							Metadata:    &nmstate.IfaceMetadata{Pid: 0, NetworkName: secondaryNetworkName},
 						},
 						{
@@ -1061,8 +1061,8 @@ var _ = Describe("netpod", func() {
 						},
 					},
 					LinuxStack: nmstate.LinuxStack{
-						IPv4: nmstate.LinuxStackIP4{Forwarding: pointer.P(true)},
-						IPv6: nmstate.LinuxStackIP6{Forwarding: pointer.P(true)},
+						IPv4: nmstate.LinuxStackIP4{Forwarding: new(true)},
+						IPv6: nmstate.LinuxStackIP6{Forwarding: new(true)},
 					},
 				}),
 			)
@@ -1101,7 +1101,7 @@ var _ = Describe("netpod", func() {
 				MacAddress: "12:34:56:78:90:ab",
 				MTU:        1500,
 				IPv4: nmstate.IP{
-					Enabled: pointer.P(true),
+					Enabled: new(true),
 					Address: []nmstate.IPAddress{{
 						IP:        primaryIPv4Address,
 						PrefixLen: 30,
@@ -1154,14 +1154,14 @@ var _ = Describe("netpod", func() {
 				MacAddress: podIfaceNewMAC,
 				MTU:        1500,
 				IPv4: nmstate.IP{
-					Enabled: pointer.P(true),
+					Enabled: new(true),
 					Address: []nmstate.IPAddress{{
 						IP:        primaryIPv4Address,
 						PrefixLen: 30,
 					}},
 				},
 				IPv6: nmstate.IP{
-					Enabled: pointer.P(true),
+					Enabled: new(true),
 					Address: []nmstate.IPAddress{{
 						IP:        primaryIPv6Address,
 						PrefixLen: 64,
@@ -1334,8 +1334,8 @@ var _ = Describe("netpod", func() {
 							State:      nmstate.IfaceStateUp,
 							MacAddress: "02:00:00:00:00:00",
 							MTU:        1500,
-							IPv4:       nmstate.IP{Enabled: pointer.P(false)},
-							IPv6:       nmstate.IP{Enabled: pointer.P(false)},
+							IPv4:       nmstate.IP{Enabled: new(false)},
+							IPv6:       nmstate.IP{Enabled: new(false)},
 							LinuxStack: nmstate.LinuxIfaceStack{},
 							Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 						},
@@ -1386,7 +1386,7 @@ var _ = Describe("netpod", func() {
 							State:       nmstate.IfaceStateUp,
 							IPv4:        ipDisabled,
 							IPv6:        ipDisabled,
-							LinuxStack:  nmstate.LinuxIfaceStack{PortLearning: pointer.P(false)},
+							LinuxStack:  nmstate.LinuxIfaceStack{PortLearning: new(false)},
 							Metadata:    &nmstate.IfaceMetadata{Pid: 0, NetworkName: testNet2},
 						},
 						{
@@ -1440,8 +1440,8 @@ var _ = Describe("netpod", func() {
 							State:      nmstate.IfaceStateUp,
 							MacAddress: "02:00:00:00:00:00",
 							MTU:        1500,
-							IPv4:       nmstate.IP{Enabled: pointer.P(false)},
-							IPv6:       nmstate.IP{Enabled: pointer.P(false)},
+							IPv4:       nmstate.IP{Enabled: new(false)},
+							IPv6:       nmstate.IP{Enabled: new(false)},
 							LinuxStack: nmstate.LinuxIfaceStack{},
 							Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 						},
@@ -1544,8 +1544,8 @@ var _ = Describe("netpod", func() {
 							State:      nmstate.IfaceStateUp,
 							MacAddress: "02:00:00:00:00:00",
 							MTU:        1500,
-							IPv4:       nmstate.IP{Enabled: pointer.P(false)},
-							IPv6:       nmstate.IP{Enabled: pointer.P(false)},
+							IPv4:       nmstate.IP{Enabled: new(false)},
+							IPv6:       nmstate.IP{Enabled: new(false)},
 							LinuxStack: nmstate.LinuxIfaceStack{},
 							Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 						},
@@ -1572,7 +1572,7 @@ var _ = Describe("netpod", func() {
 							State:       nmstate.IfaceStateUp,
 							IPv4:        ipDisabled,
 							IPv6:        ipDisabled,
-							LinuxStack:  nmstate.LinuxIfaceStack{PortLearning: pointer.P(false)},
+							LinuxStack:  nmstate.LinuxIfaceStack{PortLearning: new(false)},
 							Metadata:    &nmstate.IfaceMetadata{Pid: 0, NetworkName: testNet1},
 						},
 						{
@@ -1734,8 +1734,8 @@ var _ = Describe("netpod", func() {
 						State:      nmstate.IfaceStateUp,
 						MacAddress: "02:00:00:00:00:00",
 						MTU:        1500,
-						IPv4:       nmstate.IP{Enabled: pointer.P(false)},
-						IPv6:       nmstate.IP{Enabled: pointer.P(false)},
+						IPv4:       nmstate.IP{Enabled: new(false)},
+						IPv6:       nmstate.IP{Enabled: new(false)},
 						LinuxStack: nmstate.LinuxIfaceStack{},
 						Metadata:   &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 					},
@@ -1762,7 +1762,7 @@ var _ = Describe("netpod", func() {
 						State:       nmstate.IfaceStateUp,
 						IPv4:        ipDisabled,
 						IPv6:        ipDisabled,
-						LinuxStack:  nmstate.LinuxIfaceStack{PortLearning: pointer.P(false)},
+						LinuxStack:  nmstate.LinuxIfaceStack{PortLearning: new(false)},
 						Metadata:    &nmstate.IfaceMetadata{Pid: 0, NetworkName: testNet1},
 					},
 					{
@@ -1850,14 +1850,14 @@ var _ = Describe("netpod", func() {
 					MacAddress: podIfaceOrignalMAC,
 					MTU:        1500,
 					IPv4: nmstate.IP{
-						Enabled: pointer.P(true),
+						Enabled: new(true),
 						Address: []nmstate.IPAddress{{
 							IP:        primaryIPv4Address,
 							PrefixLen: 30,
 						}},
 					},
 					IPv6: nmstate.IP{
-						Enabled: pointer.P(true),
+						Enabled: new(true),
 						Address: []nmstate.IPAddress{{
 							IP:        primaryIPv6Address,
 							PrefixLen: 64,
@@ -1895,7 +1895,7 @@ var _ = Describe("netpod", func() {
 							Controller:  "k6t-eth0",
 							IPv4:        ipDisabled,
 							IPv6:        ipDisabled,
-							LinuxStack:  nmstate.LinuxIfaceStack{PortLearning: pointer.P(false)},
+							LinuxStack:  nmstate.LinuxIfaceStack{PortLearning: new(false)},
 							Metadata:    &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},
 						},
 						{
@@ -1913,11 +1913,11 @@ var _ = Describe("netpod", func() {
 							MacAddress: podIfaceOrignalMAC,
 							MTU:        1500,
 							IPv4: nmstate.IP{
-								Enabled: pointer.P(true),
+								Enabled: new(true),
 								Address: []nmstate.IPAddress{{IP: primaryIPv4Address, PrefixLen: 30}},
 							},
 							IPv6: nmstate.IP{
-								Enabled: pointer.P(true),
+								Enabled: new(true),
 								Address: []nmstate.IPAddress{{IP: primaryIPv6Address, PrefixLen: 64}},
 							},
 							Metadata: &nmstate.IfaceMetadata{Pid: 0, NetworkName: defaultPodNetworkName},

--- a/pkg/network/setup/netstat.go
+++ b/pkg/network/setup/netstat.go
@@ -64,7 +64,7 @@ func NewNetStateWithCustomFactory(cacheCreator cacheCreator) *NetStat {
 }
 
 func (c *NetStat) Teardown(vmi *v1.VirtualMachineInstance) {
-	c.podInterfaceVolatileCache.Range(func(key, value interface{}) bool {
+	c.podInterfaceVolatileCache.Range(func(key, value any) bool {
 		if strings.HasPrefix(key.(string), string(vmi.UID)) {
 			c.podInterfaceVolatileCache.Delete(key)
 		}
@@ -251,7 +251,7 @@ func (c *NetStat) getPodInterfacefromFileCache(vmi *v1.VirtualMachineInstance, i
 
 func (c *NetStat) removeAbsentIfacesFromVolatileCache(vmi *v1.VirtualMachineInstance) {
 	interfaceByName := netvmispec.IndexInterfaceSpecByName(vmi.Spec.Domain.Devices.Interfaces)
-	c.podInterfaceVolatileCache.Range(func(key, value interface{}) bool {
+	c.podInterfaceVolatileCache.Range(func(key, value any) bool {
 		if strings.HasPrefix(key.(string), string(vmi.UID)) {
 			if iface, ok := interfaceByName[ifaceNameFromKey(key.(string), vmi.UID)]; ok && iface.State == v1.InterfaceStateAbsent {
 				c.podInterfaceVolatileCache.Delete(key)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Over its lifetime the KubeVirt codebase has been written against many Go releases, so it carries idioms from several generations side by side. Go 1.26 reworked [`go fix`](https://pkg.go.dev/cmd/fix) into an analysis-based modernizer that rewrites those older idioms into their current equivalents (see the [Go blog post](https://go.dev/blog/gofix) for background).

Today `go fix` is not run anywhere, so there is no way to apply these modernizations consistently or to keep them from drifting back. This PR treats that as a modernization opportunity and wires the tool into the build as an opt-in, incrementally gated check: `make gofix` applies `go fix` over an explicit list of packages (`hack/linter/go-fix-paths.txt`),                                                                                                                      
and `make lint` runs `go fix -diff` over the same list and fails on any pending fix, so once a package is modernized it stays modernized.

Every `pkg/network` subpackage is opted in, with the resulting fixes applied.                                                                                                                                                                          
                                                                                                                                                                                                    
The mechanism is deliberately generic: the same list-driven gate can grow to other packages and trees in follow-ups, one reviewable step at a time.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
A tradeoff to be aware of: future Go version bumps may introduce new go fix rewrites, which could require updating all covered paths as part of the toolchain upgrade.
<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

