### PR TITLE
client-go: Cancel stalled websocket handshakes

### DIFF
--- a/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/generated_mock_kubevirt.go
@@ -1642,6 +1642,21 @@ func (mr *MockVirtualMachineInstanceInterfaceMockRecorder) PortForward(name, por
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PortForward", reflect.TypeOf((*MockVirtualMachineInstanceInterface)(nil).PortForward), name, port, protocol)
 }
 
+// PortForwardContext mocks base method.
+func (m *MockVirtualMachineInstanceInterface) PortForwardContext(ctx context.Context, name string, port int, protocol string) (v123.StreamInterface, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PortForwardContext", ctx, name, port, protocol)
+	ret0, _ := ret[0].(v123.StreamInterface)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PortForwardContext indicates an expected call of PortForwardContext.
+func (mr *MockVirtualMachineInstanceInterfaceMockRecorder) PortForwardContext(ctx, name, port, protocol any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PortForwardContext", reflect.TypeOf((*MockVirtualMachineInstanceInterface)(nil).PortForwardContext), ctx, name, port, protocol)
+}
+
 // RedefineCheckpoint mocks base method.
 func (m *MockVirtualMachineInstanceInterface) RedefineCheckpoint(ctx context.Context, name string, checkpoint *v1alpha16.BackupCheckpoint) error {
 	m.ctrl.T.Helper()
@@ -1772,6 +1787,21 @@ func (mr *MockVirtualMachineInstanceInterfaceMockRecorder) SerialConsole(name, o
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SerialConsole", reflect.TypeOf((*MockVirtualMachineInstanceInterface)(nil).SerialConsole), name, options)
 }
 
+// SerialConsoleContext mocks base method.
+func (m *MockVirtualMachineInstanceInterface) SerialConsoleContext(ctx context.Context, name string, options *v123.SerialConsoleOptions) (v123.StreamInterface, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SerialConsoleContext", ctx, name, options)
+	ret0, _ := ret[0].(v123.StreamInterface)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SerialConsoleContext indicates an expected call of SerialConsoleContext.
+func (mr *MockVirtualMachineInstanceInterfaceMockRecorder) SerialConsoleContext(ctx, name, options any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SerialConsoleContext", reflect.TypeOf((*MockVirtualMachineInstanceInterface)(nil).SerialConsoleContext), ctx, name, options)
+}
+
 // SoftReboot mocks base method.
 func (m *MockVirtualMachineInstanceInterface) SoftReboot(ctx context.Context, name string) error {
 	m.ctrl.T.Helper()
@@ -1799,6 +1829,21 @@ func (m *MockVirtualMachineInstanceInterface) USBRedir(vmiName string) (v123.Str
 func (mr *MockVirtualMachineInstanceInterfaceMockRecorder) USBRedir(vmiName any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "USBRedir", reflect.TypeOf((*MockVirtualMachineInstanceInterface)(nil).USBRedir), vmiName)
+}
+
+// USBRedirContext mocks base method.
+func (m *MockVirtualMachineInstanceInterface) USBRedirContext(ctx context.Context, vmiName string) (v123.StreamInterface, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "USBRedirContext", ctx, vmiName)
+	ret0, _ := ret[0].(v123.StreamInterface)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// USBRedirContext indicates an expected call of USBRedirContext.
+func (mr *MockVirtualMachineInstanceInterfaceMockRecorder) USBRedirContext(ctx, vmiName any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "USBRedirContext", reflect.TypeOf((*MockVirtualMachineInstanceInterface)(nil).USBRedirContext), ctx, vmiName)
 }
 
 // Unfreeze mocks base method.
@@ -1874,6 +1919,21 @@ func (mr *MockVirtualMachineInstanceInterfaceMockRecorder) VNC(name, preserveSes
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VNC", reflect.TypeOf((*MockVirtualMachineInstanceInterface)(nil).VNC), name, preserveSession)
 }
 
+// VNCContext mocks base method.
+func (m *MockVirtualMachineInstanceInterface) VNCContext(ctx context.Context, name string, preserveSession bool) (v123.StreamInterface, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "VNCContext", ctx, name, preserveSession)
+	ret0, _ := ret[0].(v123.StreamInterface)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// VNCContext indicates an expected call of VNCContext.
+func (mr *MockVirtualMachineInstanceInterfaceMockRecorder) VNCContext(ctx, name, preserveSession any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VNCContext", reflect.TypeOf((*MockVirtualMachineInstanceInterface)(nil).VNCContext), ctx, name, preserveSession)
+}
+
 // VSOCK mocks base method.
 func (m *MockVirtualMachineInstanceInterface) VSOCK(name string, options *v122.VSOCKOptions) (v123.StreamInterface, error) {
 	m.ctrl.T.Helper()
@@ -1887,6 +1947,21 @@ func (m *MockVirtualMachineInstanceInterface) VSOCK(name string, options *v122.V
 func (mr *MockVirtualMachineInstanceInterfaceMockRecorder) VSOCK(name, options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VSOCK", reflect.TypeOf((*MockVirtualMachineInstanceInterface)(nil).VSOCK), name, options)
+}
+
+// VSOCKContext mocks base method.
+func (m *MockVirtualMachineInstanceInterface) VSOCKContext(ctx context.Context, name string, options *v122.VSOCKOptions) (v123.StreamInterface, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "VSOCKContext", ctx, name, options)
+	ret0, _ := ret[0].(v123.StreamInterface)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// VSOCKContext indicates an expected call of VSOCKContext.
+func (mr *MockVirtualMachineInstanceInterfaceMockRecorder) VSOCKContext(ctx, name, options any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "VSOCKContext", reflect.TypeOf((*MockVirtualMachineInstanceInterface)(nil).VSOCKContext), ctx, name, options)
 }
 
 // Watch mocks base method.
@@ -2489,6 +2564,21 @@ func (m *MockVirtualMachineInterface) PortForward(name string, port int, protoco
 func (mr *MockVirtualMachineInterfaceMockRecorder) PortForward(name, port, protocol any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PortForward", reflect.TypeOf((*MockVirtualMachineInterface)(nil).PortForward), name, port, protocol)
+}
+
+// PortForwardContext mocks base method.
+func (m *MockVirtualMachineInterface) PortForwardContext(ctx context.Context, name string, port int, protocol string) (v123.StreamInterface, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PortForwardContext", ctx, name, port, protocol)
+	ret0, _ := ret[0].(v123.StreamInterface)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PortForwardContext indicates an expected call of PortForwardContext.
+func (mr *MockVirtualMachineInterfaceMockRecorder) PortForwardContext(ctx, name, port, protocol any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PortForwardContext", reflect.TypeOf((*MockVirtualMachineInterface)(nil).PortForwardContext), ctx, name, port, protocol)
 }
 
 // RemoveMemoryDump mocks base method.

--- a/staging/src/kubevirt.io/client-go/kubecli/vm.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/vm.go
@@ -99,5 +99,9 @@ func (v *vm) UpdateStatus(ctx context.Context, vmi *v1.VirtualMachine, opts k8sm
 }
 
 func (v *vm) PortForward(name string, port int, protocol string) (kvcorev1.StreamInterface, error) {
-	return kvcorev1.AsyncSubresourceHelper(v.config, v.resource, v.namespace, name, buildPortForwardResourcePath(port, protocol), url.Values{})
+	return v.PortForwardContext(context.Background(), name, port, protocol)
+}
+
+func (v *vm) PortForwardContext(ctx context.Context, name string, port int, protocol string) (kvcorev1.StreamInterface, error) {
+	return kvcorev1.AsyncSubresourceHelperContext(ctx, v.config, v.resource, v.namespace, name, buildPortForwardResourcePath(port, protocol), url.Values{})
 }

--- a/staging/src/kubevirt.io/client-go/kubecli/vmi.go
+++ b/staging/src/kubevirt.io/client-go/kubecli/vmi.go
@@ -21,6 +21,7 @@ package kubecli
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -60,17 +61,29 @@ type vmis struct {
 }
 
 func (v *vmis) USBRedir(name string) (kvcorev1.StreamInterface, error) {
-	return kvcorev1.AsyncSubresourceHelper(v.config, v.resource, v.namespace, name, "usbredir", url.Values{})
+	return v.USBRedirContext(context.Background(), name)
+}
+
+func (v *vmis) USBRedirContext(ctx context.Context, name string) (kvcorev1.StreamInterface, error) {
+	return kvcorev1.AsyncSubresourceHelperContext(ctx, v.config, v.resource, v.namespace, name, "usbredir", url.Values{})
 }
 
 func (v *vmis) VNC(name string, preserveSession bool) (kvcorev1.StreamInterface, error) {
+	return v.VNCContext(context.Background(), name, preserveSession)
+}
+
+func (v *vmis) VNCContext(ctx context.Context, name string, preserveSession bool) (kvcorev1.StreamInterface, error) {
 	queryParams := url.Values{}
 	queryParams.Add("preserveSession", strconv.FormatBool(preserveSession))
-	return kvcorev1.AsyncSubresourceHelper(v.config, v.resource, v.namespace, name, "vnc", queryParams)
+	return kvcorev1.AsyncSubresourceHelperContext(ctx, v.config, v.resource, v.namespace, name, "vnc", queryParams)
 }
 
 func (v *vmis) PortForward(name string, port int, protocol string) (kvcorev1.StreamInterface, error) {
-	return kvcorev1.AsyncSubresourceHelper(v.config, v.resource, v.namespace, name, buildPortForwardResourcePath(port, protocol), url.Values{})
+	return v.PortForwardContext(context.Background(), name, port, protocol)
+}
+
+func (v *vmis) PortForwardContext(ctx context.Context, name string, port int, protocol string) (kvcorev1.StreamInterface, error) {
+	return kvcorev1.AsyncSubresourceHelperContext(ctx, v.config, v.resource, v.namespace, name, buildPortForwardResourcePath(port, protocol), url.Values{})
 }
 
 func buildPortForwardResourcePath(port int, protocol string) string {
@@ -86,52 +99,43 @@ func buildPortForwardResourcePath(port int, protocol string) string {
 	return resource.String()
 }
 
-type connectionStruct struct {
-	con kvcorev1.StreamInterface
-	err error
+func (v *vmis) SerialConsole(name string, options *kvcorev1.SerialConsoleOptions) (kvcorev1.StreamInterface, error) {
+	return v.SerialConsoleContext(context.Background(), name, options)
 }
 
-func (v *vmis) SerialConsole(name string, options *kvcorev1.SerialConsoleOptions) (kvcorev1.StreamInterface, error) {
-
+func (v *vmis) SerialConsoleContext(ctx context.Context, name string, options *kvcorev1.SerialConsoleOptions) (kvcorev1.StreamInterface, error) {
 	if options != nil && options.ConnectionTimeout != 0 {
-		timeoutChan := time.Tick(options.ConnectionTimeout)
-		connectionChan := make(chan connectionStruct)
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, options.ConnectionTimeout)
+		defer cancel()
 
-		go func() {
-			for {
-
-				select {
-				case <-timeoutChan:
-					connectionChan <- connectionStruct{
-						con: nil,
-						err: fmt.Errorf("Timeout trying to connect to the virtual machine instance"),
-					}
-					return
-				default:
-				}
-
-				con, err := kvcorev1.AsyncSubresourceHelper(v.config, v.resource, v.namespace, name, "console", url.Values{})
-				if err != nil {
-					asyncSubresourceError, ok := err.(*kvcorev1.AsyncSubresourceError)
-					// return if response status code does not equal to 400
-					if !ok || asyncSubresourceError.GetStatusCode() != http.StatusBadRequest {
-						connectionChan <- connectionStruct{con: nil, err: err}
-						return
-					}
-
-					time.Sleep(1 * time.Second)
-					continue
-				}
-
-				connectionChan <- connectionStruct{con: con, err: nil}
-				return
+		for {
+			con, err := kvcorev1.AsyncSubresourceHelperContext(ctx, v.config, v.resource, v.namespace, name, "console", url.Values{})
+			if err == nil {
+				return con, nil
 			}
-		}()
-		conStruct := <-connectionChan
-		return conStruct.con, conStruct.err
-	} else {
-		return kvcorev1.AsyncSubresourceHelper(v.config, v.resource, v.namespace, name, "console", url.Values{})
+			asyncSubresourceError, ok := err.(*kvcorev1.AsyncSubresourceError)
+			// return if response status code does not equal to 400
+			if !ok || asyncSubresourceError.GetStatusCode() != http.StatusBadRequest {
+				if errors.Is(err, context.DeadlineExceeded) {
+					return nil, fmt.Errorf("Timeout trying to connect to the virtual machine instance")
+				}
+				return nil, err
+			}
+
+			timer := time.NewTimer(time.Second)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+					return nil, fmt.Errorf("Timeout trying to connect to the virtual machine instance")
+				}
+				return nil, ctx.Err()
+			case <-timer.C:
+			}
+		}
 	}
+	return kvcorev1.AsyncSubresourceHelperContext(ctx, v.config, v.resource, v.namespace, name, "console", url.Values{})
 }
 
 func (v *vmis) Get(ctx context.Context, name string, options metav1.GetOptions) (vmi *v1.VirtualMachineInstance, err error) {
@@ -169,6 +173,10 @@ func (v *vmis) Patch(ctx context.Context, name string, pt types.PatchType, data 
 }
 
 func (v *vmis) VSOCK(name string, options *v1.VSOCKOptions) (kvcorev1.StreamInterface, error) {
+	return v.VSOCKContext(context.Background(), name, options)
+}
+
+func (v *vmis) VSOCKContext(ctx context.Context, name string, options *v1.VSOCKOptions) (kvcorev1.StreamInterface, error) {
 	if options == nil || options.TargetPort == 0 {
 		return nil, fmt.Errorf("target port is required but not provided")
 	}
@@ -179,5 +187,5 @@ func (v *vmis) VSOCK(name string, options *v1.VSOCKOptions) (kvcorev1.StreamInte
 		useTLS = *options.UseTLS
 	}
 	queryParams.Add("tls", strconv.FormatBool(useTLS))
-	return kvcorev1.AsyncSubresourceHelper(v.config, v.resource, v.namespace, name, "vsock", queryParams)
+	return kvcorev1.AsyncSubresourceHelperContext(ctx, v.config, v.resource, v.namespace, name, "vsock", queryParams)
 }

--- a/staging/src/kubevirt.io/client-go/kubevirt/typed/core/v1/async.go
+++ b/staging/src/kubevirt.io/client-go/kubevirt/typed/core/v1/async.go
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -9,6 +10,7 @@ import (
 	"net/url"
 	"path"
 	"strings"
+	"time"
 
 	"github.com/gorilla/websocket"
 
@@ -19,6 +21,8 @@ import (
 	v1 "kubevirt.io/api/core/v1"
 	"kubevirt.io/client-go/subresources"
 )
+
+const websocketHandshakeTimeout = 45 * time.Second
 
 type StreamOptions struct {
 	In  io.Reader
@@ -42,13 +46,27 @@ func (a *AsyncSubresourceError) GetStatusCode() int {
 	return a.StatusCode
 }
 
+// AsyncSubresourceHelper opens a subresource websocket stream.
 // params are strings with "key=value" format
 func AsyncSubresourceHelper(config *rest.Config, resource, namespace, name string, subresource string, queryParams url.Values) (StreamInterface, error) {
+	return AsyncSubresourceHelperContext(context.Background(), config, resource, namespace, name, subresource, queryParams)
+}
+
+// AsyncSubresourceHelperContext opens a subresource websocket stream.
+// ctx bounds the handshake; canceling it unblocks the caller and closes an
+// in-flight upgrade.
+// params are strings with "key=value" format
+func AsyncSubresourceHelperContext(ctx context.Context, config *rest.Config, resource, namespace, name string, subresource string, queryParams url.Values) (StreamInterface, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, fmt.Errorf("Can't connect to websocket: %w", err)
+	}
 
 	done := make(chan struct{})
 
 	aws := &AsyncWSRoundTripper{
-		Connection: make(chan *websocket.Conn),
+		// Buffer so a handshake that finishes after the caller has stopped
+		// waiting can still be received and closed by releaseHandshake.
+		Connection: make(chan *websocket.Conn, 1),
 		Done:       done,
 	}
 	// Create a round tripper with all necessary kubernetes security details
@@ -62,6 +80,8 @@ func AsyncSubresourceHelper(config *rest.Config, resource, namespace, name strin
 	if err != nil {
 		return nil, fmt.Errorf("unable to create request for remote execution: %v", err)
 	}
+	// Propagate ctx so DialContext can cancel a stalled handshake
+	req = req.WithContext(ctx)
 
 	errChan := make(chan error, 1)
 
@@ -96,12 +116,30 @@ func AsyncSubresourceHelper(config *rest.Config, resource, namespace, name strin
 
 	select {
 	case err = <-errChan:
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, fmt.Errorf("Can't connect to websocket: %w", ctxErr)
+		}
 		return nil, err
 	case ws := <-aws.Connection:
 		return &wsStreamer{
 			conn: ws,
 			done: done,
 		}, nil
+	case <-ctx.Done():
+		// Don't wait on the result channels if the caller has given up
+		go releaseHandshake(aws, errChan, done)
+		return nil, fmt.Errorf("Can't connect to websocket: %w", ctx.Err())
+	}
+}
+
+// releaseHandshake closes a websocket that completed after the caller stopped
+// waiting, so the round-trip goroutine is not left parked in WebsocketCallback.
+func releaseHandshake(aws *AsyncWSRoundTripper, errChan <-chan error, done chan struct{}) {
+	select {
+	case ws := <-aws.Connection:
+		_ = ws.Close()
+		close(done)
+	case <-errChan:
 	}
 }
 
@@ -113,7 +151,7 @@ type WebsocketRoundTripper struct {
 }
 
 func (d *WebsocketRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
-	conn, resp, err := d.Dialer.Dial(r.URL.String(), r.Header)
+	conn, resp, err := d.Dialer.DialContext(r.Context(), r.URL.String(), r.Header)
 	if err == nil {
 		defer conn.Close()
 	}
@@ -148,17 +186,19 @@ func roundTripperFromConfig(config *rest.Config, callback RoundTripCallback) (ht
 		return nil, err
 	}
 
-	// Configure the websocket dialer
+	// Configure the websocket dialer. HandshakeTimeout is set explicitly
+	// because a new Dialer does not inherit DefaultDialer's 45s timeout.
 	proxy := http.ProxyFromEnvironment
 	if config.Proxy != nil {
 		proxy = config.Proxy
 	}
 	dialer := &websocket.Dialer{
-		Proxy:           proxy,
-		TLSClientConfig: tlsConfig,
-		WriteBufferSize: WebsocketMessageBufferSize,
-		ReadBufferSize:  WebsocketMessageBufferSize,
-		Subprotocols:    []string{subresources.PlainStreamProtocolName},
+		Proxy:            proxy,
+		TLSClientConfig:  tlsConfig,
+		WriteBufferSize:  WebsocketMessageBufferSize,
+		ReadBufferSize:   WebsocketMessageBufferSize,
+		Subprotocols:     []string{subresources.PlainStreamProtocolName},
+		HandshakeTimeout: websocketHandshakeTimeout,
 	}
 
 	// Create a roundtripper which will pass in the final underlying websocket connection to a callback

--- a/staging/src/kubevirt.io/client-go/kubevirt/typed/core/v1/async.go
+++ b/staging/src/kubevirt.io/client-go/kubevirt/typed/core/v1/async.go
@@ -119,6 +119,11 @@ func AsyncSubresourceHelperContext(ctx context.Context, config *rest.Config, res
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return nil, fmt.Errorf("Can't connect to websocket: %w", ctxErr)
 		}
+		// The socket deadline can fire before the context's cancellation timer
+		// updates ctx.Err(). Honor the caller's deadline in either case.
+		if deadline, ok := ctx.Deadline(); ok && !time.Now().Before(deadline) {
+			return nil, fmt.Errorf("Can't connect to websocket: %w", context.DeadlineExceeded)
+		}
 		return nil, err
 	case ws := <-aws.Connection:
 		return &wsStreamer{

--- a/staging/src/kubevirt.io/client-go/kubevirt/typed/core/v1/fake/fake_virtualmachine_expansion.go
+++ b/staging/src/kubevirt.io/client-go/kubevirt/typed/core/v1/fake/fake_virtualmachine_expansion.go
@@ -102,6 +102,10 @@ func (c *fakeVirtualMachines) RemoveVolume(ctx context.Context, name string, rem
 }
 
 func (c *fakeVirtualMachines) PortForward(name string, port int, protocol string) (kubevirtv1.StreamInterface, error) {
+	return c.PortForwardContext(context.Background(), name, port, protocol)
+}
+
+func (c *fakeVirtualMachines) PortForwardContext(ctx context.Context, name string, port int, protocol string) (kubevirtv1.StreamInterface, error) {
 	return nil, nil
 }
 

--- a/staging/src/kubevirt.io/client-go/kubevirt/typed/core/v1/fake/fake_virtualmachineinstance_expansion.go
+++ b/staging/src/kubevirt.io/client-go/kubevirt/typed/core/v1/fake/fake_virtualmachineinstance_expansion.go
@@ -32,14 +32,26 @@ import (
 )
 
 func (c *fakeVirtualMachineInstances) SerialConsole(name string, options *kvcorev1.SerialConsoleOptions) (kvcorev1.StreamInterface, error) {
+	return c.SerialConsoleContext(context.Background(), name, options)
+}
+
+func (c *fakeVirtualMachineInstances) SerialConsoleContext(ctx context.Context, name string, options *kvcorev1.SerialConsoleOptions) (kvcorev1.StreamInterface, error) {
 	return nil, nil
 }
 
 func (c *fakeVirtualMachineInstances) USBRedir(vmiName string) (kvcorev1.StreamInterface, error) {
+	return c.USBRedirContext(context.Background(), vmiName)
+}
+
+func (c *fakeVirtualMachineInstances) USBRedirContext(ctx context.Context, vmiName string) (kvcorev1.StreamInterface, error) {
 	return nil, nil
 }
 
 func (c *fakeVirtualMachineInstances) VNC(name string, preserveSession bool) (kvcorev1.StreamInterface, error) {
+	return c.VNCContext(context.Background(), name, preserveSession)
+}
+
+func (c *fakeVirtualMachineInstances) VNCContext(ctx context.Context, name string, preserveSession bool) (kvcorev1.StreamInterface, error) {
 	return nil, nil
 }
 
@@ -48,6 +60,10 @@ func (c *fakeVirtualMachineInstances) Screenshot(ctx context.Context, name strin
 }
 
 func (c *fakeVirtualMachineInstances) PortForward(name string, port int, protocol string) (kvcorev1.StreamInterface, error) {
+	return c.PortForwardContext(context.Background(), name, port, protocol)
+}
+
+func (c *fakeVirtualMachineInstances) PortForwardContext(ctx context.Context, name string, port int, protocol string) (kvcorev1.StreamInterface, error) {
 	return nil, nil
 }
 
@@ -130,6 +146,10 @@ func (c *fakeVirtualMachineInstances) RemoveVolume(ctx context.Context, name str
 }
 
 func (c *fakeVirtualMachineInstances) VSOCK(name string, options *v1.VSOCKOptions) (kvcorev1.StreamInterface, error) {
+	return c.VSOCKContext(context.Background(), name, options)
+}
+
+func (c *fakeVirtualMachineInstances) VSOCKContext(ctx context.Context, name string, options *v1.VSOCKOptions) (kvcorev1.StreamInterface, error) {
 	return nil, nil
 }
 

--- a/staging/src/kubevirt.io/client-go/kubevirt/typed/core/v1/streamer_test.go
+++ b/staging/src/kubevirt.io/client-go/kubevirt/typed/core/v1/streamer_test.go
@@ -21,6 +21,7 @@ package v1
 
 import (
 	"bytes"
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"runtime"
@@ -111,6 +112,60 @@ var _ = Describe("wsStreamer", func() {
 		Expect(func() { _ = conn.Close() }).ToNot(Panic())
 	})
 })
+
+var _ = Describe("AsyncSubresourceHelperContext", func() {
+	It("should fail when the context is already cancelled", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		_, err := AsyncSubresourceHelperContext(ctx, &rest.Config{Host: "http://127.0.0.1"}, "virtualmachineinstances", "default", "testvmi", "vsock", nil)
+		Expect(err).To(MatchError(context.Canceled))
+	})
+
+	It("should fail a stalled handshake when the context deadline expires", func() {
+		server := newHangingUpgradeServer()
+		defer server.Close()
+
+		ctx, cancel := context.WithTimeout(context.Background(), 200*time.Millisecond)
+		defer cancel()
+
+		start := time.Now()
+		_, err := AsyncSubresourceHelperContext(ctx, &rest.Config{Host: server.URL}, "virtualmachineinstances", "default", "testvmi", "vsock", nil)
+		Expect(err).To(MatchError(context.DeadlineExceeded))
+		Expect(time.Since(start)).To(BeNumerically("<", 5*time.Second))
+	})
+
+	It("should still open a stream when the context has not expired", func() {
+		server := newEchoWebsocketServer()
+		defer server.Close()
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+
+		stream, err := AsyncSubresourceHelperContext(ctx, &rest.Config{Host: server.URL}, "virtualmachineinstances", "default", "testvmi", "vsock", nil)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(stream.AsConn().Close()).To(Succeed())
+	})
+})
+
+// newHangingUpgradeServer accepts the TCP connection and never writes a
+// websocket 101, reproducing a stalled handshake.
+func newHangingUpgradeServer() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer GinkgoRecover()
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			return
+		}
+		conn, _, err := hj.Hijack()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		buf := make([]byte, 1)
+		_, _ = conn.Read(buf)
+	}))
+}
 
 // newEchoWebsocketServer upgrades every request to a websocket and holds
 // it open until the client hangs up.

--- a/staging/src/kubevirt.io/client-go/kubevirt/typed/core/v1/streamer_test.go
+++ b/staging/src/kubevirt.io/client-go/kubevirt/typed/core/v1/streamer_test.go
@@ -135,6 +135,35 @@ var _ = Describe("AsyncSubresourceHelperContext", func() {
 		Expect(time.Since(start)).To(BeNumerically("<", 5*time.Second))
 	})
 
+	It("should report the context deadline when the socket times out before context cancellation", func() {
+		server := newHangingUpgradeServer()
+		defer server.Close()
+
+		// Keep Err() nil and Done() open to reproduce the socket deadline
+		// firing before the context's cancellation timer runs.
+		ctx := deadlineOnlyContext{
+			Context:  context.Background(),
+			deadline: time.Now().Add(200 * time.Millisecond),
+		}
+
+		_, err := AsyncSubresourceHelperContext(ctx, &rest.Config{Host: server.URL}, "virtualmachineinstances", "default", "testvmi", "vsock", nil)
+		Expect(err).To(MatchError(context.DeadlineExceeded))
+	})
+
+	It("should preserve handshake errors before the context deadline", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "console is not ready", http.StatusBadRequest)
+		}))
+		defer server.Close()
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+		defer cancel()
+
+		_, err := AsyncSubresourceHelperContext(ctx, &rest.Config{Host: server.URL}, "virtualmachineinstances", "default", "testvmi", "console", nil)
+		Expect(err).To(BeAssignableToTypeOf(&AsyncSubresourceError{}))
+		Expect(err.(*AsyncSubresourceError).GetStatusCode()).To(Equal(http.StatusBadRequest))
+	})
+
 	It("should still open a stream when the context has not expired", func() {
 		server := newEchoWebsocketServer()
 		defer server.Close()
@@ -147,6 +176,15 @@ var _ = Describe("AsyncSubresourceHelperContext", func() {
 		Expect(stream.AsConn().Close()).To(Succeed())
 	})
 })
