### PR TITLE
net: Retry interrupted address dumps

### DIFF
--- a/pkg/network/driver/nmstate/BUILD.bazel
+++ b/pkg/network/driver/nmstate/BUILD.bazel
@@ -38,5 +38,6 @@ go_test(
         "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
         "//vendor/github.com/onsi/gomega:go_default_library",
         "//vendor/github.com/vishvananda/netlink:go_default_library",
+        "//vendor/golang.org/x/sys/unix:go_default_library",
     ],
 )

--- a/pkg/network/driver/nmstate/spec.go
+++ b/pkg/network/driver/nmstate/spec.go
@@ -67,7 +67,7 @@ func (n NMState) Apply(spec *Spec) error {
 				return fmt.Errorf("type collision on link %s: actual %s, requested %s", iface.Name, linkType, iface.TypeName)
 			}
 			if serr := n.setupInterface(iface, link); serr != nil {
-				return fmt.Errorf("failed to setup link [%s]: %v", iface.Name, serr)
+				return fmt.Errorf("failed to setup link [%s]: %w", iface.Name, serr)
 			}
 		}
 	}
@@ -260,9 +260,22 @@ func (n NMState) addIPAddresses(ips []IPAddress, link vishnetlink.Link) error {
 }
 
 func (n NMState) deleteIPAddresses(link vishnetlink.Link) error {
-	addresses, err := n.adapter.AddrList(link, vishnetlink.FAMILY_ALL)
+	const maxAddrListAttempts = 5
+
+	// Interrupted dumps can contain incomplete results, so only use addresses from a successful attempt.
+	var addresses []vishnetlink.Addr
+	var err error
+	for range maxAddrListAttempts {
+		addresses, err = n.adapter.AddrList(link, vishnetlink.FAMILY_ALL)
+		if err == nil {
+			break
+		}
+		if !errors.Is(err, vishnetlink.ErrDumpInterrupted) && !errors.Is(err, unix.EINTR) {
+			break
+		}
+	}
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to list IP addresses on link %s: %w", link.Attrs().Name, err)
 	}
 	for _, addr := range addresses {
 		if err := n.adapter.AddrDel(link, &addr); err != nil {

--- a/pkg/network/driver/nmstate/spec_test.go
+++ b/pkg/network/driver/nmstate/spec_test.go
@@ -20,8 +20,12 @@
 package nmstate_test
 
 import (
+	"errors"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	vishnetlink "github.com/vishvananda/netlink"
+	"golang.org/x/sys/unix"
 
 	"kubevirt.io/kubevirt/pkg/network/driver/procsys"
 
@@ -38,6 +42,23 @@ const (
 	ip6Addr0   = "2001::1"
 	ip6Prefix0 = 64
 )
+
+type addrListTestAdapter struct {
+	*testAdapter
+	addrList func(vishnetlink.Link, int) ([]vishnetlink.Addr, error)
+	addrDel  func(vishnetlink.Link, *vishnetlink.Addr) error
+}
+
+func (a *addrListTestAdapter) AddrList(link vishnetlink.Link, family int) ([]vishnetlink.Addr, error) {
+	return a.addrList(link, family)
+}
+
+func (a *addrListTestAdapter) AddrDel(link vishnetlink.Link, addr *vishnetlink.Addr) error {
+	if a.addrDel != nil {
+		return a.addrDel(link, addr)
+	}
+	return a.testAdapter.AddrDel(link, addr)
+}
 
 // The test strategy is to setup and read the state of the network configuration through the nmstate API.
 // Then, assert that the returned (nmstate) status is indeed as expected.
@@ -123,6 +144,87 @@ var _ = Describe("NMState Spec interfaces", func() {
 			},
 		),
 	)
+
+	Context("when listing IP addresses", func() {
+		newSpec := func() *nmstate.Spec {
+			return &nmstate.Spec{Interfaces: []nmstate.Interface{{
+				Name:     dummyName,
+				TypeName: nmstate.TypeDummy,
+			}}}
+		}
+
+		DescribeTable("retries interrupted dumps and discards partial results", func(interruptedErr error) {
+			addrListCalls := 0
+			addrDelCalls := 0
+			adapter := &addrListTestAdapter{
+				testAdapter: newTestAdapter(),
+				addrList: func(vishnetlink.Link, int) ([]vishnetlink.Addr, error) {
+					addrListCalls++
+					if addrListCalls == 1 {
+						return []vishnetlink.Addr{{}}, interruptedErr
+					}
+					return nil, nil
+				},
+				addrDel: func(vishnetlink.Link, *vishnetlink.Addr) error {
+					addrDelCalls++
+					return nil
+				},
+			}
+			nmState = nmstate.New(nmstate.WithAdapter(adapter))
+
+			Expect(nmState.Apply(newSpec())).To(Succeed())
+			Expect(addrListCalls).To(Equal(2))
+			Expect(addrDelCalls).To(BeZero())
+		},
+			Entry("when the dump is interrupted", vishnetlink.ErrDumpInterrupted),
+			Entry("when the system call is interrupted", unix.EINTR),
+		)
+
+		DescribeTable("stops after a bounded number of interrupted dumps", func(interruptedErr error) {
+			addrListCalls := 0
+			addrDelCalls := 0
+			adapter := &addrListTestAdapter{
+				testAdapter: newTestAdapter(),
+				addrList: func(vishnetlink.Link, int) ([]vishnetlink.Addr, error) {
+					addrListCalls++
+					return []vishnetlink.Addr{{}}, interruptedErr
+				},
+				addrDel: func(vishnetlink.Link, *vishnetlink.Addr) error {
+					addrDelCalls++
+					return nil
+				},
+			}
+			nmState = nmstate.New(nmstate.WithAdapter(adapter))
+
+			err := nmState.Apply(newSpec())
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, interruptedErr)).To(BeTrue())
+			Expect(err.Error()).To(ContainSubstring("failed to list IP addresses on link " + dummyName))
+			Expect(addrListCalls).To(Equal(5))
+			Expect(addrDelCalls).To(BeZero())
+		},
+			Entry("when the dump is interrupted", vishnetlink.ErrDumpInterrupted),
+			Entry("when the system call is interrupted", unix.EINTR),
+		)
+
+		It("does not retry a non-interruption error", func() {
+			addrListErr := errors.New("address list failed")
+			addrListCalls := 0
+			adapter := &addrListTestAdapter{
+				testAdapter: newTestAdapter(),
+				addrList: func(vishnetlink.Link, int) ([]vishnetlink.Addr, error) {
+					addrListCalls++
+					return nil, addrListErr
+				},
+			}
+			nmState = nmstate.New(nmstate.WithAdapter(adapter))
+
+			err := nmState.Apply(newSpec())
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, addrListErr)).To(BeTrue())
+			Expect(addrListCalls).To(Equal(1))
+		})
+	})
 
 	Context("given an existing interface", func() {
 		BeforeEach(func() {


### PR DESCRIPTION
### What this PR does

#### Before this PR:

During pod network setup, a netlink address dump interrupted by
`ErrDumpInterrupted` or `EINTR` immediately failed interface setup.

An interrupted dump can also return partial and inconsistent results. The
resulting error was propagated as a critical network error, potentially causing
the VMI startup to fail.

#### After this PR:

KubeVirt retries the complete address dump up to five times when it is
interrupted.

Partial results from interrupted attempts are discarded. Non-interruption
errors return immediately, while errors after retry exhaustion preserve their
identity and include the affected interface in the error message.

### References

- Fixes #18906
- Similar netlink interruption handling:
  https://github.com/containernetworking/plugins/pull/1154

### Why we need it and why it was done in this way

`AddrList` is a read-only netlink dump, so retrying the complete operation is
safe and keeps the fix local to the failing operation. Only results from a
successful dump are used for address reconciliation.

The following tradeoffs were made:

- Retries are bounded at five attempts to avoid an unbounded setup loop.
- Retries are performed immediately because the complete read-only dump is
  restarted and no partial state is applied.
- Final errors are returned instead of accepting potentially inconsistent
  results.

The following alternatives were considered:

- Using partial results from an interrupted dump was rejected because the
  kernel explicitly reports that they may be incomplete or inconsistent.
- Retrying the entire network setup was rejected because setup includes
  stateful and mutating operations.
- Adding retry behavior to the shared netlink adapter was considered broader
  than necessary for this focused bug fix.

Links to places where the discussion took place:

- https://github.com/kubevirt/kubevirt/issues/18906

### Special notes for your reviewer

Unit tests inject both `netlink.ErrDumpInterrupted` and raw `unix.EINTR` at the
nmstate adapter boundary. They verify successful retries, partial-result
discarding, bounded failure, immediate handling of non-interruption errors, and
preservation of wrapped error identity.

A deterministic e2e test was not added because reproducing the kernel
`NLM_F_DUMP_INTR` condition reliably requires fault injection at the netlink
boundary, which is covered directly by the unit tests.

### Checklist

- [x] Design: A VEP is not required; this is an internal bug fix with no API or architectural change.
- [x] PR: The PR description documents the failure mode and implementation.
- [x] Code: The change is limited to the affected address dump operation.
- [x] Refactor: No unrelated refactoring is included.
- [x] Upgrade: No upgrade-flow impact is expected.
- [x] Testing: Deterministic unit tests cover the affected adapter boundary and error paths.
- [x] Documentation: No user-guide update is required; there is no user-facing API change.
- [x] Community: A broader announcement is not required for this focused bug fix.

### Release note

```release-note
Retry interrupted netlink address dumps during pod network setup to prevent transient dump interruptions from failing VMI startup.
```