### PR TITLE
storage/export: move token generation out of pkg/util

### DIFF
--- a/pkg/storage/export/export/BUILD.bazel
+++ b/pkg/storage/export/export/BUILD.bazel
@@ -28,7 +28,6 @@ go_library(
         "//pkg/storage/snapshot:go_default_library",
         "//pkg/storage/types:go_default_library",
         "//pkg/storage/utils:go_default_library",
-        "//pkg/util:go_default_library",
         "//pkg/util/tls:go_default_library",
         "//pkg/virt-config:go_default_library",
         "//pkg/virt-controller/watch/util:go_default_library",

--- a/pkg/storage/export/export/export.go
+++ b/pkg/storage/export/export/export.go
@@ -22,6 +22,7 @@ package export
 import (
 	"context"
 	"crypto/ecdsa"
+	cryptorand "crypto/rand"
 	"encoding/json"
 	"fmt"
 	"path"
@@ -63,7 +64,6 @@ import (
 	"kubevirt.io/kubevirt/pkg/storage/snapshot"
 	"kubevirt.io/kubevirt/pkg/storage/types"
 	storageutils "kubevirt.io/kubevirt/pkg/storage/utils"
-	kutil "kubevirt.io/kubevirt/pkg/util"
 	kvtls "kubevirt.io/kubevirt/pkg/util/tls"
 	virtconfig "kubevirt.io/kubevirt/pkg/virt-config"
 	watchutil "kubevirt.io/kubevirt/pkg/virt-controller/watch/util"
@@ -937,10 +937,7 @@ func (ctrl *VMExportController) handleVMExportToken(vmExport *exportv1.VirtualMa
 		vmExport.Status.TokenSecretRef = &generatedSecretName
 	}
 
-	token, err := kutil.GenerateVMExportToken()
-	if err != nil {
-		return err
-	}
+	token := cryptorand.Text()
 
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -960,7 +957,7 @@ func (ctrl *VMExportController) handleVMExportToken(vmExport *exportv1.VirtualMa
 		},
 	}
 
-	secret, err = ctrl.Client.CoreV1().Secrets(vmExport.Namespace).Create(context.Background(), secret, metav1.CreateOptions{})
+	secret, err := ctrl.Client.CoreV1().Secrets(vmExport.Namespace).Create(context.Background(), secret, metav1.CreateOptions{})
 	if err != nil {
 		if errors.IsAlreadyExists(err) {
 			return nil

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1,9 +1,7 @@
 package util
 
 import (
-	"crypto/rand"
 	"fmt"
-	"math/big"
 	"path/filepath"
 	"strings"
 
@@ -145,22 +143,6 @@ func CalcExpectedMemoryDumpSize(vmi *v1.VirtualMachineInstance) *resource.Quanti
 	expectedPvcSize := resource.NewQuantity(int64(memoryDumpOverhead), vmiMemoryReq.Format)
 	expectedPvcSize.Add(*vmiMemoryReq)
 	return expectedPvcSize
-}
-
-// GenerateVMExportToken creates a cryptographically secure token for VM export
-func GenerateVMExportToken() (string, error) {
-	const alphanums = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz"
-	const tokenLen = 20
-	ret := make([]byte, tokenLen)
-	for i := range ret {
-		num, err := rand.Int(rand.Reader, big.NewInt(int64(len(alphanums))))
-		if err != nil {
-			return "", err
-		}
-		ret[i] = alphanums[num.Int64()]
-	}
-
-	return string(ret), nil
 }
 
 // GenerateKubeVirtGroupVersionKind ensures a provided object registered with KubeVirts generated schema

--- a/pkg/virtctl/vmexport/vmexport.go
+++ b/pkg/virtctl/vmexport/vmexport.go
@@ -22,6 +22,7 @@ package vmexport
 import (
 	"compress/gzip"
 	"context"
+	"crypto/rand"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
@@ -849,11 +850,8 @@ func copyFileWithProgressBar(output io.Writer, resp *http.Response, decompress b
 
 // getOrCreateTokenSecret obtains a token secret to be used along with the virtualMachineExport
 func getOrCreateTokenSecret(client kubecli.KubevirtClient, vmexport *exportv1.VirtualMachineExport) (*k8sv1.Secret, error) {
-	// Securely randomize a 20 char string to be used as a token
-	token, err := util.GenerateVMExportToken()
-	if err != nil {
-		return nil, err
-	}
+	// Securely randomize a string to be used as a token
+	token := rand.Text()
 
 	ownerRef := metav1.NewControllerRef(vmexport, schema.GroupVersionKind{
 		Group:   exportv1.SchemeGroupVersion.Group,
@@ -876,7 +874,7 @@ func getOrCreateTokenSecret(client kubecli.KubevirtClient, vmexport *exportv1.Vi
 		},
 	}
 
-	secret, err = client.CoreV1().Secrets(vmexport.Namespace).Create(context.Background(), secret, metav1.CreateOptions{})
+	secret, err := client.CoreV1().Secrets(vmexport.Namespace).Create(context.Background(), secret, metav1.CreateOptions{})
 	if err != nil && !k8serrors.IsAlreadyExists(err) {
 		return nil, err
 	}


### PR DESCRIPTION
pkg/util is a generic dumping ground; token generation is specific to VM export. I though to move it to a new pkg/storage/export/vmtoken package, but replacing it with crypto/rand's Text() is even simpler.

Assisted-By: Claude Sonnet 4.6

/kind cleanup

```release-note
NONE
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - VM export authentication tokens are now generated using cryptographically secure randomness.
  - Tokens remain 20-character alphanumeric values.

- **Bug Fixes**
  - Updated VM export workflows to use the centralized token-generation implementation, preserving existing token behavior while improving consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->