### PR TITLE
network tests: use math/rand for GenerateRandomMac

### DIFF
--- a/tests/libnet/mac.go
+++ b/tests/libnet/mac.go
@@ -20,8 +20,8 @@
 package libnet
 
 import (
-	cryptorand "crypto/rand"
 	"fmt"
+	"math/rand/v2"
 	"net"
 
 	expect "github.com/google/goexpect"
@@ -31,15 +31,13 @@ import (
 	"kubevirt.io/kubevirt/tests/console"
 )
 
-func GenerateRandomMac() (net.HardwareAddr, error) {
-	prefix := net.HardwareAddr{0x02, 0x00, 0x00} // local unicast prefix
-	const macByteSize = 3
-	suffix := make(net.HardwareAddr, macByteSize)
-	_, err := cryptorand.Read(suffix)
-	if err != nil {
-		return nil, err
-	}
-	return append(prefix, suffix...), nil
+func GenerateRandomMac() net.HardwareAddr {
+	// A test MAC needs no cryptographic randomness; math/rand avoids wasting entropy.
+	suffix := rand.Uint32() //nolint:gosec
+	// 0x02 marks the address as locally administered unicast. The byte conversions
+	// intentionally truncate suffix to its low bytes (gosec G115 does not apply), and
+	// the 8/16 shifts select those bytes (not mnd magic numbers).
+	return net.HardwareAddr{0x02, 0x00, 0x00, byte(suffix), byte(suffix >> 8), byte(suffix >> 16)} //nolint:gosec,mnd
 }
 
 func CheckMacAddress(vmi *v1.VirtualMachineInstance, interfaceName, macAddress string) error {

--- a/tests/network/bindingplugin.go
+++ b/tests/network/bindingplugin.go
@@ -128,11 +128,7 @@ var _ = Describe(SIG("network binding plugin", Serial, decorators.NetCustomBindi
 
 		It("can run a virtual machine with one macvtap interface", func() {
 			var vmi *v1.VirtualMachineInstance
-			var chosenMAC string
-
-			chosenMACHW, err := libnet.GenerateRandomMac()
-			Expect(err).ToNot(HaveOccurred())
-			chosenMAC = chosenMACHW.String()
+			chosenMAC := libnet.GenerateRandomMac().String()
 
 			ifaceName := "macvtapIface"
 			vmi = libvmifact.NewAlpineWithTestTooling(
@@ -144,7 +140,7 @@ var _ = Describe(SIG("network binding plugin", Serial, decorators.NetCustomBindi
 				libvmi.WithNetwork(libvmi.MultusNetwork(ifaceName, macvtapNetworkName)))
 
 			namespace := testsuite.GetTestNamespace(nil)
-			vmi, err = kubevirt.Client().VirtualMachineInstance(namespace).Create(
+			vmi, err := kubevirt.Client().VirtualMachineInstance(namespace).Create(
 				context.Background(), vmi, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 			vmi = libwait.WaitUntilVMIReady(

--- a/tests/network/bindingplugin_macvtap.go
+++ b/tests/network/bindingplugin_macvtap.go
@@ -69,12 +69,8 @@ var _ = Describe(SIG("VirtualMachineInstance with macvtap network binding plugin
 
 	var serverMAC, clientMAC string
 	BeforeEach(func() {
-		mac, err := libnet.GenerateRandomMac()
-		serverMAC = mac.String()
-		Expect(err).NotTo(HaveOccurred())
-		mac, err = libnet.GenerateRandomMac()
-		Expect(err).NotTo(HaveOccurred())
-		clientMAC = mac.String()
+		serverMAC = libnet.GenerateRandomMac().String()
+		clientMAC = libnet.GenerateRandomMac().String()
 	})
 
 	It("two VMs with macvtap interface should be able to communicate over macvtap network", func() {

--- a/tests/network/hotplug_bridge.go
+++ b/tests/network/hotplug_bridge.go
@@ -206,8 +206,7 @@ var _ = Describe(SIG("bridge nic-hotplug", Serial, func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			const secondHotpluggedIfaceName = "iface2"
-			secondIfaceMac, err := libnet.GenerateRandomMac()
-			Expect(err).NotTo(HaveOccurred())
+			secondIfaceMac := libnet.GenerateRandomMac()
 
 			secondHotpluggedIface := libvmi.NewInterface(secondHotpluggedIfaceName,
 				libvmi.WithBridgeBinding(),

--- a/tests/network/hotplug_sriov.go
+++ b/tests/network/hotplug_sriov.go
@@ -159,10 +159,7 @@ func createSRIOVNetworkAttachmentDefinition(namespace, networkName, sriovResourc
 }
 
 func addSRIOVInterface(vm *v1.VirtualMachine, name, netAttachDefName string) error {
-	mac, err := libnet.GenerateRandomMac()
-	if err != nil {
-		return err
-	}
+	mac := libnet.GenerateRandomMac()
 	newNetwork := *libvmi.MultusNetwork(name, netAttachDefName)
 	newIface := libvmi.NewInterface(name, libvmi.WithSRIOVBinding(), libvmi.WithMac(mac.String()))
 	return libnet.PatchVMWithNewInterface(vm, newNetwork, newIface)

--- a/tests/network/link_state.go
+++ b/tests/network/link_state.go
@@ -64,10 +64,8 @@ var _ = Describe(SIG("interface state up/down", decorators.WgS390x, func() {
 
 	It("status and guest should show correct iface state", func() {
 		testNamespace := testsuite.GetTestNamespace(nil)
-		mac1, err := libnet.GenerateRandomMac()
-		Expect(err).NotTo(HaveOccurred())
-		mac2, err := libnet.GenerateRandomMac()
-		Expect(err).NotTo(HaveOccurred())
+		mac1 := libnet.GenerateRandomMac()
+		mac2 := libnet.GenerateRandomMac()
 
 		vmi := libvmifact.NewFedora(
 			libvmi.WithInterface(v1.Interface{
@@ -91,7 +89,7 @@ var _ = Describe(SIG("interface state up/down", decorators.WgS390x, func() {
 		)
 
 		vm := libvmi.NewVirtualMachine(vmi, libvmi.WithRunStrategy(v1.RunStrategyAlways))
-		vm, err = kubevirt.Client().VirtualMachine(testNamespace).Create(context.Background(), vm, metav1.CreateOptions{})
+		vm, err := kubevirt.Client().VirtualMachine(testNamespace).Create(context.Background(), vm, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
 		Eventually(matcher.ThisVM(vm)).
@@ -148,10 +146,8 @@ var _ = Describe(SIG("interface state up/down", decorators.WgS390x, func() {
 
 	It("status and guest should show iface is down when vm with ifaces down is migrated", func() {
 		testNamespace := testsuite.GetTestNamespace(nil)
-		mac1, err := libnet.GenerateRandomMac()
-		Expect(err).NotTo(HaveOccurred())
-		mac2, err := libnet.GenerateRandomMac()
-		Expect(err).NotTo(HaveOccurred())
+		mac1 := libnet.GenerateRandomMac()
+		mac2 := libnet.GenerateRandomMac()
 
 		vmi := libvmifact.NewFedora(
 			libvmi.WithInterface(v1.Interface{
@@ -175,7 +171,7 @@ var _ = Describe(SIG("interface state up/down", decorators.WgS390x, func() {
 		)
 
 		vm := libvmi.NewVirtualMachine(vmi, libvmi.WithRunStrategy(v1.RunStrategyAlways))
-		vm, err = kubevirt.Client().VirtualMachine(testNamespace).Create(context.Background(), vm, metav1.CreateOptions{})
+		vm, err := kubevirt.Client().VirtualMachine(testNamespace).Create(context.Background(), vm, metav1.CreateOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
 		Eventually(matcher.ThisVM(vm)).

--- a/tests/network/sriov.go
+++ b/tests/network/sriov.go
@@ -838,10 +838,7 @@ func createSRIOVVmi(networkName, cidr string, opts ...libvmi.Option) (*v1.Virtua
 	//
 	// This step is needed to guarantee that no VFs on the PF carry a duplicate MAC address that may affect
 	// ability of VMIs to send and receive ICMP packets on their ports.
-	mac, err := libnet.GenerateRandomMac()
-	if err != nil {
-		return nil, err
-	}
+	mac := libnet.GenerateRandomMac()
 
 	// manually configure IP/link on sriov interfaces because there is
 	// no DHCP server to serve the address to the guest
@@ -853,7 +850,7 @@ func createSRIOVVmi(networkName, cidr string, opts ...libvmi.Option) (*v1.Virtua
 	vmi.Spec.Domain.Devices.Interfaces[secondaryInterfaceIndex].MacAddress = mac.String()
 
 	virtCli := kubevirt.Client()
-	vmi, err = virtCli.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi, metav1.CreateOptions{})
+	vmi, err := virtCli.VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).Create(context.Background(), vmi, metav1.CreateOptions{})
 	ExpectWithOffset(1, err).ToNot(HaveOccurred())
 	return vmi, nil
 }

--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -529,13 +529,9 @@ var _ = Describe(SIG("Multus", Serial, decorators.Multus, func() {
 						bridgeSubnetMask     = "/24"
 					)
 
-					initialMacAddress, err := libnet.GenerateRandomMac()
-					Expect(err).NotTo(HaveOccurred())
-					initialMacAddressStr := initialMacAddress.String()
+					initialMacAddressStr := libnet.GenerateRandomMac().String()
 
-					spoofedMacAddress, err := libnet.GenerateRandomMac()
-					Expect(err).NotTo(HaveOccurred())
-					spoofedMacAddressStr := spoofedMacAddress.String()
+					spoofedMacAddressStr := libnet.GenerateRandomMac().String()
 
 					By("Creating a VM with custom MAC address on its Linux bridge CNI interface.")
 					linuxBridgeInterfaceWithCustomMac := libvmi.NewInterface(


### PR DESCRIPTION
A randomly generated MAC address for tests carries no security requirement, so drawing from the system entropy pool via crypto/rand is wasteful. It also forced every caller to handle an error that could never meaningfully occur.

Switch to math/rand/v2, which is auto-seeded and cannot fail. This lets GenerateRandomMac drop its error return, simplifying all callers, and replaces the slice allocation and Read with a single Uint32 draw. A //nolint:gosec annotation documents that weak randomness is intentional here.

Assisted-By: Claude Opus 4.8

/kind cleanup

```release-note
NONE
```

