### PR TITLE
instancetype: inject common-instancetypes-version label into captured ControllerRevision

### DIFF
--- a/pkg/instancetype/revision/store.go
+++ b/pkg/instancetype/revision/store.go
@@ -261,6 +261,17 @@ func CreateControllerRevision(vm *virtv1.VirtualMachine, object runtime.Object) 
 		metaObj.GetGeneration(),
 	)
 
+	revisionLabels := map[string]string{
+		api.ControllerRevisionObjectGenerationLabel: fmt.Sprintf("%d", metaObj.GetGeneration()),
+		api.ControllerRevisionObjectKindLabel:       obj.GetObjectKind().GroupVersionKind().Kind,
+		api.ControllerRevisionObjectNameLabel:       metaObj.GetName(),
+		api.ControllerRevisionObjectUIDLabel:        string(metaObj.GetUID()),
+		api.ControllerRevisionObjectVersionLabel:    obj.GetObjectKind().GroupVersionKind().Version,
+	}
+	if version, ok := metaObj.GetLabels()[api.ControllerRevisionObjectCommonInstancetypesVersionLabel]; ok {
+		revisionLabels[api.ControllerRevisionObjectCommonInstancetypesVersionLabel] = version
+	}
+
 	// Removing unnecessary metadata
 	metaObj.SetLabels(nil)
 	metaObj.SetAnnotations(nil)
@@ -273,13 +284,7 @@ func CreateControllerRevision(vm *virtv1.VirtualMachine, object runtime.Object) 
 			Name:            revisionName,
 			Namespace:       vm.Namespace,
 			OwnerReferences: []metav1.OwnerReference{*metav1.NewControllerRef(vm, virtv1.VirtualMachineGroupVersionKind)},
-			Labels: map[string]string{
-				api.ControllerRevisionObjectGenerationLabel: fmt.Sprintf("%d", metaObj.GetGeneration()),
-				api.ControllerRevisionObjectKindLabel:       obj.GetObjectKind().GroupVersionKind().Kind,
-				api.ControllerRevisionObjectNameLabel:       metaObj.GetName(),
-				api.ControllerRevisionObjectUIDLabel:        string(metaObj.GetUID()),
-				api.ControllerRevisionObjectVersionLabel:    obj.GetObjectKind().GroupVersionKind().Version,
-			},
+			Labels:          revisionLabels,
 		},
 		Data: runtime.RawExtension{
 			Object: obj,

--- a/pkg/instancetype/revision/store_test.go
+++ b/pkg/instancetype/revision/store_test.go
@@ -677,4 +677,71 @@ var _ = Describe("Instancetype and Preferences revision handler", func() {
 			})
 		})
 	})
+
+	Context("common-instancetypes version label", func() {
+		const commonVersion = "v1.7.0"
+
+		It("CreateControllerRevision propagates common-instancetypes-version label from object", func() {
+			instancetypeWithLabel := &instancetypev1beta1.VirtualMachineClusterInstancetype{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-cluster-instancetype",
+					UID:        resourceUID,
+					Generation: resourceGeneration,
+					Labels: map[string]string{
+						apiinstancetype.ControllerRevisionObjectCommonInstancetypesVersionLabel: commonVersion,
+					},
+				},
+			}
+
+			cr, err := revision.CreateControllerRevision(vm, instancetypeWithLabel)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cr.Labels).To(HaveKeyWithValue(apiinstancetype.ControllerRevisionObjectCommonInstancetypesVersionLabel, commonVersion))
+		})
+
+		It("CreateControllerRevision does not add common-instancetypes-version label when absent", func() {
+			instancetypeWithoutLabel := &instancetypev1beta1.VirtualMachineClusterInstancetype{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-cluster-instancetype",
+					UID:        resourceUID,
+					Generation: resourceGeneration,
+				},
+			}
+
+			cr, err := revision.CreateControllerRevision(vm, instancetypeWithoutLabel)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(cr.Labels).ToNot(HaveKey(apiinstancetype.ControllerRevisionObjectCommonInstancetypesVersionLabel))
+		})
+
+		It("store propagates common-instancetypes-version label from VirtualMachinePreference to created ControllerRevision", func() {
+			preferenceWithLabel := &instancetypev1beta1.VirtualMachinePreference{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-preference",
+					Namespace:  vm.Namespace,
+					UID:        resourceUID,
+					Generation: resourceGeneration,
+					Labels: map[string]string{
+						apiinstancetype.ControllerRevisionObjectCommonInstancetypesVersionLabel: commonVersion,
+					},
+				},
+			}
+
+			_, err := virtClient.VirtualMachinePreference(vm.Namespace).Create(context.Background(), preferenceWithLabel, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			err = preferenceInformerStore.Add(preferenceWithLabel)
+			Expect(err).ToNot(HaveOccurred())
+
+			vm.Spec.Preference = &virtv1.PreferenceMatcher{
+				Name: preferenceWithLabel.Name,
+				Kind: apiinstancetype.SingularPreferenceResourceName,
+			}
+
+			Expect(storeHandler.Store(vm)).To(Succeed())
+
+			createdCR, err := virtClient.AppsV1().ControllerRevisions(vm.Namespace).Get(
+				context.Background(), vm.Status.PreferenceRef.ControllerRevisionRef.Name, metav1.GetOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(createdCR.Labels).To(HaveKeyWithValue(apiinstancetype.ControllerRevisionObjectCommonInstancetypesVersionLabel, commonVersion))
+		})
+	})
 })

