### PR TITLE
docs: update log verbosity documentation

### DIFF
--- a/api/openapi-spec/swagger.json
+++ b/api/openapi-spec/swagger.json
@@ -16357,11 +16357,11 @@
     }
    },
    "v1.LogVerbosity": {
-    "description": "LogVerbosity sets log verbosity level of  various components",
+    "description": "LogVerbosity sets log verbosity level of various components",
     "type": "object",
     "properties": {
      "nodeVerbosity": {
-      "description": "NodeVerbosity represents a map of nodes with a specific verbosity level",
+      "description": "NodeVerbosity represents a map of node names to specific log verbosity levels. Allows overriding verbosity on specific nodes without altering cluster-wide settings. Changes take effect on the fly without triggering a pod restart.",
       "type": "object",
       "additionalProperties": {
        "type": "integer",
@@ -16370,26 +16370,32 @@
       }
      },
      "virtAPI": {
+      "description": "VirtAPI specifies the log verbosity level for the virt-api deployment. A higher value increases the amount of logged information. Changes take effect on the fly without triggering a pod restart. Default: 2. Levels up to 9 produce progressively more detailed logs.",
       "type": "integer",
       "format": "int32"
      },
      "virtController": {
+      "description": "VirtController specifies the log verbosity level for the virt-controller deployment. A higher value increases the amount of logged information. Changes take effect on the fly without triggering a pod restart. Default: 2. Levels up to 9 produce progressively more detailed logs.",
       "type": "integer",
       "format": "int32"
      },
      "virtHandler": {
+      "description": "VirtHandler specifies the log verbosity level for the virt-handler DaemonSet. A higher value increases the amount of logged information. Changes take effect on the fly without triggering a pod restart. Default: 2. Levels up to 9 produce progressively more detailed logs.",
       "type": "integer",
       "format": "int32"
      },
      "virtLauncher": {
+      "description": "VirtLauncher specifies the log verbosity level for virt-launcher pods managing VMI workloads. A higher value increases the amount of logged information. Changes apply to newly created virt-launcher pods. Existing pods retain their original verbosity. Default: 2. Levels up to 9 produce progressively more detailed logs.",
       "type": "integer",
       "format": "int32"
      },
      "virtOperator": {
+      "description": "VirtOperator specifies the log verbosity level for the virt-operator deployment. A higher value increases the amount of logged information. Changes take effect on the fly without triggering a pod restart. Default: 2. Levels up to 9 produce progressively more detailed logs.",
       "type": "integer",
       "format": "int32"
      },
      "virtSynchronizationController": {
+      "description": "VirtSynchronizationController specifies the log verbosity level for the virt-synchronization-controller component. A higher value increases the amount of logged information. Changes take effect on the fly without triggering a pod restart. Default: 2. Levels up to 9 produce progressively more detailed logs.",
       "type": "integer",
       "format": "int32"
      }

--- a/manifests/generated/kv-resource.yaml
+++ b/manifests/generated/kv-resource.yaml
@@ -475,26 +475,58 @@ spec:
                         type: array
                         x-kubernetes-list-type: atomic
                       logVerbosity:
-                        description: LogVerbosity sets log verbosity level of  various
+                        description: LogVerbosity sets log verbosity level of various
                           components
                         properties:
                           nodeVerbosity:
                             additionalProperties:
                               type: integer
-                            description: NodeVerbosity represents a map of nodes with
-                              a specific verbosity level
+                            description: |-
+                              NodeVerbosity represents a map of node names to specific log verbosity levels.
+                              Allows overriding verbosity on specific nodes without altering cluster-wide settings.
+                              Changes take effect on the fly without triggering a pod restart.
                             type: object
                           virtAPI:
+                            description: |-
+                              VirtAPI specifies the log verbosity level for the virt-api deployment.
+                              A higher value increases the amount of logged information.
+                              Changes take effect on the fly without triggering a pod restart.
+                              Default: 2. Levels up to 9 produce progressively more detailed logs.
                             type: integer
                           virtController:
+                            description: |-
+                              VirtController specifies the log verbosity level for the virt-controller deployment.
+                              A higher value increases the amount of logged information.
+                              Changes take effect on the fly without triggering a pod restart.
+                              Default: 2. Levels up to 9 produce progressively more detailed logs.
                             type: integer
                           virtHandler:
+                            description: |-
+                              VirtHandler specifies the log verbosity level for the virt-handler DaemonSet.
+                              A higher value increases the amount of logged information.
+                              Changes take effect on the fly without triggering a pod restart.
+                              Default: 2. Levels up to 9 produce progressively more detailed logs.
                             type: integer
                           virtLauncher:
+                            description: |-
+                              VirtLauncher specifies the log verbosity level for virt-launcher pods managing VMI workloads.
+                              A higher value increases the amount of logged information.
+                              Changes apply to newly created virt-launcher pods. Existing pods retain their original verbosity.
+                              Default: 2. Levels up to 9 produce progressively more detailed logs.
                             type: integer
                           virtOperator:
+                            description: |-
+                              VirtOperator specifies the log verbosity level for the virt-operator deployment.
+                              A higher value increases the amount of logged information.
+                              Changes take effect on the fly without triggering a pod restart.
+                              Default: 2. Levels up to 9 produce progressively more detailed logs.
                             type: integer
                           virtSynchronizationController:
+                            description: |-
+                              VirtSynchronizationController specifies the log verbosity level for the virt-synchronization-controller component.
+                              A higher value increases the amount of logged information.
+                              Changes take effect on the fly without triggering a pod restart.
+                              Default: 2. Levels up to 9 produce progressively more detailed logs.
                             type: integer
                         type: object
                       memoryOvercommit:
@@ -3981,26 +4013,58 @@ spec:
                         type: array
                         x-kubernetes-list-type: atomic
                       logVerbosity:
-                        description: LogVerbosity sets log verbosity level of  various
+                        description: LogVerbosity sets log verbosity level of various
                           components
                         properties:
                           nodeVerbosity:
                             additionalProperties:
                               type: integer
-                            description: NodeVerbosity represents a map of nodes with
-                              a specific verbosity level
+                            description: |-
+                              NodeVerbosity represents a map of node names to specific log verbosity levels.
+                              Allows overriding verbosity on specific nodes without altering cluster-wide settings.
+                              Changes take effect on the fly without triggering a pod restart.
                             type: object
                           virtAPI:
+                            description: |-
+                              VirtAPI specifies the log verbosity level for the virt-api deployment.
+                              A higher value increases the amount of logged information.
+                              Changes take effect on the fly without triggering a pod restart.
+                              Default: 2. Levels up to 9 produce progressively more detailed logs.
                             type: integer
                           virtController:
+                            description: |-
+                              VirtController specifies the log verbosity level for the virt-controller deployment.
+                              A higher value increases the amount of logged information.
+                              Changes take effect on the fly without triggering a pod restart.
+                              Default: 2. Levels up to 9 produce progressively more detailed logs.
                             type: integer
                           virtHandler:
+                            description: |-
+                              VirtHandler specifies the log verbosity level for the virt-handler DaemonSet.
+                              A higher value increases the amount of logged information.
+                              Changes take effect on the fly without triggering a pod restart.
+                              Default: 2. Levels up to 9 produce progressively more detailed logs.
                             type: integer
                           virtLauncher:
+                            description: |-
+                              VirtLauncher specifies the log verbosity level for virt-launcher pods managing VMI workloads.
+                              A higher value increases the amount of logged information.
+                              Changes apply to newly created virt-launcher pods. Existing pods retain their original verbosity.
+                              Default: 2. Levels up to 9 produce progressively more detailed logs.
                             type: integer
                           virtOperator:
+                            description: |-
+                              VirtOperator specifies the log verbosity level for the virt-operator deployment.
+                              A higher value increases the amount of logged information.
+                              Changes take effect on the fly without triggering a pod restart.
+                              Default: 2. Levels up to 9 produce progressively more detailed logs.
                             type: integer
                           virtSynchronizationController:
+                            description: |-
+                              VirtSynchronizationController specifies the log verbosity level for the virt-synchronization-controller component.
+                              A higher value increases the amount of logged information.
+                              Changes take effect on the fly without triggering a pod restart.
+                              Default: 2. Levels up to 9 produce progressively more detailed logs.
                             type: integer
                         type: object
                       memoryOvercommit:

--- a/pkg/virt-operator/resource/generate/components/validations_generated.go
+++ b/pkg/virt-operator/resource/generate/components/validations_generated.go
@@ -1079,25 +1079,57 @@ var CRDsValidation map[string]string = map[string]string{
                   type: array
                   x-kubernetes-list-type: atomic
                 logVerbosity:
-                  description: LogVerbosity sets log verbosity level of  various components
+                  description: LogVerbosity sets log verbosity level of various components
                   properties:
                     nodeVerbosity:
                       additionalProperties:
                         type: integer
-                      description: NodeVerbosity represents a map of nodes with a
-                        specific verbosity level
+                      description: |-
+                        NodeVerbosity represents a map of node names to specific log verbosity levels.
+                        Allows overriding verbosity on specific nodes without altering cluster-wide settings.
+                        Changes take effect on the fly without triggering a pod restart.
                       type: object
                     virtAPI:
+                      description: |-
+                        VirtAPI specifies the log verbosity level for the virt-api deployment.
+                        A higher value increases the amount of logged information.
+                        Changes take effect on the fly without triggering a pod restart.
+                        Default: 2. Levels up to 9 produce progressively more detailed logs.
                       type: integer
                     virtController:
+                      description: |-
+                        VirtController specifies the log verbosity level for the virt-controller deployment.
+                        A higher value increases the amount of logged information.
+                        Changes take effect on the fly without triggering a pod restart.
+                        Default: 2. Levels up to 9 produce progressively more detailed logs.
                       type: integer
                     virtHandler:
+                      description: |-
+                        VirtHandler specifies the log verbosity level for the virt-handler DaemonSet.
+                        A higher value increases the amount of logged information.
+                        Changes take effect on the fly without triggering a pod restart.
+                        Default: 2. Levels up to 9 produce progressively more detailed logs.
                       type: integer
                     virtLauncher:
+                      description: |-
+                        VirtLauncher specifies the log verbosity level for virt-launcher pods managing VMI workloads.
+                        A higher value increases the amount of logged information.
+                        Changes apply to newly created virt-launcher pods. Existing pods retain their original verbosity.
+                        Default: 2. Levels up to 9 produce progressively more detailed logs.
                       type: integer
                     virtOperator:
+                      description: |-
+                        VirtOperator specifies the log verbosity level for the virt-operator deployment.
+                        A higher value increases the amount of logged information.
+                        Changes take effect on the fly without triggering a pod restart.
+                        Default: 2. Levels up to 9 produce progressively more detailed logs.
                       type: integer
                     virtSynchronizationController:
+                      description: |-
+                        VirtSynchronizationController specifies the log verbosity level for the virt-synchronization-controller component.
+                        A higher value increases the amount of logged information.
+                        Changes take effect on the fly without triggering a pod restart.
+                        Default: 2. Levels up to 9 produce progressively more detailed logs.
                       type: integer
                   type: object
                 memoryOvercommit:

--- a/staging/src/kubevirt.io/api/core/v1/types.go
+++ b/staging/src/kubevirt.io/api/core/v1/types.go
@@ -3712,15 +3712,48 @@ type DeveloperConfiguration struct {
 	ClusterProfiler bool `json:"clusterProfiler,omitempty"`
 }
 
-// LogVerbosity sets log verbosity level of  various components
+// LogVerbosity sets log verbosity level of various components
 type LogVerbosity struct {
-	VirtAPI                       uint `json:"virtAPI,omitempty"`
-	VirtController                uint `json:"virtController,omitempty"`
-	VirtHandler                   uint `json:"virtHandler,omitempty"`
-	VirtLauncher                  uint `json:"virtLauncher,omitempty"`
-	VirtOperator                  uint `json:"virtOperator,omitempty"`
+	// VirtAPI specifies the log verbosity level for the virt-api deployment.
+	// A higher value increases the amount of logged information.
+	// Changes take effect on the fly without triggering a pod restart.
+	// Default: 2. Levels up to 9 produce progressively more detailed logs.
+	// +optional
+	VirtAPI uint `json:"virtAPI,omitempty"`
+	// VirtController specifies the log verbosity level for the virt-controller deployment.
+	// A higher value increases the amount of logged information.
+	// Changes take effect on the fly without triggering a pod restart.
+	// Default: 2. Levels up to 9 produce progressively more detailed logs.
+	// +optional
+	VirtController uint `json:"virtController,omitempty"`
+	// VirtHandler specifies the log verbosity level for the virt-handler DaemonSet.
+	// A higher value increases the amount of logged information.
+	// Changes take effect on the fly without triggering a pod restart.
+	// Default: 2. Levels up to 9 produce progressively more detailed logs.
+	// +optional
+	VirtHandler uint `json:"virtHandler,omitempty"`
+	// VirtLauncher specifies the log verbosity level for virt-launcher pods managing VMI workloads.
+	// A higher value increases the amount of logged information.
+	// Changes apply to newly created virt-launcher pods. Existing pods retain their original verbosity.
+	// Default: 2. Levels up to 9 produce progressively more detailed logs.
+	// +optional
+	VirtLauncher uint `json:"virtLauncher,omitempty"`
+	// VirtOperator specifies the log verbosity level for the virt-operator deployment.
+	// A higher value increases the amount of logged information.
+	// Changes take effect on the fly without triggering a pod restart.
+	// Default: 2. Levels up to 9 produce progressively more detailed logs.
+	// +optional
+	VirtOperator uint `json:"virtOperator,omitempty"`
+	// VirtSynchronizationController specifies the log verbosity level for the virt-synchronization-controller component.
+	// A higher value increases the amount of logged information.
+	// Changes take effect on the fly without triggering a pod restart.
+	// Default: 2. Levels up to 9 produce progressively more detailed logs.
+	// +optional
 	VirtSynchronizationController uint `json:"virtSynchronizationController,omitempty"`
-	// NodeVerbosity represents a map of nodes with a specific verbosity level
+	// NodeVerbosity represents a map of node names to specific log verbosity levels.
+	// Allows overriding verbosity on specific nodes without altering cluster-wide settings.
+	// Changes take effect on the fly without triggering a pod restart.
+	// +optional
 	NodeVerbosity map[string]uint `json:"nodeVerbosity,omitempty"`
 }
 

--- a/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
+++ b/staging/src/kubevirt.io/api/core/v1/types_swagger_generated.go
@@ -1124,8 +1124,14 @@ func (DeveloperConfiguration) SwaggerDoc() map[string]string {
 
 func (LogVerbosity) SwaggerDoc() map[string]string {
 	return map[string]string{
-		"":              "LogVerbosity sets log verbosity level of  various components",
-		"nodeVerbosity": "NodeVerbosity represents a map of nodes with a specific verbosity level",
+		"":                              "LogVerbosity sets log verbosity level of various components",
+		"virtAPI":                       "VirtAPI specifies the log verbosity level for the virt-api deployment.\nA higher value increases the amount of logged information.\nChanges take effect on the fly without triggering a pod restart.\nDefault: 2. Levels up to 9 produce progressively more detailed logs.\n+optional",
+		"virtController":                "VirtController specifies the log verbosity level for the virt-controller deployment.\nA higher value increases the amount of logged information.\nChanges take effect on the fly without triggering a pod restart.\nDefault: 2. Levels up to 9 produce progressively more detailed logs.\n+optional",
+		"virtHandler":                   "VirtHandler specifies the log verbosity level for the virt-handler DaemonSet.\nA higher value increases the amount of logged information.\nChanges take effect on the fly without triggering a pod restart.\nDefault: 2. Levels up to 9 produce progressively more detailed logs.\n+optional",
+		"virtLauncher":                  "VirtLauncher specifies the log verbosity level for virt-launcher pods managing VMI workloads.\nA higher value increases the amount of logged information.\nChanges apply to newly created virt-launcher pods. Existing pods retain their original verbosity.\nDefault: 2. Levels up to 9 produce progressively more detailed logs.\n+optional",
+		"virtOperator":                  "VirtOperator specifies the log verbosity level for the virt-operator deployment.\nA higher value increases the amount of logged information.\nChanges take effect on the fly without triggering a pod restart.\nDefault: 2. Levels up to 9 produce progressively more detailed logs.\n+optional",
+		"virtSynchronizationController": "VirtSynchronizationController specifies the log verbosity level for the virt-synchronization-controller component.\nA higher value increases the amount of logged information.\nChanges take effect on the fly without triggering a pod restart.\nDefault: 2. Levels up to 9 produce progressively more detailed logs.\n+optional",
+		"nodeVerbosity":                 "NodeVerbosity represents a map of node names to specific log verbosity levels.\nAllows overriding verbosity on specific nodes without altering cluster-wide settings.\nChanges take effect on the fly without triggering a pod restart.\n+optional",
 	}
 }
 

--- a/staging/src/kubevirt.io/client-go/api/openapi_generated.go
+++ b/staging/src/kubevirt.io/client-go/api/openapi_generated.go
@@ -23871,48 +23871,54 @@ func schema_kubevirtio_api_core_v1_LogVerbosity(ref common.ReferenceCallback) co
 	return common.OpenAPIDefinition{
 		Schema: spec.Schema{
 			SchemaProps: spec.SchemaProps{
-				Description: "LogVerbosity sets log verbosity level of  various components",
+				Description: "LogVerbosity sets log verbosity level of various components",
 				Type:        []string{"object"},
 				Properties: map[string]spec.Schema{
 					"virtAPI": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"integer"},
-							Format: "int32",
+							Description: "VirtAPI specifies the log verbosity level for the virt-api deployment. A higher value increases the amount of logged information. Changes take effect on the fly without triggering a pod restart. Default: 2. Levels up to 9 produce progressively more detailed logs.",
+							Type:        []string{"integer"},
+							Format:      "int32",
 						},
 					},
 					"virtController": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"integer"},
-							Format: "int32",
+							Description: "VirtController specifies the log verbosity level for the virt-controller deployment. A higher value increases the amount of logged information. Changes take effect on the fly without triggering a pod restart. Default: 2. Levels up to 9 produce progressively more detailed logs.",
+							Type:        []string{"integer"},
+							Format:      "int32",
 						},
 					},
 					"virtHandler": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"integer"},
-							Format: "int32",
+							Description: "VirtHandler specifies the log verbosity level for the virt-handler DaemonSet. A higher value increases the amount of logged information. Changes take effect on the fly without triggering a pod restart. Default: 2. Levels up to 9 produce progressively more detailed logs.",
+							Type:        []string{"integer"},
+							Format:      "int32",
 						},
 					},
 					"virtLauncher": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"integer"},
