### PR TITLE
net, dra_test: Standardize validations in tests

### DIFF
--- a/pkg/network/admitter/dra_test.go
+++ b/pkg/network/admitter/dra_test.go
@@ -23,6 +23,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/ptr"
 
@@ -36,9 +37,12 @@ var _ = Describe("Validate network DRA", func() {
 		spec := newDRASpec()
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{})
 		causes := validator.Validate()
-		Expect(causes).To(HaveLen(1))
-		Expect(causes[0].Message).To(Equal("vmi.spec.networks contains DRA networks but NetworkDevicesWithDRA feature gate is not enabled"))
-		Expect(causes[0].Field).To(Equal("fake.networks"))
+		expectedCauses := []metav1.StatusCause{{
+			Type:    metav1.CauseTypeFieldValueInvalid,
+			Message: "vmi.spec.networks contains DRA networks but NetworkDevicesWithDRA feature gate is not enabled",
+			Field:   "fake.networks",
+		}}
+		Expect(causes).To(Equal(expectedCauses))
 	})
 
 	It("should accept valid DRA network when feature gate is enabled", func() {
@@ -53,9 +57,12 @@ var _ = Describe("Validate network DRA", func() {
 		spec.Networks[0].ResourceClaim.ClaimName = ""
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{networkDRAEnabled: true})
 		causes := validator.Validate()
-		Expect(causes).To(HaveLen(1))
-		Expect(causes[0].Message).To(Equal("claimName is required for DRA network"))
-		Expect(causes[0].Field).To(Equal("fake.networks[0].resourceClaim.claimName"))
+		expectedCauses := []metav1.StatusCause{{
+			Type:    metav1.CauseTypeFieldValueRequired,
+			Message: "claimName is required for DRA network",
+			Field:   "fake.networks[0].resourceClaim.claimName",
+		}}
+		Expect(causes).To(Equal(expectedCauses))
 	})
 
 	It("should reject DRA network with empty requestName", func() {
@@ -63,9 +70,12 @@ var _ = Describe("Validate network DRA", func() {
 		spec.Networks[0].ResourceClaim.RequestName = ""
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{networkDRAEnabled: true})
 		causes := validator.Validate()
-		Expect(causes).To(HaveLen(1))
-		Expect(causes[0].Message).To(Equal("requestName is required for DRA network"))
-		Expect(causes[0].Field).To(Equal("fake.networks[0].resourceClaim.requestName"))
+		expectedCauses := []metav1.StatusCause{{
+			Type:    metav1.CauseTypeFieldValueRequired,
+			Message: "requestName is required for DRA network",
+			Field:   "fake.networks[0].resourceClaim.requestName",
+		}}
+		Expect(causes).To(Equal(expectedCauses))
 	})
 
 	It("should reject DRA network with non-existent resourceClaim reference", func() {
@@ -73,9 +83,12 @@ var _ = Describe("Validate network DRA", func() {
 		spec.Networks[0].ResourceClaim.ClaimName = "missing-claim"
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{networkDRAEnabled: true})
 		causes := validator.Validate()
-		Expect(causes).To(HaveLen(1))
-		Expect(causes[0].Message).To(Equal(`network references resourceClaim "missing-claim" which is not defined in spec.resourceClaims`))
-		Expect(causes[0].Field).To(Equal("fake.networks[0].resourceClaim.claimName"))
+		expectedCauses := []metav1.StatusCause{{
+			Type:    metav1.CauseTypeFieldValueNotFound,
+			Message: `network references resourceClaim "missing-claim" which is not defined in spec.resourceClaims`,
+			Field:   "fake.networks[0].resourceClaim.claimName",
+		}}
+		Expect(causes).To(Equal(expectedCauses))
 	})
 
 	It("should reject duplicate claimName/requestName across DRA networks", func() {
@@ -112,9 +125,12 @@ var _ = Describe("Validate network DRA", func() {
 		}
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{networkDRAEnabled: true})
 		causes := validator.Validate()
-		Expect(causes).To(HaveLen(1))
-		Expect(causes[0].Message).To(Equal(`duplicate claimName/requestName combination "claim1/vf"`))
-		Expect(causes[0].Field).To(Equal("fake.networks[1]"))
+		expectedCauses := []metav1.StatusCause{{
+			Type:    metav1.CauseTypeFieldValueDuplicate,
+			Message: `duplicate claimName/requestName combination "claim1/vf"`,
+			Field:   "fake.networks[1]",
+		}}
+		Expect(causes).To(Equal(expectedCauses))
 	})
 
 	It("should reject mixing Multus and DRA networks", func() {
@@ -138,9 +154,12 @@ var _ = Describe("Validate network DRA", func() {
 		}
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{networkDRAEnabled: true})
 		causes := validator.Validate()
-		Expect(causes).To(HaveLen(1))
-		Expect(causes[0].Message).To(Equal("mixing Multus and DRA resourceClaim networks in the same VMI is not supported"))
-		Expect(causes[0].Field).To(Equal("fake.networks"))
+		expectedCauses := []metav1.StatusCause{{
+			Type:    metav1.CauseTypeFieldValueInvalid,
+			Message: "mixing Multus and DRA resourceClaim networks in the same VMI is not supported",
+			Field:   "fake.networks",
+		}}
+		Expect(causes).To(Equal(expectedCauses))
 	})
 
 	DescribeTable("should reject DRA network with core interface binding",
@@ -189,9 +208,12 @@ var _ = Describe("Validate network DRA", func() {
 		spec.Domain.Devices.Interfaces = nil
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{networkDRAEnabled: true})
 		causes := validator.Validate()
-		Expect(causes).To(HaveLen(1))
-		Expect(causes[0].Message).To(Equal("fake.networks[0].name 'dra-net' not found."))
-		Expect(causes[0].Field).To(Equal("fake.networks[0].name"))
+		expectedCauses := []metav1.StatusCause{{
+			Type:    metav1.CauseTypeFieldValueRequired,
+			Message: "fake.networks[0].name 'dra-net' not found.",
+			Field:   "fake.networks[0].name",
+		}}
+		Expect(causes).To(Equal(expectedCauses))
 	})
 })
 


### PR DESCRIPTION
### What this PR does
Use Expect(actual).To(Equal(expected)) where possible, replacing multiple per field assertions. This pins the exact cause count and type, catching extra/missing causes and wrong types regression that the old assertions could pass silently.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

