### PR TITLE
passt: retry repair when a setup step fails

### DIFF
--- a/pkg/network/passt/repair.go
+++ b/pkg/network/passt/repair.go
@@ -79,11 +79,13 @@ func (r *RepairManager) HandleMigrationSource(vmi *v1.VirtualMachineInstance,
 
 	passtDir, err := socketDirFunc(vmi)
 	if err != nil {
+		r.activeVMs.SetInactive(vmi)
 		return err
 	}
 
 	repairSocket, err := r.findRepairSocketFunc(passtDir)
 	if err != nil {
+		r.activeVMs.SetInactive(vmi)
 		return err
 	}
 	r.execCommandFunc(repairSocket, vmi, r.activeVMs.SetInactive)
@@ -104,6 +106,7 @@ func (r *RepairManager) HandleMigrationTarget(vmi *v1.VirtualMachineInstance,
 
 	passtDir, err := socketDirFunc(vmi)
 	if err != nil {
+		r.activeVMs.SetInactive(vmi)
 		return err
 	}
 

--- a/pkg/network/passt/repair_test.go
+++ b/pkg/network/passt/repair_test.go
@@ -183,6 +183,69 @@ var _ = Describe("Passt Repair Handler", func() {
 		Expect(handler.HandleMigrationTarget(vmi, failingSocketDirFunc)).To(MatchError(expectedError))
 	})
 
+	DescribeTable("should allow retry after a dirFunc error",
+		func(handleMigration func(*passt.RepairManager, *v1.VirtualMachineInstance, func(*v1.VirtualMachineInstance) (string, error)) error) {
+			repairCallCount := 0
+			dirFuncCallCount := 0
+			handler := passt.NewRepairManagerWithOptions(
+				stubFindRepairSocketInDir,
+				func(string, *v1.VirtualMachineInstance, func(instance *v1.VirtualMachineInstance)) {
+					repairCallCount++
+				},
+				newActiveVMs(),
+			)
+
+			vmi := libvmi.New(
+				libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithPasstBinding())),
+				libvmi.WithNetwork(v1.DefaultPodNetwork()),
+			)
+			failOnceDirFunc := func(*v1.VirtualMachineInstance) (string, error) {
+				dirFuncCallCount++
+				if dirFuncCallCount == 1 {
+					return "", errors.New("transient error")
+				}
+				return "/var/run/passt", nil
+			}
+
+			Expect(handleMigration(handler, vmi, failOnceDirFunc)).To(MatchError("transient error"))
+			Expect(repairCallCount).To(Equal(0))
+
+			Expect(handleMigration(handler, vmi, failOnceDirFunc)).To(Succeed())
+			Expect(repairCallCount).To(Equal(1))
+		},
+		Entry("HandleMigrationSource", (*passt.RepairManager).HandleMigrationSource),
+		Entry("HandleMigrationTarget", (*passt.RepairManager).HandleMigrationTarget),
+	)
+
+	It("HandleMigrationSource should allow retry after findRepairSocketFunc error", func() {
+		repairCallCount := 0
+		findSocketCallCount := 0
+		handler := passt.NewRepairManagerWithOptions(
+			func(string) (string, error) {
+				findSocketCallCount++
+				if findSocketCallCount == 1 {
+					return "", errors.New("transient error")
+				}
+				return "/var/run/passt/repair.socket.repair", nil
+			},
+			func(string, *v1.VirtualMachineInstance, func(instance *v1.VirtualMachineInstance)) {
+				repairCallCount++
+			},
+			newActiveVMs(),
+		)
+
+		vmi := libvmi.New(
+			libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithPasstBinding())),
+			libvmi.WithNetwork(v1.DefaultPodNetwork()),
+		)
+
+		Expect(handler.HandleMigrationSource(vmi, stubSocketDir)).To(MatchError("transient error"))
+		Expect(repairCallCount).To(Equal(0))
+
+		Expect(handler.HandleMigrationSource(vmi, stubSocketDir)).To(Succeed())
+		Expect(repairCallCount).To(Equal(1))
+	})
+
 	It("Should not run HandleMigrationSource because it is already running", func() {
 		vmi := libvmi.New(
 			libvmi.WithInterface(libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithPasstBinding())),
@@ -244,7 +307,9 @@ func (s *activeVMs) TestAndSetActive(vmi *v1.VirtualMachineInstance) bool {
 	return isActive
 }
 
-func (s *activeVMs) SetInactive(_ *v1.VirtualMachineInstance) {}
+func (s *activeVMs) SetInactive(vmi *v1.VirtualMachineInstance) {
+	delete(s.running, vmi.UID)
+}
 
 func newActiveVMs() *activeVMs {
 	return &activeVMs{running: map[types.UID]struct{}{}}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Before passt repair runs, a guard marks the VMI active so concurrent attempts are skipped. If a step preceding the repair fails, the VMI stays marked active forever: every later attempt hits the guard and returns without doing anything or reporting an error, so passt repair is never run again for that VMI, even once the original failure clears (for example a transient error).

Clear the active mark on these error paths so the VMI is retried.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed passt repair being permanently skipped for a VMI after a transient setup error.
```

