### PR TITLE
net, converter, passt: Use 'libvmi' directly

### DIFF
--- a/pkg/libvmi/network.go
+++ b/pkg/libvmi/network.go
@@ -108,6 +108,13 @@ func WithPorts(ports ...kvirtv1.Port) InterfaceOption {
 	}
 }
 
+// WithACPIIndex sets the ACPI index.
+func WithACPIIndex(acpiIdx int) InterfaceOption {
+	return func(iface *kvirtv1.Interface) {
+		iface.ACPIIndex = acpiIdx
+	}
+}
+
 // WithPciAddress sets the guest PCI address.
 func WithPciAddress(pciAddress string) InterfaceOption {
 	return func(iface *kvirtv1.Interface) {

--- a/pkg/virt-launcher/virtwrap/converter/network/passt_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/network/passt_test.go
@@ -81,7 +81,9 @@ var _ = Describe("Passt Network Domain Configurator", func() {
 			),
 			Entry("invalid custom PCI address",
 				libvmi.New(
-					libvmi.WithInterface(newPasstInterface(withIfacePCI("invalid-pci-address"))),
+					libvmi.WithInterface(libvmi.NewInterface(
+						v1.DefaultPodNetwork().Name, libvmi.WithPasstBinding(), libvmi.WithPciAddress("invalid-pci-address"),
+					)),
 					libvmi.WithNetwork(v1.DefaultPodNetwork()),
 					libvmistatus.WithStatus(
 						libvmistatus.New(
@@ -112,14 +114,14 @@ var _ = Describe("Passt Network Domain Configurator", func() {
 				Expect(domain.Spec.Devices.Interfaces[0]).To(Equal(expectedDomainIface))
 			},
 			Entry("passt binding",
-				newPasstInterface(),
+				libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithPasstBinding()),
 				newPasstDomainInterface("default", virtioModel,
 					withPasstBackend(),
 					withPasstPortForwardAll(),
 				),
 			),
 			Entry("PCI address",
-				newPasstInterface(withIfacePCI("0000:02:02.0")),
+				libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithPasstBinding(), libvmi.WithPciAddress("0000:02:02.0")),
 				newPasstDomainInterface("default", virtioModel,
 					withPasstBackend(),
 					withPasstPortForwardAll(),
@@ -127,15 +129,15 @@ var _ = Describe("Passt Network Domain Configurator", func() {
 				),
 			),
 			Entry("MAC address",
-				newPasstInterface(withIfaceMAC("02:02:02:02:02:02")),
+				libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithPasstBinding(), libvmi.WithMac("02:02:02:02:02:02")),
 				newPasstDomainInterface("default", virtioModel,
 					withPasstBackend(),
 					withPasstPortForwardAll(),
 					withMAC("02:02:02:02:02:02"),
 				),
 			),
-			Entry("ACPI address",
-				newPasstInterface(withIfaceACPI(2)),
+			Entry("ACPI Index",
+				libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithPasstBinding(), libvmi.WithACPIIndex(2)),
 				newPasstDomainInterface("default", virtioModel,
 					withPasstBackend(),
 					withPasstPortForwardAll(),
@@ -143,39 +145,39 @@ var _ = Describe("Passt Network Domain Configurator", func() {
 				),
 			),
 			Entry("non virtio model",
-				newPasstInterface(withIfaceModel("e1000")),
+				libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithPasstBinding(), libvmi.WithModel("e1000")),
 				newPasstDomainInterface("default", "e1000",
 					withPasstBackend(),
 					withPasstPortForwardAll(),
 				),
 			),
 			Entry("tcp ports (should forward tcp ports only)",
-				newPasstInterface(withIfacePorts([]v1.Port{
-					{Protocol: "TCP", Port: 1},
-					{Protocol: "TCP", Port: 4},
-				})),
+				libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithPasstBinding(), libvmi.WithPorts(
+					v1.Port{Protocol: "TCP", Port: 1},
+					v1.Port{Protocol: "TCP", Port: 4},
+				)),
 				newPasstDomainInterface("default", virtioModel,
 					withPasstBackend(),
 					withPasstPortForwardTCP([]uint{1, 4}),
 				),
 			),
 			Entry("udp ports (should forward udp ports only)",
-				newPasstInterface(withIfacePorts([]v1.Port{
-					{Protocol: "UDP", Port: 2},
-					{Protocol: "UDP", Port: 3},
-				})),
+				libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithPasstBinding(), libvmi.WithPorts(
+					v1.Port{Protocol: "UDP", Port: 2},
+					v1.Port{Protocol: "UDP", Port: 3},
+				)),
 				newPasstDomainInterface("default", virtioModel,
 					withPasstBackend(),
 					withPasstPortForwardUDP([]uint{2, 3}),
 				),
 			),
 			Entry("both tcp and udp ports",
-				newPasstInterface(withIfacePorts([]v1.Port{
-					{Port: 1},
-					{Protocol: "UDP", Port: 2},
-					{Protocol: "UDP", Port: 3},
-					{Protocol: "TCP", Port: 4},
-				})),
+				libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithPasstBinding(), libvmi.WithPorts(
+					v1.Port{Port: 1},
+					v1.Port{Protocol: "UDP", Port: 2},
+					v1.Port{Protocol: "UDP", Port: 3},
+					v1.Port{Protocol: "TCP", Port: 4},
+				)),
 				newPasstDomainInterface("default", virtioModel,
 					withPasstBackend(),
 					withPasstPortForwardTCP([]uint{1, 4}),
@@ -433,47 +435,5 @@ func withACPI(index int) passtOption {
 func withSourceDevice(sourceDevice string) passtOption {
 	return func(iface *api.Interface) {
 		iface.Source.Device = sourceDevice
-	}
-}
-
-type ifaceOption func(iface *v1.Interface)
-
-func newPasstInterface(options ...ifaceOption) v1.Interface {
-	newIface := libvmi.NewInterface(v1.DefaultPodNetwork().Name, libvmi.WithPasstBinding())
-
-	for _, f := range options {
-		f(&newIface)
-	}
-	return newIface
-}
-
-func withIfaceMAC(macAddress string) ifaceOption {
-	return func(iface *v1.Interface) {
-		iface.MacAddress = macAddress
-	}
-}
-
-func withIfacePCI(pciAddress string) ifaceOption {
-	return func(iface *v1.Interface) {
-		iface.PciAddress = pciAddress
-	}
-}
-
-func withIfaceACPI(apciIdx int) ifaceOption {
-	return func(iface *v1.Interface) {
-		iface.ACPIIndex = apciIdx
-	}
-}
-
-func withIfaceModel(model string) ifaceOption {
-	return func(iface *v1.Interface) {
-		iface.Model = model
-	}
-}
-
-func withIfacePorts(ports []v1.Port) ifaceOption {
-	return func(iface *v1.Interface) {
-		iface.Ports = []v1.Port{}
-		iface.Ports = append(iface.Ports, ports...)
 	}
 }


### PR DESCRIPTION

### What this PR does

Replace local functions with standardized libvmi functions. Removes code duplication and increases discoverability and readability

#### Before this PR:

Passt_test.go used several local functions equivalent to functions declared in libvim/network.go


#### After this PR:

Passt_test.go uses the libvmi functions

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configuring an ACPI index on network interfaces.

* **Tests**
  * Updated passt network configuration tests to use the shared interface configuration options.
  * Renamed the ACPI address test to reflect ACPI index configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->