### PR TITLE
net, tests: Opt-in tests/network & tests/libnet to gofix

### DIFF
--- a/hack/linter/go-fix-paths.txt
+++ b/hack/linter/go-fix-paths.txt
@@ -1,2 +1,3 @@
 pkg/network
+tests/libnet
 tests/network

--- a/hack/linter/go-fix-paths.txt
+++ b/hack/linter/go-fix-paths.txt
@@ -1,1 +1,2 @@
 pkg/network
+tests/network

--- a/tests/libnet/cloudinit/BUILD.bazel
+++ b/tests/libnet/cloudinit/BUILD.bazel
@@ -9,7 +9,6 @@ go_library(
     importpath = "kubevirt.io/kubevirt/tests/libnet/cloudinit",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/pointer:go_default_library",
         "//tests/libnet/cluster:go_default_library",
         "//tests/libnet/dns:go_default_library",
         "//vendor/sigs.k8s.io/yaml:go_default_library",

--- a/tests/libnet/cloudinit/cloudinit.go
+++ b/tests/libnet/cloudinit/cloudinit.go
@@ -22,7 +22,6 @@ package cloudinit
 import (
 	"fmt"
 
-	"kubevirt.io/kubevirt/pkg/pointer"
 	"kubevirt.io/kubevirt/tests/libnet/cluster"
 	"kubevirt.io/kubevirt/tests/libnet/dns"
 
@@ -83,28 +82,28 @@ func WithAddresses(addresses ...string) NetworkDataInterfaceOption {
 
 func WithDHCP4Enabled() NetworkDataInterfaceOption {
 	return func(networkDataInterface *CloudInitInterface) error {
-		networkDataInterface.DHCP4 = pointer.P(true)
+		networkDataInterface.DHCP4 = new(true)
 		return nil
 	}
 }
 
 func WithDHCP6Enabled() NetworkDataInterfaceOption {
 	return func(networkDataInterface *CloudInitInterface) error {
-		networkDataInterface.DHCP6 = pointer.P(true)
+		networkDataInterface.DHCP6 = new(true)
 		return nil
 	}
 }
 
 func WithDHCP4Disabled() NetworkDataInterfaceOption {
 	return func(networkDataInterface *CloudInitInterface) error {
-		networkDataInterface.DHCP4 = pointer.P(false)
+		networkDataInterface.DHCP4 = new(false)
 		return nil
 	}
 }
 
 func WithDHCP6Disabled() NetworkDataInterfaceOption {
 	return func(networkDataInterface *CloudInitInterface) error {
-		networkDataInterface.DHCP6 = pointer.P(false)
+		networkDataInterface.DHCP6 = new(false)
 		return nil
 	}
 }
@@ -159,7 +158,7 @@ type CloudInitInterface struct {
 	Gateway6       string                `json:"gateway6,omitempty"`
 	Nameservers    *CloudInitNameservers `json:"nameservers,omitempty"`
 	MACAddress     string                `json:"macaddress,omitempty"`
-	Match          CloudInitMatch        `json:"match,omitempty"`
+	Match          CloudInitMatch        `json:"match"`
 	MTU            int                   `json:"mtu,omitempty"`
 	Routes         []CloudInitRoute      `json:"routes,omitempty"`
 	SetName        string                `json:"set-name,omitempty"`

--- a/tests/libnet/netattachdef.go
+++ b/tests/libnet/netattachdef.go
@@ -38,14 +38,14 @@ const (
 	ResourceNameAnnotation = "k8s.v1.cni.cncf.io/resourceName"
 )
 
-type pluginConfOption func(map[string]interface{})
+type pluginConfOption func(map[string]any)
 
 func NewBridgeNetAttachDef(name, bridgeName string, opts ...pluginConfOption) *nadv1.NetworkAttachmentDefinition {
 	const cniPluginType = "bridge"
 
 	pluginConfig := NewNetPluginConfig(
 		cniPluginType,
-		map[string]interface{}{"bridge": bridgeName},
+		map[string]any{"bridge": bridgeName},
 	)
 	for _, f := range opts {
 		f(pluginConfig)
@@ -55,7 +55,7 @@ func NewBridgeNetAttachDef(name, bridgeName string, opts ...pluginConfOption) *n
 
 func NewSriovNetAttachDef(name string, vlanID int, opts ...pluginConfOption) *nadv1.NetworkAttachmentDefinition {
 	const pluginType = "sriov"
-	pluginConf := map[string]interface{}{"vlan": vlanID}
+	pluginConf := map[string]any{"vlan": vlanID}
 	for _, f := range opts {
 		f(pluginConf)
 	}
@@ -81,9 +81,9 @@ func NewNetAttachDef(name, config string) *nadv1.NetworkAttachmentDefinition {
 	}
 }
 
-func NewNetConfig(name string, pluginsConfigs ...map[string]interface{}) string {
+func NewNetConfig(name string, pluginsConfigs ...map[string]any) string {
 	const cniVersion = "0.3.1"
-	netConfig := map[string]interface{}{
+	netConfig := map[string]any{
 		"cniVersion": cniVersion,
 		"name":       name,
 	}
@@ -105,40 +105,40 @@ func NewNetConfig(name string, pluginsConfigs ...map[string]interface{}) string 
 	return string(rawNetConfig)
 }
 
-func NewNetPluginConfig(cniType string, conf map[string]interface{}) map[string]interface{} {
+func NewNetPluginConfig(cniType string, conf map[string]any) map[string]any {
 	if conf == nil {
-		conf = map[string]interface{}{}
+		conf = map[string]any{}
 	}
 	conf["type"] = cniType
 	return conf
 }
 
 func WithMTU(mtu int) pluginConfOption {
-	return func(conf map[string]interface{}) {
+	return func(conf map[string]any) {
 		conf["mtu"] = mtu
 	}
 }
 
 func WithVLAN(vlanID int) pluginConfOption {
-	return func(conf map[string]interface{}) {
+	return func(conf map[string]any) {
 		conf["vlan"] = vlanID
 	}
 }
 
 func WithMacSpoofChk(enabled bool) pluginConfOption {
-	return func(conf map[string]interface{}) {
+	return func(conf map[string]any) {
 		conf["macspoofchk"] = enabled
 	}
 }
 
 func WithIPAM(ipam map[string]string) pluginConfOption {
-	return func(conf map[string]interface{}) {
+	return func(conf map[string]any) {
 		conf["ipam"] = ipam
 	}
 }
 
 func WithLinkState() pluginConfOption {
-	return func(conf map[string]interface{}) {
+	return func(conf map[string]any) {
 		conf["link_state"] = "enable"
 	}
 }

--- a/tests/network/framework.go
+++ b/tests/network/framework.go
@@ -23,6 +23,6 @@ import (
 	"kubevirt.io/kubevirt/tests/decorators"
 )
 
-func SIG(text string, args ...interface{}) (extendedText string, newArgs []interface{}) {
+func SIG(text string, args ...any) (extendedText string, newArgs []any) {
 	return decorators.SIG("[sig-network]", text, decorators.SigNetwork, args)
 }

--- a/tests/network/sriov.go
+++ b/tests/network/sriov.go
@@ -918,9 +918,9 @@ func lookupDeviceVCPUAffinityOnPod(pod *k8sv1.Pod, pciAddress string, domSpec *a
 	return alignedVCPUs
 }
 
-func withLinkState() func(map[string]interface{}) {
+func withLinkState() func(map[string]any) {
 	if flags.EmulatedSRIOV {
-		return func(_ map[string]interface{}) {}
+		return func(_ map[string]any) {}
 	}
 	return libnet.WithLinkState()
 }

--- a/tests/network/vmi_istio.go
+++ b/tests/network/vmi_istio.go
@@ -505,14 +505,14 @@ func createPasstVm(ports []v1.Port) *v1.VirtualMachineInstance {
 
 func generateStrictPeerAuthentication() *unstructured.Unstructured {
 	return &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"apiVersion": fmt.Sprintf("%s/%s", securityIstioIO, istioApiVersion),
 			"kind":       "PeerAuthentication",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name": "strict-pa",
 			},
-			"spec": map[string]interface{}{
-				"mtls": map[string]interface{}{
+			"spec": map[string]any{
+				"mtls": map[string]any{
 					"mode": "STRICT",
 				},
 			},
@@ -522,14 +522,14 @@ func generateStrictPeerAuthentication() *unstructured.Unstructured {
 
 func generateRegistryOnlySidecar() *unstructured.Unstructured {
 	return &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"apiVersion": fmt.Sprintf("%s/%s", networkingIstioIO, istioApiVersion),
 			"kind":       "Sidecar",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name": "registry-only-sidecar",
 			},
-			"spec": map[string]interface{}{
-				"outboundTrafficPolicy": map[string]interface{}{
+			"spec": map[string]any{
+				"outboundTrafficPolicy": map[string]any{
 					"mode": "REGISTRY_ONLY",
 				},
 			},
@@ -539,32 +539,32 @@ func generateRegistryOnlySidecar() *unstructured.Unstructured {
 
 func generateVirtualService() *unstructured.Unstructured {
 	return &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"apiVersion": fmt.Sprintf("%s/%s", networkingIstioIO, istioApiVersion),
 			"kind":       "VirtualService",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name": "vmi-server-vs",
 			},
-			"spec": map[string]interface{}{
+			"spec": map[string]any{
 				"gateways": []string{
 					vmiServerGateway,
 				},
 				"hosts": []string{
 					fmt.Sprintf("%s.example.com", vmiServerHostName),
 				},
-				"http": []interface{}{
-					map[string]interface{}{
-						"match": []map[string]interface{}{
+				"http": []any{
+					map[string]any{
+						"match": []map[string]any{
 							{
-								"uri": map[string]interface{}{
+								"uri": map[string]any{
 									"prefix": "/",
 								},
 							},
 						},
-						"route": []map[string]interface{}{
+						"route": []map[string]any{
 							{
-								"destination": map[string]interface{}{
-									"port": map[string]interface{}{
+								"destination": map[string]any{
+									"port": map[string]any{
 										"number": vmiServerTestPort,
 									},
 									"host":   vmiServerHostName,
@@ -581,18 +581,18 @@ func generateVirtualService() *unstructured.Unstructured {
 
 func generateDestinationRule() *unstructured.Unstructured {
 	return &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"apiVersion": fmt.Sprintf("%s/%s", networkingIstioIO, istioApiVersion),
 			"kind":       "DestinationRule",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name": "vmi-server-dr",
 			},
-			"spec": map[string]interface{}{
+			"spec": map[string]any{
 				"host": vmiServerHostName,
-				"subsets": []map[string]interface{}{
+				"subsets": []map[string]any{
 					{
 						"name": "v1",
-						"labels": map[string]interface{}{
+						"labels": map[string]any{
 							"version": "v1",
 						},
 					},
@@ -604,19 +604,19 @@ func generateDestinationRule() *unstructured.Unstructured {
 
 func generateGateway() *unstructured.Unstructured {
 	return &unstructured.Unstructured{
-		Object: map[string]interface{}{
+		Object: map[string]any{
 			"apiVersion": fmt.Sprintf("%s/%s", networkingIstioIO, istioApiVersion),
 			"kind":       "Gateway",
-			"metadata": map[string]interface{}{
+			"metadata": map[string]any{
 				"name": vmiServerGateway,
 			},
-			"spec": map[string]interface{}{
-				"selector": map[string]interface{}{
+			"spec": map[string]any{
+				"selector": map[string]any{
 					"istio": "ingressgateway",
 				},
-				"servers": []map[string]interface{}{
+				"servers": []map[string]any{
 					{
-						"port": map[string]interface{}{
+						"port": map[string]any{
 							"number":   80,
 							"name":     "http",
 							"protocol": "HTTP",

--- a/tests/network/vmi_multus.go
+++ b/tests/network/vmi_multus.go
@@ -698,18 +698,19 @@ func configureAlpineInterfaceIP(vmi *v1.VirtualMachineInstance, ifaceName, stati
 }
 
 func activateDHCPOnVMInterfaces(vmi *v1.VirtualMachineInstance, ifacesNames ...string) error {
-	interfacesConfig := "auto lo\\niface lo inet loopback\\n\\n"
+	var interfacesConfig strings.Builder
+	interfacesConfig.WriteString("auto lo\\niface lo inet loopback\\n\\n")
 
 	for idx := range ifacesNames {
-		interfacesConfig += fmt.Sprintf("auto %s\\niface %s inet dhcp\\nhostname localhost\\n\\n",
+		interfacesConfig.WriteString(fmt.Sprintf("auto %s\\niface %s inet dhcp\\nhostname localhost\\n\\n",
 			ifacesNames[idx],
-			ifacesNames[idx])
+			ifacesNames[idx]))
 	}
 
 	return console.SafeExpectBatch(vmi, []expect.Batcher{
 		&expect.BSnd{S: "\n"},
 		&expect.BExp{R: ""},
-		&expect.BSnd{S: "echo $'" + interfacesConfig + "' > /etc/network/interfaces\n"},
+		&expect.BSnd{S: "echo $'" + interfacesConfig.String() + "' > /etc/network/interfaces\n"},
 		&expect.BExp{R: ""},
 		&expect.BSnd{S: "/etc/init.d/networking restart\n"},
 		&expect.BExp{R: ""},
@@ -744,7 +745,7 @@ func createPtpNetworkAttachmentDefinition(namespace, networkName, subnet string)
 	ipam := map[string]string{"type": "host-local", "subnet": subnet}
 	netAttachDef := libnet.NewNetAttachDef(
 		networkName,
-		libnet.NewNetConfig("mynet", libnet.NewNetPluginConfig(pluginType, map[string]interface{}{"ipam": ipam})),
+		libnet.NewNetConfig("mynet", libnet.NewNetPluginConfig(pluginType, map[string]any{"ipam": ipam})),
 	)
 	_, err := libnet.CreateNetAttachDef(context.Background(), namespace, netAttachDef)
 	return err


### PR DESCRIPTION

### What this PR does

Modernized code in two directories by opting them to the gofix paths and running "make gofix" on both.


### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```

