### PR TITLE
vm: Ignore defaulted maxGuest and cpu.model

### DIFF
--- a/pkg/virt-controller/watch/vm/vm.go
+++ b/pkg/virt-controller/watch/vm/vm.go
@@ -3055,6 +3055,30 @@ func (c *Controller) syncRestartRequired(lastSeenVMSpec *virtv1.VirtualMachineSp
 		lastSeenVM.Spec.Template.Spec.Domain.Firmware.UUID = currentVM.Spec.Template.Spec.Domain.Firmware.UUID
 	}
 
+	// Neutralize memory.maxGuest if the VMI already has the same value.
+	// This happens when the defaulter writes maxGuest onto the VMI and that
+	// value is later persisted on the VM template.
+	if vmi != nil && vmi.Spec.Domain.Memory != nil && vmi.Spec.Domain.Memory.MaxGuest != nil &&
+		currentVM.Spec.Template.Spec.Domain.Memory != nil && currentVM.Spec.Template.Spec.Domain.Memory.MaxGuest != nil &&
+		vmi.Spec.Domain.Memory.MaxGuest.Equal(*currentVM.Spec.Template.Spec.Domain.Memory.MaxGuest) {
+		if lastSeenVM.Spec.Template.Spec.Domain.Memory == nil {
+			lastSeenVM.Spec.Template.Spec.Domain.Memory = &virtv1.Memory{}
+		}
+		lastSeenVM.Spec.Template.Spec.Domain.Memory.MaxGuest = currentVM.Spec.Template.Spec.Domain.Memory.MaxGuest
+	}
+
+	// Neutralize cpu.model if the VMI already has the same value.
+	// This happens when the defaulter writes host-model onto the VMI and that
+	// value is later persisted on the VM template.
+	if vmi != nil && vmi.Spec.Domain.CPU != nil && vmi.Spec.Domain.CPU.Model != "" &&
+		currentVM.Spec.Template.Spec.Domain.CPU != nil && currentVM.Spec.Template.Spec.Domain.CPU.Model != "" &&
+		vmi.Spec.Domain.CPU.Model == currentVM.Spec.Template.Spec.Domain.CPU.Model {
+		if lastSeenVM.Spec.Template.Spec.Domain.CPU == nil {
+			lastSeenVM.Spec.Template.Spec.Domain.CPU = &virtv1.CPU{}
+		}
+		lastSeenVM.Spec.Template.Spec.Domain.CPU.Model = currentVM.Spec.Template.Spec.Domain.CPU.Model
+	}
+
 	if !equality.Semantic.DeepEqual(lastSeenVM.Spec.Template.Spec, currentVM.Spec.Template.Spec) {
 		setRestartRequired(vm, "a non-live-updatable field was changed in the template spec")
 		return true

--- a/pkg/virt-controller/watch/vm/vm.go
+++ b/pkg/virt-controller/watch/vm/vm.go
@@ -3068,8 +3068,8 @@ func (c *Controller) syncRestartRequired(lastSeenVMSpec *virtv1.VirtualMachineSp
 	}
 
 	// Neutralize cpu.model if the VMI already has the same value.
-	// This happens when the defaulter writes host-model onto the VMI and that
-	// value is later persisted on the VM template.
+	// This happens when the defaulter writes a CPU model (often host-model)
+	// onto the VMI and that value is later persisted on the VM template.
 	if vmi != nil && vmi.Spec.Domain.CPU != nil && vmi.Spec.Domain.CPU.Model != "" &&
 		currentVM.Spec.Template.Spec.Domain.CPU != nil && currentVM.Spec.Template.Spec.Domain.CPU.Model != "" &&
 		vmi.Spec.Domain.CPU.Model == currentVM.Spec.Template.Spec.Domain.CPU.Model {
@@ -3086,7 +3086,7 @@ func (c *Controller) syncRestartRequired(lastSeenVMSpec *virtv1.VirtualMachineSp
 
 	// If no restart is needed, remove any existing RestartRequired condition.
 	// This handles cases where a previous condition was set but is no longer valid,
-	// such as when the firmware UUID synchronizer persisted a UUID that matches the VMI's UUID.
+	// such as firmware UUID persistence or KubeVirt-defaulted maxGuest/cpu.model.
 	vmConditionManager := controller.NewVirtualMachineConditionManager()
 	if vmConditionManager.HasCondition(vm, virtv1.VirtualMachineRestartRequired) {
 		vmConditionManager.RemoveCondition(vm, virtv1.VirtualMachineRestartRequired)

--- a/pkg/virt-controller/watch/vm/vm_test.go
+++ b/pkg/virt-controller/watch/vm/vm_test.go
@@ -6863,6 +6863,119 @@ var _ = Describe("VirtualMachine", func() {
 				Entry("should raise RestartRequired when VM and VMI UUIDs differ", types.UID("different-uuid-than-vmi"), matcher.HaveConditionTrue(v1.VirtualMachineRestartRequired)),
 			)
 
+			DescribeTable("RestartRequired condition based on VM and VMI maxGuest comparison", func(vmMaxGuest, vmiMaxGuest resource.Quantity, expected gomegatypes.GomegaMatcher) {
+				testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kv)
+
+				By("Creating a VM without maxGuest")
+				controller.crIndexer.Add(createVMRevision(vm))
+
+				By("Creating a VMI with the given maxGuest")
+				vmi = SetupVMIFromVM(vm)
+				vmi.Spec.Domain.Memory.MaxGuest = pointer.P(vmiMaxGuest)
+				controller.vmiIndexer.Add(vmi)
+
+				By("Setting maxGuest on the VM spec")
+				vm.Spec.Template.Spec.Domain.Memory.MaxGuest = pointer.P(vmMaxGuest)
+				createdVM, err := virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Create(context.TODO(), vm, metav1.CreateOptions{})
+				Expect(err).To(Succeed())
+				addVirtualMachine(createdVM)
+
+				By("Executing the controller")
+				sanityExecute(createdVM)
+				createdVM, err = virtFakeClient.KubevirtV1().VirtualMachines(createdVM.Namespace).Get(context.TODO(), createdVM.Name, metav1.GetOptions{})
+				Expect(err).To(Succeed())
+				Expect(createdVM).To(expected)
+			},
+				Entry("should not raise RestartRequired when VM and VMI maxGuest match", resource.MustParse("8Gi"), resource.MustParse("8Gi"), matcher.HaveConditionMissingOrFalse(v1.VirtualMachineRestartRequired)),
+				Entry("should raise RestartRequired when VM and VMI maxGuest differ", resource.MustParse("16Gi"), resource.MustParse("8Gi"), matcher.HaveConditionTrue(v1.VirtualMachineRestartRequired)),
+			)
+
+			DescribeTable("RestartRequired condition based on VM and VMI cpu.model comparison", func(vmModel, vmiModel string, expected gomegatypes.GomegaMatcher) {
+				testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kv)
+
+				By("Creating a VM without cpu.model")
+				controller.crIndexer.Add(createVMRevision(vm))
+
+				By("Creating a VMI with the given cpu.model")
+				vmi = SetupVMIFromVM(vm)
+				vmi.Spec.Domain.CPU.Model = vmiModel
+				controller.vmiIndexer.Add(vmi)
+
+				By("Setting cpu.model on the VM spec")
+				vm.Spec.Template.Spec.Domain.CPU.Model = vmModel
+				createdVM, err := virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Create(context.TODO(), vm, metav1.CreateOptions{})
+				Expect(err).To(Succeed())
+				addVirtualMachine(createdVM)
+
+				By("Executing the controller")
+				sanityExecute(createdVM)
+				createdVM, err = virtFakeClient.KubevirtV1().VirtualMachines(createdVM.Namespace).Get(context.TODO(), createdVM.Name, metav1.GetOptions{})
+				Expect(err).To(Succeed())
+				Expect(createdVM).To(expected)
+			},
+				Entry("should not raise RestartRequired when VM and VMI cpu.model match", v1.DefaultCPUModel, v1.DefaultCPUModel, matcher.HaveConditionMissingOrFalse(v1.VirtualMachineRestartRequired)),
+				Entry("should raise RestartRequired when VM and VMI cpu.model differ", "EPYC", v1.DefaultCPUModel, matcher.HaveConditionTrue(v1.VirtualMachineRestartRequired)),
+			)
+
+			It("should clear existing RestartRequired when only defaulted maxGuest and cpu.model differ", func() {
+				testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kv)
+
+				By("Creating a VM with an existing RestartRequired condition and no defaulted fields")
+				vm.Status.Conditions = append(vm.Status.Conditions, v1.VirtualMachineCondition{
+					Type:   v1.VirtualMachineRestartRequired,
+					Status: k8sv1.ConditionTrue,
+				})
+				controller.crIndexer.Add(createVMRevision(vm))
+
+				By("Creating a VMI with KubeVirt-defaulted maxGuest and cpu.model")
+				vmi = SetupVMIFromVM(vm)
+				maxGuest := resource.MustParse("8Gi")
+				vmi.Spec.Domain.Memory.MaxGuest = pointer.P(maxGuest)
+				vmi.Spec.Domain.CPU.Model = v1.DefaultCPUModel
+				controller.vmiIndexer.Add(vmi)
+
+				By("Persisting those same defaults on the current VM spec")
+				vm.Spec.Template.Spec.Domain.Memory.MaxGuest = pointer.P(maxGuest)
+				vm.Spec.Template.Spec.Domain.CPU.Model = v1.DefaultCPUModel
+				createdVM, err := virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Create(context.TODO(), vm, metav1.CreateOptions{})
+				Expect(err).To(Succeed())
+				addVirtualMachine(createdVM)
+
+				By("Executing the controller")
+				sanityExecute(createdVM)
+				createdVM, err = virtFakeClient.KubevirtV1().VirtualMachines(createdVM.Namespace).Get(context.TODO(), createdVM.Name, metav1.GetOptions{})
+				Expect(err).To(Succeed())
+
+				By("Verifying the RestartRequired condition was removed")
+				Expect(createdVM).To(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineRestartRequired))
+			})
+
+			It("should still raise RestartRequired when maxGuest matches but cpu.cores differ", func() {
+				testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kv)
+
+				By("Creating a VM with 2 cores and no maxGuest")
+				controller.crIndexer.Add(createVMRevision(vm))
+
+				By("Creating a VMI with 2 cores and defaulted maxGuest")
+				vmi = SetupVMIFromVM(vm)
+				maxGuest := resource.MustParse("8Gi")
+				vmi.Spec.Domain.Memory.MaxGuest = pointer.P(maxGuest)
+				controller.vmiIndexer.Add(vmi)
+
+				By("Persisting matching maxGuest but changing cpu.cores to 4")
+				vm.Spec.Template.Spec.Domain.Memory.MaxGuest = pointer.P(maxGuest)
+				vm.Spec.Template.Spec.Domain.CPU.Cores = 4
+				createdVM, err := virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Create(context.TODO(), vm, metav1.CreateOptions{})
+				Expect(err).To(Succeed())
+				addVirtualMachine(createdVM)
+
+				By("Executing the controller expecting RestartRequired for the cores change")
+				sanityExecute(createdVM)
+				createdVM, err = virtFakeClient.KubevirtV1().VirtualMachines(createdVM.Namespace).Get(context.TODO(), createdVM.Name, metav1.GetOptions{})
+				Expect(err).To(Succeed())
+				Expect(createdVM).To(matcher.HaveConditionTrue(v1.VirtualMachineRestartRequired))
+			})
+
 			It("should clear existing RestartRequired condition when VM and VMI specs match", func() {
 				By("Creating a VM with an existing RestartRequired condition")
 				vm.Status.Conditions = append(vm.Status.Conditions, v1.VirtualMachineCondition{

--- a/pkg/virt-controller/watch/vm/vm_test.go
+++ b/pkg/virt-controller/watch/vm/vm_test.go
@@ -6867,6 +6867,7 @@ var _ = Describe("VirtualMachine", func() {
 				testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kv)
 
 				By("Creating a VM without maxGuest")
+				Expect(vm.Spec.Template.Spec.Domain.Memory.MaxGuest).To(BeNil())
 				controller.crIndexer.Add(createVMRevision(vm))
 
 				By("Creating a VMI with the given maxGuest")
@@ -6887,6 +6888,7 @@ var _ = Describe("VirtualMachine", func() {
 				Expect(createdVM).To(expected)
 			},
 				Entry("should not raise RestartRequired when VM and VMI maxGuest match", resource.MustParse("8Gi"), resource.MustParse("8Gi"), matcher.HaveConditionMissingOrFalse(v1.VirtualMachineRestartRequired)),
+				Entry("should not raise RestartRequired when VM and VMI maxGuest match canonical quantities", resource.MustParse("8Gi"), resource.MustParse("8192Mi"), matcher.HaveConditionMissingOrFalse(v1.VirtualMachineRestartRequired)),
 				Entry("should raise RestartRequired when VM and VMI maxGuest differ", resource.MustParse("16Gi"), resource.MustParse("8Gi"), matcher.HaveConditionTrue(v1.VirtualMachineRestartRequired)),
 			)
 
@@ -6894,6 +6896,7 @@ var _ = Describe("VirtualMachine", func() {
 				testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kv)
 
 				By("Creating a VM without cpu.model")
+				Expect(vm.Spec.Template.Spec.Domain.CPU.Model).To(BeEmpty())
 				controller.crIndexer.Add(createVMRevision(vm))
 
 				By("Creating a VMI with the given cpu.model")
@@ -6956,14 +6959,16 @@ var _ = Describe("VirtualMachine", func() {
 				By("Creating a VM with 2 cores and no maxGuest")
 				controller.crIndexer.Add(createVMRevision(vm))
 
-				By("Creating a VMI with 2 cores and defaulted maxGuest")
+				By("Creating a VMI with 2 cores, defaulted maxGuest, and defaulted cpu.model")
 				vmi = SetupVMIFromVM(vm)
 				maxGuest := resource.MustParse("8Gi")
 				vmi.Spec.Domain.Memory.MaxGuest = pointer.P(maxGuest)
+				vmi.Spec.Domain.CPU.Model = v1.DefaultCPUModel
 				controller.vmiIndexer.Add(vmi)
 
-				By("Persisting matching maxGuest but changing cpu.cores to 4")
+				By("Persisting matching defaults but changing cpu.cores to 4")
 				vm.Spec.Template.Spec.Domain.Memory.MaxGuest = pointer.P(maxGuest)
+				vm.Spec.Template.Spec.Domain.CPU.Model = v1.DefaultCPUModel
 				vm.Spec.Template.Spec.Domain.CPU.Cores = 4
 				createdVM, err := virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Create(context.TODO(), vm, metav1.CreateOptions{})
 				Expect(err).To(Succeed())
@@ -6974,6 +6979,64 @@ var _ = Describe("VirtualMachine", func() {
 				createdVM, err = virtFakeClient.KubevirtV1().VirtualMachines(createdVM.Namespace).Get(context.TODO(), createdVM.Name, metav1.GetOptions{})
 				Expect(err).To(Succeed())
 				Expect(createdVM).To(matcher.HaveConditionTrue(v1.VirtualMachineRestartRequired))
+			})
+
+			It("should not raise RestartRequired when lastSeen Memory is nil and maxGuest matches VMI", func() {
+				testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kv)
+
+				By("Creating a VM with no Memory object")
+				vm.Spec.Template.Spec.Domain.Memory = nil
+				controller.crIndexer.Add(createVMRevision(vm))
+
+				By("Creating a VMI with guest memory and defaulted maxGuest")
+				vmi = SetupVMIFromVM(vm)
+				guest := resource.MustParse("128Mi")
+				maxGuest := resource.MustParse("8Gi")
+				vmi.Spec.Domain.Memory = &v1.Memory{
+					Guest:    pointer.P(guest),
+					MaxGuest: pointer.P(maxGuest),
+				}
+				controller.vmiIndexer.Add(vmi)
+
+				By("Persisting matching Memory on the current VM spec")
+				vm.Spec.Template.Spec.Domain.Memory = &v1.Memory{
+					Guest:    pointer.P(guest),
+					MaxGuest: pointer.P(maxGuest),
+				}
+				createdVM, err := virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Create(context.TODO(), vm, metav1.CreateOptions{})
+				Expect(err).To(Succeed())
+				addVirtualMachine(createdVM)
+
+				By("Executing the controller")
+				sanityExecute(createdVM)
+				createdVM, err = virtFakeClient.KubevirtV1().VirtualMachines(createdVM.Namespace).Get(context.TODO(), createdVM.Name, metav1.GetOptions{})
+				Expect(err).To(Succeed())
+				Expect(createdVM).To(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineRestartRequired))
+			})
+
+			It("should not raise RestartRequired when lastSeen CPU is nil and cpu.model matches VMI", func() {
+				testutils.UpdateFakeKubeVirtClusterConfig(kvStore, kv)
+
+				By("Creating a VM with no CPU object")
+				vm.Spec.Template.Spec.Domain.CPU = nil
+				controller.crIndexer.Add(createVMRevision(vm))
+
+				By("Creating a VMI with defaulted cpu.model")
+				vmi = SetupVMIFromVM(vm)
+				vmi.Spec.Domain.CPU = &v1.CPU{Model: v1.DefaultCPUModel}
+				controller.vmiIndexer.Add(vmi)
+
+				By("Persisting matching cpu.model on the current VM spec")
+				vm.Spec.Template.Spec.Domain.CPU = &v1.CPU{Model: v1.DefaultCPUModel}
+				createdVM, err := virtFakeClient.KubevirtV1().VirtualMachines(vm.Namespace).Create(context.TODO(), vm, metav1.CreateOptions{})
+				Expect(err).To(Succeed())
+				addVirtualMachine(createdVM)
+
+				By("Executing the controller")
+				sanityExecute(createdVM)
+				createdVM, err = virtFakeClient.KubevirtV1().VirtualMachines(createdVM.Namespace).Get(context.TODO(), createdVM.Name, metav1.GetOptions{})
+				Expect(err).To(Succeed())
+				Expect(createdVM).To(matcher.HaveConditionMissingOrFalse(v1.VirtualMachineRestartRequired))
 			})
 
 			It("should clear existing RestartRequired condition when VM and VMI specs match", func() {


### PR DESCRIPTION
### What this PR does
#### Before this PR:
KubeVirt defaults `memory.maxGuest` and `cpu.model` (`host-model`) onto the VMI. If those same values later appear on the VM template, `syncRestartRequired()` treated that as a user change to a non-live-updatable field. `RestartRequired` stayed True, live migration did not clear it, and hotplug stayed blocked.

#### After this PR:
`syncRestartRequired()` ignores `memory.maxGuest` and `cpu.model` when the running VMI already has the same values, using the same neutralization pattern as firmware UUID. Unrelated spec changes (for example `cpu.cores`) still set `RestartRequired`. A stale condition is cleared when those defaults were the only remaining diff.

### References
- Fixes #17610

### Why we need it and why it was done in this way
The following tradeoffs were made:
Neutralize in the restart-required compare instead of writing defaults back onto the VirtualMachine spec. Back-propagation would mutate user YAML and fight GitOps/Harvester reconcilers.

The following alternatives were considered:
- Persist defaulted fields onto the VM template (rejected: mutates user intent, overwritten by provisioners).
- Clear `RestartRequired` on live migration (rejected: incomplete; the next sync would set it again).

Links to places where the discussion took place: https://github.com/kubevirt/kubevirt/issues/17610

### Special notes for your reviewer
Unit tests cover match, mismatch, stale-condition clear, and partial neutralization (`maxGuest` matches but `cpu.cores` differs).

### Checklist
- [x] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
Fix RestartRequired staying set when only KubeVirt-defaulted memory.maxGuest or cpu.model differ from the VM template.
```

## Test plan
- [ ] `go test ./pkg/virt-controller/watch/vm/` — maxGuest match/mismatch, cpu.model match/mismatch, stale clear, cores still require restart
- [ ] Create a VM with only `memory.guest` and `cpu.cores`; persist matching defaulted `maxGuest`/`cpu.model` on the template; confirm `RestartRequired` is not set
- [ ] Change `cpu.cores` on a running VM and confirm `RestartRequired` is still set

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved restart detection for virtual machines when defaulted memory or CPU model values match the current configuration.
  * Prevented unnecessary restart-required notifications when only defaulted values differ.
  * Continued to require a restart when CPU core settings differ.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->