### PR TITLE
network: move PodIfaceCacheData into launcher pod's emptyDir

### DIFF
--- a/pkg/network/cache/podinterface.go
+++ b/pkg/network/cache/podinterface.go
@@ -20,6 +20,7 @@
 package cache
 
 import (
+	"fmt"
 	"path/filepath"
 
 	v1 "kubevirt.io/api/core/v1"
@@ -46,33 +47,52 @@ type PodInterfaceCache struct {
 	cache *Cache
 }
 
-func ReadPodInterfaceCache(c cacheCreator, uid, ifaceName string) (*PodIfaceCacheData, error) {
-	podCache, err := NewPodInterfaceCache(c, uid).IfaceEntry(ifaceName)
+func ReadPodInterfaceCache(c cacheCreator, pid int, ifaceName string) (*PodIfaceCacheData, error) {
+	podCache, err := NewPodInterfaceCache(c, pid).IfaceEntry(ifaceName)
 	if err != nil {
 		return nil, err
 	}
 	return podCache.Read()
 }
 
-func WritePodInterfaceCache(c cacheCreator, uid, ifaceName string, cacheInterface *PodIfaceCacheData) error {
-	podCache, err := NewPodInterfaceCache(c, uid).IfaceEntry(ifaceName)
+func WritePodInterfaceCache(c cacheCreator, pid int, ifaceName string, data *PodIfaceCacheData) error {
+	podCache, err := NewPodInterfaceCache(c, pid).IfaceEntry(ifaceName)
 	if err != nil {
 		return err
 	}
-	return podCache.Write(cacheInterface)
+	return podCache.Write(data)
 }
 
-func DeletePodInterfaceCache(c cacheCreator, uid, ifaceName string) error {
-	podCache, err := NewPodInterfaceCache(c, uid).IfaceEntry(ifaceName)
+func DeletePodInterfaceCache(c cacheCreator, pid int, ifaceName string) error {
+	podCache, err := NewPodInterfaceCache(c, pid).IfaceEntry(ifaceName)
 	if err != nil {
 		return err
 	}
 	return podCache.Remove()
 }
 
-func NewPodInterfaceCache(creator cacheCreator, uid string) PodInterfaceCache {
+// ReadLegacyPodInterfaceCache reads from the pre-upgrade virt-handler-local path keyed by
+// VMI UID. Use only for upgrade fallback reads; new code must use ReadPodInterfaceCache.
+func ReadLegacyPodInterfaceCache(c cacheCreator, uid, ifaceName string) (*PodIfaceCacheData, error) {
+	podCache, err := NewLegacyPodInterfaceCache(c, uid).IfaceEntry(ifaceName)
+	if err != nil {
+		return nil, err
+	}
+	return podCache.Read()
+}
+
+// NewLegacyPodInterfaceCache returns a cache rooted in virt-handler's local filesystem,
+// keyed by VMI UID. Use only for upgrade fallback reads and teardown cleanup;
+// new code should use NewPodInterfaceCache with the launcher PID.
+func NewLegacyPodInterfaceCache(creator cacheCreator, uid string) PodInterfaceCache {
 	const podIfaceCacheDirName = "network-info-cache"
 	return PodInterfaceCache{creator.New(filepath.Join(util.VirtPrivateDir, podIfaceCacheDirName, uid))}
+}
+
+func NewPodInterfaceCache(creator cacheCreator, pid int) PodInterfaceCache {
+	const podIfaceCacheDirName = "network-info-cache"
+	podRootFilesystemPath := fmt.Sprintf("/proc/%d/root", pid)
+	return PodInterfaceCache{creator.New(filepath.Join(podRootFilesystemPath, util.VirtPrivateDir, podIfaceCacheDirName))}
 }
 
 func (p PodInterfaceCache) IfaceEntry(ifaceName string) (PodInterfaceCache, error) {

--- a/pkg/network/cache/podinterface_test.go
+++ b/pkg/network/cache/podinterface_test.go
@@ -33,7 +33,7 @@ import (
 
 var _ = Describe("Pod Interface", func() {
 
-	const UID = "123"
+	const fakePID = 123
 	var cacheCreator tempCacheCreator
 	var podIfaceCache netcache.PodInterfaceCache
 	var cacheData netcache.PodIfaceCacheData
@@ -41,7 +41,7 @@ var _ = Describe("Pod Interface", func() {
 	BeforeEach(dutils.MockDefaultOwnershipManager)
 
 	BeforeEach(func() {
-		podCache := netcache.NewPodInterfaceCache(&cacheCreator, UID)
+		podCache := netcache.NewPodInterfaceCache(&cacheCreator, fakePID)
 
 		var err error
 		podIfaceCache, err = podCache.IfaceEntry("net0")

--- a/pkg/network/setup/configstatecache.go
+++ b/pkg/network/setup/configstatecache.go
@@ -33,49 +33,56 @@ const defaultState = cache.PodIfaceNetworkPreparationPending
 
 type ConfigStateCache struct {
 	vmiUID                string
+	launcherPid           int
 	cacheCreator          cacheCreator
 	volatilePodIfaceState map[string]cache.PodIfaceState
 }
 
-func NewConfigStateCache(vmiUID string, cacheCreator cacheCreator) ConfigStateCache {
-	return NewConfigStateCacheWithPodIfaceStateData(vmiUID, cacheCreator, map[string]cache.PodIfaceState{})
+func NewConfigStateCache(vmiUID string, launcherPid int, cacheCreator cacheCreator) ConfigStateCache {
+	return ConfigStateCache{
+		vmiUID:                vmiUID,
+		launcherPid:           launcherPid,
+		cacheCreator:          cacheCreator,
+		volatilePodIfaceState: map[string]cache.PodIfaceState{},
+	}
 }
 
-func NewConfigStateCacheWithPodIfaceStateData(vmiUID string, cacheCreator cacheCreator, volatilePodIfaceState map[string]cache.PodIfaceState) ConfigStateCache {
-	return ConfigStateCache{vmiUID, cacheCreator, volatilePodIfaceState}
+func NewConfigStateCacheWithPodIfaceStateData(vmiUID string, launcherPid int, cacheCreator cacheCreator, volatilePodIfaceState map[string]cache.PodIfaceState) ConfigStateCache {
+	return ConfigStateCache{
+		vmiUID:                vmiUID,
+		launcherPid:           launcherPid,
+		cacheCreator:          cacheCreator,
+		volatilePodIfaceState: volatilePodIfaceState,
+	}
 }
 
 func (c *ConfigStateCache) Read(key string) (cache.PodIfaceState, error) {
-	if volatilePodIfaceState, ok := c.volatilePodIfaceState[key]; ok {
-		return volatilePodIfaceState, nil
+	if v, ok := c.volatilePodIfaceState[key]; ok {
+		return v, nil
 	}
-	podIfaceCacheData, err := cache.ReadPodInterfaceCache(c.cacheCreator, c.vmiUID, key)
-	var state cache.PodIfaceState
+	data, err := c.readPodIface(key)
 	if err != nil {
-		if !errors.Is(err, os.ErrNotExist) {
-			return defaultState, fmt.Errorf("failed to read pod interface network state from cache: %v", err)
-		}
-		state = defaultState
-	} else {
-		state = podIfaceCacheData.State
+		return defaultState, fmt.Errorf("failed to read pod interface network state from cache: %v", err)
+	}
+	state := defaultState
+	if data != nil {
+		state = data.State
 	}
 	c.volatilePodIfaceState[key] = state
 	return state, nil
 }
 
 func (c *ConfigStateCache) Write(key string, state cache.PodIfaceState) error {
-	podIfaceCacheData, err := cache.ReadPodInterfaceCache(c.cacheCreator, c.vmiUID, key)
+	podIfaceCacheData, err := c.readPodIface(key)
 	if err != nil {
-		if !errors.Is(err, os.ErrNotExist) {
-			log.Log.Reason(err).Errorf("failed to read pod interface network (%s) state from cache", key)
-			return err
-		}
+		log.Log.Reason(err).Errorf("failed to read pod interface network (%s) state from cache", key)
+		return err
+	}
+	if podIfaceCacheData == nil {
 		podIfaceCacheData = &cache.PodIfaceCacheData{}
 	}
-
 	podIfaceCacheData.State = state
-	err = cache.WritePodInterfaceCache(c.cacheCreator, c.vmiUID, key, podIfaceCacheData)
-	if err != nil {
+	if err := c.writePodIface(key, podIfaceCacheData); err != nil {
 		log.Log.Reason(err).Errorf("failed to write pod interface network (%s) state to cache", key)
 		return err
 	}
@@ -85,17 +92,48 @@ func (c *ConfigStateCache) Write(key string, state cache.PodIfaceState) error {
 
 func (c *ConfigStateCache) Delete(key string) error {
 	delete(c.volatilePodIfaceState, key)
-	podIfaceCacheData, err := cache.ReadPodInterfaceCache(c.cacheCreator, c.vmiUID, key)
+	podIfaceCacheData, err := c.readPodIface(key)
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return nil
-		}
 		return err
+	}
+	if podIfaceCacheData == nil {
+		return nil
 	}
 	podIfaceCacheData.State = cache.PodIfaceNetworkPreparationPending
-	err = cache.WritePodInterfaceCache(c.cacheCreator, c.vmiUID, key, podIfaceCacheData)
+	return c.writePodIface(key, podIfaceCacheData)
+}
+
+// readPodIface reads PodIfaceCacheData from disk. Returns (nil, nil) when absent.
+// Tries the launcher procfs path first, then the pre-upgrade virt-handler-local path.
+func (c *ConfigStateCache) readPodIface(key string) (*cache.PodIfaceCacheData, error) {
+	entry, err := cache.NewPodInterfaceCache(c.cacheCreator, c.launcherPid).IfaceEntry(key)
+	if err == nil {
+		data, err := entry.Read()
+		if err == nil {
+			return data, nil
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			return nil, err
+		}
+	}
+	// Upgrade fallback: check pre-upgrade virt-handler-local path (read-only).
+	return c.readPreUpgradeState(key)
+}
+
+func (c *ConfigStateCache) writePodIface(key string, data *cache.PodIfaceCacheData) error {
+	entry, err := cache.NewPodInterfaceCache(c.cacheCreator, c.launcherPid).IfaceEntry(key)
 	if err != nil {
 		return err
 	}
-	return nil
+	return entry.Write(data)
+}
+
+// readPreUpgradeState reads from the pre-upgrade virt-handler-local cache path.
+// Remove once all virt-launchers have been upgraded and restarted at least once.
+func (c *ConfigStateCache) readPreUpgradeState(key string) (*cache.PodIfaceCacheData, error) {
+	data, err := cache.ReadLegacyPodInterfaceCache(c.cacheCreator, c.vmiUID, key)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	return data, err
 }

--- a/pkg/network/setup/configstatecache_test.go
+++ b/pkg/network/setup/configstatecache_test.go
@@ -34,6 +34,7 @@ var _ = Describe("config state cache", func() {
 	const (
 		uid     = "123"
 		testNet = "testnet"
+		fakePID = 42
 	)
 	var (
 		configStateCache      network.ConfigStateCache
@@ -44,7 +45,7 @@ var _ = Describe("config state cache", func() {
 	BeforeEach(func() {
 		dutils.MockDefaultOwnershipManager()
 		volatilePodIfaceState = map[string]cache.PodIfaceState{}
-		configStateCache = network.NewConfigStateCacheWithPodIfaceStateData(uid, &baseCacheCreator, volatilePodIfaceState)
+		configStateCache = network.NewConfigStateCacheWithPodIfaceStateData(uid, fakePID, &baseCacheCreator, volatilePodIfaceState)
 	})
 	AfterEach(func() {
 		Expect(baseCacheCreator.New("").Delete()).To(Succeed())
@@ -57,14 +58,14 @@ var _ = Describe("config state cache", func() {
 		})
 		It("state stored only in the file cache", func() {
 			podIfaceCacheData := &cache.PodIfaceCacheData{State: cache.PodIfaceNetworkPreparationStarted}
-			Expect(cache.WritePodInterfaceCache(&baseCacheCreator, uid, testNet, podIfaceCacheData)).To(Succeed())
+			Expect(cache.WritePodInterfaceCache(&baseCacheCreator, fakePID, testNet, podIfaceCacheData)).To(Succeed())
 
 			Expect(configStateCache.Read(testNet)).To(Equal(cache.PodIfaceNetworkPreparationStarted))
 			Expect(volatilePodIfaceState[testNet]).To(Equal(cache.PodIfaceNetworkPreparationStarted))
 		})
 		It("state stored only in file cache while the memory cache is not empty", func() {
 			podIfaceCacheData := &cache.PodIfaceCacheData{State: cache.PodIfaceNetworkPreparationStarted}
-			Expect(cache.WritePodInterfaceCache(&baseCacheCreator, uid, testNet, podIfaceCacheData)).To(Succeed())
+			Expect(cache.WritePodInterfaceCache(&baseCacheCreator, fakePID, testNet, podIfaceCacheData)).To(Succeed())
 
 			volatilePodIfaceState["not"+testNet] = cache.PodIfaceNetworkPreparationStarted
 
@@ -80,7 +81,7 @@ var _ = Describe("config state cache", func() {
 		})
 		It("state stored in both the file cache and the memory, prefer memory", func() {
 			podIfaceCacheData := &cache.PodIfaceCacheData{State: cache.PodIfaceNetworkPreparationStarted}
-			Expect(cache.WritePodInterfaceCache(&baseCacheCreator, uid, testNet, podIfaceCacheData)).To(Succeed())
+			Expect(cache.WritePodInterfaceCache(&baseCacheCreator, fakePID, testNet, podIfaceCacheData)).To(Succeed())
 			volatilePodIfaceState[testNet] = cache.PodIfaceNetworkPreparationFinished
 
 			Expect(configStateCache.Read(testNet)).To(Equal(cache.PodIfaceNetworkPreparationFinished))
@@ -92,26 +93,24 @@ var _ = Describe("config state cache", func() {
 			err := configStateCache.Write(testNet, cache.PodIfaceNetworkPreparationStarted)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(volatilePodIfaceState[testNet]).To(Equal(cache.PodIfaceNetworkPreparationStarted))
-			podIfaceCacheData, err := cache.ReadPodInterfaceCache(&baseCacheCreator, uid, testNet)
+			podIfaceCacheData, err := cache.ReadPodInterfaceCache(&baseCacheCreator, fakePID, testNet)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(podIfaceCacheData.State).To(Equal(cache.PodIfaceNetworkPreparationStarted))
-
 		})
 		It("to a non empty cache", func() {
 			err := configStateCache.Write(testNet, cache.PodIfaceNetworkPreparationStarted)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(volatilePodIfaceState[testNet]).To(Equal(cache.PodIfaceNetworkPreparationStarted))
-			podIfaceCacheData, err := cache.ReadPodInterfaceCache(&baseCacheCreator, uid, testNet)
+			podIfaceCacheData, err := cache.ReadPodInterfaceCache(&baseCacheCreator, fakePID, testNet)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(podIfaceCacheData.State).To(Equal(cache.PodIfaceNetworkPreparationStarted))
 
 			err = configStateCache.Write(testNet, cache.PodIfaceNetworkPreparationFinished)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(volatilePodIfaceState[testNet]).To(Equal(cache.PodIfaceNetworkPreparationFinished))
-			podIfaceCacheData, err = cache.ReadPodInterfaceCache(&baseCacheCreator, uid, testNet)
+			podIfaceCacheData, err = cache.ReadPodInterfaceCache(&baseCacheCreator, fakePID, testNet)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(podIfaceCacheData.State).To(Equal(cache.PodIfaceNetworkPreparationFinished))
-
 		})
 	})
 

--- a/pkg/network/setup/netconf.go
+++ b/pkg/network/setup/netconf.go
@@ -44,6 +44,24 @@ type cacheCreator interface {
 	New(filePath string) *cache.Cache
 }
 
+// launcherPIDsByUID maps VMI UID (string) to launcher PID (string).
+// Written by Setup(), deleted by Teardown(), read by NetStat.
+var launcherPIDsByUID sync.Map
+
+// StoreLauncherPID registers the PID of a launcher pod for a VMI UID.
+// Production code goes through Setup(); this is exposed only so tests can
+// exercise the primary (non-upgrade-fallback) read path in NetStat without
+// running a full Setup.
+func StoreLauncherPID(vmiUID string, pid int) {
+	launcherPIDsByUID.Store(vmiUID, pid)
+}
+
+// DeleteLauncherPID removes the PID registration for a VMI UID.
+// Counterpart of StoreLauncherPID for test cleanup.
+func DeleteLauncherPID(vmiUID string) {
+	launcherPIDsByUID.Delete(vmiUID)
+}
+
 type clusterConfigurer interface {
 	GetNetworkBindings() map[string]v1.InterfaceBindingPlugin
 	PortRangesSpecGateEnabled() bool
@@ -83,11 +101,13 @@ func NewNetConfWithCustomFactoryAndConfigState(nsFactory nsFactory, cacheCreator
 
 // Setup applies (privilege) network related changes for an existing virt-launcher pod.
 func (c *NetConf) Setup(vmi *v1.VirtualMachineInstance, networks []v1.Network, launcherPid int) error {
+	launcherPIDsByUID.Store(string(vmi.UID), launcherPid)
+
 	c.configStateMutex.RLock()
 	state, ok := c.state[string(vmi.UID)]
 	c.configStateMutex.RUnlock()
 	if !ok {
-		configStateCache := NewConfigStateCache(string(vmi.UID), c.cacheCreator)
+		configStateCache := NewConfigStateCache(string(vmi.UID), launcherPid, c.cacheCreator)
 		ns := c.nsFactory(launcherPid)
 		state = netpod.NewState(&configStateCache, ns)
 		c.configStateMutex.Lock()
@@ -122,10 +142,11 @@ func (c *NetConf) Setup(vmi *v1.VirtualMachineInstance, networks []v1.Network, l
 }
 
 func (c *NetConf) Teardown(vmi *v1.VirtualMachineInstance) error {
+	launcherPIDsByUID.Delete(string(vmi.UID))
 	c.configStateMutex.Lock()
 	delete(c.state, string(vmi.UID))
 	c.configStateMutex.Unlock()
-	podCache := cache.NewPodInterfaceCache(c.cacheCreator, string(vmi.UID))
+	podCache := cache.NewLegacyPodInterfaceCache(c.cacheCreator, string(vmi.UID))
 	if err := podCache.Remove(); err != nil {
 		return fmt.Errorf("teardown failed, err: %w", err)
 	}

--- a/pkg/network/setup/netpod/discover.go
+++ b/pkg/network/setup/netpod/discover.go
@@ -103,7 +103,7 @@ func (n NetPod) discover(currentStatus *nmstate.Status) error {
 }
 
 func (n NetPod) storePodInterfaceData(vmiSpecIface v1.Interface, ifaceState nmstate.Interface) error {
-	ifCache, err := cache.ReadPodInterfaceCache(n.cacheCreator, n.vmiUID, vmiSpecIface.Name)
+	ifCache, err := cache.ReadPodInterfaceCache(n.cacheCreator, n.podPID, vmiSpecIface.Name)
 	if err != nil {
 		if !errors.Is(err, os.ErrNotExist) {
 			return fmt.Errorf("failed to read pod interface cache for %s: %v", vmiSpecIface.Name, err)
@@ -130,7 +130,7 @@ func (n NetPod) storePodInterfaceData(vmiSpecIface v1.Interface, ifaceState nmst
 	}
 	ifCache.PodIP = ifCache.PodIPs[0]
 
-	if err := cache.WritePodInterfaceCache(n.cacheCreator, n.vmiUID, vmiSpecIface.Name, ifCache); err != nil {
+	if err := cache.WritePodInterfaceCache(n.cacheCreator, n.podPID, vmiSpecIface.Name, ifCache); err != nil {
 		log.Log.Reason(err).Errorf("failed to write pod interface data to cache")
 		return err
 	}

--- a/pkg/network/setup/netpod/netpod.go
+++ b/pkg/network/setup/netpod/netpod.go
@@ -703,7 +703,7 @@ func (n NetPod) clearCache(nets []v1.Network) error {
 		// the PodInterface cache should be the last one to be cleaned.
 		// It should be cleaned as the last step of the cleanup, since it is the indicator the cleanup should be done/not over yet.
 		if len(unplugErrors) == 0 {
-			err = cache.DeletePodInterfaceCache(n.cacheCreator, n.vmiUID, net.Name)
+			err = cache.DeletePodInterfaceCache(n.cacheCreator, n.podPID, net.Name)
 			if err != nil {
 				unplugErrors = append(unplugErrors, err)
 			}

--- a/pkg/network/setup/netpod/netpod_test.go
+++ b/pkg/network/setup/netpod/netpod_test.go
@@ -49,6 +49,7 @@ const (
 	defaultPodNetworkName = "default"
 
 	vmiUID = "12345"
+	podPID = 0
 
 	primaryIPv4Address = "10.222.222.1"
 	primaryIPv6Address = "2001::1"
@@ -267,7 +268,7 @@ var _ = Describe("netpod", func() {
 		Expect(masqstub.bridgeIfaceSpec.Name).To(Equal("k6t-eth0"))
 		Expect(masqstub.podIfaceSpec.Name).To(Equal("eth0"))
 		Expect(masqstub.vmiIfaceSpec.Name).To(Equal(defaultPodNetworkName))
-		Expect(cache.ReadPodInterfaceCache(&baseCacheCreator, vmiUID, defaultPodNetworkName)).To(Equal(&cache.PodIfaceCacheData{
+		Expect(cache.ReadPodInterfaceCache(&baseCacheCreator, podPID, defaultPodNetworkName)).To(Equal(&cache.PodIfaceCacheData{
 			Iface:  &vmiIface,
 			PodIP:  primaryIPv4Address,
 			PodIPs: []string{primaryIPv4Address, primaryIPv6Address},
@@ -406,7 +407,7 @@ var _ = Describe("netpod", func() {
 				}},
 			}),
 		)
-		Expect(cache.ReadPodInterfaceCache(&baseCacheCreator, vmiUID, defaultPodNetworkName)).To(Equal(&cache.PodIfaceCacheData{
+		Expect(cache.ReadPodInterfaceCache(&baseCacheCreator, podPID, defaultPodNetworkName)).To(Equal(&cache.PodIfaceCacheData{
 			Iface:  &vmiIface,
 			PodIP:  primaryIPv4Address,
 			PodIPs: []string{primaryIPv4Address},
@@ -559,7 +560,7 @@ var _ = Describe("netpod", func() {
 				}},
 			}),
 		)
-		Expect(cache.ReadPodInterfaceCache(&baseCacheCreator, vmiUID, defaultPodNetworkName)).To(Equal(&cache.PodIfaceCacheData{
+		Expect(cache.ReadPodInterfaceCache(&baseCacheCreator, podPID, defaultPodNetworkName)).To(Equal(&cache.PodIfaceCacheData{
 			Iface:  &vmiIface,
 			PodIP:  primaryIPv4Address,
 			PodIPs: []string{primaryIPv4Address},
@@ -657,7 +658,7 @@ var _ = Describe("netpod", func() {
 			}),
 		)
 		// When there are no IP/s, the pod interface data is not stored.
-		_, err := cache.ReadPodInterfaceCache(&baseCacheCreator, vmiUID, defaultPodNetworkName)
+		_, err := cache.ReadPodInterfaceCache(&baseCacheCreator, podPID, defaultPodNetworkName)
 		Expect(err).To(HaveOccurred())
 
 		Expect(cache.ReadDHCPInterfaceCache(&baseCacheCreator, "0", "eth0")).To(
@@ -890,13 +891,13 @@ var _ = Describe("netpod", func() {
 			Expect(masqstub.bridgeIfaceSpec.Name).To(Equal("k6t-eth0"))
 			Expect(masqstub.podIfaceSpec.Name).To(Equal("eth0"))
 			Expect(masqstub.vmiIfaceSpec.Name).To(Equal(defaultPodNetworkName))
-			Expect(cache.ReadPodInterfaceCache(&baseCacheCreator, vmiUID, defaultPodNetworkName)).To(Equal(&cache.PodIfaceCacheData{
+			Expect(cache.ReadPodInterfaceCache(&baseCacheCreator, podPID, defaultPodNetworkName)).To(Equal(&cache.PodIfaceCacheData{
 				Iface:  &specInterfaces[0],
 				PodIP:  primaryIPv4Address,
 				PodIPs: []string{primaryIPv4Address, primaryIPv6Address},
 			}))
 			// When there are no IP/s, the pod interface data is not stored.
-			_, err := cache.ReadPodInterfaceCache(&baseCacheCreator, vmiUID, secondaryNetworkName)
+			_, err := cache.ReadPodInterfaceCache(&baseCacheCreator, podPID, secondaryNetworkName)
 			Expect(err).To(HaveOccurred())
 		},
 			Entry("with two setup invokes", !hotplugEnabled),
@@ -1928,7 +1929,7 @@ var _ = Describe("netpod", func() {
 					}},
 				},
 			))
-			Expect(cache.ReadPodInterfaceCache(&baseCacheCreator, vmiUID, defaultPodNetworkName)).To(Equal(&cache.PodIfaceCacheData{
+			Expect(cache.ReadPodInterfaceCache(&baseCacheCreator, podPID, defaultPodNetworkName)).To(Equal(&cache.PodIfaceCacheData{
 				Iface:  &vmiIface,
 				PodIP:  primaryIPv4Address,
 				PodIPs: []string{primaryIPv4Address, primaryIPv6Address},

--- a/pkg/network/setup/netstat.go
+++ b/pkg/network/setup/netstat.go
@@ -20,9 +20,11 @@
 package network
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"net/netip"
+	"os"
 	"slices"
 	"strings"
 	"sync"
@@ -231,22 +233,45 @@ func (c *NetStat) updateIfacesStatusFromPodCache(ifacesStatus []v1.VirtualMachin
 }
 
 func (c *NetStat) getPodInterfacefromFileCache(vmi *v1.VirtualMachineInstance, ifaceName string) (*cache.PodIfaceCacheData, error) {
-	// Once the Interface files are set on the handler, they don't change
-	// If already present in the map, don't read again
-	cacheData, exists := c.podInterfaceVolatileCache.Load(vmiInterfaceKey(vmi.UID, ifaceName))
-	if exists {
-		return cacheData.(*cache.PodIfaceCacheData), nil
+	cacheKey := vmiInterfaceKey(vmi.UID, ifaceName)
+	if hit, ok := c.podInterfaceVolatileCache.Load(cacheKey); ok {
+		return hit.(*cache.PodIfaceCacheData), nil
 	}
 
-	podInterface := &cache.PodIfaceCacheData{}
-	if data, err := cache.ReadPodInterfaceCache(c.cacheCreator, string(vmi.UID), ifaceName); err == nil {
-		//FIXME error handling?
-		podInterface = data
+	var data *cache.PodIfaceCacheData
+	if pid, ok := launcherPIDsByUID.Load(string(vmi.UID)); ok {
+		entry, err := cache.NewPodInterfaceCache(c.cacheCreator, pid.(int)).IfaceEntry(ifaceName)
+		if err == nil {
+			data, err = entry.Read()
+			if err != nil && !errors.Is(err, os.ErrNotExist) {
+				return nil, fmt.Errorf("reading network state from launcher pod: %w", err)
+			}
+			if errors.Is(err, os.ErrNotExist) {
+				data = nil
+			}
+		}
 	}
 
-	c.podInterfaceVolatileCache.Store(vmiInterfaceKey(vmi.UID, ifaceName), podInterface)
+	if data == nil {
+		// Upgrade fallback: check pre-upgrade virt-handler-local path (read-only).
+		data = c.readPreUpgradeNetworkState(vmi, ifaceName)
+	}
 
-	return podInterface, nil
+	if data == nil {
+		data = &cache.PodIfaceCacheData{}
+	}
+	c.podInterfaceVolatileCache.Store(cacheKey, data)
+	return data, nil
+}
+
+// readPreUpgradeNetworkState reads from the virt-handler-local cache path used before this
+// refactor. Remove once all virt-launchers have been upgraded and restarted at least once.
+func (c *NetStat) readPreUpgradeNetworkState(vmi *v1.VirtualMachineInstance, ifaceName string) *cache.PodIfaceCacheData {
+	data, err := cache.ReadLegacyPodInterfaceCache(c.cacheCreator, string(vmi.UID), ifaceName)
+	if err != nil {
+		return nil
+	}
+	return data
 }
 
 func (c *NetStat) removeAbsentIfacesFromVolatileCache(vmi *v1.VirtualMachineInstance) {

--- a/pkg/network/setup/netstat_test.go
+++ b/pkg/network/setup/netstat_test.go
@@ -1376,16 +1376,18 @@ func newTestSetupWithVolatileCache() testSetup {
 func newTestSetup() testSetup {
 	var cacheCreator tempCacheCreator
 	const uid = "123"
+	const fakePID = 456
 	vmi := &v1.VirtualMachineInstance{}
 	vmi.UID = uid
 	dutils.MockDefaultOwnershipManager()
+	netsetup.StoreLauncherPID(uid, fakePID)
 
 	return testSetup{
 		Vmi:           vmi,
 		Domain:        &api.Domain{},
 		NetStat:       netsetup.NewNetStateWithCustomFactory(&cacheCreator),
 		cacheCreator:  &cacheCreator,
-		podIfaceCache: cache.NewPodInterfaceCache(&cacheCreator, uid),
+		podIfaceCache: cache.NewPodInterfaceCache(&cacheCreator, fakePID),
 	}
 }
 
@@ -1453,6 +1455,7 @@ func (t *testSetup) addFSCacheInterface(name string, podIPs ...string) error {
 }
 
 func (t *testSetup) Cleanup() error {
+	netsetup.DeleteLauncherPID(string(t.Vmi.UID))
 	return t.cacheCreator.New("").Delete()
 }
 


### PR DESCRIPTION
The network-info cache (PodIP, PodIPs, State) was stored on virt-handler's node-local filesystem under:
  /var/run/kubevirt-private/network-info-cache/<vmi-uid>/<iface>

This is a design problem as this case may survive the pod it represents. If the launcher pod is recreated for the same VMI (e.g. after live migration returns it to the same node), the new pod's network namespace is unconfigured, but Setup() reads State=Finished from the old on-disk entry and skips all network setup.

The fix is to store PodIfaceCacheData inside the launcher pod's private emptyDir (/var/run/kubevirt-private/network-info-cache/<iface>), which the kernel reclaims when the pod is deleted. virt-handler accesses it without a separate RPC by reading through the launcher's procfs root:
  /proc/<launcher-pid>/root/var/run/kubevirt-private/...

A gRPC call to the launcher could work but would add a new RPC method, require the launcher to be responsive at the point virt-handler reads state, and add error-handling for an otherwise-simple read. The procfs path is the same technique already used by NewDHCPInterfaceCache and avoids all of that.

The package-level launcherPIDsByUID sync.Map (populated by NetConf.Setup, read by NetStat, cleared by NetConf.Teardown) threads the launcher PID from the setup path to the status-read path without any changes outside pkg/network/.

The old UID-keyed path is preserved as the "Legacy" variant for two upgrade-safety purposes only:
  - read fallback (readPreUpgradeState / readPreUpgradeNetworkState): on first restart after upgrade, new writes go to the procfs path but old files may still exist at the UID path; we fall back there if the procfs entry is absent.
  - teardown cleanup (netconf.Teardown via NewLegacyPodInterfaceCache): removes any leftover UID-keyed directory when a VMI is torn down.

Both can be deleted in a single future commit once all launchers have been recycled at least once post-upgrade.

Assisted-By: Claude Sonnet 4.6

```release-note
NONE
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Network interface state is now associated with the launcher process, improving cache accuracy and isolation.
  - Existing network state from older versions remains available through automatic fallback during upgrades.
  - Missing cache entries are handled gracefully, allowing network setup and cleanup to continue without unnecessary errors.
  - Cache cleanup now consistently uses the appropriate launcher and legacy locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->