-							Format: "int32",
+							Description: "VirtLauncher specifies the log verbosity level for virt-launcher pods managing VMI workloads. A higher value increases the amount of logged information. Changes apply to newly created virt-launcher pods. Existing pods retain their original verbosity. Default: 2. Levels up to 9 produce progressively more detailed logs.",
+							Type:        []string{"integer"},
+							Format:      "int32",
 						},
 					},
 					"virtOperator": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"integer"},
-							Format: "int32",
+							Description: "VirtOperator specifies the log verbosity level for the virt-operator deployment. A higher value increases the amount of logged information. Changes take effect on the fly without triggering a pod restart. Default: 2. Levels up to 9 produce progressively more detailed logs.",
+							Type:        []string{"integer"},
+							Format:      "int32",
 						},
 					},
 					"virtSynchronizationController": {
 						SchemaProps: spec.SchemaProps{
-							Type:   []string{"integer"},
-							Format: "int32",
+							Description: "VirtSynchronizationController specifies the log verbosity level for the virt-synchronization-controller component. A higher value increases the amount of logged information. Changes take effect on the fly without triggering a pod restart. Default: 2. Levels up to 9 produce progressively more detailed logs.",
+							Type:        []string{"integer"},
+							Format:      "int32",
 						},
 					},
 					"nodeVerbosity": {
 						SchemaProps: spec.SchemaProps{
-							Description: "NodeVerbosity represents a map of nodes with a specific verbosity level",
+							Description: "NodeVerbosity represents a map of node names to specific log verbosity levels. Allows overriding verbosity on specific nodes without altering cluster-wide settings. Changes take effect on the fly without triggering a pod restart.",
 							Type:        []string{"object"},
 							AdditionalProperties: &spec.SchemaOrBool{
 								Allows: true,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

**What this PR does / why we need it**:
When inspecting the KubeVirt CRD schema with `kubectl explain kv.spec.configuration.developerConfiguration.logVerbosity`, users expect to see field descriptions that help them understand the API.

This PR adds Go doc comments across the LogVerbosity API struct and regenerates the OpenAPI/CRD schema files. The updated descriptions explain the purpose of each component verbosity level and list common log levels.


**Jira Ticket**:
<!--  Write the link to the Jira ticket:
If the task is not tracked by a Jira ticket, just write "NONE".
-->
```jira-ticket
https://redhat.atlassian.net/browse/CNV-79956
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
none
```
