### PR TITLE
virt-launcher: make node-labeller device setup best-effort

### DIFF
--- a/cmd/virt-launcher/node-labeller/node-labeller.sh
+++ b/cmd/virt-launcher/node-labeller/node-labeller.sh
@@ -31,18 +31,25 @@ set -o pipefail
 
 VIRTTYPE=qemu
 
+# Device setup is best-effort: in restricted environments (e.g. rootless podman)
+# we may not be able to create or chmod the device, so we fall back to software
+# emulation rather than failing the init container and blocking the deployment.
 if [ ! -e "$HYPERVISOR_DEV_PATH" ] && [ -n "$HYPERVISOR_DEV_MINOR" ]; then
-  mknod "$HYPERVISOR_DEV_PATH" c 10 "$HYPERVISOR_DEV_MINOR"
+  mknod "$HYPERVISOR_DEV_PATH" c 10 "$HYPERVISOR_DEV_MINOR" || echo "Warning: cannot create $HYPERVISOR_DEV_PATH, falling back to software emulation (virttype=qemu)"
 fi
 
 if [ -e "$HYPERVISOR_DEV_PATH" ]; then
-    chmod o+rw "$HYPERVISOR_DEV_PATH"
-    VIRTTYPE=${PREFERRED_VIRTTYPE}
+    # Keep hardware acceleration if the device is (or can be made) writable.
+    if chmod o+rw "$HYPERVISOR_DEV_PATH" || [ -w "$HYPERVISOR_DEV_PATH" ]; then
+        VIRTTYPE=${PREFERRED_VIRTTYPE}
+    else
+        echo "Warning: cannot access $HYPERVISOR_DEV_PATH, falling back to software emulation (virttype=qemu)"
+    fi
 fi
 
 if [ -e /dev/sev ]; then
-  # QEMU requires RW access to query SEV capabilities
-  chmod o+rw /dev/sev
+  # QEMU requires RW access to query SEV capabilities; skip if we cannot chmod it.
+  chmod o+rw /dev/sev || echo "Warning: cannot chmod /dev/sev, SEV capabilities may not be detected"
 fi
 
 virtqemud -d


### PR DESCRIPTION
### What this PR does
#### Before this PR:
The virt-handler node-labeller init container (`node-labeller.sh`) runs with
`set -eo pipefail`. If it cannot `chmod`/`mknod` the hypervisor device (or
`/dev/sev`) it aborts. On hosts where `/dev/kvm` exists but cannot be chmod-ed
by the container's effective user — e.g. CI under rootless podman, where the
container "root" is a mapped, non-owning host user — the init container fails,
`capabilities.xml` is never written, virt-handler panics on startup reading it,
and the KubeVirt CR never reaches `Deployed`, timing out the deployment before
any VMI is created.

#### After this PR:
Device setup is best-effort. Hardware acceleration is kept when the hypervisor
device is already writable (`chmod ... || [ -w ... ]`); otherwise the script
falls back to software emulation (`virttype=qemu`) — the same behaviour already
used when the device is absent — instead of failing the init container. The same
tolerance is applied to the `mknod` fallback and the `/dev/sev` chmod.

### References
- Fixes #19017
- Originally observed via https://github.com/containers/kubernetes-mcp-server/issues/1410

### Why we need it and why it was done in this way
The fix is deliberately scoped to the deploy-time init container, which is the
sole cause of the deployment timeout. The per-VMI ownership path
(`claimDeviceOwnership`/`SetFileOwnership`) is already emulation-safe: with
`AllowEmulation` enabled, the launcher pod does not request the
`devices.kubevirt.io/kvm` resource, so `/dev/kvm` is never injected into the
launcher pod and the existing missing-device guard returns without attempting a
chown. No change is needed there.

The following alternatives were considered:
- Blindly `chmod ... || true` and always fall back to emulation: rejected
  because it would drop hardware acceleration even when `/dev/kvm` is already
  world-writable (common under rootless podman). The `[ -w ]` check preserves
  acceleration in that case.

### Special notes for your reviewer
There is no existing shell-test harness for `node-labeller.sh`, so this change
has no accompanying unit test. Pre-existing shellcheck SC2086 findings on
unrelated lines were left untouched to keep the diff focused.

### Checklist
- [x] Design: A VEP was considered and is not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it (Boy Scout Rule)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires new unit tests. New features and bug fixes require at least one e2e test
- [x] Documentation: A user-guide update was considered and is not required
- [x] Community: Announcement to kubevirt-dev was considered
- [x] AI Contributions: The PR abides by the KubeVirt AI Contribution Policy.

### Release note
```release-note
Fixed virt-handler node-labeller init container failing on hosts where /dev/kvm cannot be chmod-ed (e.g. rootless podman), which previously blocked KubeVirt deployment. The node-labeller now falls back to software emulation instead of failing.
```
