### PR TITLE
cmd, sidecars, test-vhostuser-binding: Introduce  test vhostuser net binding plugin

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -322,6 +322,13 @@ image_push(
 )
 
 image_push(
+    name = "push-network-vhostuserdra-binding",
+    image = "//cmd/sidecars/network-vhostuserdra-binding:network-vhostuserdra-binding-image",
+    registry = "quay.io",
+    repository = "kubevirt/network-vhostuserdra-binding",
+)
+
+image_push(
     name = "push-example-hook-sidecar",
     image = "//cmd/sidecars/smbios:example-hook-sidecar-image",
     registry = "quay.io",

--- a/cmd/sidecars/network-vhostuserdra-binding/BUILD.bazel
+++ b/cmd/sidecars/network-vhostuserdra-binding/BUILD.bazel
@@ -1,0 +1,50 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@rules_pkg//:pkg.bzl", "pkg_tar")
+load("//bazel:image.bzl", "kubevirt_image")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "kubevirt.io/kubevirt/cmd/sidecars/network-vhostuserdra-binding",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//cmd/sidecars/network-vhostuserdra-binding/server:go_default_library",
+        "//pkg/hooks:go_default_library",
+        "//pkg/hooks/info:go_default_library",
+        "//pkg/hooks/v1alpha3:go_default_library",
+        "//staging/src/kubevirt.io/client-go/log:go_default_library",
+        "//vendor/google.golang.org/grpc:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "network-vhostuserdra-binding",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+pkg_tar(
+    name = "get-version",
+    srcs = ["//:get-version"],
+    package_dir = "/",
+)
+
+pkg_tar(
+    name = "network-vhostuserdra-binding-tar",
+    srcs = [":network-vhostuserdra-binding"],
+    package_dir = "/",
+)
+
+kubevirt_image(
+    name = "version-container",
+    base = "//:passwd-image",
+    tars = [":get-version"],
+)
+
+kubevirt_image(
+    name = "network-vhostuserdra-binding-image",
+    base = ":version-container",
+    entrypoint = ["/network-vhostuserdra-binding"],
+    tars = [":network-vhostuserdra-binding-tar"],
+    visibility = ["//visibility:public"],
+)

--- a/cmd/sidecars/network-vhostuserdra-binding/OWNERS
+++ b/cmd/sidecars/network-vhostuserdra-binding/OWNERS
@@ -1,0 +1,6 @@
+reviewers:
+  - sig-network-reviewers
+approvers:
+  - sig-network-approvers
+labels:
+  - sig/network

--- a/cmd/sidecars/network-vhostuserdra-binding/README.md
+++ b/cmd/sidecars/network-vhostuserdra-binding/README.md
@@ -1,0 +1,5 @@
+# KubeVirt vhostuser DRA Network Binding Plugin
+
+Configures a VM interface as a vhost-user interface via KubeVirt's hook sidecar,
+using a socket provisioned by a DRA network driver.
+

--- a/cmd/sidecars/network-vhostuserdra-binding/callback/BUILD.bazel
+++ b/cmd/sidecars/network-vhostuserdra-binding/callback/BUILD.bazel
@@ -1,0 +1,25 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["callback.go"],
+    importpath = "kubevirt.io/kubevirt/cmd/sidecars/network-vhostuserdra-binding/callback",
+    visibility = ["//visibility:public"],
+    deps = ["//pkg/virt-launcher/virtwrap/api:go_default_library"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "callback_suite_test.go",
+        "callback_test.go",
+    ],
+    race = "on",
+    deps = [
+        ":go_default_library",
+        "//pkg/virt-launcher/virtwrap/api:go_default_library",
+        "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+    ],
+)

--- a/cmd/sidecars/network-vhostuserdra-binding/callback/callback.go
+++ b/cmd/sidecars/network-vhostuserdra-binding/callback/callback.go
@@ -1,0 +1,57 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package callback
+
+import (
+	"encoding/xml"
+	"fmt"
+
+	domainschema "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
+)
+
+const libvirtDomainQemuSchema = "http://libvirt.org/schemas/domain/qemu/1.0"
+
+type domainSpecMutator interface {
+	Mutate(*domainschema.DomainSpec) (*domainschema.DomainSpec, error)
+}
+
+func OnDefineDomain(domainXML []byte, domSpecMutator domainSpecMutator) ([]byte, error) {
+	domainSpec := &domainschema.DomainSpec{
+		// Unmarshalling domain spec makes the XML namespace attribute empty.
+		// Some domain parameters requires namespace to be defined.
+		// e.g: https://libvirt.org/drvqemu.html#pass-through-of-arbitrary-qemu-commands
+		XmlNS: libvirtDomainQemuSchema,
+	}
+	if err := xml.Unmarshal(domainXML, domainSpec); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal given domain spec: %v", err)
+	}
+
+	updatedDomainSpec, err := domSpecMutator.Mutate(domainSpec)
+	if err != nil {
+		return nil, err
+	}
+
+	updatedDomainSpecXML, err := xml.Marshal(updatedDomainSpec)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal updated domain spec: %v", err)
+	}
+
+	return updatedDomainSpecXML, nil
+}

