### PR TITLE
e2e, net: Fix minor spelling mistake

### DIFF
--- a/tests/network/link_state.go
+++ b/tests/network/link_state.go
@@ -51,7 +51,7 @@ var _ = Describe(SIG("interface state up/down", decorators.WgS390x, func() {
 		nadName                  = "bridge-nad"
 	)
 	const (
-		waitForGAConnectedTimout        = 6 * time.Minute
+		waitForGAConnectedTimeout       = 6 * time.Minute
 		waitForGAConnectedRetryInterval = 3 * time.Second
 	)
 	const waitForExpectedIfaceStatusesTimeout = 60 * time.Second
@@ -95,7 +95,7 @@ var _ = Describe(SIG("interface state up/down", decorators.WgS390x, func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		Eventually(matcher.ThisVM(vm)).
-			WithTimeout(waitForGAConnectedTimout).
+			WithTimeout(waitForGAConnectedTimeout).
 			WithPolling(waitForGAConnectedRetryInterval).
 			Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 		vmi, err = kubevirt.Client().VirtualMachineInstance(testNamespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
@@ -179,7 +179,7 @@ var _ = Describe(SIG("interface state up/down", decorators.WgS390x, func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		Eventually(matcher.ThisVM(vm)).
-			WithTimeout(waitForGAConnectedTimout).
+			WithTimeout(waitForGAConnectedTimeout).
 			WithPolling(waitForGAConnectedRetryInterval).
 			Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
 		vmi, err = kubevirt.Client().VirtualMachineInstance(testNamespace).Get(context.Background(), vm.Name, metav1.GetOptions{})


### PR DESCRIPTION
### What this PR does:

Fixed a typo


### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

