### PR TITLE
Return partial VM stats when an optional guest-agent command fails

### DIFF
--- a/pkg/virt-handler/cmd-client/BUILD.bazel
+++ b/pkg/virt-handler/cmd-client/BUILD.bazel
@@ -43,6 +43,7 @@ go_test(
     deps = [
         "//pkg/handler-launcher-com/cmd/info:go_default_library",
         "//pkg/handler-launcher-com/cmd/v1:go_default_library",
+        "//pkg/virt-launcher/virtwrap/stats:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/api:go_default_library",
         "//staging/src/kubevirt.io/client-go/testutils:go_default_library",

--- a/pkg/virt-handler/cmd-client/client.go
+++ b/pkg/virt-handler/cmd-client/client.go
@@ -513,12 +513,8 @@ func (c *VirtLauncherClient) GetVMStats(request *cmdv1.VMStatsRequest) (*stats.V
 	defer cancel()
 
 	vmstatsResponse, err := c.v1client.GetVMStats(ctx, request)
-	var response *cmdv1.Response
-	if vmstatsResponse != nil {
-		response = vmstatsResponse.Response
-	}
 
-	if err := handleError(err, "GetVMStats", response); err != nil || vmstatsResponse == nil {
+	if err := handleTransportError(err, "GetVMStats"); err != nil || vmstatsResponse == nil {
 		return result, err
 	}
 

--- a/pkg/virt-handler/cmd-client/client.go
+++ b/pkg/virt-handler/cmd-client/client.go
@@ -524,7 +524,7 @@ func (c *VirtLauncherClient) GetVMStats(request *cmdv1.VMStatsRequest) (*stats.V
 		}
 	}
 
-	if vmstatsResponse.GetDirtyRateStats() != nil {
+	if vmstatsResponse.GetDirtyRateStats().GetResponse().GetSuccess() {
 		result.DirtyRateMbps = ptr.To(vmstatsResponse.GetDirtyRateStats().GetDirtyRateMbs())
 	}
 

--- a/pkg/virt-handler/cmd-client/client_test.go
+++ b/pkg/virt-handler/cmd-client/client_test.go
@@ -43,6 +43,49 @@ import (
 	cmdv1 "kubevirt.io/kubevirt/pkg/handler-launcher-com/cmd/v1"
 )
 
+var _ = Describe("GetVMStats partial results", func() {
+	var (
+		mockCmdClient *cmdv1.MockCmdClient
+		client        LauncherClient
+	)
+
+	BeforeEach(func() {
+		ctrl := gomock.NewController(GinkgoT())
+		mockCmdClient = cmdv1.NewMockCmdClient(ctrl)
+		client = newV1Client(mockCmdClient, nil)
+	})
+
+	It("returns already-collected stats when an optional agent command failed", func() {
+		mockCmdClient.EXPECT().GetVMStats(gomock.Any(), gomock.Any()).Return(&cmdv1.VMStatsResponse{
+			// Aggregate failure because guest-get-diskstats is unsupported by the guest agent.
+			Response: &cmdv1.Response{Success: false, Message: "agent data guest-get-diskstats: command not found"},
+			DomainStats: &cmdv1.DomainStatsResponse{
+				Response:    &cmdv1.Response{Success: true},
+				DomainStats: `{"Name":"test-domain"}`,
+			},
+			GuestGetDiskStats: &cmdv1.Response{Success: false, Message: "command not found"},
+		}, nil)
+
+		result, err := client.GetVMStats(&cmdv1.VMStatsRequest{
+			DomainStats:       &cmdv1.DomainStatsRequest{},
+			GuestGetDiskStats: &cmdv1.AgentDiskStatsRequest{},
+		})
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result.DomainStats.Name).To(Equal("test-domain"))
+		Expect(result.GuestGetDiskStats).To(ContainSubstring("command not found"))
+	})
+
+	It("returns an error on transport failure", func() {
+		mockCmdClient.EXPECT().GetVMStats(gomock.Any(), gomock.Any()).Return(
+			nil, status.Errorf(codes.Unavailable, "connection refused"),
+		)
+
+		_, err := client.GetVMStats(&cmdv1.VMStatsRequest{DomainStats: &cmdv1.DomainStatsRequest{}})
+		Expect(err).To(MatchError(ContainSubstring("Unavailable")))
+	})
+})
+
 var _ = Describe("Virt remote commands", func() {
 
 	var (

--- a/pkg/virt-handler/cmd-client/client_test.go
+++ b/pkg/virt-handler/cmd-client/client_test.go
@@ -41,6 +41,7 @@ import (
 
 	"kubevirt.io/kubevirt/pkg/handler-launcher-com/cmd/info"
 	cmdv1 "kubevirt.io/kubevirt/pkg/handler-launcher-com/cmd/v1"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/stats"
 )
 
 var _ = Describe("GetVMStats partial results", func() {
@@ -83,6 +84,49 @@ var _ = Describe("GetVMStats partial results", func() {
 
 		_, err := client.GetVMStats(&cmdv1.VMStatsRequest{DomainStats: &cmdv1.DomainStatsRequest{}})
 		Expect(err).To(MatchError(ContainSubstring("Unavailable")))
+	})
+
+	It("returns partial results when domain-stats collection failed", func() {
+		mockCmdClient.EXPECT().GetVMStats(gomock.Any(), gomock.Any()).Return(&cmdv1.VMStatsResponse{
+			// Aggregate failure because domain stats could not be collected.
+			Response: &cmdv1.Response{Success: false, Message: "domain stats: connection to libvirt failed"},
+			DomainStats: &cmdv1.DomainStatsResponse{
+				Response: &cmdv1.Response{Success: false, Message: "connection to libvirt failed"},
+			},
+			GuestGetLoad: &cmdv1.Response{Success: true, Message: "load1=0.5"},
+		}, nil)
+
+		result, err := client.GetVMStats(&cmdv1.VMStatsRequest{
+			DomainStats:  &cmdv1.DomainStatsRequest{},
+			GuestGetLoad: &cmdv1.AgentLoadRequest{},
+		})
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result.DomainStats).To(Equal(stats.DomainStats{}))
+		Expect(result.GuestGetLoad).To(Equal("load1=0.5"))
+	})
+
+	It("returns partial results when dirty-rate collection failed", func() {
+		mockCmdClient.EXPECT().GetVMStats(gomock.Any(), gomock.Any()).Return(&cmdv1.VMStatsResponse{
+			// Aggregate failure because dirty rate is not available yet.
+			Response: &cmdv1.Response{Success: false, Message: "dirty rate stats: MegabytesPerSecondSet is false"},
+			DomainStats: &cmdv1.DomainStatsResponse{
+				Response:    &cmdv1.Response{Success: true},
+				DomainStats: `{"Name":"test-domain"}`,
+			},
+			DirtyRateStats: &cmdv1.DirtyRateStatsResponse{
+				Response: &cmdv1.Response{Success: false, Message: "MegabytesPerSecondSet is false"},
+			},
+		}, nil)
+
+		result, err := client.GetVMStats(&cmdv1.VMStatsRequest{
+			DomainStats: &cmdv1.DomainStatsRequest{},
+			DirtyRate:   &cmdv1.DirtyRateRequest{},
+		})
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(result.DomainStats.Name).To(Equal("test-domain"))
+		Expect(result.DirtyRateMbps).To(BeNil())
 	})
 })
 

--- a/pkg/virt-handler/cmd-client/errors.go
+++ b/pkg/virt-handler/cmd-client/errors.go
@@ -43,6 +43,17 @@ func IsUnimplemented(err error) bool {
 }
 
 func handleError(err error, cmdName string, response *cmdv1.Response) error {
+	if transportErr := handleTransportError(err, cmdName); transportErr != nil {
+		return transportErr
+	}
+
+	if response != nil && !response.Success && response.Message != "" {
+		return fmt.Errorf("server error. command %s failed: %q", cmdName, response.Message)
+	}
+	return nil
+}
+
+func handleTransportError(err error, cmdName string) error {
 	if IsDisconnected(err) {
 		return err
 	} else if IsUnimplemented(err) {
@@ -54,11 +65,6 @@ func handleError(err error, cmdName string, response *cmdv1.Response) error {
 		return fmt.Errorf("command %s failed with %s: %w", cmdName, st.Code(), err)
 	}
 
-	// Fallback for old servers that embed errors in Response instead of using gRPC status codes
-	// This check can be removed once all servers are migrated
-	if response != nil && !response.Success && response.Message != "" {
-		return fmt.Errorf("server error. command %s failed: %q", cmdName, response.Message)
-	}
 	return nil
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:

virt-handler GetVMStats treats a single QEMU guest agent command failure as fatal for the entire VMI

#### After this PR:

Return partial VM stats when an optional guest-agent command fails

### References

jira-ticket: https://redhat.atlassian.net/browse/CNV-96394

<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/143

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Return partial VM stats when an optional guest-agent command fails
```

