### PR TITLE
Add feature gate dependency warnings

### DIFF
--- a/pkg/virt-config/featuregate/active.go
+++ b/pkg/virt-config/featuregate/active.go
@@ -318,7 +318,8 @@ func init() {
 	RegisterFeatureGate(FeatureGate{Name: VMStatsCollector, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: OCIExport, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: PluginsGate, State: Alpha})
-	RegisterFeatureGate(FeatureGate{Name: GraceIOVirtualization, State: Alpha})
+	RegisterFeatureGate(FeatureGate{Name: GraceIOVirtualization, State: Alpha,
+		Dependencies: []string{PCINUMAAwareTopologyEnabled, IOMMUFDGate}})
 	RegisterFeatureGate(FeatureGate{Name: IOMMUFDGate, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: FirmwareAutoSelection, State: Alpha})
 	RegisterFeatureGate(FeatureGate{Name: MigrationStallDetection, State: Alpha})

--- a/pkg/virt-config/featuregate/feature-gates.go
+++ b/pkg/virt-config/featuregate/feature-gates.go
@@ -55,6 +55,9 @@ type FeatureGate struct {
 	State       State
 	VmiSpecUsed func(spec *v1.VirtualMachineInstanceSpec) bool
 	Message     string
+	// Dependencies lists other feature gates that must be enabled for this
+	// feature gate to be fully functional
+	Dependencies []string
 }
 
 var featureGates = map[string]FeatureGate{}

--- a/pkg/virt-config/featuregate/feature-gates_test.go
+++ b/pkg/virt-config/featuregate/feature-gates_test.go
@@ -134,4 +134,21 @@ var _ = Describe("Feature Gate", func() {
 		Expect(featuregate.FeatureGateInfo(fg1.Name)).To(Equal(&fg1clone))
 		Expect(featuregate.FeatureGateInfo(fg2.Name)).To(Equal(&fg2))
 	})
+
+	It("registered FGs should not be more mature than their dependencies", func() {
+		maturity := map[featuregate.State]int{featuregate.Alpha: 1, featuregate.Beta: 2, featuregate.GA: 3}
+
+		for _, fg := range featuregate.GetRegisteredFeatureGates() {
+			for _, depName := range fg.Dependencies {
+				dep := featuregate.FeatureGateInfo(depName)
+				Expect(dep).ToNot(BeNil(), "%s depends on unregistered feature gate %s", fg.Name, depName)
+				Expect(maturity).To(HaveKey(fg.State),
+					"%s is %s and should not declare dependencies", fg.Name, fg.State)
+				Expect(maturity).To(HaveKey(dep.State),
+					"%s depends on %s, which is %s", fg.Name, dep.Name, dep.State)
+				Expect(maturity[fg.State]).To(BeNumerically("<=", maturity[dep.State]),
+					"%s (%s) is more mature than its dependency %s (%s)", fg.Name, fg.State, dep.Name, dep.State)
+			}
+		}
+	})
 })

--- a/pkg/virt-config/featuregate/validator.go
+++ b/pkg/virt-config/featuregate/validator.go
@@ -20,10 +20,31 @@
 package featuregate
 
 import (
+	"fmt"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	v1 "kubevirt.io/api/core/v1"
 )
+
+const DependencyWarningPattern = "feature gate %s depends on feature gate %s, which is not enabled"
+
+// WarnMissingDependencies returns a warning for every enabled feature gate that
+// declares a dependency on a feature gate which is not enabled
+func WarnMissingDependencies(devConfig *v1.DeveloperConfiguration) []string {
+	var warnings []string
+	for _, fg := range GetRegisteredFeatureGates() {
+		if !IsEnabled(fg.Name, devConfig) {
+			continue
+		}
+		for _, dep := range fg.Dependencies {
+			if !IsEnabled(dep, devConfig) {
+				warnings = append(warnings, fmt.Sprintf(DependencyWarningPattern, fg.Name, dep))
+			}
+		}
+	}
+	return warnings
+}
 
 func ValidateFeatureGates(featureGates []string, vmiSpec *v1.VirtualMachineInstanceSpec) []metav1.StatusCause {
 	var causes []metav1.StatusCause

--- a/pkg/virt-config/featuregate/validator_test.go
+++ b/pkg/virt-config/featuregate/validator_test.go
@@ -20,6 +20,8 @@
 package featuregate_test
 
 import (
+	"fmt"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -58,4 +60,63 @@ var _ = Describe("Validator", func() {
 			}},
 		),
 	)
