### PR TITLE
Fix monitoring compatibility after kubevirtci Prometheus stack upgrade

### DIFF
--- a/hack/cluster-deploy.sh
+++ b/hack/cluster-deploy.sh
@@ -57,6 +57,8 @@ function _ensure_cdi_deployment() {
 function configure_prometheus() {
     if [[ $KUBEVIRT_DEPLOY_PROMETHEUS == "true" ]] && _kubectl get crd prometheuses.monitoring.coreos.com; then
         _kubectl patch prometheus k8s -n monitoring --type=json -p '[{"op": "replace", "path": "/spec/ruleSelector", "value":{}}, {"op": "replace", "path": "/spec/ruleNamespaceSelector", "value":{"matchLabels": {"kubevirt.io": ""}}}]'
+        _kubectl patch deployment kube-state-metrics -n monitoring --type=json -p '[{"op": "add", "path": "/spec/template/spec/containers/0/args/-", "value": "--metric-labels-allowlist=pods=[*],nodes=[*],namespaces=[*],persistentvolumes=[*],persistentvolumeclaims=[*],poddisruptionbudgets=[*]"}]'
+        _kubectl rollout status deployment kube-state-metrics -n monitoring --timeout=5m
     fi
 }
 

--- a/manifests/generated/operator-csv.yaml.in
+++ b/manifests/generated/operator-csv.yaml.in
@@ -185,6 +185,14 @@ spec:
           - delete
           - patch
         - apiGroups:
+          - discovery.k8s.io
+          resources:
+          - endpointslices
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
           - ""
           resources:
           - configmaps

--- a/manifests/generated/rbac-operator.authorization.k8s.yaml.in
+++ b/manifests/generated/rbac-operator.authorization.k8s.yaml.in
@@ -218,6 +218,14 @@ rules:
   - delete
   - patch
 - apiGroups:
+  - discovery.k8s.io
+  resources:
+  - endpointslices
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - ""
   resources:
   - configmaps

--- a/pkg/virt-operator/resource/generate/rbac/operator.go
+++ b/pkg/virt-operator/resource/generate/rbac/operator.go
@@ -120,6 +120,19 @@ func NewOperatorClusterRole() *rbacv1.ClusterRole {
 			},
 			{
 				APIGroups: []string{
+					"discovery.k8s.io",
+				},
+				Resources: []string{
+					"endpointslices",
+				},
+				Verbs: []string{
+					"get",
+					"list",
+					"watch",
+				},
+			},
+			{
+				APIGroups: []string{
 					"",
 				},
 				Resources: []string{

--- a/pkg/virt-operator/resource/generate/rbac/operator_test.go
+++ b/pkg/virt-operator/resource/generate/rbac/operator_test.go
@@ -72,6 +72,25 @@ var _ = Describe("RBAC", func() {
 			Expect(clusterRole).ToNot(BeNil())
 			expectExactRuleDoesntExists(clusterRole.Rules, "", "secrets", "get", "list", "watch")
 		})
+
+		It("holds every permission granted by the monitoring role", func() {
+			clusterRole := getFirstItemOfType(forOperator, reflect.TypeOf(&rbacv1.ClusterRole{})).(*rbacv1.ClusterRole)
+			Expect(clusterRole).ToNot(BeNil())
+
+			monitorRole := getObject(
+				GetAllServiceMonitor(expectedNamespace, "monitoring", "prometheus-k8s"),
+				reflect.TypeOf(&rbacv1.Role{}), MONITOR_SERVICEACCOUNT_NAME,
+			).(*rbacv1.Role)
+			Expect(monitorRole).ToNot(BeNil())
+
+			for _, rule := range monitorRole.Rules {
+				for _, apiGroup := range rule.APIGroups {
+					for _, resource := range rule.Resources {
+						expectRuleIsGranted(clusterRole.Rules, apiGroup, resource, rule.Verbs...)
+					}
+				}
+			}
+		})
 	})
 
 	Context("GetKubevirtComponentsServiceAccounts", func() {
@@ -100,6 +119,27 @@ func getFirstItemOfType(items []interface{}, tp reflect.Type) interface{} {
 		}
 	}
 	return nil
+}
+
+func expectRuleIsGranted(rules []rbacv1.PolicyRule, apiGroup, resource string, verbs ...string) {
+	for _, rule := range rules {
+		if !contains(rule.APIGroups, apiGroup) || !contains(rule.Resources, resource) {
+			continue
+		}
+
+		granted := true
+		for _, verb := range verbs {
+			if !contains(rule.Verbs, verb) {
+				granted = false
+				break
+			}
+		}
+		if granted {
+			return
+		}
+	}
+
+	Fail(fmt.Sprintf("Rule (apiGroup: %s, resource: %s, verbs: %v) not granted", apiGroup, resource, verbs))
 }
 
 func expectExactRuleDoesntExists(rules []rbacv1.PolicyRule, apiGroup, resource string, verbs ...string) {

--- a/pkg/virt-operator/resource/generate/rbac/servicemonitor.go
+++ b/pkg/virt-operator/resource/generate/rbac/servicemonitor.go
@@ -63,6 +63,17 @@ func newServiceMonitorRole(namespace string) *rbacv1.Role {
 					"get", "list", "watch",
 				},
 			},
+			{
+				APIGroups: []string{
+					"discovery.k8s.io",
+				},
+				Resources: []string{
+					"endpointslices",
+				},
+				Verbs: []string{
+					"get", "list", "watch",
+				},
+			},
 		},
 	}
 }

