### PR TITLE
e2e, net: NAD Swap using interconnected bridges

### DIFF
--- a/automation/test.sh
+++ b/automation/test.sh
@@ -89,6 +89,8 @@ case "$TARGET" in
     export KUBEVIRT_DEPLOY_ISTIO=true
     export KUBEVIRT_DEPLOY_NETWORK_RESOURCES_INJECTOR=true
     export KUBEVIRT_PROVIDER=${TARGET/-sig-network*/}
+    export KUBEVIRT_NUM_SECONDARY_NICS=2
+    export KUBEVIRT_SECONDARY_NIC_BRIDGES=true
     ;;
   *emulated-igb*)
     export KUBEVIRT_PROVIDER=${TARGET/-emulated-igb*/}

--- a/tests/network/nad_live_update.go
+++ b/tests/network/nad_live_update.go
@@ -60,6 +60,7 @@ var _ = Describe(SIG("NAD name live update", decorators.RequiresTwoSchedulableNo
 	var (
 		testNamespace string
 		virtClient    kubecli.KubevirtClient
+		staticVMI2    *v1.VirtualMachineInstance
 	)
 
 	BeforeEach(func() {
@@ -100,6 +101,8 @@ var _ = Describe(SIG("NAD name live update", decorators.RequiresTwoSchedulableNo
 		const (
 			staticVMI1Name = "static-vmi-1"
 			staticVMI1IP   = "10.1.1.10"
+			staticVMI2Name = "static-vmi-2"
+			staticVMI2IP   = "10.1.1.20"
 			subnetMask     = "/24"
 		)
 
@@ -125,6 +128,17 @@ var _ = Describe(SIG("NAD name live update", decorators.RequiresTwoSchedulableNo
 		vm := libvmi.NewVirtualMachine(vmi, libvmi.WithRunStrategy(v1.RunStrategyAlways))
 		vm, err = kubevirt.Client().VirtualMachine(testNamespace).Create(context.Background(), vm, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
+
+		staticVMI2, err = newVMI(
+			staticVMI2Name,
+			targetNAD,
+			staticVMI2IP+subnetMask,
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		staticVMI2, err = kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(staticVMI2)).
+			Create(context.Background(), staticVMI2, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
 
 		Eventually(matcher.ThisVMI(staticVMI1)).WithTimeout(timeoutInterval).WithPolling(pollingInterval).
 			Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
@@ -173,23 +187,6 @@ var _ = Describe(SIG("NAD name live update", decorators.RequiresTwoSchedulableNo
 				Not(BeEmpty()),
 				Not(Equal(sourceNodeName)),
 			))
-
-		var staticVMI2 *v1.VirtualMachineInstance
-		const (
-			staticVMI2Name = "static-vmi-2"
-			staticVMI2IP   = "10.1.1.20"
-			subnetMask     = "/24"
-		)
-		staticVMI2, err = newVMI(
-			staticVMI2Name,
-			targetNAD,
-			staticVMI2IP+subnetMask,
-		)
-		Expect(err).ToNot(HaveOccurred())
-
-		staticVMI2, err = kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(staticVMI2)).
-			Create(context.Background(), staticVMI2, metav1.CreateOptions{})
-		Expect(err).ToNot(HaveOccurred())
 
 		Eventually(matcher.ThisVMI(staticVMI2)).WithTimeout(timeoutInterval).WithPolling(pollingInterval).
 			Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))

--- a/tests/network/nad_live_update.go
+++ b/tests/network/nad_live_update.go
@@ -44,7 +44,6 @@ import (
 	"kubevirt.io/kubevirt/tests/libkubevirt/config"
 	"kubevirt.io/kubevirt/tests/libnet"
 	"kubevirt.io/kubevirt/tests/libnet/cloudinit"
-	"kubevirt.io/kubevirt/tests/libnode"
 	"kubevirt.io/kubevirt/tests/libvmifact"
 	"kubevirt.io/kubevirt/tests/testsuite"
 )
@@ -59,9 +58,8 @@ var _ = Describe(SIG("NAD name live update", decorators.RequiresTwoSchedulableNo
 		timeoutInterval = 5 * time.Minute
 	)
 	var (
-		testNamespace  string
-		virtClient     kubecli.KubevirtClient
-		sourceNodeName string
+		testNamespace string
+		virtClient    kubecli.KubevirtClient
 	)
 
 	BeforeEach(func() {
@@ -87,32 +85,28 @@ var _ = Describe(SIG("NAD name live update", decorators.RequiresTwoSchedulableNo
 
 	BeforeEach(func() {
 		testNamespace = testsuite.GetTestNamespace(nil)
-		const br1 = "br-1"
+		const br1 = "br1"
 		netAttachDef1 := libnet.NewBridgeNetAttachDef(sourceNAD, br1)
 		_, err := libnet.CreateNetAttachDef(context.Background(), testNamespace, netAttachDef1)
 		Expect(err).NotTo(HaveOccurred())
 
-		const br2 = "br-2"
+		const br2 = "br2"
 		netAttachDef2 := libnet.NewBridgeNetAttachDef(targetNAD, br2)
 		_, err = libnet.CreateNetAttachDef(context.Background(), testNamespace, netAttachDef2)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	BeforeEach(func() {
-		nodes := libnode.GetAllSchedulableNodes(kubevirt.Client())
-		sourceNodeName = nodes.Items[0].Name
-
 		const (
 			staticVMI1Name = "static-vmi-1"
 			staticVMI1IP   = "10.1.1.10"
 			subnetMask     = "/24"
 		)
 
-		staticVMI1, err := newVMIWithAffinity(
+		staticVMI1, err := newVMI(
 			staticVMI1Name,
 			sourceNAD,
 			staticVMI1IP+subnetMask,
-			sourceNodeName,
 		)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -121,11 +115,10 @@ var _ = Describe(SIG("NAD name live update", decorators.RequiresTwoSchedulableNo
 		Expect(err).ToNot(HaveOccurred())
 
 		var vmi *v1.VirtualMachineInstance
-		vmi, err = newVMIWithAffinity(
+		vmi, err = newVMI(
 			vmName,
 			sourceNAD,
 			vmIP+subnetMask,
-			sourceNodeName,
 		)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -148,12 +141,13 @@ var _ = Describe(SIG("NAD name live update", decorators.RequiresTwoSchedulableNo
 		vm, err := kubevirt.Client().VirtualMachine(testNamespace).Get(context.Background(), vmName, metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
 
-		err = updateNADNameAndRemoveAffinityRules(vm, targetNAD)
-		Expect(err).NotTo(HaveOccurred())
-
-		var vmi *v1.VirtualMachineInstance
-		vmi, err = kubevirt.Client().VirtualMachineInstance(testNamespace).Get(context.Background(), vmName, metav1.GetOptions{})
+		vmi, err := kubevirt.Client().VirtualMachineInstance(testNamespace).Get(context.Background(), vmName, metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
+		sourceNodeName := vmi.Status.NodeName
+		Expect(sourceNodeName).ToNot(BeEmpty())
+
+		err = updateNADName(vm, targetNAD)
+		Expect(err).NotTo(HaveOccurred())
 
 		By("Waiting for migration condition to appear and disappear")
 		Eventually(matcher.ThisVMI(vmi)).
@@ -180,19 +174,16 @@ var _ = Describe(SIG("NAD name live update", decorators.RequiresTwoSchedulableNo
 				Not(Equal(sourceNodeName)),
 			))
 
-		targetNode := vmi.Status.NodeName
-
 		var staticVMI2 *v1.VirtualMachineInstance
 		const (
 			staticVMI2Name = "static-vmi-2"
 			staticVMI2IP   = "10.1.1.20"
 			subnetMask     = "/24"
 		)
-		staticVMI2, err = newVMIWithAffinity(
+		staticVMI2, err = newVMI(
 			staticVMI2Name,
 			targetNAD,
 			staticVMI2IP+subnetMask,
-			targetNode,
 		)
 		Expect(err).ToNot(HaveOccurred())
 
@@ -209,9 +200,8 @@ var _ = Describe(SIG("NAD name live update", decorators.RequiresTwoSchedulableNo
 	})
 }))
 
-func updateNADNameAndRemoveAffinityRules(vm *v1.VirtualMachine, targetNAD string) error {
+func updateNADName(vm *v1.VirtualMachine, targetNAD string) error {
 	patchData, err := patch.New(
-		patch.WithRemove("/spec/template/spec/affinity"),
 		patch.WithReplace("/spec/template/spec/networks/0/multus/networkName", targetNAD),
 	).GeneratePayload()
 	if err != nil {
@@ -222,7 +212,7 @@ func updateNADNameAndRemoveAffinityRules(vm *v1.VirtualMachine, targetNAD string
 	return err
 }
 
-func newVMIWithAffinity(name, nad, ip, node string) (*v1.VirtualMachineInstance, error) {
+func newVMI(name, nad, ip string) (*v1.VirtualMachineInstance, error) {
 	const ifaceName = "net1"
 	networkData1, err := cloudinit.NewNetworkData(
 		cloudinit.WithEthernet("eth0",
@@ -236,7 +226,6 @@ func newVMIWithAffinity(name, nad, ip, node string) (*v1.VirtualMachineInstance,
 		libvmi.WithName(name),
 		libvmi.WithInterface(libvmi.NewInterface(ifaceName, libvmi.WithBridgeBinding())),
 		libvmi.WithNetwork(libvmi.MultusNetwork(ifaceName, nad)),
-		libvmi.WithNodeAffinityFor(node),
 		libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(networkData1)),
 	)
 	return vmi, nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Enable `KUBEVIRT_NUM_SECONDARY_NICS` and `KUBEVIRT_SECONDARY_NIC_BRIDGES` for the standard sig-network test lane, in order to utilize `bridge` CNI with cross bridge node connectivity.
Refactor the NAD Live Update test such that it no longer relies on specific node assignments and affinity taking advantage of cross node bridge connectivity. 

#### Before this PR:

#### After this PR:

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

