### PR TITLE
virt-controller: Propagate launcher pull secret

### DIFF
--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1058,6 +1058,14 @@ func sidecarContainerName(i int) string {
 	return fmt.Sprintf("hook-sidecar-%d", i)
 }
 
+func (t *TemplateService) launcherImagePullSecrets() []k8sv1.LocalObjectReference {
+	if t.imagePullSecret == "" {
+		return nil
+	}
+
+	return []k8sv1.LocalObjectReference{{Name: t.imagePullSecret}}
+}
+
 func (t *TemplateService) RenderHotplugAttachmentPodTemplate(volumes []*v1.Volume, ownerPod *k8sv1.Pod, vmi *v1.VirtualMachineInstance, claimMap map[string]*k8sv1.PersistentVolumeClaim) (*k8sv1.Pod, error) {
 	zero := int64(0)
 	runUser := int64(util.NonRootUID)
@@ -1143,6 +1151,7 @@ func (t *TemplateService) RenderHotplugAttachmentPodTemplate(volumes []*v1.Volum
 			Tolerations:                   tolerations,
 			Volumes:                       []k8sv1.Volume{emptyDirVolume(hotplugDisks)},
 			TerminationGracePeriodSeconds: &zero,
+			ImagePullSecrets:              t.launcherImagePullSecrets(),
 		},
 	}
 
@@ -1292,6 +1301,7 @@ func (t *TemplateService) RenderHotplugAttachmentTriggerPodTemplate(volume *v1.V
 				emptyDirVolume(hotplugDisks),
 			},
 			TerminationGracePeriodSeconds: &zero,
+			ImagePullSecrets:              t.launcherImagePullSecrets(),
 		},
 	}
 

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -2978,6 +2978,48 @@ var _ = Describe("Template", func() {
 				Expect(pod.Spec.ImagePullSecrets[0].Name).To(Equal("pull-secret-1"))
 			})
 
+			It("should contain launcher's secret in hotplug attachment pod spec", func() {
+				config, kvStore, svc = configFactory(defaultArch)
+				vmi := api.NewMinimalVMI("testvmi")
+				ownerPod, err := svc.RenderLaunchManifest(vmi)
+				Expect(err).ToNot(HaveOccurred())
+
+				vmi.Status.SelinuxContext = "test_u:test_r:test_t:s0"
+				pod, err := svc.RenderHotplugAttachmentPodTemplate(nil, ownerPod, vmi, nil)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(pod.Spec.ImagePullSecrets).To(Equal([]k8sv1.LocalObjectReference{{Name: "pull-secret-1"}}))
+			})
+
+			It("should contain launcher's secret in hotplug attachment trigger pod spec", func() {
+				config, kvStore, svc = configFactory(defaultArch)
+				vmi := api.NewMinimalVMI("testvmi")
+				ownerPod, err := svc.RenderLaunchManifest(vmi)
+				Expect(err).ToNot(HaveOccurred())
+
+				vmi.Status.SelinuxContext = "test_u:test_r:test_t:s0"
+				pod, err := svc.RenderHotplugAttachmentTriggerPodTemplate(&v1.Volume{Name: "test"}, ownerPod, vmi, "test", true, false)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(pod.Spec.ImagePullSecrets).To(Equal([]k8sv1.LocalObjectReference{{Name: "pull-secret-1"}}))
+			})
+
+			It("should omit an empty launcher secret from hotplug pod specs", func() {
+				config, kvStore, svc = configFactory(defaultArch)
+				svc.imagePullSecret = ""
+				vmi := api.NewMinimalVMI("testvmi")
+				ownerPod, err := svc.RenderLaunchManifest(vmi)
+				Expect(err).ToNot(HaveOccurred())
+
+				vmi.Status.SelinuxContext = "test_u:test_r:test_t:s0"
+				attachmentPod, err := svc.RenderHotplugAttachmentPodTemplate(nil, ownerPod, vmi, nil)
+				Expect(err).ToNot(HaveOccurred())
+				triggerPod, err := svc.RenderHotplugAttachmentTriggerPodTemplate(&v1.Volume{Name: "test"}, ownerPod, vmi, "test", true, false)
+				Expect(err).ToNot(HaveOccurred())
+
+				Expect(attachmentPod.Spec.ImagePullSecrets).To(BeEmpty())
+				Expect(triggerPod.Spec.ImagePullSecrets).To(BeEmpty())
+			})
 		})
 
 		Context("with ContainerDisk pull secrets", func() {


### PR DESCRIPTION
### What this PR does

#### Before this PR:

The explicit virt-controller `--image-pull-secret` option was propagated to
virt-launcher pods, but not to the hotplug attachment and population trigger
pods that use the same virt-launcher image.

When the image is hosted in a private registry, these helper pods could fail
with `ImagePullBackOff` and `401 Unauthorized`.

This is exposed reliably by Kubernetes 1.35 cached-image credential
verification. An image being present on the node is no longer sufficient when
the pod cannot present credentials matching those used to pull it.

#### After this PR:

Hotplug attachment and population trigger pods receive the explicitly
configured virt-launcher image pull secret.

When `--image-pull-secret` is not configured, behavior remains unchanged.

The existing virt-launcher image-holder behavior is also unchanged. The holder
continues to preload and retain the image, while the explicit pull-secret
option authorizes launcher-related pods when credential verification is
required.

### References

- Related to #8302
- Kubernetes KEP-2535: Ensure Secret Pulled Images

### Why we need it and why it was done in this way

Hotplug helper pods run the configured virt-launcher image and are owned by a
virt-launcher pod, but they did not consume the existing explicit
`--image-pull-secret` configuration.

This change extends that existing opt-in contract to both helper pod types. It
does not propagate KubeVirt CR image pull secrets, alter service accounts, or
replace the image-holder design.

The following tradeoffs were made:

Only the explicitly configured launcher pull secret is propagated. Copying all
secrets from the owner pod would be broader than necessary.

The image pull policy is left unchanged so the existing cache-first and
image-holder behavior is preserved.

The following alternatives were considered:

- Adding the registry secret to the namespace default ServiceAccount. This
  works but grants the credential to every pod using that ServiceAccount.
- Injecting the secret with a mutating webhook. This is more complex and makes
  hotplug startup depend on another admission component.
- Disabling cached-image credential verification. This weakens the Kubernetes
  security behavior and is not viable as the behavior becomes mandatory.

No Kubernetes-version check is used. Missing credentials are incorrect on all
versions; Kubernetes 1.35 only makes the cached-image failure deterministic.

### Special notes for your reviewer

Tests cover:

- Propagation to hotplug attachment pods.
- Propagation to hotplug population trigger pods.
- Unchanged behavior when the explicit secret is empty.

Validation:

`go test ./pkg/virt-controller/services -count=1`

### Checklist

- [x] Design: A VEP is not required for this focused bug fix
- [x] PR: The description explains the behavior and motivation
- [x] Code: The change reuses the existing explicit configuration
- [x] Refactor: No unrelated refactoring is included
- [x] Upgrade: Existing empty-configuration behavior remains unchanged
- [ ] Testing: Unit coverage is included; no private-registry E2E is included
- [x] Documentation: No user-facing API or configuration change
- [ ] Community: Announcement to kubevirt-dev was not required
- [x] AI Contributions: The commit identifies the AI contribution

### Release note

```release-note
Propagate the explicitly configured virt-launcher image pull secret to hotplug attachment and population trigger pods.
```
