### PR TITLE
Make exporter pod volume names unique

### DIFF
--- a/pkg/storage/export/export/export.go
+++ b/pkg/storage/export/export/export.go
@@ -25,6 +25,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"path"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -91,6 +92,7 @@ const (
 	noVolumeVMReason          = "VMNoVolumes"
 	noVolumeSnapshotReason    = "VMSnapshotNoVolumes"
 	notAllPVCsCreatedReason   = "NotAllPVCsCreated"
+	duplicatePVCReason        = "DuplicatePVC"
 	VMSnapshotNotFoundReason  = "VMSnapshotNotFound"
 	ociDigestsComputedReason  = "DigestsComputed"
 	ociDigestsPendingReason   = "DigestsPending"
@@ -208,8 +210,36 @@ func (sv *sourceVolumes) isSourceAvailable() bool {
 	return !sv.inUse && sv.isPopulated
 }
 
+// duplicatePVCNames returns the names of PVCs referenced by more than one volume.
+func (sv *sourceVolumes) duplicatePVCNames() []string {
+	seen := make(map[string]int, len(sv.volumes))
+	var duplicates []string
+	for _, volume := range sv.volumes {
+		if volume.pvc == nil {
+			continue
+		}
+		seen[volume.pvc.Name]++
+		if seen[volume.pvc.Name] == 2 {
+			duplicates = append(duplicates, volume.pvc.Name)
+		}
+	}
+	slices.Sort(duplicates)
+	return duplicates
+}
+
+// hasContent reports whether there is anything to export. A PVC can only be
+// mounted once into the exporter pod, so duplicates leave nothing exportable.
 func (sv *sourceVolumes) hasContent() bool {
-	return len(sv.volumes) > 0
+	return len(sv.volumes) > 0 && len(sv.duplicatePVCNames()) == 0
+}
+
+func (sv *sourceVolumes) ReadyCondition() exportv1.Condition {
+	if duplicates := sv.duplicatePVCNames(); len(duplicates) > 0 {
+		return newReadyCondition(corev1.ConditionFalse, duplicatePVCReason,
+			fmt.Sprintf("Source references the same PersistentVolumeClaim from more than one volume: %s",
+				strings.Join(duplicates, ", ")))
+	}
+	return sv.readyCondition
 }
 
 func (sv *sourceVolumes) configurePodVolumes(podManifest *corev1.Pod) {

--- a/pkg/storage/export/export/export.go
+++ b/pkg/storage/export/export/export.go
@@ -248,7 +248,7 @@ func (sv *sourceVolumes) configurePodVolumes(podManifest *corev1.Pod) {
 	for i, volume := range sv.volumes {
 		var mountPoint string
 		pvc := volume.pvc
-		volumeName := getExportPodVolumeName(pvc)
+		volumeName := getExportPodVolumeName(pvc, i)
 		if types.IsPVCBlock(pvc.Spec.VolumeMode) {
 			mountPoint = fmt.Sprintf("%s/%s", blockVolumeMountPath, volumeName)
 			podManifest.Spec.Containers[0].VolumeDevices = append(podManifest.Spec.Containers[0].VolumeDevices, corev1.VolumeDevice{
@@ -1036,8 +1036,14 @@ func (ctrl *VMExportController) getExportPodName(vmExport *exportv1.VirtualMachi
 	return naming.GetName(exportPrefix, vmExport.Name, validation.DNS1035LabelMaxLength)
 }
 
-func getExportPodVolumeName(pvc *corev1.PersistentVolumeClaim) string {
-	return getExportPodVolumeNameFromStr(pvc.Name)
+// getExportPodVolumeName builds the name a PVC is mounted under in the exporter
+// pod. Uniqueness comes from the index added as prefix.
+func getExportPodVolumeName(pvc *corev1.PersistentVolumeClaim, index int) string {
+	name := fmt.Sprintf("vol%d-%s", index, strings.ReplaceAll(pvc.Name, ".", "-"))
+	if len(name) > validation.DNS1035LabelMaxLength {
+		name = name[:validation.DNS1035LabelMaxLength]
+	}
+	return strings.TrimRight(name, "-")
 }
 
 // getExportPodVolumeNameFromStr sanitizes and hashes the PVC name into the

--- a/pkg/storage/export/export/export.go
+++ b/pkg/storage/export/export/export.go
@@ -1040,11 +1040,13 @@ func getExportPodVolumeName(pvc *corev1.PersistentVolumeClaim) string {
 	return getExportPodVolumeNameFromStr(pvc.Name)
 }
 
-// getExportPodVolumeNameFromStr sanitizes and hashes the PVC name to match the volume name used in the Pod.
+// getExportPodVolumeNameFromStr sanitizes and hashes the PVC name into the
+// volume name used in the exporter pod.
 //
-// CRITICAL: This logic must stay strictly in sync with the volume naming logic used in 'createExportPod'.
-// If the logic in createExportPod changes (e.g. prefix or hashing algorithm), this function MUST be updated
-// to match, otherwise the export server will fail to locate the mounted volumes.
+// CRITICAL: GetVolumeInfo falls back to this to resolve the volumes of exporter
+// pods created before the PVC name was passed in their environment, so it has
+// to keep deriving the name those pods were created with. Changing the pod
+// volume naming means adding a new function, not changing this one.
 func getExportPodVolumeNameFromStr(claimName string) string {
 	pvcName := strings.ReplaceAll(claimName, ".", "-")
 	// Using the formatted PVC name if it's under the max length.
@@ -1482,6 +1484,9 @@ func addVolumeEnvironmentVariables(exportContainer *corev1.Container, pvc *corev
 	exportContainer.Env = append(exportContainer.Env, corev1.EnvVar{
 		Name:  fmt.Sprintf("VOLUME%d_EXPORT_PATH", index),
 		Value: mountPoint,
+	}, corev1.EnvVar{
+		Name:  fmt.Sprintf("VOLUME%d_EXPORT_PVC_NAME", index),
+		Value: pvc.Name,
 	})
 	if types.IsPVCBlock(pvc.Spec.VolumeMode) {
 		exportContainer.Env = append(exportContainer.Env, corev1.EnvVar{

--- a/pkg/storage/export/export/export.go
+++ b/pkg/storage/export/export/export.go
@@ -23,6 +23,7 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"path"
 	"slices"
@@ -33,7 +34,7 @@ import (
 	"github.com/openshift/library-go/pkg/build/naming"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
-	"k8s.io/apimachinery/pkg/api/errors"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	k8stypes "k8s.io/apimachinery/pkg/types"
@@ -87,6 +88,7 @@ const (
 	podPendingReason          = "PodPending"
 	podReadyReason            = "PodReady"
 	podCompletedReason        = "PodCompleted"
+	exporterPodErrorReason    = "ExporterPodError"
 	vmNotFoundReason          = "VMNotFound"
 	volumesNotPopulatedReason = "VolumesNotPopulated"
 	noVolumeVMReason          = "VMNoVolumes"
@@ -786,12 +788,14 @@ func (ctrl *VMExportController) handleSource(vmExport *exportv1.VirtualMachineEx
 		return 0, err
 	}
 
-	pod, err := ctrl.manageExporterPod(vmExport, service, source)
-	if err != nil {
-		return 0, err
+	// Update the status even on failure, so the export does not stay empty.
+	pod, podErr := ctrl.manageExporterPod(vmExport, service, source)
+	requeue, statusErr := ctrl.updateStatus(vmExport, pod, service, source, podErr)
+	if podErr != nil {
+		return 0, errors.Join(podErr, statusErr)
 	}
 
-	return ctrl.updateStatus(vmExport, pod, service, source)
+	return requeue, statusErr
 }
 
 func (ctrl *VMExportController) manageExporterPod(vmExport *exportv1.VirtualMachineExport, service *corev1.Service, source exportSource) (*corev1.Pod, error) {
@@ -831,7 +835,7 @@ func (ctrl *VMExportController) manageExporterPod(vmExport *exportv1.VirtualMach
 
 func (ctrl *VMExportController) deleteExporterPod(vmExport *exportv1.VirtualMachineExport, pod *corev1.Pod, deleteReason, message string) error {
 	ctrl.Recorder.Event(vmExport, corev1.EventTypeWarning, deleteReason, message)
-	if err := ctrl.Client.CoreV1().Pods(vmExport.Namespace).Delete(context.Background(), pod.Name, metav1.DeleteOptions{}); !errors.IsNotFound(err) {
+	if err := ctrl.Client.CoreV1().Pods(vmExport.Namespace).Delete(context.Background(), pod.Name, metav1.DeleteOptions{}); !k8serrors.IsNotFound(err) {
 		return err
 	}
 	return nil
@@ -892,7 +896,7 @@ func (ctrl *VMExportController) createCertSecret(vmExport *exportv1.VirtualMachi
 		return err
 	}
 	_, err = ctrl.Client.CoreV1().Secrets(vmExport.Namespace).Create(context.Background(), secret, metav1.CreateOptions{})
-	if err != nil && !errors.IsAlreadyExists(err) {
+	if err != nil && !k8serrors.IsAlreadyExists(err) {
 		return err
 	} else if err == nil {
 		log.Log.V(3).Infof("Created new exporter pod secret")
@@ -992,7 +996,7 @@ func (ctrl *VMExportController) handleVMExportToken(vmExport *exportv1.VirtualMa
 
 	secret, err = ctrl.Client.CoreV1().Secrets(vmExport.Namespace).Create(context.Background(), secret, metav1.CreateOptions{})
 	if err != nil {
-		if errors.IsAlreadyExists(err) {
+		if k8serrors.IsAlreadyExists(err) {
 			return nil
 		}
 		return err
@@ -1331,7 +1335,7 @@ func (ctrl *VMExportController) reconcileManifestAndAddToPod(vmExport *exportv1.
 	}
 	cm, err := ctrl.Client.CoreV1().ConfigMaps(vmExport.Namespace).Get(context.Background(), manifestConfigMap.Name, metav1.GetOptions{})
 	if err != nil {
-		if !errors.IsNotFound(err) {
+		if !k8serrors.IsNotFound(err) {
 			return err
 		}
 		cm, err = ctrl.Client.CoreV1().ConfigMaps(vmExport.Namespace).Create(context.Background(), manifestConfigMap, metav1.CreateOptions{})
@@ -1535,12 +1539,12 @@ func (ctrl *VMExportController) isKubevirtContentType(pvc *corev1.PersistentVolu
 	return isKubevirt
 }
 
-func (ctrl *VMExportController) updateStatus(vmExport *exportv1.VirtualMachineExport, exporterPod *corev1.Pod, service *corev1.Service, source exportSource) (time.Duration, error) {
+func (ctrl *VMExportController) updateStatus(vmExport *exportv1.VirtualMachineExport, exporterPod *corev1.Pod, service *corev1.Service, source exportSource, podErr error) (time.Duration, error) {
 	var requeue time.Duration
 
 	vmExportCopy := vmExport.DeepCopy()
 
-	if err := ctrl.updateCommonVMExportStatusFields(vmExport, vmExportCopy, exporterPod, service, source); err != nil {
+	if err := ctrl.updateCommonVMExportStatusFields(vmExport, vmExportCopy, exporterPod, service, source, podErr); err != nil {
 		return requeue, err
 	}
 
@@ -1555,13 +1559,17 @@ func (ctrl *VMExportController) updateStatus(vmExport *exportv1.VirtualMachineEx
 	return requeue, nil
 }
 
-func (ctrl *VMExportController) updateCommonVMExportStatusFields(vmExport, vmExportCopy *exportv1.VirtualMachineExport, exporterPod *corev1.Pod, service *corev1.Service, source exportSource) error {
+func (ctrl *VMExportController) updateCommonVMExportStatusFields(vmExport, vmExportCopy *exportv1.VirtualMachineExport, exporterPod *corev1.Pod, service *corev1.Service, source exportSource, podErr error) error {
 	var err error
 
 	vmExportCopy.Status.ServiceName = service.Name
 	vmExportCopy.Status.Links = &exportv1.VirtualMachineExportLinks{}
 	if exporterPod == nil {
-		vmExportCopy.Status.Conditions = updateCondition(vmExportCopy.Status.Conditions, source.ReadyCondition())
+		condition := source.ReadyCondition()
+		if podErr != nil {
+			condition = newReadyCondition(corev1.ConditionFalse, exporterPodErrorReason, podErr.Error())
+		}
+		vmExportCopy.Status.Conditions = updateCondition(vmExportCopy.Status.Conditions, condition)
 		vmExportCopy.Status.Phase = exportv1.Pending
 	} else {
 		if optutil.PodIsReady(exporterPod) {

--- a/pkg/storage/export/export/export_test.go
+++ b/pkg/storage/export/export/export_test.go
@@ -1222,6 +1222,40 @@ var _ = Describe("Export controller", func() {
 		Entry("PVC name with same length as limit", strings.Repeat("a", validation.DNS1035LabelMaxLength)),
 	)
 
+	DescribeTable("sourceVolumes should report PVCs referenced by more than one volume", func(pvcNames []string, expectedDuplicates []string) {
+		sv := &sourceVolumes{
+			readyCondition: newReadyCondition(k8sv1.ConditionTrue, podReadyReason, ""),
+		}
+		for _, name := range pvcNames {
+			sv.volumes = append(sv.volumes, sourceVolume{
+				pvc: &k8sv1.PersistentVolumeClaim{ObjectMeta: metav1.ObjectMeta{Name: name}},
+			})
+		}
+
+		Expect(sv.duplicatePVCNames()).To(Equal(expectedDuplicates))
+		Expect(sv.hasContent()).To(Equal(len(pvcNames) > 0 && len(expectedDuplicates) == 0))
+
+		condition := sv.ReadyCondition()
+		Expect(condition.Type).To(Equal(exportv1.ConditionReady))
+		if len(expectedDuplicates) == 0 {
+			Expect(condition.Status).To(Equal(k8sv1.ConditionTrue))
+			Expect(condition.Reason).ToNot(Equal(duplicatePVCReason))
+			return
+		}
+		Expect(condition.Status).To(Equal(k8sv1.ConditionFalse))
+		Expect(condition.Reason).To(Equal(duplicatePVCReason))
+		for _, name := range expectedDuplicates {
+			Expect(condition.Message).To(ContainSubstring(name))
+		}
+	},
+		Entry("no volumes", nil, nil),
+		Entry("distinct PVCs", []string{"pvc1", "pvc2"}, nil),
+		Entry("names differing only by dots", []string{"my.disk", "my-disk"}, nil),
+		Entry("one PVC twice", []string{"shared", "shared"}, []string{"shared"}),
+		Entry("one PVC three times reported once", []string{"shared", "shared", "shared"}, []string{"shared"}),
+		Entry("two duplicates sorted", []string{"b", "a", "b", "a"}, []string{"a", "b"}),
+	)
+
 	DescribeTable("GetVolumeInfo should correctly resolve volume paths for various PVC names", func(pvcName string) {
 		targetName := getExportPodVolumeNameFromStr(pvcName)
 		sp := &ServerPaths{

--- a/pkg/storage/export/export/export_test.go
+++ b/pkg/storage/export/export/export_test.go
@@ -1105,7 +1105,7 @@ var _ = Describe("Export controller", func() {
 		vmExportCopy := vmExport.DeepCopy()
 		svc := &k8sv1.Service{ObjectMeta: metav1.ObjectMeta{Name: "test-svc", Namespace: testNamespace}}
 
-		err := controller.updateCommonVMExportStatusFields(vmExport, vmExportCopy, pod, svc, source)
+		err := controller.updateCommonVMExportStatusFields(vmExport, vmExportCopy, pod, svc, source, nil)
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(vmExportCopy.Status.Conditions).To(ContainElement(gstruct.MatchFields(gstruct.IgnoreExtras, gstruct.Fields{
@@ -1145,7 +1145,7 @@ var _ = Describe("Export controller", func() {
 			Status: k8sv1.PodStatus{Phase: k8sv1.PodRunning, ContainerStatuses: []k8sv1.ContainerStatus{{Ready: true}}},
 		}
 
-		err := controller.updateCommonVMExportStatusFields(vmExport, vmExportCopy, pod, svc, source)
+		err := controller.updateCommonVMExportStatusFields(vmExport, vmExportCopy, pod, svc, source, nil)
 		Expect(err).ToNot(HaveOccurred())
 
 		for _, cond := range vmExportCopy.Status.Conditions {

--- a/pkg/storage/export/export/export_test.go
+++ b/pkg/storage/export/export/export_test.go
@@ -899,7 +899,7 @@ var _ = Describe("Export controller", func() {
 			}
 		}
 		Expect(pod.Spec.Volumes).To(ContainElement(k8sv1.Volume{
-			Name: testPVCName,
+			Name: "vol0-" + testPVCName,
 			VolumeSource: k8sv1.VolumeSource{
 				PersistentVolumeClaim: &k8sv1.PersistentVolumeClaimVolumeSource{
 					ClaimName: testPVCName,
@@ -935,8 +935,8 @@ var _ = Describe("Export controller", func() {
 		}))
 		Expect(pod.Spec.Containers[0].VolumeDevices).To(HaveLen(1))
 		Expect(pod.Spec.Containers[0].VolumeDevices).To(ContainElement(k8sv1.VolumeDevice{
-			Name:       testPVC.Name,
-			DevicePath: fmt.Sprintf("%s/%s", blockVolumeMountPath, testPVC.Name),
+			Name:       "vol0-" + testPVC.Name,
+			DevicePath: fmt.Sprintf("%s/vol0-%s", blockVolumeMountPath, testPVC.Name),
 		}))
 		Expect(pod.Labels).To(And(
 			HaveKeyWithValue(exportServiceLabel, controller.getExportLabelValue(testVMExport)),
@@ -1157,7 +1157,7 @@ var _ = Describe("Export controller", func() {
 		Entry("VMTemplate source, gate disabled", createVMTemplateVMExport(), NewVMTemplateSource(nil, &sourceVolumes{}), false),
 	)
 
-	DescribeTable("Volumemount names should be trimmed depending on the PVC name", func(pvcName string) {
+	DescribeTable("Volumemount names should be unique and trimmed depending on the PVC name", func(pvcName, expectedName string) {
 		testVMExport := createPVCVMExportWithName(pvcName)
 		testPVC := &k8sv1.PersistentVolumeClaim{
 			ObjectMeta: metav1.ObjectMeta{
@@ -1207,19 +1207,42 @@ var _ = Describe("Export controller", func() {
 		Expect(pod.Spec.Containers).To(HaveLen(1))
 		Expect(pod.Spec.Containers[0].VolumeDevices).To(HaveLen(1))
 		Expect(pod.Spec.Containers[0].VolumeDevices).To(ContainElement(k8sv1.VolumeDevice{
-			Name:       getExportPodVolumeName(testPVC),
-			DevicePath: fmt.Sprintf("%s/%s", blockVolumeMountPath, getExportPodVolumeName(testPVC)),
+			Name:       expectedName,
+			DevicePath: fmt.Sprintf("%s/%s", blockVolumeMountPath, expectedName),
 		}))
-		if len(pvcName) > validation.DNS1035LabelMaxLength {
-			Expect(len(pod.Spec.Containers[0].VolumeDevices[0].Name)).To(BeNumerically("<", 63))
-		} else {
-			Expect(pod.Spec.Containers[0].VolumeDevices[0].Name).To(Equal(pvcName))
-		}
+		Expect(validation.IsDNS1123Label(expectedName)).To(BeEmpty())
 	},
-		Entry("PVC name within limit", "pvc-name-within-limit"),
-		Entry("PVC name exceeding limit", strings.Repeat("a", validation.DNS1035LabelMaxLength+1)),
-		Entry("PVC name with same length as limit", strings.Repeat("a", validation.DNS1035LabelMaxLength)),
+		Entry("PVC name within limit", "pvc-name-within-limit", "vol0-pvc-name-within-limit"),
+		Entry("PVC name with dots", "pvc.with.dots", "vol0-pvc-with-dots"),
+		Entry("PVC name with same length as limit",
+			strings.Repeat("a", validation.DNS1035LabelMaxLength),
+			"vol0-"+strings.Repeat("a", validation.DNS1035LabelMaxLength-5)),
+		Entry("PVC name exceeding limit",
+			strings.Repeat("a", validation.DNS1035LabelMaxLength+1),
+			"vol0-"+strings.Repeat("a", validation.DNS1035LabelMaxLength-5)),
+		Entry("PVC name truncated onto a dash",
+			strings.Repeat("a", validation.DNS1035LabelMaxLength-6)+"-b",
+			"vol0-"+strings.Repeat("a", validation.DNS1035LabelMaxLength-6)),
 	)
+
+	It("Volumemount names should not collide for claims differing only in dots", func() {
+		sv := &sourceVolumes{}
+		for _, name := range []string{"my.disk", "my-disk"} {
+			sv.volumes = append(sv.volumes, sourceVolume{
+				pvc: &k8sv1.PersistentVolumeClaim{
+					ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNamespace},
+				},
+			})
+		}
+
+		pod := &k8sv1.Pod{Spec: k8sv1.PodSpec{Containers: []k8sv1.Container{{}}}}
+		sv.configurePodVolumes(pod)
+
+		Expect(pod.Spec.Volumes).To(HaveLen(2))
+		Expect(pod.Spec.Volumes[0].Name).ToNot(Equal(pod.Spec.Volumes[1].Name))
+		Expect(pod.Spec.Containers[0].VolumeMounts).To(HaveLen(2))
+		Expect(pod.Spec.Containers[0].VolumeMounts[0].MountPath).ToNot(Equal(pod.Spec.Containers[0].VolumeMounts[1].MountPath))
+	})
 
 	DescribeTable("sourceVolumes should report PVCs referenced by more than one volume", func(pvcNames []string, expectedDuplicates []string) {
 		sv := &sourceVolumes{

--- a/pkg/storage/export/export/export_test.go
+++ b/pkg/storage/export/export/export_test.go
@@ -24,7 +24,6 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -1256,30 +1255,48 @@ var _ = Describe("Export controller", func() {
 		Entry("two duplicates sorted", []string{"b", "a", "b", "a"}, []string{"a", "b"}),
 	)
 
-	DescribeTable("GetVolumeInfo should correctly resolve volume paths for various PVC names", func(pvcName string) {
-		targetName := getExportPodVolumeNameFromStr(pvcName)
+	DescribeTable("GetVolumeInfo should resolve volumes by PVC name", func(pvcNames ...string) {
+		sp := &ServerPaths{}
+		for i, pvcName := range pvcNames {
+			sp.Volumes = append(sp.Volumes, VolumeInfo{
+				Path:    fmt.Sprintf("/var/run/kubevirt-export/volume%d", i),
+				PVCName: pvcName,
+			})
+		}
+
+		for i, pvcName := range pvcNames {
+			result := sp.GetVolumeInfo(pvcName)
+			Expect(result).ToNot(BeNil())
+			Expect(result.Path).To(Equal(fmt.Sprintf("/var/run/kubevirt-export/volume%d", i)))
+		}
+		Expect(sp.GetVolumeInfo("does-not-exist")).To(BeNil())
+	},
+		Entry("Short name", "pvc-name"),
+		Entry("Name with dots", "pvc.with.dots"),
+		Entry("Long name exceeding limit", strings.Repeat("a", validation.DNS1035LabelMaxLength+1)),
+		// Both sanitize to the same mount directory, resolving by PVC name
+		// keeps them apart.
+		Entry("Names differing only by dots", "my.disk", "my-disk"),
+	)
+
+	DescribeTable("GetVolumeInfo should fall back to the mount directory without a PVC name", func(pvcName, mountName string) {
 		sp := &ServerPaths{
 			Volumes: []VolumeInfo{
 				{
-					Path: "/var/run/kubevirt-export/" + targetName,
+					Path: "/var/run/kubevirt-export/" + mountName,
 				},
 			},
 		}
 
 		result := sp.GetVolumeInfo(pvcName)
 		Expect(result).ToNot(BeNil())
-
-		_, foundName := filepath.Split(filepath.Clean(result.Path))
-		Expect(foundName).To(Equal(targetName))
-
-		if len(pvcName) > validation.DNS1035LabelMaxLength {
-			Expect(len(foundName)).To(BeNumerically("<", 63))
-			Expect(foundName).To(HavePrefix(exportPrefix))
-		}
+		Expect(result.Path).To(Equal("/var/run/kubevirt-export/" + mountName))
 	},
-		Entry("Short name", "pvc-name"),
-		Entry("Name with dots", "pvc.with.dots"),
-		Entry("Long name exceeding limit", strings.Repeat("a", validation.DNS1035LabelMaxLength+1)),
+		Entry("Short name", "pvc-name", "pvc-name"),
+		Entry("Name with dots", "pvc.with.dots", "pvc-with-dots"),
+		Entry("Long name exceeding limit",
+			strings.Repeat("a", validation.DNS1035LabelMaxLength+1),
+			"virt-export-419f8d5e"),
 	)
 
 	It("CreateServerPaths should parse OCI URI", func() {
@@ -1290,6 +1307,27 @@ var _ = Describe("Export controller", func() {
 		}
 		paths := CreateServerPaths(env)
 		Expect(paths.OCIURI).To(Equal(uri))
+	})
+
+	It("CreateServerPaths should parse the PVC name of a volume", func() {
+		paths := CreateServerPaths(map[string]string{
+			"VOLUME0_EXPORT_PATH":     "/export-volumes/my-disk",
+			"VOLUME0_EXPORT_PVC_NAME": "my.disk",
+		})
+		Expect(paths.Volumes).To(HaveLen(1))
+		Expect(paths.Volumes[0].PVCName).To(Equal("my.disk"))
+	})
+
+	It("The exporter pod should be passed the PVC name of every volume", func() {
+		pvc := &k8sv1.PersistentVolumeClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: "my.disk", Namespace: testNamespace},
+		}
+		container := &k8sv1.Container{}
+		addVolumeEnvironmentVariables(container, pvc, 0, "/export-volumes/my-disk", true)
+		Expect(container.Env).To(ContainElement(k8sv1.EnvVar{
+			Name:  "VOLUME0_EXPORT_PVC_NAME",
+			Value: "my.disk",
+		}))
 	})
 
 	DescribeTable("service name should be sanitized", func(exportName, expectedServiceName string) {

--- a/pkg/storage/export/export/paths.go
+++ b/pkg/storage/export/export/paths.go
@@ -31,6 +31,7 @@ import (
 // VolumeInfo contains paths for a volume
 type VolumeInfo struct {
 	Path       string
+	PVCName    string
 	ArchiveURI string
 	DirURI     string
 	RawURI     string
@@ -96,6 +97,7 @@ func CreateServerPaths(env map[string]string) *ServerPaths {
 		envPrefix := strings.TrimSuffix(k, "_EXPORT_PATH")
 		vi := VolumeInfo{
 			Path:       env[k],
+			PVCName:    env[envPrefix+"_EXPORT_PVC_NAME"],
 			ArchiveURI: env[envPrefix+"_EXPORT_ARCHIVE_URI"],
 			DirURI:     env[envPrefix+"_EXPORT_DIR_URI"],
 			RawURI:     env[envPrefix+"_EXPORT_RAW_URI"],
@@ -117,11 +119,21 @@ func CreateServerPaths(env map[string]string) *ServerPaths {
 
 // GetVolumeInfo returns the VolumeInfo for a given PVC name
 func (sp *ServerPaths) GetVolumeInfo(pvcName string) *VolumeInfo {
-	targetName := getExportPodVolumeNameFromStr(pvcName)
-	for _, v := range sp.Volumes {
-		_, n := filepath.Split(filepath.Clean(v.Path))
-		if n == targetName {
-			return &v
+	for i := range sp.Volumes {
+		if sp.Volumes[i].PVCName == pvcName {
+			return &sp.Volumes[i]
+		}
+	}
+
+	// Fall back to the mount directory for exporter pods created before the
+	// PVC name was passed in the environment.
+	mountName := getExportPodVolumeNameFromStr(pvcName)
+	for i := range sp.Volumes {
+		if sp.Volumes[i].PVCName != "" {
+			continue
+		}
+		if _, n := filepath.Split(filepath.Clean(sp.Volumes[i].Path)); n == mountName {
+			return &sp.Volumes[i]
 		}
 	}
 	return nil

--- a/pkg/storage/export/export/pvc-source.go
+++ b/pkg/storage/export/export/pvc-source.go
@@ -59,7 +59,7 @@ func (s *PVCSource) SourceCondition() exportv1.Condition {
 }
 
 func (s *PVCSource) ReadyCondition() exportv1.Condition {
-	return s.sourceVolumes.readyCondition
+	return s.sourceVolumes.ReadyCondition()
 }
 
 func (s *PVCSource) ConfigurePod(pod *corev1.Pod) {

--- a/pkg/storage/export/export/vm-source.go
+++ b/pkg/storage/export/export/vm-source.go
@@ -61,7 +61,7 @@ func (s *VMSource) SourceCondition() exportv1.Condition {
 }
 
 func (s *VMSource) ReadyCondition() exportv1.Condition {
-	return s.sourceVolumes.readyCondition
+	return s.sourceVolumes.ReadyCondition()
 }
 
 func (s *VMSource) ConfigurePod(pod *corev1.Pod) {
@@ -81,11 +81,14 @@ func (s *VMSource) UpdateStatus(vmExport *exportv1.VirtualMachineExport, pod *co
 
 	vmExport.Status.VirtualMachineName = pointer.P(vmExport.Spec.Source.Name)
 
-	if !s.HasContent() {
+	// Only report skipped while no pod is running, a ready export keeps its links.
+	if pod == nil && !s.HasContent() {
 		vmExport.Status.Phase = exportv1.Skipped
 	}
 
-	if !s.sourceVolumes.isPopulated && s.ReadyCondition().Reason != vmNotFoundReason {
+	if !s.sourceVolumes.isPopulated &&
+		s.ReadyCondition().Reason != vmNotFoundReason &&
+		s.ReadyCondition().Reason != duplicatePVCReason {
 		requeue = requeueTime
 	}
 

--- a/pkg/storage/export/export/vm-source_test.go
+++ b/pkg/storage/export/export/vm-source_test.go
@@ -612,6 +612,97 @@ var _ = Describe("PVC source", func() {
 		Expect(retry).To(BeEquivalentTo(0))
 	})
 
+	createVMWithDuplicatePVC := func() *virtv1.VirtualMachine {
+		vm := createVMWithoutVolumes()
+		for _, name := range []string{"volume1", "volume2"} {
+			vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, virtv1.Volume{
+				Name: name,
+				VolumeSource: virtv1.VolumeSource{
+					PersistentVolumeClaim: &virtv1.PersistentVolumeClaimVolumeSource{
+						PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
+							ClaimName: "shared",
+						},
+					},
+				},
+			})
+		}
+		return vm
+	}
+
+	It("Should be in skipped phase when two VM volumes reference the same PVC", func() {
+		testVMExport := createVMVMExport()
+		controller.VMInformer.GetStore().Add(createVMWithDuplicatePVC())
+		controller.PVCInformer.GetStore().Add(createPVC("shared", "kubevirt"))
+		k8sClient.Fake.PrependReactor("create", "pods", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+			Fail("no exporter pod must be created for a source with duplicate PVCs")
+			return true, nil, nil
+		})
+		updated := false
+		vmExportClient.Fake.PrependReactor("update", "virtualmachineexports", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+			update, ok := action.(testing.UpdateAction)
+			Expect(ok).To(BeTrue())
+			vmExport, ok := update.GetObject().(*exportv1.VirtualMachineExport)
+			Expect(ok).To(BeTrue())
+			verifyLinksEmpty(vmExport)
+			Expect(vmExport.Status.Phase).To(Equal(exportv1.Skipped))
+			Expect(vmExport.Status.Conditions).To(ContainElement(SatisfyAll(
+				HaveField("Type", exportv1.ConditionReady),
+				HaveField("Status", k8sv1.ConditionFalse),
+				HaveField("Reason", duplicatePVCReason),
+				HaveField("Message", ContainSubstring("shared")),
+			)))
+			updated = true
+			return true, vmExport, nil
+		})
+		retry, err := controller.updateVMExport(testVMExport)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(retry).To(BeEquivalentTo(0))
+		Expect(updated).To(BeTrue())
+	})
+
+	It("Should export once the duplicate PVC is removed from the VM", func() {
+		testVMExport := createVMVMExport()
+		controller.VMInformer.GetStore().Add(createVMWithDuplicatePVC())
+		controller.PVCInformer.GetStore().Add(createPVC("shared", "kubevirt"))
+		var updated *exportv1.VirtualMachineExport
+		vmExportClient.Fake.PrependReactor("update", "virtualmachineexports", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+			update, ok := action.(testing.UpdateAction)
+			Expect(ok).To(BeTrue())
+			vmExport, ok := update.GetObject().(*exportv1.VirtualMachineExport)
+			Expect(ok).To(BeTrue())
+			updated = vmExport
+			return true, vmExport, nil
+		})
+		// Keep the service informer in sync so the second reconcile finds it.
+		k8sClient.Fake.PrependReactor("create", "services", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+			create, ok := action.(testing.CreateAction)
+			Expect(ok).To(BeTrue())
+			service, ok := create.GetObject().(*k8sv1.Service)
+			Expect(ok).To(BeTrue())
+			controller.ServiceInformer.GetStore().Add(service)
+			return true, service, nil
+		})
+
+		retry, err := controller.updateVMExport(testVMExport)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(retry).To(BeEquivalentTo(0))
+		Expect(updated).ToNot(BeNil())
+		Expect(updated.Status.Phase).To(Equal(exportv1.Skipped))
+
+		// The user drops the duplicate volume, which re-enqueues the export.
+		vm := createVMWithDuplicatePVC()
+		vm.Spec.Template.Spec.Volumes = vm.Spec.Template.Spec.Volumes[:1]
+		controller.VMInformer.GetStore().Update(vm)
+		expectExporterCreate(k8sClient, k8sv1.PodRunning)
+
+		updated = nil
+		retry, err = controller.updateVMExport(testVMExport)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(retry).To(BeEquivalentTo(0))
+		Expect(updated).ToNot(BeNil())
+		Expect(updated.Status.Phase).To(Equal(exportv1.Ready))
+	})
+
 	It("Should be in skipped phase when VM does not exist", func() {
 		testVMExport := createVMVMExport()
 		vmExportClient.Fake.PrependReactor("update", "virtualmachineexports", func(action testing.Action) (handled bool, obj runtime.Object, err error) {

--- a/pkg/storage/export/export/vm-source_test.go
+++ b/pkg/storage/export/export/vm-source_test.go
@@ -32,8 +32,10 @@ import (
 	k8sv1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	extv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	k8sfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/testing"
 	"k8s.io/client-go/tools/cache"
@@ -60,6 +62,9 @@ import (
 
 const (
 	testVmName = "test-vm"
+
+	podFailureMsg          = "pod creation denied"
+	statusUpdateFailureMsg = "status update denied"
 )
 
 var _ = Describe("PVC source", func() {
@@ -701,6 +706,83 @@ var _ = Describe("PVC source", func() {
 		Expect(retry).To(BeEquivalentTo(0))
 		Expect(updated).ToNot(BeNil())
 		Expect(updated.Status.Phase).To(Equal(exportv1.Ready))
+	})
+
+	It("Should report the status when the exporter pod cannot be managed", func() {
+		testVMExport := createVMVMExport()
+		controller.VMInformer.GetStore().Add(createVMWithPVCs())
+		controller.PVCInformer.GetStore().Add(createPVC("volume1", "kubevirt"))
+		controller.PVCInformer.GetStore().Add(createPVC("volume2", "kubevirt"))
+		k8sClient.Fake.PrependReactor("create", "pods", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+			return true, nil, errors.NewForbidden(schema.GroupResource{Resource: "pods"}, "", fmt.Errorf("%s", podFailureMsg))
+		})
+		updated := false
+		vmExportClient.Fake.PrependReactor("update", "virtualmachineexports", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+			update, ok := action.(testing.UpdateAction)
+			Expect(ok).To(BeTrue())
+			vmExport, ok := update.GetObject().(*exportv1.VirtualMachineExport)
+			Expect(ok).To(BeTrue())
+			Expect(vmExport.Status.Phase).To(Equal(exportv1.Pending))
+			Expect(vmExport.Status.Conditions).To(ContainElement(SatisfyAll(
+				HaveField("Type", exportv1.ConditionReady),
+				HaveField("Status", k8sv1.ConditionFalse),
+				HaveField("Reason", exporterPodErrorReason),
+				HaveField("Message", ContainSubstring(podFailureMsg)),
+			)))
+			updated = true
+			return true, vmExport, nil
+		})
+		_, err := controller.updateVMExport(testVMExport)
+		Expect(err).To(HaveOccurred())
+		Expect(updated).To(BeTrue(), "status must be persisted even when the exporter pod cannot be managed")
+	})
+
+	It("Should report the status when an existing exporter pod cannot be managed", func() {
+		testVMExport := createVMVMExport()
+		controller.VMInformer.GetStore().Add(createVMWithPVCs())
+		controller.PVCInformer.GetStore().Add(createPVC("volume1", "kubevirt"))
+		controller.PVCInformer.GetStore().Add(createPVC("volume2", "kubevirt"))
+		// The pod already exists, so this fails past the creation of one.
+		controller.PodInformer.GetStore().Add(createExporterPod(controller.getExportPodName(testVMExport), k8sv1.PodPending))
+		k8sClient.Fake.PrependReactor("create", "pods", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+			Fail("no exporter pod must be created when one already exists")
+			return true, nil, nil
+		})
+		updated := false
+		vmExportClient.Fake.PrependReactor("update", "virtualmachineexports", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+			update, ok := action.(testing.UpdateAction)
+			Expect(ok).To(BeTrue())
+			vmExport, ok := update.GetObject().(*exportv1.VirtualMachineExport)
+			Expect(ok).To(BeTrue())
+			Expect(vmExport.Status.Conditions).To(ContainElement(SatisfyAll(
+				HaveField("Type", exportv1.ConditionReady),
+				HaveField("Status", k8sv1.ConditionFalse),
+				HaveField("Reason", exporterPodErrorReason),
+			)))
+			updated = true
+			return true, vmExport, nil
+		})
+		_, err := controller.updateVMExport(testVMExport)
+		Expect(err).To(HaveOccurred())
+		Expect(updated).To(BeTrue())
+	})
+
+	It("Should surface both errors when the status update fails too", func() {
+		testVMExport := createVMVMExport()
+		controller.VMInformer.GetStore().Add(createVMWithPVCs())
+		controller.PVCInformer.GetStore().Add(createPVC("volume1", "kubevirt"))
+		controller.PVCInformer.GetStore().Add(createPVC("volume2", "kubevirt"))
+		k8sClient.Fake.PrependReactor("create", "pods", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+			return true, nil, errors.NewForbidden(schema.GroupResource{Resource: "pods"}, "", fmt.Errorf("%s", podFailureMsg))
+		})
+		vmExportClient.Fake.PrependReactor("update", "virtualmachineexports", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+			return true, nil, errors.NewInternalError(fmt.Errorf("%s", statusUpdateFailureMsg))
+		})
+		_, err := controller.updateVMExport(testVMExport)
+		Expect(err).To(SatisfyAll(
+			MatchError(ContainSubstring(podFailureMsg)),
+			MatchError(ContainSubstring(statusUpdateFailureMsg)),
+		))
 	})
 
 	It("Should be in skipped phase when VM does not exist", func() {

--- a/pkg/storage/export/export/vmsnapshot-source.go
+++ b/pkg/storage/export/export/vmsnapshot-source.go
@@ -71,7 +71,7 @@ func (s *VMSnapshotSource) SourceCondition() exportv1.Condition {
 }
 
 func (s *VMSnapshotSource) ReadyCondition() exportv1.Condition {
-	return s.sourceVolumes.readyCondition
+	return s.sourceVolumes.ReadyCondition()
 }
 
 func (s *VMSnapshotSource) ConfigurePod(pod *corev1.Pod) {
@@ -92,18 +92,27 @@ func (s *VMSnapshotSource) ConfigureExportLink(exportLink *exportv1.VirtualMachi
 func (s *VMSnapshotSource) UpdateStatus(vmExport *exportv1.VirtualMachineExport, pod *corev1.Pod, svc *corev1.Service) (time.Duration, error) {
 	vmExport.Status.VirtualMachineName = pointer.P(s.vmName)
 
-	if err := s.updateVMSnapshotExportStatusConditions(vmExport); err != nil {
+	if err := s.updateVMSnapshotExportStatusConditions(vmExport, pod); err != nil {
 		return 0, err
 	}
 
 	return 0, nil
 }
 
-func (s *VMSnapshotSource) updateVMSnapshotExportStatusConditions(vmExportCopy *exportv1.VirtualMachineExport) error {
+func (s *VMSnapshotSource) updateVMSnapshotExportStatusConditions(vmExportCopy *exportv1.VirtualMachineExport, pod *corev1.Pod) error {
 	// Handle no volumes case
 	if !s.HasContent() {
+		if len(s.sourceVolumes.duplicatePVCNames()) > 0 {
+			if pod == nil {
+				vmExportCopy.Status.Phase = exportv1.Skipped
+			}
+			return nil
+		}
+
 		vmExportCopy.Status.Conditions = updateCondition(vmExportCopy.Status.Conditions, s.SourceCondition())
-		if s.SourceCondition().Reason == noVolumeSnapshotReason || s.SourceCondition().Reason == VMSnapshotNotFoundReason {
+		// Only report skipped while no pod is running, a ready export keeps its links.
+		if pod == nil &&
+			(s.SourceCondition().Reason == noVolumeSnapshotReason || s.SourceCondition().Reason == VMSnapshotNotFoundReason) {
 			vmExportCopy.Status.Phase = exportv1.Skipped
 		}
 		return nil

--- a/pkg/storage/export/export/vmsnapshot-source_test.go
+++ b/pkg/storage/export/export/vmsnapshot-source_test.go
@@ -538,6 +538,53 @@ var _ = Describe("VMSnapshot source", func() {
 		Expect(retry).To(BeEquivalentTo(0))
 	})
 
+	It("Should be in skipped phase when two volume backups restore to the same PVC", func() {
+		testVMExport := createSnapshotVMExport()
+		// Restore PVCs are named <export>-<pvc>, so both backups collapse onto one.
+		const secondVolumesnapshotName = "test-snapshot-2"
+		content := createTestVMSnapshotContent("snapshot-content")
+		second := content.Spec.VolumeBackups[0]
+		second.VolumeName = "test-volume-2"
+		second.VolumeSnapshotName = pointer.P(secondVolumesnapshotName)
+		content.Spec.VolumeBackups = append(content.Spec.VolumeBackups, second)
+		content.Status.VolumeSnapshotStatus = append(content.Status.VolumeSnapshotStatus,
+			snapshotv1.VolumeSnapshotStatus{
+				VolumeSnapshotName: secondVolumesnapshotName,
+				ReadyToUse:         pointer.P(true),
+			})
+
+		k8sClient.Fake.PrependReactor("create", "pods", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+			Fail("no exporter pod must be created for a source with duplicate PVCs")
+			return true, nil, nil
+		})
+		updated := false
+		vmExportClient.Fake.PrependReactor("update", "virtualmachineexports", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+			update, ok := action.(testing.UpdateAction)
+			Expect(ok).To(BeTrue())
+			vmExport, ok := update.GetObject().(*exportv1.VirtualMachineExport)
+			Expect(ok).To(BeTrue())
+			verifyLinksEmpty(vmExport)
+			Expect(vmExport.Status.Phase).To(Equal(exportv1.Skipped))
+			Expect(vmExport.Status.Conditions).To(ContainElement(SatisfyAll(
+				HaveField("Type", exportv1.ConditionReady),
+				HaveField("Status", k8sv1.ConditionFalse),
+				HaveField("Reason", duplicatePVCReason),
+				HaveField("Message", ContainSubstring("test-test-snapshot")),
+			)))
+			updated = true
+			return true, vmExport, nil
+		})
+
+		pvcInformer.GetStore().Add(createRestoredPVC("test-test-snapshot"))
+		vmSnapshotInformer.GetStore().Add(createTestVMSnapshot(true))
+		vmSnapshotContentInformer.GetStore().Add(content)
+		fakeVolumeSnapshotProvider.Add(createTestVolumeSnapshot(testVolumesnapshotName))
+		retry, err := controller.updateVMExport(testVMExport)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(retry).To(BeEquivalentTo(0))
+		Expect(updated).To(BeTrue())
+	})
+
 	It("Should update status with correct links from snapshot with kubevirt content type", func() {
 		testVMExport := createSnapshotVMExport()
 		restoreName := fmt.Sprintf("%s-%s", testVMExport.Name, testVolumesnapshotName)

--- a/pkg/storage/export/export/vmtemplate-source.go
+++ b/pkg/storage/export/export/vmtemplate-source.go
@@ -75,7 +75,7 @@ func (s *VMTemplateSource) SourceCondition() exportv1.Condition {
 }
 
 func (s *VMTemplateSource) ReadyCondition() exportv1.Condition {
-	return s.sourceVolumes.readyCondition
+	return s.sourceVolumes.ReadyCondition()
 }
 
 func (s *VMTemplateSource) ConfigurePod(pod *corev1.Pod) {
@@ -85,13 +85,15 @@ func (s *VMTemplateSource) ConfigurePod(pod *corev1.Pod) {
 func (s *VMTemplateSource) ConfigureExportLink(_ *exportv1.VirtualMachineExportLink, _ *ServerPaths, _ *exportv1.VirtualMachineExport, _ *corev1.Pod, _, _ string) {
 }
 
-func (s *VMTemplateSource) UpdateStatus(vmExport *exportv1.VirtualMachineExport, _ *corev1.Pod, _ *corev1.Service) (time.Duration, error) {
-	if !s.HasContent() {
+func (s *VMTemplateSource) UpdateStatus(vmExport *exportv1.VirtualMachineExport, pod *corev1.Pod, _ *corev1.Service) (time.Duration, error) {
+	// Only report skipped while no pod is running, a ready export keeps its links.
+	if pod == nil && !s.HasContent() {
 		vmExport.Status.Phase = exportv1.Skipped
 	}
 
 	if !s.sourceVolumes.isPopulated &&
-		s.ReadyCondition().Reason != vmTemplateNotFoundReason {
+		s.ReadyCondition().Reason != vmTemplateNotFoundReason &&
+		s.ReadyCondition().Reason != duplicatePVCReason {
 		return requeueTime, nil
 	}
 

--- a/pkg/storage/export/export/vmtemplate-source_test.go
+++ b/pkg/storage/export/export/vmtemplate-source_test.go
@@ -289,6 +289,39 @@ var _ = Describe("VMTemplate source", func() {
 				},
 			}))).To(Succeed())
 		}, volumesNotPopulatedReason, requeueTime),
+		// The raw-name skip only catches volumes named after a DVT, so both
+		// collection paths add the same claim.
+		Entry("when a DVT source PVC is also referenced by a volume", func() {
+			Expect(vmTemplateInformer.GetStore().Add(newTemplate(&virtv1.VirtualMachine{
+				Spec: virtv1.VirtualMachineSpec{
+					DataVolumeTemplates: []virtv1.DataVolumeTemplateSpec{
+						{
+							ObjectMeta: metav1.ObjectMeta{Name: dvtName},
+							Spec: cdiv1.DataVolumeSpec{
+								Source: &cdiv1.DataVolumeSource{
+									PVC: &cdiv1.DataVolumeSourcePVC{Name: sourcePVCName},
+								},
+							},
+						},
+					},
+					Template: &virtv1.VirtualMachineInstanceTemplateSpec{
+						Spec: virtv1.VirtualMachineInstanceSpec{
+							Volumes: []virtv1.Volume{{
+								Name: "volume1",
+								VolumeSource: virtv1.VolumeSource{
+									PersistentVolumeClaim: &virtv1.PersistentVolumeClaimVolumeSource{
+										PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
+											ClaimName: sourcePVCName,
+										},
+									},
+								},
+							}},
+						},
+					},
+				},
+			}))).To(Succeed())
+			Expect(pvcInformer.GetStore().Add(createPVC(sourcePVCName, "kubevirt"))).To(Succeed())
+		}, duplicatePVCReason, time.Duration(0)),
 	)
 
 	It("Should create VMTemplate export with DVT source PVC", func() {

--- a/pkg/storage/export/virt-exportserver/oci.go
+++ b/pkg/storage/export/virt-exportserver/oci.go
@@ -89,9 +89,15 @@ func collectDiskInfo(paths *export.ServerPaths) ([]oci.DiskInfo, error) {
 			p = path.Join(p, "disk.img")
 		}
 
+		// Older exporter pods do not carry the PVC name in their environment.
+		volumeName := vi.PVCName
+		if volumeName == "" {
+			volumeName = path.Base(vi.Path)
+		}
+
 		disks = append(disks, oci.DiskInfo{
 			FilePath:   p,
-			VolumeName: path.Base(vi.Path),
+			VolumeName: volumeName,
 		})
 	}
 	return disks, nil

--- a/pkg/storage/export/virt-exportserver/oci_test.go
+++ b/pkg/storage/export/virt-exportserver/oci_test.go
@@ -25,6 +25,8 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -295,6 +297,44 @@ var _ = Describe("OCI export", func() {
 		It("should return empty architecture when embedded VM has none", func() {
 			tpl := createTemplate("")
 			Expect(extractArchitectureFromVMTemplate(tpl)).To(BeEmpty())
+		})
+	})
+
+	Context("collectDiskInfo", func() {
+		var dir string
+
+		BeforeEach(func() {
+			dir = GinkgoT().TempDir()
+			Expect(os.WriteFile(filepath.Join(dir, "disk.img"), []byte("data"), 0o600)).To(Succeed())
+		})
+
+		It("should name the disk after the PVC", func() {
+			disks, err := collectDiskInfo(&export.ServerPaths{
+				Volumes: []export.VolumeInfo{{Path: dir, PVCName: "my.disk"}},
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(disks).To(ConsistOf(oci.DiskInfo{
+				FilePath:   filepath.Join(dir, "disk.img"),
+				VolumeName: "my.disk",
+			}))
+		})
+
+		It("should fall back to the mount directory without a PVC name", func() {
+			disks, err := collectDiskInfo(&export.ServerPaths{
+				Volumes: []export.VolumeInfo{{Path: dir}},
+			})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(disks).To(ConsistOf(oci.DiskInfo{
+				FilePath:   filepath.Join(dir, "disk.img"),
+				VolumeName: filepath.Base(dir),
+			}))
+		})
+
+		It("should error when the volume path does not exist", func() {
+			_, err := collectDiskInfo(&export.ServerPaths{
+				Volumes: []export.VolumeInfo{{Path: filepath.Join(dir, "missing")}},
+			})
+			Expect(err).To(HaveOccurred())
 		})
 	})
 })

--- a/tests/storage/export.go
+++ b/tests/storage/export.go
@@ -2291,6 +2291,49 @@ var _ = Describe(SIG("Export", func() {
 		}
 	})
 
+	It("should export a VM with claims differing only in dots", func() {
+		sc, exists := libstorage.GetRWOFileSystemStorageClass()
+		if !exists {
+			Fail("Fail test when Filesystem storage is not present")
+		}
+		ns := testsuite.GetTestNamespace(nil)
+
+		// Both claims sanitize to the same exporter pod volume name.
+		claimNames := []string{"my.disk", "my-disk"}
+		var diskOpts []libvmi.Option
+		for i, claimName := range claimNames {
+			dv := createDataVolume(libdv.NewDataVolume(
+				libdv.WithName(claimName),
+				libdv.WithNamespace(ns),
+				libdv.WithBlankImageSource(),
+				libdv.WithStorage(libdv.StorageWithStorageClass(sc)),
+			))
+			Eventually(ThisPVCWith(ns, dv.Name), 160).Should(Exist())
+			diskOpts = append(diskOpts, libvmi.WithPersistentVolumeClaim(fmt.Sprintf("dotdisk%d", i), claimName))
+		}
+
+		vm := createVM(libvmi.NewVirtualMachine(libvmifact.NewAlpine(diskOpts...)))
+
+		if libstorage.IsStorageClassBindingModeWaitForFirstConsumer(sc) {
+			vm = libvmops.StartVirtualMachine(vm)
+			libvmops.StopVirtualMachine(vm)
+		}
+		for _, claimName := range claimNames {
+			libstorage.EventuallyDVWith(ns, claimName, 240, HaveSucceeded())
+		}
+
+		token := createExportTokenSecret(vm.Name, vm.Namespace)
+		export := createVMExportObject(vm.Name, vm.Namespace, token)
+		Expect(export).ToNot(BeNil())
+		export = waitForExportPhase(export, exportv1.Ready)
+
+		By("Both claims are exported as their own volume")
+		Expect(export.Status.Links.Internal.Volumes).To(ConsistOf(
+			HaveField("Name", claimNames[0]),
+			HaveField("Name", claimNames[1]),
+		))
+	})
+
 	It("should mark the status phase skipped when two VM volumes reference the same PVC", func() {
 		sc, exists := libstorage.GetRWOFileSystemStorageClass()
 		if !exists {

--- a/tests/storage/export.go
+++ b/tests/storage/export.go
@@ -103,6 +103,7 @@ const (
 	podReadyReason            = "PodReady"
 	inUseReason               = "InUse"
 	volumesNotPopulatedReason = "VolumesNotPopulated"
+	duplicatePVCReason        = "DuplicatePVC"
 
 	proxyUrlBase = "https://virt-exportproxy.%s.svc/api/export.kubevirt.io/v1/namespaces/%s/virtualmachineexports/%s%s"
 
@@ -2288,6 +2289,71 @@ var _ = Describe(SIG("Export", func() {
 			waitForDisksComplete(vm)
 			waitForExportPhase(export, exportv1.Ready)
 		}
+	})
+
+	It("should mark the status phase skipped when two VM volumes reference the same PVC", func() {
+		sc, exists := libstorage.GetRWOFileSystemStorageClass()
+		if !exists {
+			Fail("Fail test when Filesystem storage is not present")
+		}
+		vm := libvmi.NewVirtualMachine(libvmifact.NewAlpine())
+		vm = createVM(vm)
+
+		dv := libdv.NewDataVolume(
+			libdv.WithNamespace(vm.Namespace),
+			libdv.WithBlankImageSource(),
+			libdv.WithStorage(libdv.StorageWithStorageClass(sc)),
+		)
+		dv = createDataVolume(dv)
+		Eventually(ThisPVCWith(vm.Namespace, dv.Name), 160).Should(Exist())
+
+		By("Adding the same claim to the VM twice")
+		vm, err = virtClient.VirtualMachine(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		for _, name := range []string{"blank-disk", "duplicate-disk"} {
+			vm.Spec.Template.Spec.Volumes = append(vm.Spec.Template.Spec.Volumes, v1.Volume{
+				Name: name,
+				VolumeSource: v1.VolumeSource{
+					PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+						PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
+							ClaimName: dv.Name,
+						},
+					},
+				},
+			})
+		}
+		vm, err = virtClient.VirtualMachine(vm.Namespace).Update(context.Background(), vm, metav1.UpdateOptions{}) //nolint:forbidigo
+		Expect(err).ToNot(HaveOccurred())
+
+		token := createExportTokenSecret(vm.Name, vm.Namespace)
+		export := createVMExportObject(vm.Name, vm.Namespace, token)
+		Expect(export).ToNot(BeNil())
+		waitForExportPhase(export, exportv1.Skipped)
+		waitForExportCondition(export, MatchConditionIgnoreTimeStamp(exportv1.Condition{
+			Type:    exportv1.ConditionReady,
+			Status:  k8sv1.ConditionFalse,
+			Reason:  duplicatePVCReason,
+			Message: fmt.Sprintf("Source references the same PersistentVolumeClaim from more than one volume: %s", dv.Name),
+		}), "export should report the duplicate PVC")
+
+		By("Removing the duplicate volume, the export recovers on its own")
+		vm, err = virtClient.VirtualMachine(vm.Namespace).Get(context.Background(), vm.Name, metav1.GetOptions{})
+		Expect(err).ToNot(HaveOccurred())
+		volumes := vm.Spec.Template.Spec.Volumes
+		vm.Spec.Template.Spec.Volumes = volumes[:len(volumes)-1]
+		vm, err = virtClient.VirtualMachine(vm.Namespace).Update(context.Background(), vm, metav1.UpdateOptions{}) //nolint:forbidigo
+		Expect(err).ToNot(HaveOccurred())
+
+		if libstorage.IsStorageClassBindingModeWaitForFirstConsumer(sc) {
+			// With WFFC the volume only populates once it has a consumer.
+			waitForExportPhase(export, exportv1.Pending)
+			vm = libvmops.StartVirtualMachine(vm)
+			waitForDisksComplete(vm)
+			libvmops.StopVirtualMachine(vm)
+		} else {
+			waitForDisksComplete(vm)
+		}
+		waitForExportPhase(export, exportv1.Ready)
 	})
 
 	Context(" with potential KubeVirt CR update", Serial, func() {


### PR DESCRIPTION
### What this PR does
#### Before this PR:

The volume a PVC is mounted under in the exporter pod was named after the sanitized claim name, so claims differing only in dots, like `my.disk` and `my-disk`, produced the same name. The API server rejected the pod and the export never completed.

#### After this PR:

The name is prefixed with the index of the volume, which is unique on its own.

### References

- Fixes #19020, together with #19057
- Depends on #19057 and #19058, which it is stacked on. Only the last commit belongs to this PR.
- Followed by #19066, which is stacked on this

### Why we need it and why it was done in this way

The second collision in #19020, next to the duplicate PVCs in #19057. Deduplicating on the derived name was not an option, the claims are distinct disks and both have to be exported.

### Special notes for your reviewer

Nothing derives anything from the mount directory name since #19058, the claim name is only kept in it to keep the pod readable. The exported volume names in the status are unaffected, they stay the claim names.

### Checklist

- [x] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
Fixed a bug where a VirtualMachineExport of a VM with two claims whose names differ only in dots would never complete
```



