### PR TITLE
pkg, net, admitter: Use 'libvmi' directly in admitter tests

### DIFF
--- a/pkg/network/admitter/admit_test.go
+++ b/pkg/network/admitter/admit_test.go
@@ -36,18 +36,15 @@ import (
 
 var _ = Describe("Validating VMI network spec", func() {
 	DescribeTable("network interface state valid value", func(value v1.InterfaceState) {
-		vm := libvmi.New(
-			libvmi.WithInterface(v1.Interface{
-				Name:                   "foo",
-				State:                  value,
-				InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}},
-			}),
-			libvmi.WithNetwork(&v1.Network{
-				Name:          "foo",
-				NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{NetworkName: "net"}},
-			}),
+		vmi := libvmi.New(
+			libvmi.WithInterface(libvmi.NewInterface(
+				"foo",
+				libvmi.WithBridgeBinding(),
+				libvmi.WithState(value))),
+			libvmi.WithNetwork(libvmi.MultusNetwork("foo", "net")),
 		)
-		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vm.Spec, stubClusterConfigChecker{})
+
+		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vmi.Spec, stubClusterConfigChecker{})
 		Expect(validator.Validate()).To(BeEmpty())
 	},
 		Entry("is empty", v1.InterfaceState("")),
@@ -58,14 +55,14 @@ var _ = Describe("Validating VMI network spec", func() {
 
 	It("network interface state value is invalid", func() {
 		vm := libvmi.New(
+			libvmi.WithInterface(libvmi.NewInterface(
+				"foo",
+				libvmi.WithMasqueradeBinding(),
+				libvmi.WithState("foo"),
+			)),
 			libvmi.WithNetwork(&v1.Network{
 				Name:          "foo",
 				NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}},
-			}),
-			libvmi.WithInterface(v1.Interface{
-				Name:                   "foo",
-				State:                  v1.InterfaceState("foo"),
-				InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}},
 			}),
 		)
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vm.Spec, stubClusterConfigChecker{})
@@ -78,18 +75,15 @@ var _ = Describe("Validating VMI network spec", func() {
 	})
 
 	DescribeTable("network interface state ", func(state v1.InterfaceState, messageRegex types.GomegaMatcher) {
-		vm := libvmi.New(
-			libvmi.WithInterface(v1.Interface{
-				Name:                   "foo",
-				State:                  state,
-				InterfaceBindingMethod: v1.InterfaceBindingMethod{SRIOV: &v1.InterfaceSRIOV{}},
-			}),
-			libvmi.WithNetwork(&v1.Network{
-				Name:          "foo",
-				NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{NetworkName: "net"}},
-			}),
+		vmi := libvmi.New(
+			libvmi.WithInterface(libvmi.NewInterface(
+				"foo",
+				libvmi.WithSRIOVBinding(),
+				libvmi.WithState(state),
+			)),
+			libvmi.WithNetwork(libvmi.MultusNetwork("foo", "net")),
 		)
-		statusCause := admitter.NewValidator(k8sfield.NewPath("fake"), &vm.Spec, stubClusterConfigChecker{}).Validate()
+		statusCause := admitter.NewValidator(k8sfield.NewPath("fake"), &vmi.Spec, stubClusterConfigChecker{}).Validate()
 		Expect(statusCause).To(HaveLen(1))
 		Expect(statusCause[0]).To(MatchAllFields(Fields{
 			"Type":    Equal(metav1.CauseType("FieldValueInvalid")),
@@ -103,20 +97,20 @@ var _ = Describe("Validating VMI network spec", func() {
 	)
 
 	It("network interface state value of absent is not supported on the default network", func() {
-		vm := libvmi.New(
+		vmi := libvmi.New(
+			libvmi.WithInterface(libvmi.NewInterface(
+				"foo",
+				libvmi.WithBridgeBinding(),
+				libvmi.WithState(v1.InterfaceStateAbsent),
+			)),
 			libvmi.WithNetwork(&v1.Network{
 				Name:          "foo",
 				NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}},
 			}),
-			libvmi.WithInterface(v1.Interface{
-				Name:                   "foo",
-				State:                  v1.InterfaceStateAbsent,
-				InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}},
-			}),
 		)
 		clusterConfig := stubClusterConfigChecker{bridgeBindingOnPodNetEnabled: true}
 
-		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vm.Spec, clusterConfig)
+		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vmi.Spec, clusterConfig)
 		Expect(validator.Validate()).To(
 			ConsistOf(metav1.StatusCause{
 				Type:    "FieldValueInvalid",

--- a/pkg/network/admitter/binding_test.go
+++ b/pkg/network/admitter/binding_test.go
@@ -34,19 +34,19 @@ import (
 
 var _ = Describe("Validating network binding combinations", func() {
 	It("network interface has both binding plugin and interface binding method", func() {
-		vm := libvmi.New(
-			libvmi.WithInterface(v1.Interface{
-				Name:                   "foo",
-				InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}},
-				Binding:                &v1.PluginBinding{Name: "boo"},
-			}),
+		vmi := libvmi.New(
+			libvmi.WithInterface(libvmi.NewInterface(
+				"foo",
+				libvmi.WithBridgeBinding(),
+				libvmi.WithBindingPlugin(v1.PluginBinding{Name: "boo"}),
+			)),
 			libvmi.WithNetwork(&v1.Network{
 				Name:          "foo",
 				NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}},
 			}),
 		)
 		clusterConfig := stubClusterConfigChecker{bridgeBindingOnPodNetEnabled: true}
-		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vm.Spec, clusterConfig)
+		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vmi.Spec, clusterConfig)
 		Expect(validator.Validate()).To(
 			ConsistOf(metav1.StatusCause{
 				Type:    "FieldValueInvalid",
@@ -56,33 +56,33 @@ var _ = Describe("Validating network binding combinations", func() {
 	})
 
 	It("network interface has only plugin binding", func() {
-		vm := libvmi.New(
-			libvmi.WithInterface(v1.Interface{
-				Name:    "foo",
-				Binding: &v1.PluginBinding{Name: "boo"},
-			}),
+		vmi := libvmi.New(
+			libvmi.WithInterface(libvmi.NewInterface(
+				"foo",
+				libvmi.WithBindingPlugin(v1.PluginBinding{Name: "boo"}),
+			)),
 			libvmi.WithNetwork(&v1.Network{
 				Name:          "foo",
 				NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}},
 			}),
 		)
 		clusterConfig := stubClusterConfigChecker{}
-		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vm.Spec, clusterConfig)
+		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vmi.Spec, clusterConfig)
 		Expect(validator.Validate()).To(BeEmpty())
 	})
 
 	It("network interface has neither binding plugin nor interface binding method", func() {
-		vm := libvmi.New(
-			libvmi.WithInterface(v1.Interface{
-				Name: "foo",
-			}),
+		vmi := libvmi.New(
+			libvmi.WithInterface(libvmi.NewInterface(
+				"foo",
+			)),
 			libvmi.WithNetwork(&v1.Network{
 				Name:          "foo",
 				NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}},
 			}),
 		)
 		clusterConfig := stubClusterConfigChecker{}
-		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vm.Spec, clusterConfig)
+		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vmi.Spec, clusterConfig)
 		Expect(validator.Validate()).To(
 			ConsistOf(metav1.StatusCause{
 				Type:    "FieldValueInvalid",
@@ -92,7 +92,7 @@ var _ = Describe("Validating network binding combinations", func() {
 	})
 
 	It("network interface has more than one binding method", func() {
-		vm := libvmi.New(
+		vmi := libvmi.New(
 			libvmi.WithInterface(v1.Interface{
 				Name: "foo",
 				InterfaceBindingMethod: v1.InterfaceBindingMethod{
@@ -106,7 +106,7 @@ var _ = Describe("Validating network binding combinations", func() {
 			}),
 		)
 		clusterConfig := stubClusterConfigChecker{bridgeBindingOnPodNetEnabled: true}
-		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vm.Spec, clusterConfig)
+		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vmi.Spec, clusterConfig)
 		Expect(validator.Validate()).To(
 			ConsistOf(metav1.StatusCause{
 				Type:    "FieldValueInvalid",
@@ -116,18 +116,18 @@ var _ = Describe("Validating network binding combinations", func() {
 	})
 
 	It("network interface has only binding method", func() {
-		vm := libvmi.New(
+		vmi := libvmi.New(
+			libvmi.WithInterface(libvmi.NewInterface(
+				"foo",
+				libvmi.WithBridgeBinding(),
+			)),
 			libvmi.WithNetwork(&v1.Network{
 				Name:          "foo",
 				NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}},
 			}),
-			libvmi.WithInterface(v1.Interface{
-				Name:                   "foo",
-				InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}},
-			}),
 		)
 		clusterConfig := stubClusterConfigChecker{bridgeBindingOnPodNetEnabled: true}
-		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vm.Spec, clusterConfig)
+		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vmi.Spec, clusterConfig)
 		Expect(validator.Validate()).To(BeEmpty())
 	})
 })
@@ -135,15 +135,10 @@ var _ = Describe("Validating network binding combinations", func() {
 var _ = Describe("Validating core binding", func() {
 	It("should reject a masquerade interface on a network different than pod", func() {
 		vmi := libvmi.New(
-			libvmi.WithInterface(v1.Interface{
-				Name:                   "default",
-				InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}},
-				Ports:                  []v1.Port{{Name: "test"}},
-			}),
-			libvmi.WithNetwork(&v1.Network{
-				Name:          "default",
-				NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{NetworkName: "test"}},
-			}),
+
+			libvmi.WithInterface(libvmi.InterfaceDeviceWithMasqueradeBinding(v1.Port{Name: "test"})),
+
+			libvmi.WithNetwork(libvmi.MultusNetwork("default", "test")),
 		)
 
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vmi.Spec, stubClusterConfigChecker{})
@@ -158,12 +153,14 @@ var _ = Describe("Validating core binding", func() {
 
 	It("should reject a masquerade interface with a specified reserved MAC address", func() {
 		vmi := libvmi.New(
+
+			libvmi.WithInterface(libvmi.NewInterface(
+				"default",
+				libvmi.WithMasqueradeBinding(),
+				libvmi.WithMac("02:00:00:00:00:00"),
+			)),
+
 			libvmi.WithNetwork(v1.DefaultPodNetwork()),
-			libvmi.WithInterface(v1.Interface{
-				Name:                   "default",
-				InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}},
-				MacAddress:             "02:00:00:00:00:00",
-			}),
 		)
 
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), &vmi.Spec, stubClusterConfigChecker{})

--- a/pkg/network/admitter/dra_test.go
+++ b/pkg/network/admitter/dra_test.go
@@ -22,6 +22,7 @@ package admitter_test
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"kubevirt.io/kubevirt/pkg/libvmi"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
@@ -94,34 +95,12 @@ var _ = Describe("Validate network DRA", func() {
 	It("should reject duplicate claimName/requestName across DRA networks", func() {
 		spec := newDRASpec()
 		spec.Domain.Devices.Interfaces = []v1.Interface{
-			{
-				Name:    "dra-net-1",
-				Binding: &v1.PluginBinding{Name: "netbinding"},
-			},
-			{
-				Name:    "dra-net-2",
-				Binding: &v1.PluginBinding{Name: "netbinding"},
-			},
+			libvmi.NewInterface("dra-net-1", libvmi.WithBindingPlugin(v1.PluginBinding{Name: "netbinding"})),
+			libvmi.NewInterface("dra-net-2", libvmi.WithBindingPlugin(v1.PluginBinding{Name: "netbinding"})),
 		}
 		spec.Networks = []v1.Network{
-			{
-				Name: "dra-net-1",
-				NetworkSource: v1.NetworkSource{
-					ResourceClaim: &v1.ClaimRequest{
-						ClaimName:   "claim1",
-						RequestName: "vf",
-					},
-				},
-			},
-			{
-				Name: "dra-net-2",
-				NetworkSource: v1.NetworkSource{
-					ResourceClaim: &v1.ClaimRequest{
-						ClaimName:   "claim1",
-						RequestName: "vf",
-					},
-				},
-			},
+			*libvmi.DRANetwork("dra-net-1", "claim1", "vf"),
+			*libvmi.DRANetwork("dra-net-2", "claim1", "vf"),
 		}
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{networkDRAEnabled: true})
 		causes := validator.Validate()
@@ -136,20 +115,11 @@ var _ = Describe("Validate network DRA", func() {
 	It("should reject mixing Multus and DRA networks", func() {
 		spec := newDRASpec()
 		spec.Domain.Devices.Interfaces = []v1.Interface{
-			{
-				Name:    "multus-net",
-				Binding: &v1.PluginBinding{Name: "netbinding"},
-			},
-			{
-				Name:    "dra-net",
-				Binding: &v1.PluginBinding{Name: "netbinding"},
-			},
+			libvmi.NewInterface("multus-net", libvmi.WithBindingPlugin(v1.PluginBinding{Name: "netbinding"})),
+			libvmi.NewInterface("dra-net", libvmi.WithBindingPlugin(v1.PluginBinding{Name: "netbinding"})),
 		}
 		spec.Networks = []v1.Network{
-			{
-				Name:          "multus-net",
-				NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{NetworkName: "nad1"}},
-			},
+			*libvmi.MultusNetwork("multus-net", "nad1"),
 			spec.Networks[0],
 		}
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{networkDRAEnabled: true})
@@ -180,18 +150,8 @@ var _ = Describe("Validate network DRA", func() {
 	It("should accept DRA network with plugin interface binding", func() {
 		spec := newDRASpec()
 		spec.Domain.Devices.Interfaces = []v1.Interface{
-			{
-				Name: "default",
-				InterfaceBindingMethod: v1.InterfaceBindingMethod{
-					Masquerade: &v1.InterfaceMasquerade{},
-				},
-			},
-			{
-				Name: "dra-net",
-				Binding: &v1.PluginBinding{
-					Name: "vhostuser",
-				},
-			},
+			libvmi.NewInterface("default", libvmi.WithMasqueradeBinding()),
+			libvmi.NewInterface("dra-net", libvmi.WithBindingPlugin(v1.PluginBinding{Name: "vhostuser"})),
 		}
 		spec.Networks = append(spec.Networks, v1.Network{
 			Name:          "default",

--- a/pkg/network/admitter/netiface_test.go
+++ b/pkg/network/admitter/netiface_test.go
@@ -24,6 +24,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"kubevirt.io/kubevirt/pkg/libvmi"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
@@ -54,7 +55,7 @@ var _ = Describe("Validating VMI network spec", func() {
 
 	It("should reject interface with missing network", func() {
 		spec := &v1.VirtualMachineInstanceSpec{}
-		spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultBridgeNetworkInterface()}
+		spec.Domain.Devices.Interfaces = []v1.Interface{libvmi.InterfaceDeviceWithBridgeBinding("default")}
 		spec.Networks = []v1.Network{}
 
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{})
@@ -69,20 +70,10 @@ var _ = Describe("Validating VMI network spec", func() {
 
 	It("should reject networks with duplicate names", func() {
 		spec := &v1.VirtualMachineInstanceSpec{}
-		spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultBridgeNetworkInterface()}
+		spec.Domain.Devices.Interfaces = []v1.Interface{libvmi.InterfaceDeviceWithBridgeBinding("default")}
 		spec.Networks = []v1.Network{
-			{
-				Name: "default",
-				NetworkSource: v1.NetworkSource{
-					Pod: &v1.PodNetwork{},
-				},
-			},
-			{
-				Name: "default",
-				NetworkSource: v1.NetworkSource{
-					Multus: &v1.MultusNetwork{NetworkName: "test"},
-				},
-			},
+			*v1.DefaultPodNetwork(),
+			*libvmi.MultusNetwork("default", "test"),
 		}
 
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{})
@@ -98,12 +89,12 @@ var _ = Describe("Validating VMI network spec", func() {
 	It("should reject interfaces with duplicate names", func() {
 		spec := &v1.VirtualMachineInstanceSpec{}
 		spec.Domain.Devices.Interfaces = []v1.Interface{
-			*v1.DefaultBridgeNetworkInterface(),
-			*v1.DefaultBridgeNetworkInterface(),
+			libvmi.InterfaceDeviceWithBridgeBinding("default"),
+			libvmi.InterfaceDeviceWithBridgeBinding("default"),
 		}
 		spec.Networks = []v1.Network{
-			{Name: "default", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}},
-			{Name: "default", NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{NetworkName: "test"}}},
+			*v1.DefaultPodNetwork(),
+			*libvmi.MultusNetwork("default", "test"),
 		}
 
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{})
@@ -118,11 +109,14 @@ var _ = Describe("Validating VMI network spec", func() {
 
 	It("should reject interface named with unsupported characters", func() {
 		spec := &v1.VirtualMachineInstanceSpec{}
-		spec.Domain.Devices.Interfaces = []v1.Interface{{
-			Name:                   "bad.name",
-			InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}},
-		}}
-		spec.Networks = []v1.Network{{Name: "bad.name", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}}}
+
+		spec.Domain.Devices.Interfaces = []v1.Interface{
+			libvmi.NewInterface("bad.name", libvmi.WithMasqueradeBinding()),
+		}
+
+		spec.Networks = []v1.Network{
+			{Name: "bad.name", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}},
+		}
 
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{})
 		Expect(validator.Validate()).To(ConsistOf(metav1.StatusCause{
@@ -134,9 +128,13 @@ var _ = Describe("Validating VMI network spec", func() {
 
 	It("should reject invalid interface model", func() {
 		spec := &v1.VirtualMachineInstanceSpec{}
-		spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultMasqueradeNetworkInterface()}
+		spec.Domain.Devices.Interfaces = []v1.Interface{
+			libvmi.NewInterface("default", libvmi.WithMasqueradeBinding()),
+		}
 		spec.Domain.Devices.Interfaces[0].Model = "invalid_model"
-		spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
+		spec.Networks = []v1.Network{
+			*v1.DefaultPodNetwork(),
+		}
 
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{})
 		Expect(validator.Validate()).To(ConsistOf(metav1.StatusCause{
@@ -148,7 +146,9 @@ var _ = Describe("Validating VMI network spec", func() {
 
 	It("should accept valid interface model", func() {
 		spec := &v1.VirtualMachineInstanceSpec{}
-		spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultMasqueradeNetworkInterface()}
+		spec.Domain.Devices.Interfaces = []v1.Interface{
+			libvmi.NewInterface("default", libvmi.WithMasqueradeBinding()),
+		}
 		spec.Domain.Devices.Interfaces[0].Model = v1.VirtIO
 		spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
 
@@ -158,9 +158,13 @@ var _ = Describe("Validating VMI network spec", func() {
 
 	DescribeTable("should reject invalid MAC addresses", func(macAddress, expectedMessage string) {
 		spec := &v1.VirtualMachineInstanceSpec{}
-		spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultMasqueradeNetworkInterface()}
+		spec.Domain.Devices.Interfaces = []v1.Interface{
+			libvmi.NewInterface("default", libvmi.WithMasqueradeBinding()),
+		}
 		spec.Domain.Devices.Interfaces[0].MacAddress = macAddress
-		spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
+		spec.Networks = []v1.Network{
+			*v1.DefaultPodNetwork(),
+		}
 
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{})
 		Expect(validator.Validate()).To(ConsistOf(metav1.StatusCause{
@@ -188,9 +192,13 @@ var _ = Describe("Validating VMI network spec", func() {
 
 	DescribeTable("should accept valid MAC addresses", func(macAddress string) {
 		spec := &v1.VirtualMachineInstanceSpec{}
-		spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultMasqueradeNetworkInterface()}
+		spec.Domain.Devices.Interfaces = []v1.Interface{
+			libvmi.NewInterface("default", libvmi.WithMasqueradeBinding()),
+		}
 		spec.Domain.Devices.Interfaces[0].MacAddress = macAddress
-		spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
+		spec.Networks = []v1.Network{
+			*v1.DefaultPodNetwork(),
+		}
 
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{})
 		Expect(validator.Validate()).To(BeEmpty())
@@ -203,9 +211,13 @@ var _ = Describe("Validating VMI network spec", func() {
 
 	DescribeTable("should reject invalid PCI addresses", func(pciAddress string) {
 		spec := &v1.VirtualMachineInstanceSpec{}
-		spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultMasqueradeNetworkInterface()}
+		spec.Domain.Devices.Interfaces = []v1.Interface{
+			libvmi.NewInterface("default", libvmi.WithMasqueradeBinding()),
+		}
 		spec.Domain.Devices.Interfaces[0].PciAddress = pciAddress
-		spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
+		spec.Networks = []v1.Network{
+			*v1.DefaultPodNetwork(),
+		}
 
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{})
 		Expect(validator.Validate()).To(ConsistOf(metav1.StatusCause{
@@ -221,9 +233,13 @@ var _ = Describe("Validating VMI network spec", func() {
 
 	DescribeTable("should accept valid PCI address", func(pciAddress string) {
 		spec := &v1.VirtualMachineInstanceSpec{}
-		spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultMasqueradeNetworkInterface()}
+		spec.Domain.Devices.Interfaces = []v1.Interface{
+			libvmi.NewInterface("default", libvmi.WithMasqueradeBinding()),
+		}
 		spec.Domain.Devices.Interfaces[0].PciAddress = pciAddress
-		spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
+		spec.Networks = []v1.Network{
+			*v1.DefaultPodNetwork(),
+		}
 
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{})
 		Expect(validator.Validate()).To(BeEmpty())
@@ -235,11 +251,9 @@ var _ = Describe("Validating VMI network spec", func() {
 	When("the interface port is specified", func() {
 		DescribeTable("should reject interface port with", func(ports []v1.Port, expectedCauses []metav1.StatusCause) {
 			spec := &v1.VirtualMachineInstanceSpec{}
-			spec.Domain.Devices.Interfaces = []v1.Interface{{
-				Name:                   "default",
-				InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}},
-				Ports:                  ports,
-			}}
+			spec.Domain.Devices.Interfaces = []v1.Interface{
+				libvmi.NewInterface("default", libvmi.WithMasqueradeBinding(), libvmi.WithPorts(ports...)),
+			}
 			spec.Networks = []v1.Network{{Name: "default", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}}}
 
 			validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{})
@@ -294,12 +308,10 @@ var _ = Describe("Validating VMI network spec", func() {
 
 		DescribeTable("should accept interface with", func(ports []v1.Port) {
 			spec := &v1.VirtualMachineInstanceSpec{}
-			spec.Domain.Devices.Interfaces = []v1.Interface{{
-				Name:                   "default",
-				InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}},
-				Ports:                  ports,
-			}}
-			spec.Networks = []v1.Network{{Name: "default", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}}}
+			spec.Domain.Devices.Interfaces = []v1.Interface{
+				libvmi.NewInterface("default", libvmi.WithMasqueradeBinding(), libvmi.WithPorts(ports...)),
+			}
+			spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
 
 			validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{})
 			Expect(validator.Validate()).To(BeEmpty())
@@ -320,7 +332,7 @@ var _ = Describe("Validating VMI network spec", func() {
 				InterfaceBindingMethod: v1.InterfaceBindingMethod{Masquerade: &v1.InterfaceMasquerade{}},
 				PortRanges:             []v1.PortRange{{Start: 80, End: 90}},
 			}}
-			spec.Networks = []v1.Network{{Name: "default", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}}}
+			spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
 
 			validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{portRangesSpecGateEnabled: false})
 			Expect(validator.Validate()).To(ConsistOf(metav1.StatusCause{
@@ -336,7 +348,7 @@ var _ = Describe("Validating VMI network spec", func() {
 				InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}},
 				PortRanges:             []v1.PortRange{{Protocol: "TCP", Start: 80, End: 90}},
 			}}
-			spec.Networks = []v1.Network{{Name: "default", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}}}
+			spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
 
 			validator := admitter.NewValidator(
 				k8sfield.NewPath("fake"), spec,
@@ -357,7 +369,7 @@ var _ = Describe("Validating VMI network spec", func() {
 				Ports:                  []v1.Port{{Port: 22}},
 				PortRanges:             []v1.PortRange{{Protocol: "TCP", Start: 80, End: 90}},
 			}}
-			spec.Networks = []v1.Network{{Name: "default", NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}}}
+			spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
 
 			validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{portRangesSpecGateEnabled: true})
 			Expect(validator.Validate()).To(ConsistOf(metav1.StatusCause{

--- a/pkg/network/admitter/netsource_test.go
+++ b/pkg/network/admitter/netsource_test.go
@@ -22,6 +22,7 @@ package admitter_test
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"kubevirt.io/kubevirt/pkg/libvmi"
 
 	k8sfield "k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/ptr"
@@ -37,8 +38,8 @@ var _ = Describe("Validate network source", func() {
 		const net2Name = "default2"
 		vmi := v1.VirtualMachineInstance{}
 		vmi.Spec.Domain.Devices.Interfaces = []v1.Interface{
-			{Name: net1Name, InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}},
-			{Name: net2Name, InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}},
+			libvmi.InterfaceDeviceWithBridgeBinding(net1Name),
+			libvmi.InterfaceDeviceWithBridgeBinding(net2Name),
 		}
 		vmi.Spec.Networks = []v1.Network{
 			{Name: net1Name, NetworkSource: v1.NetworkSource{Pod: &v1.PodNetwork{}}},
@@ -53,7 +54,9 @@ var _ = Describe("Validate network source", func() {
 
 	It("should reject when multiple types defined for a CNI network", func() {
 		spec := &v1.VirtualMachineInstanceSpec{}
-		spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultBridgeNetworkInterface()}
+		spec.Domain.Devices.Interfaces = []v1.Interface{
+			libvmi.InterfaceDeviceWithBridgeBinding("default"),
+		}
 		spec.Networks = []v1.Network{
 			{
 				Name: "default",
@@ -77,7 +80,7 @@ var _ = Describe("Validate network source", func() {
 			NetworkSource: v1.NetworkSource{},
 			Name:          "testnet1",
 		}
-		iface1 := v1.Interface{Name: net1.Name, InterfaceBindingMethod: v1.InterfaceBindingMethod{Bridge: &v1.InterfaceBridge{}}}
+		iface1 := libvmi.InterfaceDeviceWithBridgeBinding(net1.Name)
 		spec.Networks = []v1.Network{net1}
 		spec.Domain.Devices.Interfaces = []v1.Interface{iface1}
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{})
@@ -90,19 +93,12 @@ var _ = Describe("Validate network source", func() {
 		const draNetName = "dra-net"
 		spec := &v1.VirtualMachineInstanceSpec{}
 		spec.Domain.Devices.Interfaces = []v1.Interface{
-			{Name: draNetName, Binding: &v1.PluginBinding{Name: "netbinding"}},
+			libvmi.NewInterface(draNetName, libvmi.WithBindingPlugin(v1.PluginBinding{Name: "netbinding"})),
 		}
 		spec.ResourceClaims = []v1.VirtualMachineInstanceResourceClaim{{Name: "claim1", ResourceClaimName: ptr.To("claim1")}}
+
 		spec.Networks = []v1.Network{
-			{
-				Name: draNetName,
-				NetworkSource: v1.NetworkSource{
-					ResourceClaim: &v1.ClaimRequest{
-						ClaimName:   "claim1",
-						RequestName: "request1",
-					},
-				},
-			},
+			*libvmi.DRANetwork(draNetName, "claim1", "request1"),
 		}
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{networkDRAEnabled: true})
 		causes := validator.Validate()
@@ -113,7 +109,9 @@ var _ = Describe("Validate network source", func() {
 		func(networkSource v1.NetworkSource) {
 			spec := &v1.VirtualMachineInstanceSpec{}
 			spec.Domain.Devices.Interfaces = []v1.Interface{
-				{Name: "default", Binding: &v1.PluginBinding{Name: "netbinding"}},
+				libvmi.NewInterface(
+					"default",
+					libvmi.WithBindingPlugin(v1.PluginBinding{Name: "netbinding"})),
 			}
 			spec.ResourceClaims = []v1.VirtualMachineInstanceResourceClaim{{Name: "claim1", ResourceClaimName: ptr.To("claim1")}}
 			spec.Networks = []v1.Network{
@@ -139,11 +137,12 @@ var _ = Describe("Validate network source", func() {
 
 	It("should reject multus network source without networkName", func() {
 		spec := &v1.VirtualMachineInstanceSpec{}
-		spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultBridgeNetworkInterface()}
-		spec.Networks = []v1.Network{{
-			Name:          "default",
-			NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{}},
-		}}
+		spec.Domain.Devices.Interfaces = []v1.Interface{
+			libvmi.InterfaceDeviceWithBridgeBinding("default"),
+		}
+		spec.Networks = []v1.Network{
+			*libvmi.MultusNetwork("default", ""),
+		}
 
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{})
 		causes := validator.Validate()
@@ -154,8 +153,8 @@ var _ = Describe("Validate network source", func() {
 	It("should reject multiple multus networks with a multus default", func() {
 		spec := &v1.VirtualMachineInstanceSpec{}
 		spec.Domain.Devices.Interfaces = []v1.Interface{
-			*v1.DefaultBridgeNetworkInterface(),
-			*v1.DefaultBridgeNetworkInterface(),
+			libvmi.InterfaceDeviceWithBridgeBinding("default"),
+			libvmi.InterfaceDeviceWithBridgeBinding("default"),
 		}
 		const net1Name = "multus1"
 		const net2Name = "multus2"
@@ -188,22 +187,12 @@ var _ = Describe("Validate network source", func() {
 		const defaultMultusNetName = "defaultmultus"
 		spec := &v1.VirtualMachineInstanceSpec{}
 		spec.Domain.Devices.Interfaces = []v1.Interface{
-			*v1.DefaultBridgeNetworkInterface(),
-			{
-				Name: defaultMultusNetName,
-				InterfaceBindingMethod: v1.InterfaceBindingMethod{
-					Bridge: &v1.InterfaceBridge{},
-				},
-			},
+			libvmi.InterfaceDeviceWithBridgeBinding("default"),
+			libvmi.InterfaceDeviceWithBridgeBinding(defaultMultusNetName),
 		}
 
 		spec.Networks = []v1.Network{
-			{
-				Name: "default",
-				NetworkSource: v1.NetworkSource{
-					Pod: &v1.PodNetwork{},
-				},
-			},
+			*v1.DefaultPodNetwork(),
 			{
 				Name: defaultMultusNetName,
 				NetworkSource: v1.NetworkSource{
@@ -224,7 +213,7 @@ var _ = Describe("Validate network source", func() {
 	It("should allow single multus network with a multus default", func() {
 		spec := &v1.VirtualMachineInstanceSpec{}
 		spec.Domain.Devices.Interfaces = []v1.Interface{
-			*v1.DefaultBridgeNetworkInterface(),
+			libvmi.InterfaceDeviceWithBridgeBinding("default"),
 		}
 		spec.Domain.Devices.Interfaces[0].Name = "multus1"
 		spec.Networks = []v1.Network{
@@ -243,14 +232,11 @@ var _ = Describe("Validate network source", func() {
 
 	It("should accept networks with a multus network source and bridge interface", func() {
 		spec := &v1.VirtualMachineInstanceSpec{}
-		spec.Domain.Devices.Interfaces = []v1.Interface{*v1.DefaultBridgeNetworkInterface()}
+		spec.Domain.Devices.Interfaces = []v1.Interface{
+			libvmi.InterfaceDeviceWithBridgeBinding("default"),
+		}
 		spec.Networks = []v1.Network{
-			{
-				Name: "default",
-				NetworkSource: v1.NetworkSource{
-					Multus: &v1.MultusNetwork{NetworkName: "default"},
-				},
-			},
+			*libvmi.MultusNetwork("default", "default"),
 		}
 
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{})
@@ -261,45 +247,15 @@ var _ = Describe("Validate network source", func() {
 	It("should allow primary network and multiple secondary networks", func() {
 		spec := &v1.VirtualMachineInstanceSpec{}
 		spec.Domain.Devices.Interfaces = []v1.Interface{
-			{
-				Name: "default",
-				InterfaceBindingMethod: v1.InterfaceBindingMethod{
-					Bridge: &v1.InterfaceBridge{},
-				},
-			},
-			{
-				Name: "multus1",
-				InterfaceBindingMethod: v1.InterfaceBindingMethod{
-					Bridge: &v1.InterfaceBridge{},
-				},
-			},
-			{
-				Name: "multus2",
-				InterfaceBindingMethod: v1.InterfaceBindingMethod{
-					Bridge: &v1.InterfaceBridge{},
-				},
-			},
+			libvmi.InterfaceDeviceWithBridgeBinding("default"),
+			libvmi.InterfaceDeviceWithBridgeBinding("multus1"),
+			libvmi.InterfaceDeviceWithBridgeBinding("multus2"),
 		}
 
 		spec.Networks = []v1.Network{
-			{
-				Name: "default",
-				NetworkSource: v1.NetworkSource{
-					Pod: &v1.PodNetwork{},
-				},
-			},
-			{
-				Name: "multus1",
-				NetworkSource: v1.NetworkSource{
-					Multus: &v1.MultusNetwork{NetworkName: "multus-net1"},
-				},
-			},
-			{
-				Name: "multus2",
-				NetworkSource: v1.NetworkSource{
-					Multus: &v1.MultusNetwork{NetworkName: "multus-net2"},
-				},
-			},
+			*v1.DefaultPodNetwork(),
+			*libvmi.MultusNetwork("multus1", "multus-net1"),
+			*libvmi.MultusNetwork("multus2", "multus-net2"),
 		}
 
 		validator := admitter.NewValidator(

--- a/pkg/network/admitter/passt_test.go
+++ b/pkg/network/admitter/passt_test.go
@@ -28,20 +28,17 @@ import (
 
 	v1 "kubevirt.io/api/core/v1"
 
+	"kubevirt.io/kubevirt/pkg/libvmi"
 	"kubevirt.io/kubevirt/pkg/network/admitter"
 )
 
 var _ = Describe("Validating passtBinding core binding", func() {
 	It("should reject networks with a multus network source and passtBinding interface", func() {
 		spec := &v1.VirtualMachineInstanceSpec{}
-		spec.Domain.Devices.Interfaces = []v1.Interface{{
-			Name:                   "default",
-			InterfaceBindingMethod: v1.InterfaceBindingMethod{PasstBinding: &v1.InterfacePasstBinding{}},
-		}}
-		spec.Networks = []v1.Network{{
-			Name:          "default",
-			NetworkSource: v1.NetworkSource{Multus: &v1.MultusNetwork{NetworkName: "test"}},
-		}}
+		spec.Domain.Devices.Interfaces = []v1.Interface{
+			libvmi.NewInterface("default", libvmi.WithPasstBinding()),
+		}
+		spec.Networks = []v1.Network{*libvmi.MultusNetwork("default", "test")}
 
 		clusterConfig := stubClusterConfigChecker{passtBindingFeatureGateEnabled: true}
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, clusterConfig)
@@ -56,10 +53,9 @@ var _ = Describe("Validating passtBinding core binding", func() {
 
 	It("should reject networks with a passtBinding interface and passtBinding feature gate disabled", func() {
 		spec := &v1.VirtualMachineInstanceSpec{}
-		spec.Domain.Devices.Interfaces = []v1.Interface{{
-			Name:                   "default",
-			InterfaceBindingMethod: v1.InterfaceBindingMethod{PasstBinding: &v1.InterfacePasstBinding{}},
-		}}
+		spec.Domain.Devices.Interfaces = []v1.Interface{
+			libvmi.NewInterface("default", libvmi.WithPasstBinding()),
+		}
 		spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
 
 		validator := admitter.NewValidator(k8sfield.NewPath("fake"), spec, stubClusterConfigChecker{})
@@ -74,10 +70,9 @@ var _ = Describe("Validating passtBinding core binding", func() {
 
 	It("should accept networks with a pod network source and passtBinding interface", func() {
 		spec := &v1.VirtualMachineInstanceSpec{}
-		spec.Domain.Devices.Interfaces = []v1.Interface{{
-			Name:                   "default",
-			InterfaceBindingMethod: v1.InterfaceBindingMethod{PasstBinding: &v1.InterfacePasstBinding{}},
-		}}
+		spec.Domain.Devices.Interfaces = []v1.Interface{
+			libvmi.NewInterface("default", libvmi.WithPasstBinding()),
+		}
 		spec.Networks = []v1.Network{*v1.DefaultPodNetwork()}
 
 		clusterConfig := stubClusterConfigChecker{passtBindingFeatureGateEnabled: true}


### PR DESCRIPTION

### What this PR does

Replace raw struct literals with pkg/libvmi builder functions across the admitter test suite, for
consistency and readability.

Struct literals are kept where the builders cannot express intent clearly.


### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

