### PR TITLE
[release-1.9] seccomp: write profile file with mode 0600 instead of 0700

### DIFF
--- a/pkg/virt-handler/seccomp/seccomp.go
+++ b/pkg/virt-handler/seccomp/seccomp.go
@@ -50,10 +50,14 @@ func InstallPolicy(kubeletRoot string) error {
 		return fmt.Errorf(errMsgFormat, err)
 	}
 	if bytes.Equal(currentProfileBytes, profileBytes) {
+		// Correct permissions on profiles formerly deployed with a too-permissive mode.
+		if err := os.Chmod(profilePath, 0600); err != nil {
+			return fmt.Errorf(errMsgFormat, err)
+		}
 		return nil
 	}
 
-	if err := os.WriteFile(profilePath, profileBytes, 0700); err != nil {
+	if err := os.WriteFile(profilePath, profileBytes, 0600); err != nil {
 		return fmt.Errorf(errMsgFormat, err)
 	}
 


### PR DESCRIPTION
A JSON data file with the execute bit set is unusual and is flagged
by file-integrity monitoring tools. The kubelet reads
the file as root so no access change is needed; 0600 is the correct mode
for a root-owned data file.

This is a partial backport from https://github.com/kubevirt/kubevirt/pull/18888

/cc @jean-edouard 

```release-note
deploy non-executable /var/lib/kubelet/seccomp/kubevirt/kubevirt.json 
```