+
+type deadlineOnlyContext struct {
+	context.Context
+	deadline time.Time
+}
+
+func (c deadlineOnlyContext) Deadline() (time.Time, bool) {
+	return c.deadline, true
+}
 
 // newHangingUpgradeServer accepts the TCP connection and never writes a
 // websocket 101, reproducing a stalled handshake.

--- a/staging/src/kubevirt.io/client-go/kubevirt/typed/core/v1/virtualmachine_expansion.go
+++ b/staging/src/kubevirt.io/client-go/kubevirt/typed/core/v1/virtualmachine_expansion.go
@@ -44,6 +44,7 @@ type VirtualMachineExpansion interface {
 	AddVolume(ctx context.Context, name string, addVolumeOptions *v1.AddVolumeOptions) error
 	RemoveVolume(ctx context.Context, name string, removeVolumeOptions *v1.RemoveVolumeOptions) error
 	PortForward(name string, port int, protocol string) (StreamInterface, error)
+	PortForwardContext(ctx context.Context, name string, port int, protocol string) (StreamInterface, error)
 	MemoryDump(ctx context.Context, name string, memoryDumpRequest *v1.VirtualMachineMemoryDumpRequest) error
 	RemoveMemoryDump(ctx context.Context, name string) error
 	ObjectGraph(ctx context.Context, name string, objectGraphOptions *v1.ObjectGraphOptions) (v1.ObjectGraphNode, error)
@@ -167,6 +168,10 @@ func (c *virtualMachines) RemoveVolume(ctx context.Context, name string, removeV
 }
 
 func (c *virtualMachines) PortForward(name string, port int, protocol string) (StreamInterface, error) {
+	return c.PortForwardContext(context.Background(), name, port, protocol)
+}
+
+func (c *virtualMachines) PortForwardContext(ctx context.Context, name string, port int, protocol string) (StreamInterface, error) {
 	// TODO not implemented yet
 	//  requires clientConfig
 	return nil, fmt.Errorf("PortForward is not implemented yet in generated client")

--- a/staging/src/kubevirt.io/client-go/kubevirt/typed/core/v1/virtualmachineinstance_expansion.go
+++ b/staging/src/kubevirt.io/client-go/kubevirt/typed/core/v1/virtualmachineinstance_expansion.go
@@ -40,10 +40,14 @@ type SerialConsoleOptions struct {
 
 type VirtualMachineInstanceExpansion interface {
 	SerialConsole(name string, options *SerialConsoleOptions) (StreamInterface, error)
+	SerialConsoleContext(ctx context.Context, name string, options *SerialConsoleOptions) (StreamInterface, error)
 	USBRedir(vmiName string) (StreamInterface, error)
+	USBRedirContext(ctx context.Context, vmiName string) (StreamInterface, error)
 	VNC(name string, preserveSession bool) (StreamInterface, error)
+	VNCContext(ctx context.Context, name string, preserveSession bool) (StreamInterface, error)
 	Screenshot(ctx context.Context, name string, options *v1.ScreenshotOptions) ([]byte, error)
 	PortForward(name string, port int, protocol string) (StreamInterface, error)
+	PortForwardContext(ctx context.Context, name string, port int, protocol string) (StreamInterface, error)
 	Backup(ctx context.Context, name string, backupOptions *backupv1.BackupOptions) error
 	RedefineCheckpoint(ctx context.Context, name string, checkpoint *backupv1.BackupCheckpoint) error
 	Pause(ctx context.Context, name string, pauseOptions *v1.PauseOptions) error
@@ -59,6 +63,7 @@ type VirtualMachineInstanceExpansion interface {
 	AddVolume(ctx context.Context, name string, addVolumeOptions *v1.AddVolumeOptions) error
 	RemoveVolume(ctx context.Context, name string, removeVolumeOptions *v1.RemoveVolumeOptions) error
 	VSOCK(name string, options *v1.VSOCKOptions) (StreamInterface, error)
+	VSOCKContext(ctx context.Context, name string, options *v1.VSOCKOptions) (StreamInterface, error)
 	SEVFetchCertChain(ctx context.Context, name string) (v1.SEVPlatformInfo, error)
 	SEVQueryLaunchMeasurement(ctx context.Context, name string) (v1.SEVMeasurementInfo, error)
 	SEVSetupSession(ctx context.Context, name string, sevSessionOptions *v1.SEVSessionOptions) error
@@ -67,18 +72,30 @@ type VirtualMachineInstanceExpansion interface {
 }
 
 func (c *virtualMachineInstances) SerialConsole(name string, options *SerialConsoleOptions) (StreamInterface, error) {
+	return c.SerialConsoleContext(context.Background(), name, options)
+}
+
+func (c *virtualMachineInstances) SerialConsoleContext(ctx context.Context, name string, options *SerialConsoleOptions) (StreamInterface, error) {
 	// TODO not implemented yet
 	//  requires clientConfig
 	return nil, fmt.Errorf("SerialConsole is not implemented yet in generated client")
 }
 
 func (c *virtualMachineInstances) USBRedir(vmiName string) (StreamInterface, error) {
+	return c.USBRedirContext(context.Background(), vmiName)
+}
+
+func (c *virtualMachineInstances) USBRedirContext(ctx context.Context, vmiName string) (StreamInterface, error) {
 	// TODO not implemented yet
 	//  requires clientConfig
 	return nil, fmt.Errorf("USBRedir is not implemented yet in generated client")
 }
 
 func (c *virtualMachineInstances) VNC(name string, preserveSession bool) (StreamInterface, error) {
+	return c.VNCContext(context.Background(), name, preserveSession)
+}
+
+func (c *virtualMachineInstances) VNCContext(ctx context.Context, name string, preserveSession bool) (StreamInterface, error) {
 	// TODO not implemented yet
 	//  requires clientConfig
 	return nil, fmt.Errorf("VNC is not implemented yet in generated client")
@@ -107,6 +124,10 @@ func (c *virtualMachineInstances) Screenshot(ctx context.Context, name string, o
 }
 
 func (c *virtualMachineInstances) PortForward(name string, port int, protocol string) (StreamInterface, error) {
+	return c.PortForwardContext(context.Background(), name, port, protocol)
+}
+
+func (c *virtualMachineInstances) PortForwardContext(ctx context.Context, name string, port int, protocol string) (StreamInterface, error) {
 	// TODO not implemented yet
 	//  requires clientConfig
 	return nil, fmt.Errorf("PortForward is not implemented yet in generated client")
@@ -372,6 +393,10 @@ func (c *virtualMachineInstances) RemoveVolume(ctx context.Context, name string,
 }
 
 func (c *virtualMachineInstances) VSOCK(name string, options *v1.VSOCKOptions) (StreamInterface, error) {
+	return c.VSOCKContext(context.Background(), name, options)
+}
+
+func (c *virtualMachineInstances) VSOCKContext(ctx context.Context, name string, options *v1.VSOCKOptions) (StreamInterface, error) {
 	// TODO not implemented yet
 	//  requires clientConfig
 	return nil, fmt.Errorf("VSOCK is not implemented yet in generated client")


### PR DESCRIPTION
### What this PR does
(Drafted with AI assistance (Cursor); reviewed and tested by me)

#### Before this PR:
`AsyncSubresourceHelper` opens VMI subresource streams (VNC, console, port-forward, USB redirection, VSOCK) over a gorilla websocket. The helper does not take a `context.Context`. `WebsocketRoundTripper.RoundTrip` calls `Dialer.Dial`, which is `DialContext(context.Background(), ...)`. A newly constructed dialer does not inherit `DefaultDialer`'s 45s `HandshakeTimeout`.

If the apiserver, proxy, or virt-handler accepts the upgrade and then stalls, the call waits until the peer closes the socket. That can be hours. Callers cannot abort it. Racing the helper against `context.WithTimeout` in a goroutine unblocks the caller and leaks the TCP connection until the peer dies.

#### After this PR:
`WebsocketRoundTripper.RoundTrip` calls `DialContext` with the request context and sets `HandshakeTimeout` to 45s. `AsyncSubresourceHelperContext` puts the caller's context on the request and returns when that context is done, closing a handshake that completes in the race window.

Existing `VNC`, `VSOCK`, `SerialConsole`, `USBRedir`, and `PortForward` signatures are unchanged. They wrap `context.Background()`. Callers that need a deadline use the matching `*Context` methods.

### References
- Fixes #19067

### Why we need it and why it was done in this way
The following tradeoffs were made:
- Additive `*Context` methods rather than adding `ctx` to the existing stream signatures, so virtctl and other callers keep compiling.
- A 45s handshake timeout even when the caller uses `context.Background()`, matching gorilla `DefaultDialer`, so virtctl is no longer unbounded if the upgrade stalls.
- Once the caller's deadline has passed, the helper returns `context.DeadlineExceeded` even if the handshake also failed for another reason (a 404, a socket `i/o timeout`). The context timer and the socket deadline can fire in either order; both paths honor the expired deadline so callers using `errors.Is` see a stable sentinel. Preserving the original transport error through `Unwrap` is a follow-up.

The following alternatives were considered:
- Setting only `HandshakeTimeout` without `DialContext`. That bounds the hang but still ignores the caller's deadline.
- Changing `VNC`/`VSOCK`/etc. to take `ctx` as the first argument. Cleaner long-term, but a breaking Go API change for every implementer and caller.

Links to places where the discussion took place: https://github.com/kubevirt/kubevirt/issues/19067

### Special notes for your reviewer
- Successful handshakes behave as before. New unit tests cover an already-cancelled context, a hijacked connection that never writes 101, a socket timeout that races the context timer, a 400 that still surfaces while the deadline is in the future, and a still-valid context against a normal upgrade.
- Verified with `go test kubevirt.io/client-go/kubevirt/typed/core/v1 kubevirt.io/client-go/kubecli`.
- No e2e test: reproducing a stalled 101 needs a hijacking HTTP server, which the unit test already does.

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [x] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [x] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [x] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [x] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [x] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [x] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
```release-note
client-go: VMI subresource websocket handshakes (VNC, console, port-forward, USB redirection, VSOCK) can be cancelled or timed out via context
```
