### PR TITLE
virt-handler: clean up decentralized migration source ghost record

### DIFF
--- a/pkg/virt-handler/vm.go
+++ b/pkg/virt-handler/vm.go
@@ -408,7 +408,10 @@ func (c *VirtualMachineController) execute(key string) error {
 		return nil
 	}
 
-	if vmiExists && vmi.IsMigrationSource() {
+	// Skip a migration source only while the migration is still ongoing. A decentralized
+	// source keeps IsMigrationSource()==true even once terminal, so without the IsFinal()
+	// guard sync() never runs and the source ghost record leaks - and MigrationSourceController never deletes it
+	if vmiExists && vmi.IsMigrationSource() && !vmi.IsFinal() {
 		c.logger.Object(vmi).V(4).Info("ignoring vmi as it is a migration source")
 		return nil
 	}

--- a/pkg/virt-handler/vm_test.go
+++ b/pkg/virt-handler/vm_test.go
@@ -3533,6 +3533,127 @@ var _ = Describe("VirtualMachineInstance", func() {
 		})
 	})
 
+	Context("decentralized live migration source ghost-record cleanup", func() {
+		// A decentralized source stays IsMigrationSource()==true forever (TargetState is
+		// never cleared), so the source ghost record must be cleaned once the VMI is final -
+		// for BOTH terminal phases (Succeeded and Failed), since MigrationSourceController
+		// never deletes it. Otherwise a same-name/new-UID receiver fails to register with
+		// "differing UID".
+		DescribeTable("cleans up the source ghost record so a same-name receiver can start", func(finalPhase v1.VirtualMachineInstancePhase) {
+			const (
+				vmiName  = "testvmi"
+				vmiNs    = metav1.NamespaceDefault
+				ghostKey = vmiNs + "/" + vmiName
+			)
+			sourceUID := vmiTestUUID
+			receiverUID := uuid.NewUUID()
+			receiverSocket := cmdclient.SocketFilePathOnHost(string(receiverUID))
+
+			start := metav1.NewTime(time.Now().Add(-2 * time.Minute))
+			targetSyncAddr := "10.0.0.2:1234"
+			targetNodeAddr := "10.0.0.2"
+			migrationUID := types.UID("mig-uid-1234")
+
+			// TargetState's Sync/Node addresses keep IsMigrationSource() true forever; an
+			// EndTimestamp flips the migration from "in progress" to "completed".
+			decentralizedMigrationState := func(end *metav1.Time) *v1.VirtualMachineInstanceMigrationState {
+				return &v1.VirtualMachineInstanceMigrationState{
+					StartTimestamp: &start,
+					EndTimestamp:   end,
+					SourceNode:     host,
+					MigrationUID:   migrationUID,
+					SourceState: &v1.VirtualMachineInstanceMigrationSourceState{
+						VirtualMachineInstanceCommonMigrationState: v1.VirtualMachineInstanceCommonMigrationState{
+							Node:         host,
+							MigrationUID: migrationUID,
+						},
+					},
+					TargetState: &v1.VirtualMachineInstanceMigrationTargetState{
+						VirtualMachineInstanceCommonMigrationState: v1.VirtualMachineInstanceCommonMigrationState{
+							Node:         "targetnode",
+							MigrationUID: migrationUID,
+							SyncAddress:  &targetSyncAddr,
+						},
+						NodeAddress: &targetNodeAddr,
+					},
+				}
+			}
+
+			// Model the record the source virt-launcher added on start (GetLauncherClient).
+			By("Planting the SOURCE ghost record, as the source virt-launcher would have")
+			Expect(virtcache.GhostRecordGlobalStore.Add(vmiNs, vmiName, sockFile, sourceUID)).To(Succeed())
+			Expect(virtcache.GhostRecordGlobalStore.Exists(vmiNs, vmiName)).To(BeTrue(),
+				"sanity: the source ghost record must exist before we reconcile")
+
+			// --- STEP 1: source Running, migration in progress --------------------
+			// execute() early-returns on isMigrationInProgress, so the record is untouched.
+			By("Reconciling the running source while the migration is in progress")
+			vmi := libvmi.New(
+				libvmi.WithUID(sourceUID),
+				libvmi.WithNamespace(vmiNs),
+				libvmi.WithName(vmiName),
+				libvmistatus.WithStatus(
+					libvmistatus.New(
+						libvmistatus.WithPhase(v1.Running),
+						libvmistatus.WithNodeName(host),
+						libvmistatus.WithMigrationState(*decentralizedMigrationState(nil)),
+					),
+				),
+			)
+			Expect(vmi.IsMigrationSource()).To(BeTrue(), "sanity: VMI must look like a decentralized migration source")
+
+			domain := api.NewMinimalDomainWithUUID(vmiName, sourceUID)
+			domain.SetState(api.Running, api.ReasonUser)
+			addVMI(vmi, domain)
+
+			sanityExecute()
+			Expect(virtcache.GhostRecordGlobalStore.Exists(vmiNs, vmiName)).To(BeTrue(),
+				"a migration in progress must not disturb the source ghost record")
+
+			// --- STEP 2: guest migrates away; source domain is UNDEFINED ----------
+			// The domain is gone before the final VMI is reconciled, so the pre-fix domain-based cleanup branch never fires.
+			By("Tearing down the source domain (UNDEFINED) after the guest migrated away")
+			Expect(controller.domainStore.Delete(domain)).To(Succeed())
+
+			By("Marking the source VMI final while it stays a decentralized source")
+			end := metav1.NewTime(time.Now().Add(-1 * time.Minute))
+			vmi.Status.Phase = finalPhase
+			vmi.Status.MigrationState = decentralizedMigrationState(&end)
+			Expect(vmi.IsFinal()).To(BeTrue(), "sanity: source VMI must be in a final phase")
+			Expect(vmi.IsMigrationSource()).To(BeTrue(), "sanity: a decentralized source stays IsMigrationSource forever")
+			Expect(controller.vmiStore.Update(vmi)).To(Succeed())
+			_, err := virtfakeClient.KubevirtV1().VirtualMachineInstances(vmiNs).Update(context.TODO(), vmi, metav1.UpdateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			key, err := virtcontroller.KeyFunc(vmi)
+			Expect(err).ToNot(HaveOccurred())
+			controller.queue.Add(key)
+
+			// Expect the cleanup calls
+			mockHotplugVolumeMounter.EXPECT().UnmountAll(gomock.Any(), mockCgroupManager).Return(nil).AnyTimes()
+			client.EXPECT().DeleteDomain(gomock.Any()).Return(nil).AnyTimes()
+
+			By("Reconciling the final source after its domain is gone (post-UNDEFINED)")
+			sanityExecuteNoDomain()
+
+			// --- STEP 3: the same-name / new-UID receiver tries to register -------
+			leaked := virtcache.GhostRecordGlobalStore.Exists(vmiNs, vmiName)
+			addErr := virtcache.GhostRecordGlobalStore.Add(vmiNs, vmiName, receiverSocket, receiverUID)
+
+			Expect(addErr).ToNot(HaveOccurred(),
+				"the same-name / new-UID receiver must be able to register its ghost record; "+
+					"pre-fix this fails with \"differing UID\" because the source record leaked at "+ghostKey)
+			Expect(leaked).To(BeFalse(),
+				"the source ghost record ("+ghostKey+") must be cleaned once the migration-source VMI is final; "+
+					"it survives today because execute() early-returns on vmi.IsMigrationSource() before sync()")
+
+			// The cleanup deletion emits this event (consumed in AfterEach).
+			testutils.ExpectEvent(recorder, VMISignalDeletion)
+		},
+			Entry("when the migration source succeeded", v1.Succeeded),
+			Entry("when the migration source failed", v1.Failed),
+		)
+	})
+
 	Context("updateBackupStatus", func() {
 		startTime := metav1.Now()
 		endTime := metav1.NewTime(startTime.Add(5 * time.Minute))

--- a/tests/migration/namespace.go
+++ b/tests/migration/namespace.go
@@ -179,7 +179,7 @@ var _ = Describe(SIG("Live Migration across namespaces", decorators.RequiresDece
 
 	Context("container disk", func() {
 
-		It("[QUARANTINE]should live migrate a container disk vm, several times", decorators.Quarantine, func() {
+		It("should live migrate a container disk vm, several times", func() {
 			var targetVM *virtv1.VirtualMachine
 
 			sourceVMI := libvmifact.NewAlpine(


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:
On a decentralized live migration, the source node's virt-handler could fail to delete the source ghost record. A decentralized source keeps reporting `IsMigrationSource()==true` forever (`MigrationState.TargetState` is never cleared), so `VirtualMachineController.execute()` always took the "migration source" early-return and never reached `sync()`. Cleanup then depended solely on catching the source domain during the brief `Shutoff+Migrated` window; on a busy node the domain often reaches `Undefined` (and leaves the cache) first, so the record leaked. A later same-name VMI scheduled on that node then failed to register its ghost record with `can not add ghost record when entry already exists with differing UID`, the migration target never started, and the migration timed out — this is causing ~5% flake in `should live migrate regular disk several times` e2e test.

#### After this PR:
Once a migration source is terminal, `execute()` is no longer returning early: the flow continues going through to `sync()`, which deletes the source ghost record. A same-name/new-UID receiver on the same node can then register its own ghost record and start normally.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes https://github.com/kubevirt/kubevirt/pull/18805
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
- Added a controller-level unit test in `pkg/virt-handler/vm_test.go` that drives `execute()` through the exact source lifecycle (Running + migration in progress → domain
  undefined + VMI `Succeeded` → same-name/new-UID receiver `Add`).
- The flake itself is a timing race, so it can't be reproduced by simply re-running the e2e; the fix-sensitive guard is the unit test. This PR also de-quarantines `should live migrate regular disk several times`, which is the end-to-end coverage.
<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [X] PR: The PR description is expressive enough and will help future contributors
- [X] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [X] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [X] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [X] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [X] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [X] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [X] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed a source-side ghost record leak on decentralized live migration that could prevent a subsequent same-name VirtualMachineInstance from starting on the same node.
```

