### PR TITLE
Ignore Windows CDROM filesystems in GuestFilesystemAlmostOutOfSpace

### DIFF
--- a/hack/prom-rule-ci/prom-rules-tests.yaml
+++ b/hack/prom-rule-ci/prom-rules-tests.yaml
@@ -1902,6 +1902,78 @@ tests:
       - eval_time: 3m
         alertname: GuestFilesystemAlmostOutOfSpace
         exp_alerts: []
+
+  # GuestFilesystemAlmostOutOfSpace - Exclusions: Windows CDROM (CDFS) should be excluded
+  # QEMU Guest Agent reports ISO 9660 optical media as CDFS with 0 bytes free.
+  - interval: 1m
+    input_series:
+      - series: 'kubevirt_vmi_filesystem_capacity_bytes{name="win-vm", namespace="test-ns", disk_name="cdrom", mount_point="D:\\", file_system_type="CDFS"}'
+        values: "100x10"
+      - series: 'kubevirt_vmi_filesystem_used_bytes{name="win-vm", namespace="test-ns", disk_name="cdrom", mount_point="D:\\", file_system_type="CDFS"}'
+        values: "100 100 100 100 100 100 100 100 100 100"
+
+    alert_rule_test:
+      # at 3m: usage = 100% -> would normally alert, but CDFS optical media is excluded
+      - eval_time: 3m
+        alertname: GuestFilesystemAlmostOutOfSpace
+        exp_alerts: []
+
+  # GuestFilesystemAlmostOutOfSpace - Exclusions: Windows CDROM (UDF) should be excluded
+  # Windows GetVolumeInformation reports UDF in uppercase; the exclusion must be case-insensitive.
+  - interval: 1m
+    input_series:
+      - series: 'kubevirt_vmi_filesystem_capacity_bytes{name="win-vm", namespace="test-ns", disk_name="cdrom", mount_point="D:\\", file_system_type="UDF"}'
+        values: "100x10"
+      - series: 'kubevirt_vmi_filesystem_used_bytes{name="win-vm", namespace="test-ns", disk_name="cdrom", mount_point="D:\\", file_system_type="UDF"}'
+        values: "100 100 100 100 100 100 100 100 100 100"
+
+    alert_rule_test:
+      # at 3m: usage = 100% -> would normally alert, but UDF optical media is excluded
+      - eval_time: 3m
+        alertname: GuestFilesystemAlmostOutOfSpace
+        exp_alerts: []
+
+  # GuestFilesystemAlmostOutOfSpace - Exclusions: Linux iso9660 CDROM should be excluded
+  - interval: 1m
+    input_series:
+      - series: 'kubevirt_vmi_filesystem_capacity_bytes{name="linux-vm", namespace="test-ns", disk_name="sr0", mount_point="/mnt/cdrom", file_system_type="iso9660"}'
+        values: "100x10"
+      - series: 'kubevirt_vmi_filesystem_used_bytes{name="linux-vm", namespace="test-ns", disk_name="sr0", mount_point="/mnt/cdrom", file_system_type="iso9660"}'
+        values: "100 100 100 100 100 100 100 100 100 100"
+
+    alert_rule_test:
+      - eval_time: 3m
+        alertname: GuestFilesystemAlmostOutOfSpace
+        exp_alerts: []
+
+  # GuestFilesystemAlmostOutOfSpace - Windows NTFS data disk at 100% must still alert
+  - interval: 1m
+    input_series:
+      - series: 'kubevirt_vmi_filesystem_capacity_bytes{name="win-vm", namespace="test-ns", disk_name="sda2", mount_point="C:\\", file_system_type="NTFS"}'
+        values: "100x10"
+      - series: 'kubevirt_vmi_filesystem_used_bytes{name="win-vm", namespace="test-ns", disk_name="sda2", mount_point="C:\\", file_system_type="NTFS"}'
+        values: "100 100 100 100 100 100 100 100 100 100"
+
+    alert_rule_test:
+      - eval_time: 3m
+        alertname: GuestFilesystemAlmostOutOfSpace
+        exp_alerts:
+          - exp_annotations:
+              summary: "Guest filesystem is critically low on space"
+              description: "VirtualMachineInstance win-vm in namespace test-ns has filesystem sda2 (C:\\) usage above 95% (current: 100%)."
+              runbook_url: "https://kubevirt.io/monitoring/runbooks/GuestFilesystemAlmostOutOfSpace"
+            exp_labels:
+              severity: "critical"
+              operator_health_impact: "none"
+              kubernetes_operator_part_of: "kubevirt"
+              kubernetes_operator_component: "kubevirt"
+              name: "win-vm"
+              vm: "win-vm"
+              namespace: "test-ns"
+              disk_name: "sda2"
+              mount_point: "C:\\"
+              file_system_type: "NTFS"
+
   # VM memory pressure with swap activity
   - interval: 1m
     input_series:

--- a/pkg/monitoring/rules/alerts/vms.go
+++ b/pkg/monitoring/rules/alerts/vms.go
@@ -29,11 +29,25 @@ import (
 // excludedFilesystemTypesRegex contains filesystem types that should be ignored by space-usage alerts.
 // Rationale:
 // - Read-only image filesystems often appear 100% used and are not actionable for capacity (iso9660/CDFS, udf, squashfs, cramfs).
+// - Windows QEMU Guest Agent reports optical media as CDFS (ISO 9660) or UDF, with casing that varies
+// by guest; Linux reports iso9660/udf. Matching is case-insensitive so CDROMs (0 bytes free by definition)
+// do not fire GuestFilesystemAlmostOutOfSpace.
 // - Pseudo/kernel/ephemeral filesystems are not meaningful indicators of guest disk pressure
 // (e.g., tmpfs, proc, sysfs, cgroup*, overlay, fuse.*).
 // Keep this list aligned with common node_exporter exclusions to minimize noise in alerts.
-const excludedFilesystemTypesRegex = "CDFS|iso9660|udf|squashfs|cramfs|tmpfs|devtmpfs|proc|sysfs|selinuxfs|securityfs|pstore|debugfs|" +
+const excludedFilesystemTypesRegex = "(?i)CDFS|iso9660|udf|squashfs|cramfs|tmpfs|devtmpfs|proc|sysfs|selinuxfs|securityfs|pstore|debugfs|" +
 	"tracefs|configfs|binfmt_misc|bpf|devpts|mqueue|nsfs|rpc_pipefs|ramfs|rootfs|overlay|cgroup.*|fuse\\\\..*|fusectl"
+
+// guestFilesystemUsagePercentExpr is used/capacity * 100 for guest filesystems that
+// represent real, writable capacity (excludes optical/pseudo filesystems and Windows
+// "System Reserved").
+var guestFilesystemUsagePercentExpr = fmt.Sprintf(
+	"(kubevirt_vmi_filesystem_used_bytes{%[1]s} / kubevirt_vmi_filesystem_capacity_bytes{%[1]s})*100",
+	fmt.Sprintf(
+		"namespace!='',file_system_type!~'%s',mount_point!='System Reserved'",
+		excludedFilesystemTypesRegex,
+	),
+)
 
 // withVMLabel wraps a PromQL expression with label_replace to add a "vm"
 // typed resource label derived from the "name" label. This enables the
@@ -180,12 +194,8 @@ var vmsAlerts = []promv1.Rule{
 	},
 	{
 		Alert: "GuestFilesystemAlmostOutOfSpace",
-		Expr: intstr.FromString(withVMLabel(fmt.Sprintf(
-			"(kubevirt_vmi_filesystem_used_bytes{namespace!='',file_system_type!~'%s',mount_point!='System Reserved'} / "+
-				"kubevirt_vmi_filesystem_capacity_bytes{namespace!='',file_system_type!~'%s',mount_point!='System Reserved'})*100 >= 85 < 95",
-			excludedFilesystemTypesRegex, excludedFilesystemTypesRegex,
-		))),
-		For: ptr.To(promv1.Duration("10m")),
+		Expr:  intstr.FromString(withVMLabel(guestFilesystemUsagePercentExpr + " >= 85 < 95")),
+		For:   ptr.To(promv1.Duration("10m")),
 		Annotations: map[string]string{
 			summaryAnnotationKey: "Guest filesystem is running out of space",
 			descriptionAnnotationKey: "VirtualMachineInstance {{ $labels.name }} in namespace {{ $labels.namespace }} has " +
@@ -198,11 +208,7 @@ var vmsAlerts = []promv1.Rule{
 	},
 	{
 		Alert: "GuestFilesystemAlmostOutOfSpace",
-		Expr: intstr.FromString(withVMLabel(fmt.Sprintf(
-			"(kubevirt_vmi_filesystem_used_bytes{namespace!='',file_system_type!~'%s',mount_point!='System Reserved'} / "+
-				"kubevirt_vmi_filesystem_capacity_bytes{namespace!='',file_system_type!~'%s',mount_point!='System Reserved'})*100 >= 95",
-			excludedFilesystemTypesRegex, excludedFilesystemTypesRegex,
-		))),
+		Expr:  intstr.FromString(withVMLabel(guestFilesystemUsagePercentExpr + " >= 95")),
 		Annotations: map[string]string{
 			summaryAnnotationKey: "Guest filesystem is critically low on space",
 			descriptionAnnotationKey: "VirtualMachineInstance {{ $labels.name }} in namespace {{ $labels.namespace }} has " +


### PR DESCRIPTION
Windows QEMU Guest Agent reports optical media as CDFS or UDF with 0 bytes free, so usage is always 100%. The existing type exclusion was case-sensitive and missed Windows UDF, which made the alert fire whenever an ISO was attached.

jira-ticket: https://redhat.atlassian.net/browse/CNV-93531

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix GuestFilesystemAlmostOutOfSpace firing on Windows VMs when a UDF CDROM/ISO is attached.
```