--- a/cmd/sidecars/network-vhostuserdra-binding/callback/callback_suite_test.go
+++ b/cmd/sidecars/network-vhostuserdra-binding/callback/callback_suite_test.go
@@ -1,0 +1,30 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package callback_test
+
+import (
+	"testing"
+
+	"kubevirt.io/client-go/testutils"
+)
+
+func TestCallback(t *testing.T) {
+	testutils.KubeVirtTestSuiteSetup(t)
+}

--- a/cmd/sidecars/network-vhostuserdra-binding/callback/callback_test.go
+++ b/cmd/sidecars/network-vhostuserdra-binding/callback/callback_test.go
@@ -1,0 +1,93 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package callback_test
+
+import (
+	"encoding/xml"
+	"fmt"
+
+	"kubevirt.io/kubevirt/cmd/sidecars/network-vhostuserdra-binding/callback"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	domainschema "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
+)
+
+var _ = Describe("vhostuser hook callback handler", func() {
+	Context("on define domain", func() {
+		It("should fail given empty byte slice stream", func() {
+			_, err := callback.OnDefineDomain([]byte{}, mutatorStub{})
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should fail given invalid domain XML", func() {
+			_, err := callback.OnDefineDomain([]byte("invalid-domain-xml"), mutatorStub{})
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should fail when domain spec mutator fails", func() {
+			domain := domainschema.NewMinimalDomain("test")
+			domainXML, err := xml.Marshal(domain.Spec)
+			Expect(err).ToNot(HaveOccurred())
+
+			expectedErr := fmt.Errorf("test error")
+			domSpecMutator := mutatorStub{failMutate: expectedErr}
+
+			_, err = callback.OnDefineDomain(domainXML, domSpecMutator)
+			Expect(err).To(Equal(expectedErr))
+		})
+
+		It("given no-op mutator, domain spec should not change", func() {
+			domain := domainschema.NewMinimalDomain("test")
+			domainSpecXML, err := xml.Marshal(domain.Spec)
+			Expect(err).ToNot(HaveOccurred())
+
+			domSpecMutator := mutatorStub{domSpec: &domain.Spec}
+
+			Expect(callback.OnDefineDomain(domainSpecXML, domSpecMutator)).To(Equal(domainSpecXML))
+		})
+
+		It("domain spec should mutate successfully", func() {
+			domain := domainschema.NewMinimalDomain("test")
+			domainSpecXML, err := xml.Marshal(domain.Spec)
+			Expect(err).ToNot(HaveOccurred())
+
+			mutatedDomainSpec := domain.Spec.DeepCopy()
+			mutatedDomainSpec.Devices.Interfaces = append(mutatedDomainSpec.Devices.Interfaces,
+				domainschema.Interface{Alias: domainschema.NewUserDefinedAlias("test")})
+			domSpecMutator := mutatorStub{domSpec: mutatedDomainSpec}
+
+			mutatedDomainSpecXML, err := xml.Marshal(mutatedDomainSpec)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(callback.OnDefineDomain(domainSpecXML, domSpecMutator)).To(Equal(mutatedDomainSpecXML))
+		})
+	})
+})
+
+type mutatorStub struct {
+	domSpec    *domainschema.DomainSpec
+	failMutate error
+}
+
+func (s mutatorStub) Mutate(_ *domainschema.DomainSpec) (*domainschema.DomainSpec, error) {
+	return s.domSpec, s.failMutate
+}

--- a/cmd/sidecars/network-vhostuserdra-binding/domain/BUILD.bazel
+++ b/cmd/sidecars/network-vhostuserdra-binding/domain/BUILD.bazel
@@ -1,0 +1,32 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["configurator.go"],
+    importpath = "kubevirt.io/kubevirt/cmd/sidecars/network-vhostuserdra-binding/domain",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/network/vmispec:go_default_library",
+        "//pkg/virt-launcher/virtwrap/api:go_default_library",
+        "//pkg/virt-launcher/virtwrap/device:go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/log:go_default_library",
+    ],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "configurator_test.go",
+        "domain_suite_test.go",
+    ],
+    race = "on",
+    deps = [
+        ":go_default_library",
+        "//pkg/virt-launcher/virtwrap/api:go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/testutils:go_default_library",
+        "//vendor/github.com/onsi/ginkgo/v2:go_default_library",
+        "//vendor/github.com/onsi/gomega:go_default_library",
+    ],
+)

