### PR TITLE
reviewcfg: point CodeRabbit at API design guidelines

### DIFF
--- a/hack/reviewcfg/.coderabbit.yaml
+++ b/hack/reviewcfg/.coderabbit.yaml
@@ -23,6 +23,8 @@ reviews:
       instructions: "See docs/network/network-binding-mechanisms.md."
     - path: "pkg/monitoring/**"
       instructions: "See docs/observability/monitoring-guidelines.md."
+    - path: "{staging/src/kubevirt.io/api,pkg/virt-api/webhooks}/**"
+      instructions: "Follow the rules in docs/api/design_guidelines.md."
   tools:
     trufflehog:
       enabled: true


### PR DESCRIPTION
### What this PR does

CodeRabbit's review config (`hack/reviewcfg/.coderabbit.yaml`) already maps several path trees to project-specific guideline docs (e.g. `pkg/network/**` -> `docs/network/network-binding-mechanisms.md`), so its automated reviews cite the right conventions for the area being changed. The KubeVirt API design guidelines (`docs/api/design_guidelines.md`, introduced in #18612) had no such mapping, so CodeRabbit had no way to apply them.

This PR adds a `path_instructions` entry pointing CodeRabbit at `docs/api/design_guidelines.md` for:
- `staging/src/kubevirt.io/api/**` — the API type definitions (labeled `kind/api-change` per that directory's `OWNERS` file), where the guidelines' rules on spec/status, conditions, immutability, enums, and CEL validation are most directly applicable.
- `pkg/virt-api/webhooks/**` — the admission/validation/mutation webhooks (part of the `area/api` scope per `pkg/virt-api/OWNERS`) that enforce those rules at runtime.

### Why we need it and why it was done in this way
The following tradeoffs were made:
- Scoped the instruction to the API type definitions and the webhooks that enforce them, rather than all of `pkg/virt-api/**` or `cmd/virt-api/**`, to keep the guidance targeted at code that actually shapes or enforces API design, not REST plumbing.

The following alternatives were considered:
- Applying the guidelines doc broadly across all of `area/api` (`pkg/virt-api/**`, `cmd/virt-api/**`); rejected as too broad for now, can be widened later if useful.

### Checklist

- [x] Design: A VEP was considered and is not required (review-tooling config only)
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Refactor: You have left the code cleaner than you found it
- [x] Upgrade: N/A — review tooling config only
- [x] Testing: N/A — review tooling config only
- [x] Documentation: N/A — no user-guide impact
- [x] Community: N/A — internal review tooling change
- [x] AI Contributions: The PR abides by the KubeVirt AI Contribution Policy

### Release note
```release-note
NONE
```