+
+	Context("dependencies", func() {
+		const (
+			dependentFG = "test-dependent"
+			depFG       = "test-dependency"
+		)
+
+		registerDependent := func(fgState, depState featuregate.State) {
+			featuregate.RegisterFeatureGate(featuregate.FeatureGate{Name: depFG, State: depState})
+			featuregate.RegisterFeatureGate(featuregate.FeatureGate{
+				Name: dependentFG, State: fgState, Dependencies: []string{depFG},
+			})
+			DeferCleanup(featuregate.UnregisterFeatureGate, depFG)
+			DeferCleanup(featuregate.UnregisterFeatureGate, dependentFG)
+		}
+
+		DescribeTable("should warn about a missing dependency", func(fgState, depState featuregate.State, devConfig *v1.DeveloperConfiguration, expectWarning bool) {
+			registerDependent(fgState, depState)
+
+			warnings := featuregate.WarnMissingDependencies(devConfig)
+
+			if expectWarning {
+				Expect(warnings).To(ConsistOf(fmt.Sprintf(featuregate.DependencyWarningPattern, dependentFG, depFG)))
+			} else {
+				Expect(warnings).To(BeEmpty())
+			}
+		},
+			Entry("when an Alpha dependency is not enabled",
+				featuregate.Alpha, featuregate.Alpha,
+				&v1.DeveloperConfiguration{FeatureGates: []string{dependentFG}}, true),
+			Entry("not when an Alpha dependency is explicitly enabled",
+				featuregate.Alpha, featuregate.Alpha,
+				&v1.DeveloperConfiguration{FeatureGates: []string{dependentFG, depFG}}, false),
+			Entry("not when a Beta dependency is enabled by default",
+				featuregate.Alpha, featuregate.Beta,
+				&v1.DeveloperConfiguration{FeatureGates: []string{dependentFG}}, false),
+			Entry("when a Beta dependency is explicitly disabled",
+				featuregate.Alpha, featuregate.Beta,
+				&v1.DeveloperConfiguration{FeatureGates: []string{dependentFG}, DisabledFeatureGates: []string{depFG}}, true),
+			Entry("not when a GA dependency is not listed",
+				featuregate.Alpha, featuregate.GA,
+				&v1.DeveloperConfiguration{FeatureGates: []string{dependentFG}}, false),
+			Entry("when a Beta feature gate enabled by default has an unmet Alpha dependency",
+				featuregate.Beta, featuregate.Alpha,
+				&v1.DeveloperConfiguration{}, true),
+			Entry("when a Beta feature gate enabled by default has an unmet Alpha dependency and a nil config",
+				featuregate.Beta, featuregate.Alpha, nil, true),
+		)
+
+		It("should not warn when the feature gate is not enabled", func() {
+			registerDependent(featuregate.Alpha, featuregate.Alpha)
+
+			Expect(featuregate.WarnMissingDependencies(&v1.DeveloperConfiguration{})).To(BeEmpty())
+		})
+
+		It("should not warn for a nil developer configuration", func() {
+			Expect(featuregate.WarnMissingDependencies(nil)).To(BeEmpty())
+		})
+	})
 })

--- a/pkg/virt-operator/webhooks/kubevirt-update-admitter.go
+++ b/pkg/virt-operator/webhooks/kubevirt-update-admitter.go
@@ -125,8 +125,12 @@ func (admitter *KubeVirtUpdateAdmitter) Admit(ctx context.Context, ar *admission
 	response := validating_webhooks.NewAdmissionResponse(results)
 
 	if featureGatesChanged(&currKV.Spec, &newKV.Spec) {
-		featureGates := newKV.Spec.Configuration.DeveloperConfiguration.FeatureGates
-		response.Warnings = append(response.Warnings, warnDeprecatedFeatureGates(featureGates)...)
+		devConfig := newKV.Spec.Configuration.DeveloperConfiguration
+		response.Warnings = append(response.Warnings, warnDeprecatedFeatureGates(devConfig.FeatureGates)...)
+		for _, warning := range featuregate.WarnMissingDependencies(devConfig) {
+			log.Log.Warning(warning)
+			response.Warnings = append(response.Warnings, warning)
+		}
 	}
 
 	const mdevWarningfmt = "%s is deprecated, use mediatedDeviceTypes"

--- a/pkg/virt-operator/webhooks/kubevirt-update-admitter_test.go
+++ b/pkg/virt-operator/webhooks/kubevirt-update-admitter_test.go
@@ -572,6 +572,33 @@ var _ = Describe("Validating KubeVirtUpdate Admitter", func() {
 				[]string{"Gate1", "Gate2", "Gate3"},
 				"Gate1", "Gate2", "Gate3"),
 		)
+
+		const (
+			dependencyGate = "test-dependency-gate"
+			dependentGate  = "test-dependent-gate"
+		)
+
+		DescribeTable("should warn about an unmet feature gate dependency", func(enabledGates []string, expectWarning bool) {
+			featuregate.RegisterFeatureGate(featuregate.FeatureGate{Name: dependencyGate, State: featuregate.Alpha})
+			featuregate.RegisterFeatureGate(featuregate.FeatureGate{
+				Name: dependentGate, State: featuregate.Alpha, Dependencies: []string{dependencyGate},
+			})
+			DeferCleanup(featuregate.UnregisterFeatureGate, dependencyGate)
+			DeferCleanup(featuregate.UnregisterFeatureGate, dependentGate)
+
+			response := admitUpdate(&v1.DeveloperConfiguration{FeatureGates: enabledGates})
+
+			Expect(response.Allowed).To(BeTrue())
+			warning := fmt.Sprintf(featuregate.DependencyWarningPattern, dependentGate, dependencyGate)
+			if expectWarning {
+				Expect(response.Warnings).To(ContainElement(warning))
+			} else {
+				Expect(response.Warnings).ToNot(ContainElement(warning))
+			}
+		},
+			Entry("when the dependency is not enabled", []string{dependentGate}, true),
+			Entry("not when the dependency is enabled", []string{dependentGate, dependencyGate}, false),
+		)
 	})
 })
 


### PR DESCRIPTION
### What this PR does

Adds support for feature gate dependencies and warns when an enabled feature
gate has a dependency that is not enabled.

GraceIOVirtualization now depends on:
- PCINUMAAwareTopology
- IOMMUFD

The dependency check uses the existing feature gate enablement logic, including
feature gates that are enabled by default.

### References

Partially addresses #16998