### PR TITLE
Stop toggling feature gates per test in OCI export e2e tests

### DIFF
--- a/automation/repeated_test.sh
+++ b/automation/repeated_test.sh
@@ -250,6 +250,7 @@ add_feature_gate() {
 }
 
 add_feature_gate "Plugins"
+add_feature_gate "OCIExport"
 
 label_filter="${KUBEVIRT_LABEL_FILTER:-}"
 

--- a/automation/test.sh
+++ b/automation/test.sh
@@ -107,6 +107,7 @@ case "$TARGET" in
     export KUBEVIRT_DEPLOY_NFS_CSI=true
     export KUBEVIRT_WITH_ETC_CAPACITY="1G"
     export FAIL_ON_VM_LOG_ERRORS=true
+    add_feature_gate "OCIExport"
     ;;
   *sig-compute-realtime*)
     export KUBEVIRT_PROVIDER=${TARGET/-sig-compute-realtime/}

--- a/pkg/storage/export/export/vm-source_test.go
+++ b/pkg/storage/export/export/vm-source_test.go
@@ -19,6 +19,7 @@
 package export
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -661,5 +662,27 @@ var _ = Describe("PVC source", func() {
 		Expect(retry).To(BeEquivalentTo(0))
 		testutils.ExpectEvent(recorder, serviceCreatedEvent)
 		testutils.ExpectEvent(recorder, exporterPodFailedOrCompletedEvent)
+	})
+
+	It("should not include OCI manifest link when OCIExport feature gate is disabled", func() {
+		testVMExport := createVMVMExport()
+		controller.VMInformer.GetStore().Add(createVMWithDataVolumes())
+		controller.PVCInformer.GetStore().Add(createPVC("volume1", "kubevirt"))
+		controller.PVCInformer.GetStore().Add(createPVC("volume2", "kubevirt"))
+		expectExporterCreate(k8sClient, k8sv1.PodRunning)
+		_, err := vmExportClient.ExportV1().VirtualMachineExports(testVMExport.Namespace).Create(
+			context.Background(), testVMExport, metav1.CreateOptions{})
+		Expect(err).ToNot(HaveOccurred())
+
+		retry, err := controller.updateVMExport(testVMExport)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(retry).To(BeEquivalentTo(0))
+
+		updated, err := vmExportClient.ExportV1().VirtualMachineExports(testVMExport.Namespace).Get(
+			context.Background(), testVMExport.Name, metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(updated.Status.Links.Internal).ToNot(BeNil())
+		Expect(updated.Status.Links.Internal.Manifests).ToNot(ContainElement(
+			HaveField("Type", exportv1.OCI)))
 	})
 })

--- a/tests/decorators/decorators.go
+++ b/tests/decorators/decorators.go
@@ -98,6 +98,10 @@ var (
 	RequiresPersistentReservation = Label("RequiresPersistentReservation")
 	// RequiresPlugins requires the Plugins feature gate to be enabled on the kubevirt level
 	RequiresPlugins = Label("RequiresPlugins")
+	// RequiresOCIExport requires the OCIExport feature gate to be enabled on the kubevirt level
+	RequiresOCIExport = Label("RequiresOCIExport")
+	// RequiresTemplate requires the Template feature gate to be enabled on the kubevirt level
+	RequiresTemplate = Label("RequiresTemplate")
 
 	// RequiresBlockStorage requires a storage class with Block storage support
 	RequiresBlockStorage = Label("RequiresBlockStorage")

--- a/tests/storage/export.go
+++ b/tests/storage/export.go
@@ -2360,32 +2360,21 @@ var _ = Describe(SIG("Export", func() {
 		})
 	})
 
-	Context("OCI export", Serial, Ordered, decorators.OncePerOrderedCleanup, func() {
+	Context("OCI export", decorators.RequiresOCIExport, decorators.RequiresTemplate, func() {
 		const (
 			reasonDigestsComputed = "DigestsComputed"
 		)
 
-		var (
-			fgDisabled bool
-			sc         string
-		)
+		var sc string
 
-		BeforeAll(func() {
+		BeforeEach(func() {
+			checks.FailTestIfNoFeatureGate(featuregate.OCIExport)
+			checks.FailTestIfNoFeatureGate(featuregate.Template)
+
 			var exists bool
 			sc, exists = libstorage.GetRWOBlockStorageClass()
 			if !exists {
 				Fail("Fail test when RWO Block storage is not present")
-			}
-
-			fgDisabled = !checks.HasFeature(featuregate.OCIExport)
-			if fgDisabled {
-				kvconfig.EnableFeatureGate(featuregate.OCIExport)
-			}
-		})
-
-		AfterAll(func() {
-			if fgDisabled {
-				kvconfig.DisableFeatureGate(featuregate.OCIExport)
 			}
 		})
 
@@ -2472,25 +2461,7 @@ var _ = Describe(SIG("Export", func() {
 			verifyOCITarDownload(export, token, vm.Namespace)
 		})
 
-		It("should not include OCI manifest link when feature gate is disabled", func() {
-			if checks.HasFeature(featuregate.OCIExport) {
-				kvconfig.DisableFeatureGate(featuregate.OCIExport)
-				defer kvconfig.EnableFeatureGate(featuregate.OCIExport)
-			}
-
-			vm := createStoppedVM()
-			export, _ := createReadyVMExport(vm)
-
-			ociUrl := getManifestUrl(export.Status.Links.Internal.Manifests, exportv1.OCI)
-			Expect(ociUrl).To(BeEmpty(), "OCI manifest URL should not be present when feature gate is disabled")
-		})
-
 		It("should export VirtualMachineTemplate as OCI artifact", func() {
-			if !checks.HasFeature(featuregate.Template) {
-				kvconfig.EnableFeatureGate(featuregate.Template)
-				defer kvconfig.DisableFeatureGate(featuregate.Template)
-			}
-
 			By("Creating a stopped VM with DataVolume")
 			vm := createStoppedVM()
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
Per-test feature gate toggling caused rapid virt-controller restarts
that accumulated CrashLoopBackOff, resulting in flakes. Instead of
toggling gates per test, enable OCIExport at the sig-storage and flake
lane level and fail tests if the required gates are missing.

Replace the negative e2e test with a unit test that drives a full
controller reconcile and asserts no OCI manifest link appears when
the feature gate is disabled.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

