### PR TITLE
Add warning when disabling acpi on amd64 arch

### DIFF
--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter.go
@@ -132,9 +132,12 @@ func (admitter *VMICreateAdmitter) Admit(_ context.Context, ar *admissionv1.Admi
 		return webhookutils.ToAdmissionResponse(causes)
 	}
 
+	warnings := warnDeprecatedAPIs(&vmi.Spec, admitter.ClusterConfig)
+	warnings = append(warnings, warnDisabledACPIAmd64(&vmi.Spec, admitter.ClusterConfig)...)
+
 	return &admissionv1.AdmissionResponse{
 		Allowed:  true,
-		Warnings: warnDeprecatedAPIs(&vmi.Spec, admitter.ClusterConfig),
+		Warnings: warnings,
 	}
 }
 
@@ -149,6 +152,48 @@ func warnDeprecatedAPIs(spec *v1.VirtualMachineInstanceSpec, config *virtconfig.
 		}
 	}
 	return warnings
+}
+
+// warnDisabledACPIAmd64 warns when ACPI is explicitly disabled on amd64.
+// On BIOS boot guests QEMU injects the ACPI tables through fw_cfg, and since
+// SeaBIOS 1.17 the firmware no longer generates them internally. Disabling ACPI
+// therefore leaves BIOS guests without ACPI tables, so they are expected to fail
+// to boot or to shut down gracefully. UEFI boot is not affected as the ACPI
+// tables are provided in a different way (and SeaBIOS is not used).
+func warnDisabledACPIAmd64(spec *v1.VirtualMachineInstanceSpec, config *virtconfig.ClusterConfig) []string {
+	// The architecture is normally defaulted by the mutating webhook, but fall
+	// back to the cluster default to stay defensive if it is still unset here.
+	arch := spec.Architecture
+	if arch == "" {
+		arch = config.GetDefaultArchitecture()
+	}
+	if arch != "amd64" {
+		return nil
+	}
+
+	features := spec.Domain.Features
+	if features == nil || features.ACPI.Enabled == nil || *features.ACPI.Enabled {
+		return nil
+	}
+
+	// UEFI boot is not affected: the ACPI tables are provided in a different way
+	// and SeaBIOS is not used. Only warn for BIOS boot guests.
+	if isBootloaderEFI(spec) {
+		return nil
+	}
+
+	return []string{
+		"Explicitly disabling ACPI (spec.domain.features.acpi.enabled=false) on amd64 is not recommended: " +
+			"BIOS boot guests rely on QEMU injecting the ACPI tables and are expected to fail to boot " +
+			"or to shut down gracefully without them (UEFI boot is not affected).",
+	}
+}
+
+// isBootloaderEFI reports whether the guest is configured to boot with UEFI.
+func isBootloaderEFI(spec *v1.VirtualMachineInstanceSpec) bool {
+	return spec.Domain.Firmware != nil &&
+		spec.Domain.Firmware.Bootloader != nil &&
+		spec.Domain.Firmware.Bootloader.EFI != nil
 }
 
 func ValidateVirtualMachineInstancePerArch(field *k8sfield.Path, spec *v1.VirtualMachineInstanceSpec) []metav1.StatusCause {

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vmi-create-admitter_test.go
@@ -1170,6 +1170,68 @@ var _ = Describe("Validating VMICreate Admitter", func() {
 			Expect(resp.Warnings).To(HaveLen(1))
 		})
 
+		DescribeTable("should warn about explicitly disabling ACPI on amd64", func(arch string, acpiEnabled *bool, expectWarning bool) {
+			vmi.Spec.Architecture = arch
+			vmi.Spec.Domain.Features = &v1.Features{ACPI: v1.FeatureState{Enabled: acpiEnabled}}
+
+			ar, err := newAdmissionReviewForVMICreation(vmi)
+			Expect(err).NotTo(HaveOccurred())
+
+			resp := vmiCreateAdmitter.Admit(context.Background(), ar)
+			Expect(resp.Allowed).To(BeTrue())
+			if expectWarning {
+				Expect(resp.Warnings).To(ContainElement(ContainSubstring("disabling ACPI")))
+			} else {
+				Expect(resp.Warnings).NotTo(ContainElement(ContainSubstring("disabling ACPI")))
+			}
+		},
+			Entry("amd64 with ACPI explicitly disabled", "amd64", new(false), true),
+			Entry("amd64 with ACPI explicitly enabled", "amd64", new(true), false),
+			Entry("amd64 with ACPI unset (defaults enabled)", "amd64", nil, false),
+			Entry("arm64 with ACPI explicitly disabled", "arm64", new(false), false),
+		)
+
+		DescribeTable("should only warn about disabling ACPI on amd64 for BIOS boot guests", func(firmware *v1.Firmware, expectWarning bool) {
+			spec := &v1.VirtualMachineInstanceSpec{
+				Architecture: "amd64",
+				Domain: v1.DomainSpec{
+					Features: &v1.Features{ACPI: v1.FeatureState{Enabled: new(false)}},
+					Firmware: firmware,
+				},
+			}
+
+			warnings := warnDisabledACPIAmd64(spec, config)
+			if expectWarning {
+				Expect(warnings).To(ContainElement(ContainSubstring("disabling ACPI")))
+			} else {
+				Expect(warnings).To(BeEmpty())
+			}
+		},
+			Entry("EFI boot", &v1.Firmware{Bootloader: &v1.Bootloader{EFI: &v1.EFI{}}}, false),
+			Entry("explicit BIOS boot", &v1.Firmware{Bootloader: &v1.Bootloader{BIOS: &v1.BIOS{}}}, true),
+			Entry("empty bootloader (defaults to BIOS)", &v1.Firmware{Bootloader: &v1.Bootloader{}}, true),
+			Entry("firmware unset (defaults to BIOS)", nil, true),
+		)
+
+		DescribeTable("should fall back to the cluster default architecture when spec.architecture is unset", func(defaultArch string, expectWarning bool) {
+			spec := &v1.VirtualMachineInstanceSpec{
+				Domain: v1.DomainSpec{
+					Features: &v1.Features{ACPI: v1.FeatureState{Enabled: new(false)}},
+				},
+			}
+			updateDefaultArchitecture(defaultArch)
+
+			warnings := warnDisabledACPIAmd64(spec, config)
+			if expectWarning {
+				Expect(warnings).To(ContainElement(ContainSubstring("disabling ACPI")))
+			} else {
+				Expect(warnings).To(BeEmpty())
+			}
+		},
+			Entry("cluster default amd64", "amd64", true),
+			Entry("cluster default arm64", "arm64", false),
+		)
+
 		It("should allow BlockMultiQueue with CPU settings", func() {
 			vmi := api.NewMinimalVMI("testvm")
 			vmi.Spec.Domain.Devices.BlockMultiQueue = pointer.P(true)

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter.go
@@ -173,6 +173,7 @@ func (admitter *VMsAdmitter) Admit(ctx context.Context, ar *admissionv1.Admissio
 	}
 
 	warnings := warnDeprecatedAPIs(&vm.Spec.Template.Spec, admitter.ClusterConfig)
+	warnings = append(warnings, warnDisabledACPIAmd64(&vmCopy.Spec.Template.Spec, admitter.ClusterConfig)...)
 	if vm.Spec.Running != nil {
 		warnings = append(warnings, "spec.running is deprecated, please use spec.runStrategy instead.")
 	}

--- a/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter_test.go
+++ b/pkg/virt-api/webhooks/validating-webhook/admitters/vms-admitter_test.go
@@ -1591,6 +1591,48 @@ var _ = Describe("Validating VM Admitter", func() {
 			HavePrefix("spec.running is deprecated, please use spec.runStrategy instead.")))
 	})
 
+	DescribeTable("should warn about disabling ACPI on amd64 through the VM admitter", func(spec v1.VirtualMachineInstanceSpec, expectWarning bool) {
+		vm := &v1.VirtualMachine{
+			Spec: v1.VirtualMachineSpec{
+				RunStrategy: pointer.P(v1.RunStrategyHalted),
+				Template: &v1.VirtualMachineInstanceTemplateSpec{
+					Spec: spec,
+				},
+			},
+		}
+
+		resp := admitVm(vmsAdmitter, vm)
+		Expect(resp.Allowed).To(BeTrue())
+		if expectWarning {
+			Expect(resp.Warnings).To(ContainElement(ContainSubstring("disabling ACPI")))
+		} else {
+			Expect(resp.Warnings).NotTo(ContainElement(ContainSubstring("disabling ACPI")))
+		}
+	},
+		Entry("amd64 with ACPI explicitly disabled on BIOS boot", v1.VirtualMachineInstanceSpec{
+			Architecture: "amd64",
+			Domain:       v1.DomainSpec{Features: &v1.Features{ACPI: v1.FeatureState{Enabled: new(false)}}},
+		}, true),
+		Entry("amd64 with ACPI explicitly enabled", v1.VirtualMachineInstanceSpec{
+			Architecture: "amd64",
+			Domain:       v1.DomainSpec{Features: &v1.Features{ACPI: v1.FeatureState{Enabled: new(true)}}},
+		}, false),
+		Entry("amd64 with ACPI unset (defaults enabled)", v1.VirtualMachineInstanceSpec{
+			Architecture: "amd64",
+		}, false),
+		Entry("amd64 with ACPI explicitly disabled on EFI boot", v1.VirtualMachineInstanceSpec{
+			Architecture: "amd64",
+			Domain: v1.DomainSpec{
+				Features: &v1.Features{ACPI: v1.FeatureState{Enabled: new(false)}},
+				Firmware: &v1.Firmware{Bootloader: &v1.Bootloader{EFI: &v1.EFI{SecureBoot: pointer.P(false)}}},
+			},
+		}, false),
+		Entry("arm64 with ACPI explicitly disabled", v1.VirtualMachineInstanceSpec{
+			Architecture: "arm64",
+			Domain:       v1.DomainSpec{Features: &v1.Features{ACPI: v1.FeatureState{Enabled: new(false)}}},
+		}, false),
+	)
+
 	It("should reject request when Discontinued feature is used", func() {
 		const fgName = "test-discontinued"
 		const fgMessage = "FG is discontinued"

--- a/tests/vmi_lifecycle_test.go
+++ b/tests/vmi_lifecycle_test.go
@@ -50,7 +50,6 @@ import (
 	"kubevirt.io/kubevirt/pkg/controller"
 	"kubevirt.io/kubevirt/pkg/hypervisor"
 	"kubevirt.io/kubevirt/pkg/libvmi"
-	"kubevirt.io/kubevirt/pkg/pointer"
 	"kubevirt.io/kubevirt/pkg/virt-controller/services"
 	device_manager "kubevirt.io/kubevirt/pkg/virt-handler/device-manager"
 	"kubevirt.io/kubevirt/tests/console"
@@ -1165,19 +1164,6 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 	Describe("Softreboot a VirtualMachineInstance", decorators.ACPI, func() {
 		const vmiLaunchTimeout = 360
 
-		It("soft reboot vmi with agent connected should succeed", decorators.Conformance, decorators.WgS390x, func() {
-			vmi := libvmops.RunVMIAndExpectLaunch(libvmifact.NewFedora(withoutACPI()), vmiLaunchTimeout)
-
-			Eventually(matcher.ThisVMI(vmi), 12*time.Minute, 2*time.Second).Should(matcher.HaveConditionTrue(v1.VirtualMachineInstanceAgentConnected))
-			bootID, err := readBootID(vmi, console.LoginToFedora)
-			Expect(err).ToNot(HaveOccurred())
-
-			err = kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).SoftReboot(context.Background(), vmi.Name)
-			Expect(err).ToNot(HaveOccurred())
-
-			waitForBootIDChange(vmi, console.LoginToFedora, bootID)
-		})
-
 		It("soft reboot vmi with ACPI feature enabled should succeed", decorators.Conformance, func() {
 			vmi := libvmops.RunVMIAndExpectLaunch(libvmifact.NewFedora(), vmiLaunchTimeout)
 			Expect(console.LoginToFedora(vmi)).To(Succeed())
@@ -1195,16 +1181,6 @@ var _ = Describe("[rfe_id:273][crit:high][vendor:cnv-qe@redhat.com][level:compon
 
 			By("Waiting for VMI to reboot")
 			waitForBootIDChange(vmi, console.LoginToFedora, bootID)
-		})
-
-		It("soft reboot vmi neither have the agent connected nor the ACPI feature enabled should fail", decorators.WgS390x, decorators.Conformance, func() {
-			vmi := libvmops.RunVMIAndExpectLaunch(libvmifact.NewAlpine(withoutACPI()), vmiLaunchTimeout)
-
-			Expect(console.LoginToAlpine(vmi)).To(Succeed())
-			Eventually(matcher.ThisVMI(vmi), 30*time.Second, 2*time.Second).Should(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineInstanceAgentConnected))
-
-			err := kubevirt.Client().VirtualMachineInstance(testsuite.GetTestNamespace(vmi)).SoftReboot(context.Background(), vmi.Name)
-			Expect(err).To(MatchError(ContainSubstring("VMI neither have the agent connected nor the ACPI feature enabled")))
 		})
 
 		It("soft reboot vmi should fail to soft reboot a paused vmi", decorators.WgS390x, func() {
@@ -1558,12 +1534,4 @@ func waitForBootIDChange(vmi *v1.VirtualMachineInstance, login console.LoginToFu
 		}
 		return newBootID
 	}, 300*time.Second, 5*time.Second).ShouldNot(Equal(preRebootBootID), "expected guest to reboot (boot_id change)")
-}
-
-func withoutACPI() libvmi.Option {
-	return func(vmi *v1.VirtualMachineInstance) {
-		vmi.Spec.Domain.Features = &v1.Features{
-			ACPI: v1.FeatureState{Enabled: pointer.P(false)},
-		}
-	}
 }


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
SeaBIOS 1.17.0 removed the internal ACPI table generator.
When ACPI is disabled at the KubeVirt/QEMU layer
(spec.domain.features.acpi.enabled: false) on a BIOS/SeaBIOS guest:

1. QEMU does not pass ACPI tables via fw_cfg.
2. SeaBIOS 1.17.0 no longer generates fallback tables internally.
3. The guest cannot discover CPU topology, PCI interrupt routing,
or platform timers, and fails to initialize hardware / panics during
kernel boot.

Warn the usage of disabling acpi on amd64 arch.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #https://github.com/kubevirt/kubevirt/issues/18878
-->
- Partially addresses #https://github.com/kubevirt/kubevirt/issues/18878
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Add a warning when disabling acpi on amd64 architectures
```