--- a/pkg/instancetype/upgrade/handler.go
+++ b/pkg/instancetype/upgrade/handler.go
@@ -154,6 +154,13 @@ func (u *upgrader) upgradeControllerRevision(
 		return nil, err
 	}
 
+	if version, ok := original.Labels[instancetypeapi.ControllerRevisionObjectCommonInstancetypesVersionLabel]; ok {
+		if newCR.Labels == nil {
+			newCR.Labels = make(map[string]string)
+		}
+		newCR.Labels[instancetypeapi.ControllerRevisionObjectCommonInstancetypesVersionLabel] = version
+	}
+
 	// Recreate the CR with the now upgraded runtime.Object
 	newCR, err = u.virtClient.AppsV1().ControllerRevisions(vm.Namespace).Create(context.Background(), newCR, metav1.CreateOptions{})
 	if err != nil {

--- a/pkg/instancetype/upgrade/upgrade_test.go
+++ b/pkg/instancetype/upgrade/upgrade_test.go
@@ -166,6 +166,10 @@ var _ = Describe("ControllerRevision upgrades", func() {
 		if originalKindLabel, hasLabel := originalInstancetypeCR.Labels[instancetypeapi.ControllerRevisionObjectKindLabel]; hasLabel {
 			Expect(newInstancetypeCR.Labels).To(HaveKeyWithValue(instancetypeapi.ControllerRevisionObjectKindLabel, originalKindLabel))
 		}
+		versionLabel := instancetypeapi.ControllerRevisionObjectCommonInstancetypesVersionLabel
+		if originalVersionLabel, hasLabel := originalInstancetypeCR.Labels[versionLabel]; hasLabel {
+			Expect(newInstancetypeCR.Labels).To(HaveKeyWithValue(versionLabel, originalVersionLabel))
+		}
 
 		Expect(vm.Status.PreferenceRef.ControllerRevisionRef.Name).ToNot(Equal(originalPreferenceCR.Name))
 
@@ -180,6 +184,9 @@ var _ = Describe("ControllerRevision upgrades", func() {
 		Expect(upgrade.IsObjectLatestVersion(newPreferenceCR)).To(BeTrue())
 		if originalKindLabel, hasLabel := originalPreferenceCR.Labels[instancetypeapi.ControllerRevisionObjectKindLabel]; hasLabel {
 			Expect(newPreferenceCR.Labels).To(HaveKeyWithValue(instancetypeapi.ControllerRevisionObjectKindLabel, originalKindLabel))
+		}
+		if originalVersionLabel, hasLabel := originalPreferenceCR.Labels[versionLabel]; hasLabel {
+			Expect(newPreferenceCR.Labels).To(HaveKeyWithValue(versionLabel, originalVersionLabel))
 		}
 	},
 		Entry("v1beta1 VirtualMachineClusterPreference & VirtualMachineClusterInstancetype without version label",
@@ -260,6 +267,53 @@ var _ = Describe("ControllerRevision upgrades", func() {
 					},
 				)
 				cr.Name = "legacy-preference-cr-name"
+				delete(cr.Labels, instancetypeapi.ControllerRevisionObjectVersionLabel)
+				return cr
+			},
+		),
+		Entry("v1beta1 VirtualMachineClusterPreference & VirtualMachineClusterInstancetype with common-instancetypes-version label",
+			func() *appsv1.ControllerRevision {
+				cr := createControllerRevisionFromObject(
+					&instancetypev1beta1.VirtualMachineClusterInstancetype{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "instancetype",
+							Namespace: vm.Namespace,
+							Labels: map[string]string{
+								instancetypeapi.ControllerRevisionObjectCommonInstancetypesVersionLabel: "v1.7.0",
+							},
+						},
+						Spec: instancetypev1beta1.VirtualMachineInstancetypeSpec{
+							CPU: instancetypev1beta1.CPUInstancetype{
+								Guest: uint32(1),
+							},
+							Memory: instancetypev1beta1.MemoryInstancetype{
+								Guest: resource.MustParse("128Mi"),
+							},
+						},
+					},
+				)
+				cr.Name = "legacy-clusterinstancetype-with-version-cr-name"
+				delete(cr.Labels, instancetypeapi.ControllerRevisionObjectVersionLabel)
+				return cr
+			},
+			func() *appsv1.ControllerRevision {
+				cr := createControllerRevisionFromObject(
+					&instancetypev1beta1.VirtualMachineClusterPreference{
+						ObjectMeta: metav1.ObjectMeta{
+							Name:      "preference",
+							Namespace: vm.Namespace,
+							Labels: map[string]string{
+								instancetypeapi.ControllerRevisionObjectCommonInstancetypesVersionLabel: "v1.7.0",
+							},
+						},
+						Spec: instancetypev1beta1.VirtualMachinePreferenceSpec{
+							CPU: &instancetypev1beta1.CPUPreferences{
+								PreferredCPUTopology: pointer.P(instancetypev1beta1.Sockets),
+							},
+						},
+					},
+				)
+				cr.Name = "legacy-clusterpreference-with-version-cr-name"
 				delete(cr.Labels, instancetypeapi.ControllerRevisionObjectVersionLabel)
 				return cr
 			},

--- a/staging/src/kubevirt.io/api/instancetype/register.go
+++ b/staging/src/kubevirt.io/api/instancetype/register.go
@@ -47,9 +47,10 @@ const (
 )
 
 const (
-	ControllerRevisionObjectGenerationLabel = "instancetype.kubevirt.io/object-generation"
-	ControllerRevisionObjectKindLabel       = "instancetype.kubevirt.io/object-kind"
-	ControllerRevisionObjectNameLabel       = "instancetype.kubevirt.io/object-name"
-	ControllerRevisionObjectUIDLabel        = "instancetype.kubevirt.io/object-uid"
-	ControllerRevisionObjectVersionLabel    = "instancetype.kubevirt.io/object-version"
+	ControllerRevisionObjectGenerationLabel                 = "instancetype.kubevirt.io/object-generation"
+	ControllerRevisionObjectKindLabel                       = "instancetype.kubevirt.io/object-kind"
+	ControllerRevisionObjectNameLabel                       = "instancetype.kubevirt.io/object-name"
+	ControllerRevisionObjectUIDLabel                        = "instancetype.kubevirt.io/object-uid"
+	ControllerRevisionObjectVersionLabel                    = "instancetype.kubevirt.io/object-version"
+	ControllerRevisionObjectCommonInstancetypesVersionLabel = "instancetype.kubevirt.io/common-instancetypes-version"
 )


### PR DESCRIPTION
### What this PR does
#### Before this PR:
When a `VirtualMachine` references an instancetype or preference provided by `common-instancetypes` (e.g. `VirtualMachineClusterPreference` or `VirtualMachineClusterInstancetype`), virt-controller captures the object into a `ControllerRevision` in the VM namespace. During creation, `CreateControllerRevision` clears all metadata from the source object and only copies 5 standard object labels (`instancetype.kubevirt.io/object-{generation,kind,name,uid,version}`). The `instancetype.kubevirt.io/common-instancetypes-version` label is dropped.

#### After this PR:
When creating a `ControllerRevision` for an instancetype or preference object, any `instancetype.kubevirt.io/common-instancetypes-version` label present on the source object is propagated to the `ControllerRevision.metadata.labels`. This label is also preserved across `ControllerRevision` upgrades.

### References
- Jira: https://redhat.atlassian.net/browse/CNV-96449

### Why we need it and why it was done in this way
Allows tooling and operators (such as HCO) to easily determine the specific release version of `common-instancetypes` captured for a VM by querying the `ControllerRevision` labels directly without needing to inspect bundle resources or guess versions.

### Special notes for your reviewer
NONE

### Checklist
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires new unit tests. New features and bug fixes require at least one e2e test
- [x] Documentation: A user-guide update was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [x] Community: Announcement to kubevirt-dev was considered
- [x] AI Contributions: The PR abides by the KubeVirt AI Contribution Policy.

### Release note
```release-note
Propagate the `instancetype.kubevirt.io/common-instancetypes-version` label from referenced instancetype and preference objects to their captured `ControllerRevision` metadata labels.
```
