### PR TITLE
fix typos in code comments

### DIFF
--- a/pkg/checkpoint/checkpoint.go
+++ b/pkg/checkpoint/checkpoint.go
@@ -36,7 +36,7 @@ type CheckpointManager interface {
 
 // Provides checkpoint manager that uses key to store checkpoints
 // within provided directory. The manager uses std json package to
-// encode/decode the stucts.
+// encode/decode the structs.
 // This is thread-safe per key which is usual usage.
 func NewSimpleCheckpointManager(path, tempPath string) *simpleCheckpointManager {
 	return &simpleCheckpointManager{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -40,7 +40,7 @@ type (
 )
 
 const (
-	// ConfigMap respresents a configmap type,
+	// ConfigMap represents a configmap type,
 	// https://kubernetes.io/docs/tasks/configure-pod-container/configure-pod-configmap/
 	ConfigMap Type = "configmap"
 	// Secret represents a secret type,

--- a/pkg/host-disk/host-disk.go
+++ b/pkg/host-disk/host-disk.go
@@ -136,7 +136,7 @@ func replaceForHostDisk(volumeSource *v1.VolumeSource, volumeName string, pvcVol
 }
 
 func shouldSkipVolumeSource(passthoughFSVolumes map[string]struct{}, hotplugVolumes map[string]bool, pvcVolume map[string]v1.VolumeStatus, volumeName string) bool {
-	// If a PVC is used in a Filesystem (passthough), it should not be mapped as a HostDisk and a image file should
+	// If a PVC is used in a Filesystem (passthrough), it should not be mapped as a HostDisk and a image file should
 	// not be created.
 	if _, isPassthoughFSVolume := passthoughFSVolumes[volumeName]; isPassthoughFSVolume {
 		log.Log.V(4).Infof("this volume %s is mapped as a filesystem passthrough, will not be replaced by HostDisk", volumeName)

--- a/pkg/util/openapi/openapi.go
+++ b/pkg/util/openapi/openapi.go
@@ -231,7 +231,7 @@ func LoadOpenAPISpec(webServices []*restful.WebService) *spec.Swagger {
 	if exists {
 		prop := objectMeta.Properties["creationTimestamp"]
 		prop.Type = spec.StringOrArray{"string", "null"}
-		// mask v1.Time as in validation v1.Time override sting,null type
+		// mask v1.Time as in validation v1.Time override string,null type
 		prop.Ref = spec.Ref{}
 		objectMeta.Properties["creationTimestamp"] = prop
 	}

--- a/pkg/util/os_helper.go
+++ b/pkg/util/os_helper.go
@@ -30,7 +30,7 @@ import (
 // CloseIOAndCheckErr closes the file and check the returned error.
 // If there was an error a log messages will be printed.
 // If a valid address (not nil) is passed in  err the function will also update the error
-// Note: to update the error the calling funtion need to use named returned variable (If called as defer function)
+// Note: to update the error the calling function need to use named returned variable (If called as defer function)
 func CloseIOAndCheckErr(c io.Closer, err *error) {
 	if ferr := c.Close(); ferr != nil {
 		log.DefaultLogger().Reason(ferr).Error("Error when closing file")
@@ -43,7 +43,7 @@ func CloseIOAndCheckErr(c io.Closer, err *error) {
 
 // The following helper functions wrap nosec annotations with os file functions that potentially assign files or directories
 // access permissions that are viewed as not secure by gosec. Since kubevirt functionality and many e2e tests rely on such
-// "unsafe" permission settings, e.g. the pathes shared between the virt-launcher and QEMU. the use of these functions avoids
+// "unsafe" permission settings, e.g. the paths shared between the virt-launcher and QEMU. the use of these functions avoids
 // have too many nosec annotations scattered in the code and refers back to places where the "unsafe" permissions are set.
 
 func MkdirAllWithNosec(pathName string) error {

--- a/pkg/virt-handler/device-manager/mediated_devices_types.go
+++ b/pkg/virt-handler/device-manager/mediated_devices_types.go
@@ -201,7 +201,7 @@ func (m *MDEVTypesManager) configureDesiredMDEVTypes() {
 		if parents, exist := m.availableMdevTypesMap[mdevTypeToConfigure]; exist {
 			if len(parents) > 0 {
 				// Currently, we can configure only one mdev type per card.
-				// Find the next available parent to congigure and remove the
+				// Find the next available parent to configure and remove the
 				// configured parents from the list.
 				parent, remainingParents := m.getNextAvailableParentToConfigure(parents)
 				parents = remainingParents

--- a/pkg/virt-handler/retry_manager.go
+++ b/pkg/virt-handler/retry_manager.go
@@ -26,7 +26,7 @@ import (
 	"kubevirt.io/client-go/log"
 )
 
-// FailRetryManager is the manger to handle asynchronous retry used by virt-handler.
+// FailRetryManager is the manager to handle asynchronous retry used by virt-handler.
 // When a failure event happens, virt-handler will try to fix it. The result of the
 // fix is reflected by whether we receive the failure signal again afterwards.
 // If we did, we want to schedule the retry in an exponential backoff manner.

--- a/pkg/virt-launcher/virtwrap/agent-poller/agent_parser.go
+++ b/pkg/virt-launcher/virtwrap/agent-poller/agent_parser.go
@@ -24,7 +24,7 @@ func stripAgentResponse(agentReply string) string {
 	return stripRE.FindStringSubmatch(agentReply)[1]
 }
 
-// stripAgentStringResponse use regex to stip the wrapping item
+// stripAgentStringResponse use regex to strip the wrapping item
 // and returns the embedded string response
 // unlike stripAgentResponse the response is a simple string
 // rather then a complex object

--- a/pkg/virt-launcher/virtwrap/agent/exec.go
+++ b/pkg/virt-launcher/virtwrap/agent/exec.go
@@ -34,7 +34,7 @@ func (e ExecExitCode) Error() string {
 	return fmt.Sprint("exited with error code:", e.ExitCode)
 }
 
-// GuestExec sends the provided command and args to the guest agent for execution and returns an error on an unsucessful exit code
+// GuestExec sends the provided command and args to the guest agent for execution and returns an error on an unsuccessful exit code
 // The resulting stdout will be returned as a string
 func GuestExec(virConn cli.Connection, domName string, command string, args []string, timeoutSeconds int32) (string, error) {
 	stdOut := ""

--- a/pkg/virt-launcher/virtwrap/api/schema.go
+++ b/pkg/virt-launcher/virtwrap/api/schema.go
@@ -772,7 +772,7 @@ type ACPIHostDev struct {
 
 // BEGIN Controller -----------------------------
 
-// Controller represens libvirt controller element https://libvirt.org/formatdomain.html#elementsControllers
+// Controller represents libvirt controller element https://libvirt.org/formatdomain.html#elementsControllers
 type Controller struct {
 	Type      string            `xml:"type,attr"`
 	Index     string            `xml:"index,attr"`
@@ -998,7 +998,7 @@ type ConsoleSource struct {
 
 // END Serial -----------------------------
 
-// BEGIN Inteface -----------------------------
+// BEGIN Interface -----------------------------
 
 type Interface struct {
 	XMLName             xml.Name               `xml:"interface"`

--- a/pkg/virt-launcher/virtwrap/live-migration-source.go
+++ b/pkg/virt-launcher/virtwrap/live-migration-source.go
@@ -1083,7 +1083,7 @@ func generateMigrationParams(dom cli.VirDomain, vmi *v1.VirtualMachineInstance, 
 	if vmi.Status.MigrationState != nil && vmi.Status.MigrationState.TargetState != nil &&
 		vmi.Status.MigrationState.TargetState.VirtualMachineInstanceUID != nil {
 		log.Log.Object(vmi).Infof("Replacing VMI UID %s with target VMI UID %s in the XML", vmi.UID, *vmi.Status.MigrationState.TargetState.VirtualMachineInstanceUID)
-		// Replace all occurences of the VMI UID in the XML with the target UID.
+		// Replace all occurrences of the VMI UID in the XML with the target UID.
 		xmlstr = strings.ReplaceAll(xmlstr, string(vmi.UID), string(*vmi.Status.MigrationState.TargetState.VirtualMachineInstanceUID))
 	}
 

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -239,7 +239,7 @@ type LibvirtDomainManager struct {
 	domainDirtyRateStatsCache *virtcache.TimeDefinedCache[*stats.DomainStatsDirtyRate]
 	agentDataCaches           map[string]*virtcache.TimeDefinedCache[string]
 
-	// Device aliasas are updated only through hotplug events and SyncVMI
+	// Device aliases are updated only through hotplug events and SyncVMI
 	devAliasMap  map[string]string
 	devAliasLock sync.RWMutex
 
@@ -554,7 +554,7 @@ func (l *LibvirtDomainManager) setGuestTime(vmi *v1.VirtualMachineInstance) {
 							latestErr = fmt.Errorf("%s, %s", unresponsive, err)
 							log.Log.Object(vmi).Reason(err).V(9).Info(unresponsive)
 						case libvirt.ERR_OPERATION_UNSUPPORTED:
-							// no need to retry as this opertaion is not supported
+							// no need to retry as this operation is not supported
 							log.Log.Object(vmi).Reason(err).Warning("failed to set time: not supported")
 							return
 						case libvirt.ERR_ARGUMENT_UNSUPPORTED:

--- a/pkg/virt-launcher/virtwrap/storage/fsfreeze.go
+++ b/pkg/virt-launcher/virtwrap/storage/fsfreeze.go
@@ -87,7 +87,7 @@ func (m *StorageManager) UnfreezeVMI(vmi *v1.VirtualMachineInstance) error {
 	domainName := api.VMINamespaceKeyFunc(vmi)
 	fsfreezeStatus, err := m.getParsedFSStatus(domainName)
 	if err == nil {
-		// prevent initating fs thaw to prevent rerunning the thaw hook
+		// prevent initiating fs thaw to prevent rerunning the thaw hook
 		if fsfreezeStatus == api.FSThawed {
 			return nil
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

Fixes 16 spelling mistakes in Go comments under `pkg/`, found with `codespell`. Comments only — no identifiers, log messages, error strings, or generated files were touched.

Notably left alone on purpose:
- `pkg/virt-launcher/virtwrap/api/schema.go` has `xml:"newtork,attr,omitempty"` on `InterfaceSource.Network`. That looks like a typo too, but it is a wire-format struct tag, so changing it would change libvirt XML serialization. Out of scope here.
- Generated code (`*.pb.go`), `vendor/`, `staging/`, and the `passt` binding sources (`passt` is a real tool name).

**Which issue(s) this PR fixes**: None

**Special notes for your reviewer**: No behaviour change; comments only.

AI disclosure per the KubeVirt AI Contribution Policy: this change was prepared with Claude assistance and the commit carries an `Assisted-by` trailer. Every line was reviewed by hand.

**Release note**:
```release-note
NONE
```