--- a/tests/libmonitoring/prometheus.go
+++ b/tests/libmonitoring/prometheus.go
@@ -130,6 +130,45 @@ func WaitForMetricValueWithLabelsToBe(
 	}, 3*time.Minute, 1*time.Second).Should(BeNumerically(comparator, expectedValue))
 }
 
+func WaitForHistogramBucketValueToBe(
+	client kubecli.KubevirtClient,
+	metric string,
+	bucket float64,
+	offset int,
+	comparator string,
+	expectedValue float64,
+) {
+	EventuallyWithOffset(offset, func() float64 {
+		i, err := GetHistogramBucketValue(client, metric, bucket)
+		if err != nil {
+			return -1
+		}
+		return i
+	}, 3*time.Minute, 1*time.Second).Should(
+		BeNumerically(comparator, expectedValue),
+		"Histogram %s has no bucket with upper bound %v holding a value %s %f",
+		metric, bucket, comparator, expectedValue,
+	)
+}
+
+func GetHistogramBucketValue(cli kubecli.KubevirtClient, query string, bucket float64) (float64, error) {
+	result, err := fetchMetric(cli, query)
+	if err != nil {
+		return -1, err
+	}
+
+	for i := range result.Data.Result {
+		upperBound, parseErr := strconv.ParseFloat(result.Data.Result[i].Metric["le"], 64)
+		if parseErr != nil || upperBound != bucket {
+			continue
+		}
+
+		return parseMetricValue(result.Data.Result[i].Value[1])
+	}
+
+	return -1, fmt.Errorf("bucket with upper bound %v not populated yet", bucket)
+}
+
 func GetMetricValueWithLabels(cli kubecli.KubevirtClient, query string, labels map[string]string) (float64, error) {
 	result, err := fetchMetric(cli, query)
 	if err != nil {
@@ -137,15 +176,16 @@ func GetMetricValueWithLabels(cli kubecli.KubevirtClient, query string, labels m
 	}
 
 	returnObj := findMetricWithLabels(result, labels)
-	var output string
-
 	if returnObj == nil {
 		return -1, fmt.Errorf("metric value not populated yet")
 	}
 
-	if s, ok := returnObj.(string); ok {
-		output = s
-	} else {
+	return parseMetricValue(returnObj)
+}
+
+func parseMetricValue(value interface{}) (float64, error) {
+	output, ok := value.(string)
+	if !ok {
 		return -1, fmt.Errorf("metric value is not string")
 	}
 

--- a/tests/monitoring/vm_monitoring.go
+++ b/tests/monitoring/vm_monitoring.go
@@ -23,7 +23,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strconv"
 	"time"
 
 	"kubevirt.io/kubevirt/tests/console"
@@ -92,10 +91,10 @@ var _ = Describe("[sig-monitoring]VM Monitoring", decorators.SigMonitoring, func
 
 		It("should have kubevirt_vmi_phase_transition_time_seconds buckets correctly configured", func() {
 			for _, bucket := range virtcontroller.PhaseTransitionTimeBuckets() {
-				labels := map[string]string{"le": strconv.FormatFloat(bucket, 'f', -1, 64)}
-
-				GinkgoLogr.Info("Checking bucket", "labels", labels)
-				libmonitoring.WaitForMetricValueWithLabelsToBe(virtClient, "kubevirt_vmi_phase_transition_time_seconds_bucket", labels, 0, ">=", 0)
+				GinkgoLogr.Info("Checking bucket", "le", bucket)
+				libmonitoring.WaitForHistogramBucketValueToBe(
+					virtClient, "kubevirt_vmi_phase_transition_time_seconds_bucket", bucket, 0, ">=", 0,
+				)
 			}
 		})
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does
#### Before this PR:

After https://github.com/kubevirt/kubevirtci/commit/06efd9b61818216a95fba7ba252e7cf280cec322 (bumped in https://github.com/kubevirt/kubevirt/commit/734c7869885b451089c48c91315695fc08241237), Prometheus in sig-monitoring lane discovers targets through EndpointSlices instead of Endpoints when the Prometheus CR sets serviceDiscoveryRole to EndpointSlice, which is the kube-prometheus default since v0.18.0. The phase-transition bucket tests previously also matched le as an exact string, but in the new Prometheus versions le="1.0" never matched the test's "1".

kubevirtci also dropped --metric-labels-allowlist from kube-state-metrics, so kube_*_labels metrics lost their label_* labels and the vm:kubevirt_vmsnapshot_*:sum recording rules produced nothing.

#### After this PR:

- Allows Prometheus to list EndpointSlices in the KubeVirt namespace
- WaitForHistogramBucketValueToBe parses le and compares numerically
- Add kube-state-metrics kubevirtci removed metric-labels-allowlist in cluster-deploy.sh

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow Prometheus to list EndpointSlices in the KubeVirt namespace
```

