### PR TITLE
dockerized: skip owner/group preservation in rsync sync

### DIFF
--- a/hack/dockerized
+++ b/hack/dockerized
@@ -123,7 +123,7 @@ printf "\n"
 rsynch_fail_count=0
 
 _rsync() {
-    rsync -al --contimeout="${DOCKERIZED_RSYNC_CONNECT_TIMEOUT}" --timeout="${DOCKERIZED_RSYNC_IO_TIMEOUT}" "$@"
+    rsync -al --no-owner --no-group --contimeout="${DOCKERIZED_RSYNC_CONNECT_TIMEOUT}" --timeout="${DOCKERIZED_RSYNC_IO_TIMEOUT}" "$@"
 }
 
 # Copy kubevirt into the persistent container volume


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
On rootless podman, targets that sync the source tree into the build container abort during the rsync step:

    rsync: chown "<file>" failed: Invalid argument (22)
    rsync error: some files/attrs were not transferred (code 23)

The builder's rsync daemon runs as uid 0 (hack/builder/rsyncd.conf) and the client sends owner/group metadata because _rsync() uses -a. In a rootless container the host uid maps to container uid 0 and the rest of the ids come from the subuid range, so the host user's own uid has no mapping inside the namespace. chowning received files to that uid returns EINVAL and fails the whole sync.

Ownership on the receiving side is irrelevant: the builder is a throwaway container where everything is expected to be root-owned. Add --no-owner --no-group to the shared _rsync() helper so no chown is attempted. This is a no-op for the rootful/docker path, where the files ended up root-owned either way.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