--- a/cmd/sidecars/network-vhostuserdra-binding/domain/configurator.go
+++ b/cmd/sidecars/network-vhostuserdra-binding/domain/configurator.go
@@ -1,0 +1,196 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package domain
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+
+	vmschema "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/client-go/log"
+
+	"kubevirt.io/kubevirt/pkg/network/vmispec"
+	domainschema "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
+	"kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/device"
+)
+
+const (
+	SocketDirEnvVar      = "KUBEVIRT_HOSTPATH_MOUNTPOINT"
+	SocketFileNameEnvVar = "KUBEVIRT_HOSTPATH_SOCKET"
+	SocketModeEnvVar     = "KUBEVIRT_VHOSTUSER_MODE"
+
+	DefaultSocketFileName = "vhost.sock"
+
+	socketModeClient = "client"
+	socketModeServer = "server"
+)
+
+type VhostUserNetworkConfigurator struct {
+	vmiSpecIface          *vmschema.Interface
+	socketPath            string
+	socketMode            string
+	useVirtioTransitional bool
+}
+
+func NewVhostUserNetworkConfigurator(
+	ifaces []vmschema.Interface,
+	networks []vmschema.Network,
+	bindingPluginName string,
+	useVirtioTransitional bool,
+) (*VhostUserNetworkConfigurator, error) {
+	idx := slices.IndexFunc(networks, vmispec.IsDRANetwork)
+	if idx == -1 {
+		return nil, fmt.Errorf("DRA network not found")
+	}
+	network := networks[idx]
+
+	iface := vmispec.LookupInterfaceByName(ifaces, network.Name)
+	if iface == nil {
+		return nil, fmt.Errorf("no interface found for network %q", network.Name)
+	}
+	if iface.Binding == nil || iface.Binding.Name != bindingPluginName {
+		return nil, fmt.Errorf("interface %q is not set with the %q network binding plugin",
+			network.Name, bindingPluginName)
+	}
+
+	socketDir := os.Getenv(SocketDirEnvVar)
+	if socketDir == "" {
+		return nil, fmt.Errorf("env var %q is not set; the DRA network device was not provisioned", SocketDirEnvVar)
+	}
+
+	socketFileName := os.Getenv(SocketFileNameEnvVar)
+	if socketFileName == "" {
+		socketFileName = DefaultSocketFileName
+	}
+
+	socketMode := os.Getenv(SocketModeEnvVar)
+	if socketMode == "" {
+		socketMode = socketModeClient
+	}
+	if socketMode != socketModeClient && socketMode != socketModeServer {
+		return nil, fmt.Errorf("invalid socket mode %q; must be %q or %q",
+			socketMode, socketModeClient, socketModeServer)
+	}
+
+	return &VhostUserNetworkConfigurator{
+		vmiSpecIface:          iface,
+		socketPath:            filepath.Join(socketDir, socketFileName),
+		socketMode:            socketMode,
+		useVirtioTransitional: useVirtioTransitional,
+	}, nil
+}
+
+func (c VhostUserNetworkConfigurator) Mutate(domainSpec *domainschema.DomainSpec) (*domainschema.DomainSpec, error) {
+	const (
+		sharedMemoryBackingAccessMode = "shared"
+		memfdMemoryBackingSourceType  = "memfd"
+	)
+
+	if domainSpec.MemoryBacking != nil &&
+		domainSpec.MemoryBacking.Access != nil &&
+		domainSpec.MemoryBacking.Access.Mode != sharedMemoryBackingAccessMode {
+		return nil, fmt.Errorf("memory backing access mode must be 'shared'; cannot override existing mode: %q",
+			domainSpec.MemoryBacking.Access.Mode)
+	}
+
+	generatedIface := c.generateInterface()
+
+	domainSpecCopy := domainSpec.DeepCopy()
+	if iface := lookupIfaceByAliasName(domainSpecCopy.Devices.Interfaces, c.vmiSpecIface.Name); iface != nil {
+		*iface = *generatedIface
+	} else {
+		domainSpecCopy.Devices.Interfaces = append(domainSpecCopy.Devices.Interfaces, *generatedIface)
+	}
+
+	// vhostuser interfaces require the guest memory to be shared with the
+	// vhost-user backend process.
+	if domainSpecCopy.MemoryBacking == nil {
+		domainSpecCopy.MemoryBacking = &domainschema.MemoryBacking{
+			Access: &domainschema.MemoryBackingAccess{
+				Mode: sharedMemoryBackingAccessMode,
+			},
+			Source: &domainschema.MemoryBackingSource{
+				Type: memfdMemoryBackingSourceType,
+			},
+		}
+	}
+
+	log.Log.Infof("vhostuser interface is added to domain spec successfully: %+v", generatedIface)
+
+	return domainSpecCopy, nil
+}
+
+func lookupIfaceByAliasName(ifaces []domainschema.Interface, name string) *domainschema.Interface {
+	for i := range ifaces {
+		if ifaces[i].Alias != nil && ifaces[i].Alias.GetName() == name {
+			return &ifaces[i]
+		}
+	}
+
+	return nil
+}
+
+func (c VhostUserNetworkConfigurator) generateInterface() *domainschema.Interface {
+	var ifaceModelType string
+	switch {
+	case c.vmiSpecIface.Model != "" && c.vmiSpecIface.Model != vmschema.VirtIO:
+		ifaceModelType = c.vmiSpecIface.Model
+	case c.useVirtioTransitional:
+		ifaceModelType = "virtio-transitional"
+	default:
+		ifaceModelType = "virtio-non-transitional"
+	}
+
+	var mac *domainschema.MAC
+	if c.vmiSpecIface.MacAddress != "" {
+		mac = &domainschema.MAC{MAC: c.vmiSpecIface.MacAddress}
+	}
+
+	var pciAddress *domainschema.Address
+	if c.vmiSpecIface.PciAddress != "" {
+		if addr, err := device.NewPciAddressField(c.vmiSpecIface.PciAddress); err == nil {
+			pciAddress = addr
+		} else {
+			log.Log.Reason(err).Warningf("failed to parse PCI address %q", c.vmiSpecIface.PciAddress)
+		}
+	}
+
+	var acpi *domainschema.ACPI
+	if acpiIndex := c.vmiSpecIface.ACPIIndex; acpiIndex > 0 {
+		acpi = &domainschema.ACPI{Index: uint(acpiIndex)}
+	}
+
+	return &domainschema.Interface{
+		Alias:   domainschema.NewUserDefinedAlias(c.vmiSpecIface.Name),
+		Model:   &domainschema.Model{Type: ifaceModelType},
+		Address: pciAddress,
+		MAC:     mac,
+		ACPI:    acpi,
+		Type:    "vhostuser",
+		Source: domainschema.InterfaceSource{
+			Type: "unix",
+			Path: c.socketPath,
+			Mode: c.socketMode,
+		},
+	}
+}

