### PR TITLE
tests/network: add DRA network binding plugin connectivity test

### DIFF
--- a/tests/decorators/decorators.go
+++ b/tests/decorators/decorators.go
@@ -24,6 +24,7 @@ var (
 	GPU             = Label("GPU")
 	VGPU            = Label("VGPU")
 	DRAGPU          = Label("DRA-GPU")
+	DRANetwork      = Label("DRA-Network")
 	SEV             = Label("SEV")
 	SEVES           = Label("SEVES")
 	SEVSNP          = Label("SEVSNP")

--- a/tests/network/BUILD.bazel
+++ b/tests/network/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "go_default_library",
     srcs = [
         "bindingplugin.go",
+        "bindingplugin_dra.go",
         "bindingplugin_macvtap.go",
         "dual_stack_cluster.go",
         "framework.go",
@@ -40,6 +41,7 @@ go_library(
         "//pkg/pointer:go_default_library",
         "//pkg/util/hardware:go_default_library",
         "//pkg/util/net/dns:go_default_library",
+        "//pkg/virt-config/featuregate:go_default_library",
         "//pkg/virt-launcher/virtwrap/api:go_default_library",
         "//staging/src/kubevirt.io/api/core/v1:go_default_library",
         "//staging/src/kubevirt.io/client-go/kubecli:go_default_library",
@@ -77,6 +79,7 @@ go_library(
         "//vendor/k8s.io/api/batch/v1:go_default_library",
         "//vendor/k8s.io/api/core/v1:go_default_library",
         "//vendor/k8s.io/api/networking/v1:go_default_library",
+        "//vendor/k8s.io/api/resource/v1:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/errors:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/api/resource:go_default_library",
         "//vendor/k8s.io/apimachinery/pkg/apis/meta/v1:go_default_library",

--- a/tests/network/bindingplugin_dra.go
+++ b/tests/network/bindingplugin_dra.go
@@ -1,0 +1,196 @@
+/*
+ * This file is part of the kubevirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package network
+
+import (
+	"context"
+	"slices"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	k8sv1 "k8s.io/api/core/v1"
+	resourcev1 "k8s.io/api/resource/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	v1 "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/pkg/libvmi"
+	libvmici "kubevirt.io/kubevirt/pkg/libvmi/cloudinit"
+	"kubevirt.io/kubevirt/pkg/network/vmispec"
+	"kubevirt.io/kubevirt/pkg/virt-config/featuregate"
+
+	"kubevirt.io/kubevirt/tests/console"
+	"kubevirt.io/kubevirt/tests/decorators"
+	"kubevirt.io/kubevirt/tests/framework/kubevirt"
+	"kubevirt.io/kubevirt/tests/framework/matcher"
+	"kubevirt.io/kubevirt/tests/libkubevirt/config"
+	"kubevirt.io/kubevirt/tests/libnet"
+	"kubevirt.io/kubevirt/tests/libnet/cloudinit"
+	"kubevirt.io/kubevirt/tests/libregistry"
+	"kubevirt.io/kubevirt/tests/libvmifact"
+	"kubevirt.io/kubevirt/tests/testsuite"
+)
+
+var _ = Describe(SIG("VM with DRA network binding plugin", decorators.NetCustomBindingPlugins, decorators.DRANetwork, Serial, func() {
+	const (
+		bindingName               = "dra-binding"
+		networkName               = "dranet"
+		guestIfaceName            = "eth0"
+		resourceClaimTemplateName = "dra-net-claim-template"
+		resourceClaimName         = "dra-net-claim"
+		requestName               = "netdev"
+
+		// deviceClassName must match the DeviceClass published by the test DRA
+		// network driver deployed in the cluster.
+		deviceClassName = "netdevices.example.com"
+
+		agentTimeout    = 5 * time.Minute
+		pollingInterval = 5 * time.Second
+	)
+
+	newDRAVMI := func(cidr string, opts ...libvmi.Option) (*v1.VirtualMachineInstance, error) {
+		networkData, err := cloudinit.NewNetworkData(
+			cloudinit.WithEthernet(guestIfaceName, cloudinit.WithAddresses(cidr)),
+		)
+		if err != nil {
+			return nil, err
+		}
+
+		base := []libvmi.Option{
+			libvmi.WithInterface(libvmi.InterfaceWithBindingPlugin(networkName, v1.PluginBinding{Name: bindingName})),
+			libvmi.WithNetwork(libvmi.DRANetwork(networkName, resourceClaimName, requestName)),
+			libvmi.WithResourceClaim(v1.VirtualMachineInstanceResourceClaim{
+				Name:                      resourceClaimName,
+				ResourceClaimTemplateName: new(resourceClaimTemplateName),
+			}),
+			libvmi.WithCloudInitNoCloud(libvmici.WithNoCloudNetworkData(networkData)),
+		}
+
+		return libvmifact.NewAlpineWithTestTooling(slices.Concat(base, opts)...), nil
+	}
+
+	BeforeEach(func() {
+		config.EnableFeatureGate(featuregate.NetworkDevicesWithDRAGate)
+	})
+
+	BeforeEach(func() {
+		// The test network binding plugin sidecar discovers the DRA-provisioned
+		// device and attaches it to the domain XML (see VEP #183).
+		sidecarImage := libregistry.GetUtilityImageFromRegistry("network-dra-binding")
+		err := config.RegisterKubevirtConfigChange(
+			config.WithNetBindingPluginIfNotPresent(bindingName, v1.InterfaceBindingPlugin{
+				SidecarImage: sidecarImage,
+			}),
+		)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	BeforeEach(func() {
+		resourceClaimTemplate := newResourceClaimTemplate(resourceClaimTemplateName, requestName, deviceClassName)
+		_, err := kubevirt.Client().ResourceV1().ResourceClaimTemplates(testsuite.GetTestNamespace(nil)).Create(
+			context.Background(),
+			&resourceClaimTemplate,
+			metav1.CreateOptions{},
+		)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("two VMs connected to a secondary DRA network should communicate", func() {
+		const (
+			serverIPAddr = "192.0.2.102"
+			serverCIDR   = serverIPAddr + "/24"
+			clientCIDR   = "192.0.2.101/24"
+			serverLabel  = "dra-net-server"
+		)
+
+		serverVMI, err := newDRAVMI(serverCIDR, libvmi.WithLabel(serverLabel, ""))
+		Expect(err).ToNot(HaveOccurred())
+
+		// Schedule the client on the same node as the server so both consume the
+		// node-local DRA network device and can reach each other.
+		sameNodeAsServer := k8sv1.PodAffinityTerm{
+			LabelSelector: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{Key: serverLabel, Operator: metav1.LabelSelectorOpExists},
+				},
+			},
+			TopologyKey: k8sv1.LabelHostname,
+		}
+		clientVMI, err := newDRAVMI(clientCIDR, libvmi.WithRequiredPodAffinity(sameNodeAsServer))
+		Expect(err).ToNot(HaveOccurred())
+
+		ns := testsuite.GetTestNamespace(nil)
+
+		serverVM := libvmi.NewVirtualMachine(serverVMI, libvmi.WithRunStrategy(v1.RunStrategyAlways))
+		serverVM, err = kubevirt.Client().VirtualMachine(ns).Create(context.Background(), serverVM, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		clientVM := libvmi.NewVirtualMachine(clientVMI, libvmi.WithRunStrategy(v1.RunStrategyAlways))
+		clientVM, err = kubevirt.Client().VirtualMachine(ns).Create(context.Background(), clientVM, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		By("Waiting for the guest agent to connect on both VMs")
+		Eventually(matcher.ThisVM(serverVM)).WithTimeout(agentTimeout).WithPolling(pollingInterval).
+			Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
+		Eventually(matcher.ThisVM(clientVM)).WithTimeout(agentTimeout).WithPolling(pollingInterval).
+			Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
+
+		serverVMI, err = kubevirt.Client().VirtualMachineInstance(ns).Get(context.Background(), serverVM.Name, metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		clientVMI, err = kubevirt.Client().VirtualMachineInstance(ns).Get(context.Background(), clientVM.Name, metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(console.LoginToAlpine(serverVMI)).To(Succeed())
+		Expect(console.LoginToAlpine(clientVMI)).To(Succeed())
+
+		By("Verifying the DRA network interface is reported in the VMI status")
+		Eventually(func(g Gomega) {
+			serverVMI, err = kubevirt.Client().VirtualMachineInstance(ns).Get(context.Background(), serverVM.Name, metav1.GetOptions{})
+			g.Expect(err).ToNot(HaveOccurred())
+			g.Expect(serverVMI.Status.Interfaces).To(HaveLen(1))
+			g.Expect(serverVMI.Status.Interfaces[0].InfoSource).To(Equal(vmispec.InfoSourceDomainAndGA))
+			g.Expect(serverVMI.Status.Interfaces[0].IPs).To(ContainElement(serverIPAddr))
+		}, agentTimeout, pollingInterval).Should(Succeed())
+
+		Expect(libnet.PingFromVMConsole(clientVMI, serverIPAddr)).To(Succeed())
+	})
+}))
+
+func newResourceClaimTemplate(templateName, requestName, deviceClassName string) resourcev1.ResourceClaimTemplate {
+	return resourcev1.ResourceClaimTemplate{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: templateName,
+		},
+		Spec: resourcev1.ResourceClaimTemplateSpec{
+			Spec: resourcev1.ResourceClaimSpec{
+				Devices: resourcev1.DeviceClaim{
+					Requests: []resourcev1.DeviceRequest{{
+						Name: requestName,
+						Exactly: &resourcev1.ExactDeviceRequest{
+							DeviceClassName: deviceClassName,
+						},
+					}},
+				},
+			},
+		},
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
[VEP #183](https://github.com/kubevirt/enhancements/issues/183) (Network Device DRA Support) targets beta in v1.10, whose graduation requires functional e2e coverage of a network binding plugin backed by a DRA driver. This adds the connectivity portion, which did not exist yet; live migration remains a follow-up.

Two VMs reaching each other over a shared DRA network is what proves the feature works the way users consume it.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
-->

- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/183

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
Draft: not runnable yet, as two dependencies aren't in-tree.                                                                                                                                      

- Test DRA driver - deviceClassName = "netdevices.example.com" is a placeholder, TBR once the driver's DeviceClass is known.
- Test binding plugin - sidecar image "network-dra-binding" is a placeholder, TBR once the image is built.
  Posting early for feedback on structure. Only these names should change before it runs; live migration coverage follows separately

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

