### PR TITLE
virt-launcher: fix nil deref on vGPU RamFB with unset Enabled

### DIFF
--- a/pkg/virt-launcher/virtwrap/device/hostdevice/dra/gpu_hostdev.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/dra/gpu_hostdev.go
@@ -106,7 +106,7 @@ func createHostDeviceForGPU(gpu v1.GPU, basePath string, resourceClaims []v1.Vir
 			displayEnabled := gpu.VirtualGPUOptions.Display.Enabled
 			if displayEnabled == nil || *displayEnabled {
 				hostDevice.Display = "on"
-				if gpu.VirtualGPUOptions.Display.RamFB == nil || *gpu.VirtualGPUOptions.Display.RamFB.Enabled {
+				if isRamFBEnabled(gpu.VirtualGPUOptions.Display) {
 					hostDevice.RamFB = "on"
 				}
 			}
@@ -148,6 +148,17 @@ func isVgpuDisplaySet(gpuSpecs []v1.GPU) bool {
 		}
 	}
 	return false
+}
+
+// isRamFBEnabled reports whether the boot framebuffer should be turned on for
+// the given vGPU display options. Both Display.RamFB and RamFB.Enabled are
+// optional and documented as defaulting to true, so a nil at either level means
+// enabled. virt-launcher does not run the defaulter, so it must not assume
+// Enabled is populated.
+func isRamFBEnabled(display *v1.VGPUDisplayOptions) bool {
+	return display.RamFB == nil ||
+		display.RamFB.Enabled == nil ||
+		*display.RamFB.Enabled
 }
 
 func validateCreationOfDRAGPUDevices(gpus []v1.GPU, hostDevices []api.HostDevice) error {

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/dra/gpu_hostdev_test.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/dra/gpu_hostdev_test.go
@@ -192,6 +192,71 @@ var _ = Describe("CreateDRAGPUHostDevices", func() {
 			Expect(dev.Source.Address).ToNot(BeNil())
 			Expect(dev.Source.Address.UUID).To(Equal(uuid))
 		})
+
+		It("should set ramfb when RamFB is present but Enabled is nil", func() {
+			uuid := "123e4567-e89b-12d3-a456-426614174001"
+
+			createMetadataFile("claim1", "req1", "gpu.example.com", &metadata.DeviceMetadata{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "DeviceMetadata",
+					APIVersion: metadata.APIVersionV1Alpha1,
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "claim1",
+				},
+				Requests: []metadata.DeviceMetadataRequest{{
+					Name: "req1",
+					Devices: []metadata.Device{{
+						Driver: "gpu.example.com",
+						Pool:   "gpu-pool",
+						Name:   "device1",
+						Attributes: map[resourcev1.QualifiedName]resourcev1.DeviceAttribute{
+							metadata.MDevUUIDAttribute: {StringValue: &uuid},
+						},
+					}},
+				}},
+			})
+
+			vmi := &v1.VirtualMachineInstance{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "testvmi",
+					Namespace: "default",
+				},
+				Spec: v1.VirtualMachineInstanceSpec{
+					ResourceClaims: []v1.VirtualMachineInstanceResourceClaim{{
+						Name:              "claim1",
+						ResourceClaimName: ptr.To("claim1"),
+					}},
+					Domain: v1.DomainSpec{
+						Devices: v1.Devices{
+							GPUs: []v1.GPU{{
+								Name: "vgpu1",
+								ClaimRequest: &v1.ClaimRequest{
+									ClaimName:   "claim1",
+									RequestName: "req1",
+								},
+								VirtualGPUOptions: &v1.VGPUOptions{
+									Display: &v1.VGPUDisplayOptions{
+										Enabled: ptr.To(true),
+										// RamFB present, Enabled unset: defaults to true.
+										RamFB: &v1.FeatureState{},
+									},
+								},
+							}},
+						},
+					},
+				},
+			}
+
+			hostDevices, err := CreateDRAGPUHostDevices(vmi, tempDir)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(hostDevices).To(HaveLen(1))
+
+			dev := hostDevices[0]
+			Expect(dev.Type).To(Equal(api.HostDeviceMDev))
+			Expect(dev.Display).To(Equal("on"))
+			Expect(dev.RamFB).To(Equal("on"))
+		})
 	})
 
 	Context("when the device has both pciBusID and mdevUUID", func() {

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/hostdev.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/hostdev.go
@@ -169,7 +169,7 @@ func createMDEVHostDeviceWithDisplay(hostDeviceData HostDeviceMetaData, mdevUUID
 			displayEnabled := hostDeviceData.VirtualGPUOptions.Display.Enabled
 			if displayEnabled == nil || *displayEnabled {
 				mdev.Display = "on"
-				if hostDeviceData.VirtualGPUOptions.Display.RamFB == nil || *hostDeviceData.VirtualGPUOptions.Display.RamFB.Enabled {
+				if isRamFBSet(hostDeviceData) {
 					mdev.RamFB = "on"
 				}
 			}

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/hostdev_test.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/hostdev_test.go
@@ -396,6 +396,53 @@ var _ = Describe("HostDevice", func() {
 			Expect(hostDevices, err).To(Equal([]api.HostDevice{expectHostDevice1}))
 		})
 
+		It("sets ramfb when RamFB is present but Enabled is nil", func() {
+			hostDevicesMetaData := []hostdevice.HostDeviceMetaData{
+				{
+					AliasPrefix:  aliasPrefix,
+					Name:         devName0,
+					ResourceName: resourceName0,
+					VirtualGPUOptions: &v1.VGPUOptions{
+						Display: &v1.VGPUDisplayOptions{
+							Enabled: pointer.P(true),
+							RamFB:   &v1.FeatureState{},
+						},
+					},
+				},
+			}
+			pool.AddResource(resourceName0, uuid0, uuid1)
+
+			hostDevices, err := hostdevice.CreateMDEVHostDevices(hostDevicesMetaData, pool, true)
+			expectHostDevice1.Display = "on"
+			expectHostDevice1.RamFB = "on"
+
+			Expect(hostDevices, err).To(Equal([]api.HostDevice{expectHostDevice1}))
+		})
+
+		It("does not set ramfb when RamFB.Enabled is false", func() {
+			hostDevicesMetaData := []hostdevice.HostDeviceMetaData{
+				{
+					AliasPrefix:  aliasPrefix,
+					Name:         devName0,
+					ResourceName: resourceName0,
+					VirtualGPUOptions: &v1.VGPUOptions{
+						Display: &v1.VGPUDisplayOptions{
+							Enabled: pointer.P(true),
+							RamFB: &v1.FeatureState{
+								Enabled: pointer.P(false),
+							},
+						},
+					},
+				},
+			}
+			pool.AddResource(resourceName0, uuid0, uuid1)
+
+			hostDevices, err := hostdevice.CreateMDEVHostDevices(hostDevicesMetaData, pool, true)
+			expectHostDevice1.Display = "on"
+
+			Expect(hostDevices, err).To(Equal([]api.HostDevice{expectHostDevice1}))
+		})
+
 		It("creates 2 PCI devices that are connected to different resources", func() {
 			hostDevicesMetaData := []hostdevice.HostDeviceMetaData{
 				{AliasPrefix: aliasPrefix, Name: devName0, ResourceName: resourceName0},


### PR DESCRIPTION
### What this PR does

#### Before this PR:

Two mdev paths dereference `VirtualGPUOptions.Display.RamFB.Enabled` while guarding only that `RamFB` itself is non-nil:

```go
if ...Display.RamFB == nil || *...Display.RamFB.Enabled {
```

`RamFB` is a `*v1.FeatureState` and `Enabled` is a `*bool`; both are optional and can be nil independently. When `RamFB` is present but `Enabled` is unset, the first operand is false, so the second is evaluated and virt-launcher panics with a nil pointer dereference.

#### After this PR:

Both sites go through a nil-safe check, and a `RamFB` present with `Enabled` unset is treated as enabled.

### References

- Fixes #18430

### Why we need it and why it was done in this way

#18112 already introduced the nil-safe `isRamFBSet` helper and used it on the PCI path, but the two mdev sites kept their inline copies:

- `pkg/virt-launcher/virtwrap/device/hostdevice/hostdev.go:172` — `createMDEVHostDeviceWithDisplay`, the legacy mdev path
- `pkg/virt-launcher/virtwrap/device/hostdevice/dra/gpu_hostdev.go:109` — the DRA mdev path, reached under the `GPUsWithDRA` gate

The first site now calls the existing `isRamFBSet`. The `dra` package cannot reach it — it is unexported and takes `HostDeviceMetaData` — so this adds a local `isRamFBEnabled` operating on `*v1.VGPUDisplayOptions`. That mirrors the convention already present in that package, which has its own local `isVgpuDisplaySet` alongside the one in `hostdevice`.

**The following tradeoffs were made:**

The issue notes a semantic choice: a nil guard can either preserve the API default (nil means enabled) or fail closed (nil means disabled). This PR preserves the API default, for three reasons:

1. Both fields are documented as *"Defaults to true"*.
2. `SetDefaults_FeatureState` sets `Enabled=true` whenever the `FeatureState` is present.
3. It keeps each site self-consistent: `RamFB == nil` already yields `RamFB="on"`, so a *present* `RamFB` with unset `Enabled` meaning "off" would be surprising.

Happy to flip this to fail-closed if maintainers prefer — it is a one-line change in each helper.

**The following alternatives were considered:**

Exporting a single shared helper from `hostdevice` and importing it into `dra` would remove the duplication entirely (there is no import cycle). That was left out to keep the fix minimal; glad to do it here or as a follow-up if reviewers prefer consolidation.

### Special notes for your reviewer

As the issue says, this is defense-in-depth rather than a reachable exploit — on the standard create path the mutating webhook runs the defaulter, so a normally created VMI does not carry `enabled: null`. The point is narrower: virt-launcher does not re-default this field, so it should not panic on a value it does not own.

Worth noting for coverage: all the existing display/ramfb tests go through `CreatePCIHostDevices`, which was already correct. The mdev paths had no display tests at all, which is how this survived. Both new tests panic at the respective lines if the source fix is reverted — I verified that by stashing the fix and re-running.

### Checklist

- [x] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered

### Release note

```release-note
Fixed a virt-launcher panic when a vGPU display specifies ramFB without setting its enabled field.
```