--- a/cmd/sidecars/network-vhostuserdra-binding/domain/configurator_test.go
+++ b/cmd/sidecars/network-vhostuserdra-binding/domain/configurator_test.go
@@ -1,0 +1,343 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package domain_test
+
+import (
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	vmschema "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/kubevirt/cmd/sidecars/network-vhostuserdra-binding/domain"
+
+	domainschema "kubevirt.io/kubevirt/pkg/virt-launcher/virtwrap/api"
+)
+
+const (
+	ifaceTypeVhostUser = "vhostuser"
+
+	bindingPluginName = "vhostuserdra"
+	testSocketDir     = "/var/run/kubevirt/dra/hostpath"
+)
+
+var testSocketPath = filepath.Join(testSocketDir, domain.DefaultSocketFileName)
+
+func draNetwork(name string) vmschema.Network {
+	return vmschema.Network{
+		Name: name,
+		NetworkSource: vmschema.NetworkSource{
+			ResourceClaim: &vmschema.ClaimRequest{ClaimName: "claim", RequestName: "req"},
+		},
+	}
+}
+
+var _ = Describe("vhostuser network configurator", func() {
+	Context("generate domain spec interface", func() {
+		DescribeTable("should fail to create configurator given",
+			func(ifaces []vmschema.Interface, networks []vmschema.Network) {
+				GinkgoT().Setenv(domain.SocketDirEnvVar, testSocketDir)
+
+				_, err := domain.NewVhostUserNetworkConfigurator(ifaces, networks, bindingPluginName, false)
+				Expect(err).To(HaveOccurred())
+			},
+			Entry("no DRA network",
+				[]vmschema.Interface{{Name: "default", Binding: &vmschema.PluginBinding{Name: bindingPluginName}}},
+				[]vmschema.Network{*vmschema.DefaultPodNetwork()},
+			),
+			Entry("no corresponding iface",
+				[]vmschema.Interface{{Name: "not-default", Binding: &vmschema.PluginBinding{Name: bindingPluginName}}},
+				[]vmschema.Network{draNetwork("default")},
+			),
+			Entry("interface with no binding plugin",
+				[]vmschema.Interface{{Name: "default", InterfaceBindingMethod: vmschema.InterfaceBindingMethod{Bridge: &vmschema.InterfaceBridge{}}}},
+				[]vmschema.Network{draNetwork("default")},
+			),
+			Entry("interface with a different binding plugin",
+				[]vmschema.Interface{{Name: "default", Binding: &vmschema.PluginBinding{Name: "not-vhostuserdra"}}},
+				[]vmschema.Network{draNetwork("default")},
+			),
+		)
+
+		It("should fail when the DRA mountpoint env var is not set", func() {
+			GinkgoT().Setenv(domain.SocketDirEnvVar, "")
+
+			ifaces := []vmschema.Interface{{Name: "default", Binding: &vmschema.PluginBinding{Name: bindingPluginName}}}
+			networks := []vmschema.Network{draNetwork("default")}
+
+			_, err := domain.NewVhostUserNetworkConfigurator(ifaces, networks, bindingPluginName, false)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should fail when an invalid socket mode is requested", func() {
+			GinkgoT().Setenv(domain.SocketDirEnvVar, testSocketDir)
+			GinkgoT().Setenv(domain.SocketModeEnvVar, "bogus")
+
+			ifaces := []vmschema.Interface{{Name: "default", Binding: &vmschema.PluginBinding{Name: bindingPluginName}}}
+			networks := []vmschema.Network{draNetwork("default")}
+
+			_, err := domain.NewVhostUserNetworkConfigurator(ifaces, networks, bindingPluginName, false)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should honor a custom socket file name", func() {
+			GinkgoT().Setenv(domain.SocketDirEnvVar, testSocketDir)
+			GinkgoT().Setenv(domain.SocketFileNameEnvVar, "custom.sock")
+
+			networks := []vmschema.Network{draNetwork("default")}
+			ifaces := []vmschema.Interface{{Name: "default", Binding: &vmschema.PluginBinding{Name: bindingPluginName}}}
+
+			expectedDomainIface := &domainschema.Interface{
+				Alias:  domainschema.NewUserDefinedAlias("default"),
+				Type:   ifaceTypeVhostUser,
+				Source: domainschema.InterfaceSource{Type: "unix", Path: filepath.Join(testSocketDir, "custom.sock"), Mode: "client"},
+				Model:  &domainschema.Model{Type: "virtio-non-transitional"},
+			}
+
+			testMutator, err := domain.NewVhostUserNetworkConfigurator(ifaces, networks, bindingPluginName, false)
+			Expect(err).ToNot(HaveOccurred())
+
+			mutatedDomSpec, err := testMutator.Mutate(&domainschema.DomainSpec{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(mutatedDomSpec.Devices.Interfaces).To(Equal([]domainschema.Interface{*expectedDomainIface}))
+		})
+
+		It("should honor a custom socket mode", func() {
+			GinkgoT().Setenv(domain.SocketDirEnvVar, testSocketDir)
+			GinkgoT().Setenv(domain.SocketModeEnvVar, "server")
+
+			networks := []vmschema.Network{draNetwork("default")}
+			ifaces := []vmschema.Interface{{Name: "default", Binding: &vmschema.PluginBinding{Name: bindingPluginName}}}
+
+			expectedDomainIface := &domainschema.Interface{
+				Alias:  domainschema.NewUserDefinedAlias("default"),
+				Type:   ifaceTypeVhostUser,
+				Source: domainschema.InterfaceSource{Type: "unix", Path: testSocketPath, Mode: "server"},
+				Model:  &domainschema.Model{Type: "virtio-non-transitional"},
+			}
+
+			testMutator, err := domain.NewVhostUserNetworkConfigurator(ifaces, networks, bindingPluginName, false)
+			Expect(err).ToNot(HaveOccurred())
+
+			mutatedDomSpec, err := testMutator.Mutate(&domainschema.DomainSpec{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(mutatedDomSpec.Devices.Interfaces).To(Equal([]domainschema.Interface{*expectedDomainIface}))
+		})
+
+		DescribeTable("should add interface to domain spec given iface with",
+			func(iface *vmschema.Interface, useVirtioTransitional bool, expectedDomainIface *domainschema.Interface) {
+				GinkgoT().Setenv(domain.SocketDirEnvVar, testSocketDir)
+
+				ifaces := []vmschema.Interface{*iface}
+				networks := []vmschema.Network{draNetwork("default")}
+
+				testMutator, err := domain.NewVhostUserNetworkConfigurator(ifaces, networks, bindingPluginName, useVirtioTransitional)
+				Expect(err).ToNot(HaveOccurred())
+
+				mutatedDomSpec, err := testMutator.Mutate(&domainschema.DomainSpec{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(mutatedDomSpec.Devices.Interfaces).To(Equal([]domainschema.Interface{*expectedDomainIface}))
+			},
+			Entry("vhostuser binding plugin",
+				&vmschema.Interface{Name: "default", Binding: &vmschema.PluginBinding{Name: bindingPluginName}},
+				false,
+				&domainschema.Interface{
+					Alias:  domainschema.NewUserDefinedAlias("default"),
+					Type:   ifaceTypeVhostUser,
+					Source: domainschema.InterfaceSource{Type: "unix", Path: testSocketPath, Mode: "client"},
+					Model:  &domainschema.Model{Type: "virtio-non-transitional"},
+				},
+			),
+			Entry("virtio transitional enabled",
+				&vmschema.Interface{Name: "default", Binding: &vmschema.PluginBinding{Name: bindingPluginName}},
+				true,
+				&domainschema.Interface{
+					Alias:  domainschema.NewUserDefinedAlias("default"),
+					Type:   ifaceTypeVhostUser,
+					Source: domainschema.InterfaceSource{Type: "unix", Path: testSocketPath, Mode: "client"},
+					Model:  &domainschema.Model{Type: "virtio-transitional"},
+				},
+			),
+			Entry("PCI address",
+				&vmschema.Interface{
+					Name: "default", Binding: &vmschema.PluginBinding{Name: bindingPluginName},
+					PciAddress: "0000:02:02.0",
+				},
+				false,
+				&domainschema.Interface{
+					Alias:   domainschema.NewUserDefinedAlias("default"),
+					Type:    ifaceTypeVhostUser,
+					Source:  domainschema.InterfaceSource{Type: "unix", Path: testSocketPath, Mode: "client"},
+					Model:   &domainschema.Model{Type: "virtio-non-transitional"},
+					Address: &domainschema.Address{Type: "pci", Domain: "0x0000", Bus: "0x02", Slot: "0x02", Function: "0x0"},
+				},
+			),
+			Entry("MAC address",
+				&vmschema.Interface{
+					Name: "default", Binding: &vmschema.PluginBinding{Name: bindingPluginName},
+					MacAddress: "02:02:02:02:02:02",
+				},
+				false,
+				&domainschema.Interface{
+					Alias:  domainschema.NewUserDefinedAlias("default"),
+					Type:   ifaceTypeVhostUser,
+					Source: domainschema.InterfaceSource{Type: "unix", Path: testSocketPath, Mode: "client"},
+					Model:  &domainschema.Model{Type: "virtio-non-transitional"},
+					MAC:    &domainschema.MAC{MAC: "02:02:02:02:02:02"},
+				},
+			),
+			Entry("ACPI index",
+				&vmschema.Interface{
+					Name: "default", Binding: &vmschema.PluginBinding{Name: bindingPluginName},
+					ACPIIndex: 2,
+				},
+				false,
+				&domainschema.Interface{
+					Alias:  domainschema.NewUserDefinedAlias("default"),
+					Type:   ifaceTypeVhostUser,
+					Source: domainschema.InterfaceSource{Type: "unix", Path: testSocketPath, Mode: "client"},
+					Model:  &domainschema.Model{Type: "virtio-non-transitional"},
+					ACPI:   &domainschema.ACPI{Index: uint(2)},
+				},
+			),
+			Entry("non virtio model",
+				&vmschema.Interface{
+					Name: "default", Binding: &vmschema.PluginBinding{Name: bindingPluginName},
+					Model: "e1000",
+				},
+				false,
+				&domainschema.Interface{
+					Alias:  domainschema.NewUserDefinedAlias("default"),
+					Type:   ifaceTypeVhostUser,
+					Source: domainschema.InterfaceSource{Type: "unix", Path: testSocketPath, Mode: "client"},
+					Model:  &domainschema.Model{Type: "e1000"},
+				},
+			),
+		)
+
+		It("should not override other interfaces", func() {
+			GinkgoT().Setenv(domain.SocketDirEnvVar, testSocketDir)
+
+			networks := []vmschema.Network{
+				draNetwork("default"),
+				{Name: "secondary", NetworkSource: vmschema.NetworkSource{Multus: &vmschema.MultusNetwork{NetworkName: "sec"}}},
+			}
+			ifaces := []vmschema.Interface{
+				{Name: "default", Binding: &vmschema.PluginBinding{Name: bindingPluginName}},
+				{Name: "secondary", InterfaceBindingMethod: vmschema.InterfaceBindingMethod{Bridge: &vmschema.InterfaceBridge{}}},
+			}
+
+			expectedDomainIface := &domainschema.Interface{
+				Alias:  domainschema.NewUserDefinedAlias("default"),
+				Type:   ifaceTypeVhostUser,
+				Source: domainschema.InterfaceSource{Type: "unix", Path: testSocketPath, Mode: "client"},
+				Model:  &domainschema.Model{Type: "virtio-non-transitional"},
+			}
+
+			testMutator, err := domain.NewVhostUserNetworkConfigurator(ifaces, networks, bindingPluginName, false)
+			Expect(err).ToNot(HaveOccurred())
+
+			existingIface := &domainschema.Interface{Alias: domainschema.NewUserDefinedAlias("existing-iface")}
+			testDomSpec := &domainschema.DomainSpec{
+				Devices: domainschema.Devices{
+					Interfaces: []domainschema.Interface{*existingIface},
+				},
+			}
+
+			mutatedDomSpec, err := testMutator.Mutate(testDomSpec)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(mutatedDomSpec.Devices.Interfaces).To(Equal([]domainschema.Interface{*existingIface, *expectedDomainIface}))
+		})
+
+		It("should set domain interface correctly when executed more than once", func() {
+			GinkgoT().Setenv(domain.SocketDirEnvVar, testSocketDir)
+
+			networks := []vmschema.Network{draNetwork("default")}
+			ifaces := []vmschema.Interface{{Name: "default", Binding: &vmschema.PluginBinding{Name: bindingPluginName}}}
+
+			expectedDomainIface := &domainschema.Interface{
+				Alias:  domainschema.NewUserDefinedAlias("default"),
+				Type:   ifaceTypeVhostUser,
+				Source: domainschema.InterfaceSource{Type: "unix", Path: testSocketPath, Mode: "client"},
+				Model:  &domainschema.Model{Type: "virtio-non-transitional"},
+			}
+
+			testMutator, err := domain.NewVhostUserNetworkConfigurator(ifaces, networks, bindingPluginName, false)
+			Expect(err).ToNot(HaveOccurred())
+
+			mutatedDomSpec, err := testMutator.Mutate(&domainschema.DomainSpec{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(mutatedDomSpec.Devices.Interfaces).To(Equal([]domainschema.Interface{*expectedDomainIface}))
+
+			Expect(testMutator.Mutate(mutatedDomSpec)).To(Equal(mutatedDomSpec))
+		})
+	})
+
+	Context("should define memoryBacking for vhost-user", func() {
+		var testMutator *domain.VhostUserNetworkConfigurator
+		BeforeEach(func() {
+			GinkgoT().Setenv(domain.SocketDirEnvVar, testSocketDir)
+
+			networks := []vmschema.Network{draNetwork("default")}
+			ifaces := []vmschema.Interface{{Name: "default", Binding: &vmschema.PluginBinding{Name: bindingPluginName}}}
+
+			var err error
+			testMutator, err = domain.NewVhostUserNetworkConfigurator(ifaces, networks, bindingPluginName, false)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should set shared memfd when clean domain", func() {
+			expectedMemoryBacking := &domainschema.MemoryBacking{
+				Access: &domainschema.MemoryBackingAccess{
+					Mode: "shared",
+				},
+				Source: &domainschema.MemoryBackingSource{
+					Type: "memfd",
+				},
+			}
+			mutatedDomSpec, err := testMutator.Mutate(&domainschema.DomainSpec{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(mutatedDomSpec.MemoryBacking).To(Equal(expectedMemoryBacking))
+		})
+
+		It("should fail when private memory is predefined", func() {
+			domainWithPrivateMem := &domainschema.DomainSpec{
+				MemoryBacking: &domainschema.MemoryBacking{
+					Access: &domainschema.MemoryBackingAccess{Mode: "private"},
+				},
+			}
+			_, err := testMutator.Mutate(domainWithPrivateMem)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should use other configs of backing memory as long as they are shared", func() {
+			domainWithOtherSharedMem := &domainschema.DomainSpec{
+				MemoryBacking: &domainschema.MemoryBacking{
+					Access: &domainschema.MemoryBackingAccess{Mode: "shared"},
+					Source: &domainschema.MemoryBackingSource{Type: "file"},
+				},
+			}
+			mutatedDomSpec, err := testMutator.Mutate(domainWithOtherSharedMem)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(mutatedDomSpec.MemoryBacking).To(Equal(domainWithOtherSharedMem.MemoryBacking))
+		})
+	})
+})

--- a/cmd/sidecars/network-vhostuserdra-binding/domain/domain_suite_test.go
+++ b/cmd/sidecars/network-vhostuserdra-binding/domain/domain_suite_test.go
@@ -1,0 +1,30 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright The KubeVirt Authors.
+ *
+ */
+
+package domain_test
+
+import (
+	"testing"
+
+	"kubevirt.io/client-go/testutils"
+)
+
+func TestDomain(t *testing.T) {
+	testutils.KubeVirtTestSuiteSetup(t)
+}

--- a/cmd/sidecars/network-vhostuserdra-binding/main.go
+++ b/cmd/sidecars/network-vhostuserdra-binding/main.go
@@ -1,0 +1,65 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package main
+
+import (
+	"context"
+	"net"
+	"os"
+	"path/filepath"
+
+	"google.golang.org/grpc"
+
+	"kubevirt.io/client-go/log"
+
+	"kubevirt.io/kubevirt/pkg/hooks"
+	hooksInfo "kubevirt.io/kubevirt/pkg/hooks/info"
+	hooksV1alpha3 "kubevirt.io/kubevirt/pkg/hooks/v1alpha3"
+
+	srv "kubevirt.io/kubevirt/cmd/sidecars/network-vhostuserdra-binding/server"
+)
+
+const (
+	hookSocket               = "vhostuserdra.sock"
+	defaultBindingPluginName = "vhostuserdra"
+)
+
+func main() {
+	socketPath := filepath.Join(hooks.HookSocketsSharedDirectory, hookSocket)
+	socket, err := (&net.ListenConfig{}).Listen(context.Background(), "unix", socketPath)
+	if err != nil {
+		log.Log.Reason(err).Errorf("Failed to initialized socket on path: %s", socket)
+		log.Log.Error("Check whether given directory exists and socket name is not already taken by other file")
+		os.Exit(1)
+	}
+	defer os.Remove(socketPath)
+
+	server := grpc.NewServer([]grpc.ServerOption{}...)
+	hooksInfo.RegisterInfoServer(server, srv.InfoServer{Version: "v1alpha3"})
+
+	shutdownChan := make(chan struct{})
+	bindingPluginName := os.Getenv(hooks.NetworkBindingPluginNameEnvVar)
+	if bindingPluginName == "" {
+		bindingPluginName = defaultBindingPluginName
+	}
+	hooksV1alpha3.RegisterCallbacksServer(server, srv.V1alpha3Server{Done: shutdownChan, BindingPluginName: bindingPluginName})
+	log.Log.Infof("vhostuser sidecar is now exposing its services on socket %s using %q API version", socketPath, "v1alpha3")
+	srv.Serve(server, socket, shutdownChan)
+}

--- a/cmd/sidecars/network-vhostuserdra-binding/server/BUILD.bazel
+++ b/cmd/sidecars/network-vhostuserdra-binding/server/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["server.go"],
+    importpath = "kubevirt.io/kubevirt/cmd/sidecars/network-vhostuserdra-binding/server",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//cmd/sidecars/network-vhostuserdra-binding/callback:go_default_library",
+        "//cmd/sidecars/network-vhostuserdra-binding/domain:go_default_library",
+        "//pkg/hooks/info:go_default_library",
+        "//pkg/hooks/v1alpha3:go_default_library",
+        "//staging/src/kubevirt.io/api/core/v1:go_default_library",
+        "//staging/src/kubevirt.io/client-go/log:go_default_library",
+        "//vendor/google.golang.org/grpc:go_default_library",
+    ],
+)

--- a/cmd/sidecars/network-vhostuserdra-binding/server/server.go
+++ b/cmd/sidecars/network-vhostuserdra-binding/server/server.go
@@ -1,0 +1,149 @@
+/*
+ * This file is part of the KubeVirt project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * Copyright 2023 Red Hat, Inc.
+ *
+ */
+
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"google.golang.org/grpc"
+
+	vmschema "kubevirt.io/api/core/v1"
+
+	"kubevirt.io/client-go/log"
+
+	"kubevirt.io/kubevirt/cmd/sidecars/network-vhostuserdra-binding/callback"
+	"kubevirt.io/kubevirt/cmd/sidecars/network-vhostuserdra-binding/domain"
+
+	hooksInfo "kubevirt.io/kubevirt/pkg/hooks/info"
+	hooksV1alpha3 "kubevirt.io/kubevirt/pkg/hooks/v1alpha3"
+)
+
+type InfoServer struct {
+	Version string
+}
+
+func (s InfoServer) Info(_ context.Context, _ *hooksInfo.InfoParams) (*hooksInfo.InfoResult, error) {
+	return &hooksInfo.InfoResult{
+		Name: "network-vhostuserdra-binding",
+		Versions: []string{
+			s.Version,
+		},
+		HookPoints: []*hooksInfo.HookPoint{
+			{
+				Name:     hooksInfo.OnDefineDomainHookPointName,
+				Priority: 0,
+			},
+			{
+				Name:     hooksInfo.ShutdownHookPointName,
+				Priority: 0,
+			},
+		},
+	}, nil
+}
+
+type V1alpha3Server struct {
+	Done              chan struct{}
+	BindingPluginName string
+}
+
+func (s V1alpha3Server) OnDefineDomain(
+	_ context.Context,
+	params *hooksV1alpha3.OnDefineDomainParams,
+) (*hooksV1alpha3.OnDefineDomainResult, error) {
+	vmi := &vmschema.VirtualMachineInstance{}
+	if err := json.Unmarshal(params.GetVmi(), vmi); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal VMI: %v", err)
+	}
+
+	useVirtioTransitional := vmi.Spec.Domain.Devices.UseVirtioTransitional != nil && *vmi.Spec.Domain.Devices.UseVirtioTransitional
+
+	vhostUserConfigurator, err := domain.NewVhostUserNetworkConfigurator(
+		vmi.Spec.Domain.Devices.Interfaces,
+		vmi.Spec.Networks,
+		s.BindingPluginName,
+		useVirtioTransitional,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create vhostuser configurator: %v", err)
+	}
+
+	newDomainXML, err := callback.OnDefineDomain(params.GetDomainXML(), vhostUserConfigurator)
+	if err != nil {
+		return nil, err
+	}
+
+	return &hooksV1alpha3.OnDefineDomainResult{
+		DomainXML: newDomainXML,
+	}, nil
+}
+
+func (s V1alpha3Server) PreCloudInitIso(
+	_ context.Context,
+	params *hooksV1alpha3.PreCloudInitIsoParams,
+) (*hooksV1alpha3.PreCloudInitIsoResult, error) {
+	return &hooksV1alpha3.PreCloudInitIsoResult{
+		CloudInitData: params.GetCloudInitData(),
+	}, nil
+}
+
+func (s V1alpha3Server) Shutdown(_ context.Context, _ *hooksV1alpha3.ShutdownParams) (*hooksV1alpha3.ShutdownResult, error) {
+	log.Log.Info("Shutdown vhostuser network binding")
+	s.Done <- struct{}{}
+	return &hooksV1alpha3.ShutdownResult{}, nil
+}
+
+func waitForShutdown(server *grpc.Server, errChan <-chan error, shutdownChan <-chan struct{}) {
+	// Handle signals to properly shutdown process
+	signalStopChan := make(chan os.Signal, 1)
+	signal.Notify(signalStopChan, os.Interrupt,
+		syscall.SIGHUP,
+		syscall.SIGINT,
+		syscall.SIGTERM,
+		syscall.SIGQUIT,
+	)
+	var err error
+	select {
+	case s := <-signalStopChan:
+		log.Log.Infof("vhostuser sidecar received signal: %s", s.String())
+	case err = <-errChan:
+		log.Log.Reason(err).Error("Failed to run grpc server")
+	case <-shutdownChan:
+		log.Log.Info("Exiting")
+	}
+
+	if err == nil {
+		server.GracefulStop()
+	}
+}
+
+func Serve(server *grpc.Server, socket net.Listener, shutdownChan <-chan struct{}) {
+	errChan := make(chan error)
+	go func() {
+		errChan <- server.Serve(socket)
+	}()
+
+	waitForShutdown(server, errChan, shutdownChan)
+}

--- a/hack/bazel-build-images.sh
+++ b/hack/bazel-build-images.sh
@@ -42,6 +42,7 @@ other_images_x86_64_aarch64="
     //cmd/sidecars/cloudinit:example-cloudinit-hook-sidecar-image
     //cmd/plugin-sidecars/test-domain-hook:test-domain-hook-sidecar-image
     //cmd/sidecars/network-passt-binding:network-passt-binding-image
+    //cmd/sidecars/network-vhostuserdra-binding:network-vhostuserdra-binding-image
     //cmd/pr-helper:pr-helper-image
     //containerimages:cirros-container-disk-image
     //containerimages:cirros-custom-container-disk-image

--- a/hack/bazel-push-images.sh
+++ b/hack/bazel-push-images.sh
@@ -75,6 +75,7 @@ if [[ "${ARCHITECTURE}" != "s390x" && "${ARCHITECTURE}" != "crossbuild-s390x" ]]
         virtio-container-disk
         winrmcli
         network-passt-binding
+        network-vhostuserdra-binding
     "
 fi
 

--- a/pkg/virt-launcher/virtwrap/api/schema.go
+++ b/pkg/virt-launcher/virtwrap/api/schema.go
@@ -1079,6 +1079,8 @@ type InterfaceSource struct {
 	Device  string   `xml:"dev,attr,omitempty"`
 	Bridge  string   `xml:"bridge,attr,omitempty"`
 	Mode    string   `xml:"mode,attr,omitempty"`
+	Type    string   `xml:"type,attr,omitempty"`
+	Path    string   `xml:"path,attr,omitempty"`
 	Address *Address `xml:"address,omitempty"`
 }
 


### PR DESCRIPTION
### What this PR does
To test the DRA capabilities of Kubevirt a test network binding plugin
will be used that reads the unix socket path from the
KUBEVIRT_HOSTPATH_MOUNTPOINT env var (injected by the test DRA driver
via CDI spec) and writes it to the domain XML.

Note: It mostly follows the same pattern as passt
network binding plugin.

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer
The functionality is tested by @nirdothan using his test DRA driver

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

