### PR TITLE
[release-1.8] Fix utility hotplug duplicate attachment pod

### DIFF
--- a/pkg/storage/cbt/backup.go
+++ b/pkg/storage/cbt/backup.go
@@ -1033,7 +1033,12 @@ func (ctrl *VMBackupController) addBackupFinalizer(backup *backupv1.VirtualMachi
 		return backup, err
 	}
 
-	return ctrl.client.VirtualMachineBackup(cpy.Namespace).Patch(context.Background(), cpy.Name, k8stypes.JSONPatchType, patchBytes, metav1.PatchOptions{})
+	patched, err := ctrl.client.VirtualMachineBackup(cpy.Namespace).Patch(context.Background(), cpy.Name, k8stypes.JSONPatchType, patchBytes, metav1.PatchOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to add finalizer: %w", err)
+	}
+	patched.ObjectMeta.DeepCopyInto(&backup.ObjectMeta)
+	return patched, nil
 }
 
 func (ctrl *VMBackupController) removeBackupFinalizer(backup *backupv1.VirtualMachineBackup) *SyncInfo {

--- a/pkg/storage/cbt/backup_test.go
+++ b/pkg/storage/cbt/backup_test.go
@@ -687,6 +687,29 @@ var _ = Describe("Backup Controller", func() {
 			Expect(result.Finalizers).To(ContainElement(vmBackupFinalizer))
 		})
 
+		It("should preserve status when patch response has no status", func() {
+			backup := createBackup(backupName, vmName, pvcName, backupv1.PushMode)
+			backup.Status = &backupv1.VirtualMachineBackupStatus{
+				Conditions: []backupv1.Condition{
+					newProgressingCondition(corev1.ConditionTrue, "waiting"),
+				},
+			}
+
+			addBackup(backup)
+
+			kubevirtClient.Fake.PrependReactor("patch", "virtualmachinebackups", func(action testing.Action) (handled bool, obj runtime.Object, err error) {
+				updatedBackup := backup.DeepCopy()
+				updatedBackup.Finalizers = []string{vmBackupFinalizer}
+				updatedBackup.Status = nil
+				return true, updatedBackup, nil
+			})
+
+			_, err := controller.addBackupFinalizer(backup)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(backup.Status).ToNot(BeNil())
+			Expect(backup.Status.Conditions).To(HaveLen(1))
+		})
+
 		It("should not re-add finalizer if already present", func() {
 			backup := createBackup(backupName, vmName, pvcName, backupv1.PushMode)
 			backup.Finalizers = []string{vmBackupFinalizer}

--- a/pkg/virt-controller/services/template.go
+++ b/pkg/virt-controller/services/template.go
@@ -1062,10 +1062,14 @@ func (t *TemplateService) RenderHotplugAttachmentPodTemplate(volumes []*v1.Volum
 		if claimName == "" {
 			continue
 		}
-		skipMount := false
-		if hotplugVolumeStatusMap[volume.Name] == v1.VolumeReady || hotplugVolumeStatusMap[volume.Name] == v1.HotplugVolumeMounted {
-			skipMount = true
-		}
+		// Skip container mounts for regular hotplug volumes already served by the old
+		// attachment pod (VolumeReady or HotplugVolumeMounted). Utility volumes always
+		// need a mount in the replacement pod so virt-handler can bind-mount when the
+		// volume set expands. Skipping during HotplugVolumeMounted avoids duplicate
+		// container mounts on overlapping attachment pods (same node as virt-launcher)
+		// while the disk is still attaching via the old pod.
+		phase := hotplugVolumeStatusMap[volume.Name]
+		skipMount := !types.IsUtilityVolume(vmi, volume.Name) && (phase == v1.VolumeReady || phase == v1.HotplugVolumeMounted)
 		pod.Spec.Volumes = append(pod.Spec.Volumes, k8sv1.Volume{
 			Name: volume.Name,
 			VolumeSource: k8sv1.VolumeSource{

--- a/pkg/virt-controller/services/template_test.go
+++ b/pkg/virt-controller/services/template_test.go
@@ -4491,6 +4491,80 @@ var _ = Describe("Template", func() {
 			Expect(pod.Spec.Tolerations).To(BeEquivalentTo(vmi.Spec.Tolerations))
 		})
 
+		DescribeTable("should mount filesystem hotplug volumes based on volume phase",
+			func(phase v1.VolumePhase, isUtility bool, expectVolumeMount bool) {
+				vmi := api.NewMinimalVMI("fake-vmi")
+				if isUtility {
+					vmi.Spec.UtilityVolumes = []v1.UtilityVolume{
+						{
+							Name: "testVolume",
+							PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
+								ClaimName: "pvcDevice",
+							},
+						},
+					}
+				}
+				vmi.Status.VolumeStatus = []v1.VolumeStatus{
+					{
+						Name:          "testVolume",
+						Phase:         phase,
+						HotplugVolume: &v1.HotplugVolumeStatus{},
+					},
+				}
+				ownerPod, err := svc.RenderLaunchManifest(vmi)
+				Expect(err).ToNot(HaveOccurred())
+
+				vmi.Status.SelinuxContext = "test_u:test_r:test_t:s0"
+
+				volumeName := "testVolume"
+				pvcName := "pvcDevice"
+				namespace := "testns"
+				mode := k8sv1.PersistentVolumeFilesystem
+				pvc := k8sv1.PersistentVolumeClaim{
+					TypeMeta:   metav1.TypeMeta{Kind: "PersistentVolumeClaim", APIVersion: "v1"},
+					ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: pvcName},
+					Spec: k8sv1.PersistentVolumeClaimSpec{
+						VolumeMode: &mode,
+					},
+				}
+				claimMap := map[string]*k8sv1.PersistentVolumeClaim{volumeName: &pvc}
+				volumes := []*v1.Volume{
+					{
+						Name: volumeName,
+						VolumeSource: v1.VolumeSource{
+							PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+								PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
+									ClaimName: pvcName,
+								},
+							},
+						},
+					},
+				}
+
+				pod, err := svc.RenderHotplugAttachmentPodTemplate(volumes, ownerPod, vmi, claimMap)
+				Expect(err).ToNot(HaveOccurred())
+
+				prop := k8sv1.MountPropagationHostToContainer
+				expectedMounts := []k8sv1.VolumeMount{
+					{
+						Name:             "hotplug-disks",
+						MountPath:        "/path",
+						MountPropagation: &prop,
+					},
+				}
+				if expectVolumeMount {
+					expectedMounts = append(expectedMounts, k8sv1.VolumeMount{
+						Name:      volumeName,
+						MountPath: "/" + volumeName,
+					})
+				}
+				Expect(pod.Spec.Containers[0].VolumeMounts).To(Equal(expectedMounts))
+			},
+			Entry("utility volume at HotplugVolumeMounted", v1.HotplugVolumeMounted, true, true),
+			Entry("regular hotplug volume at HotplugVolumeMounted", v1.HotplugVolumeMounted, false, false),
+			Entry("regular hotplug volume at VolumeReady", v1.VolumeReady, false, false),
+		)
+
 		It("should compute the correct volumeDevice context when rendering hotplug attachment pods with the FS PersistentVolumeClaim", func() {
 			vmi := api.NewMinimalVMI("fake-vmi")
 			ownerPod, err := svc.RenderLaunchManifest(vmi)

--- a/pkg/virt-controller/watch/vmi/vmi_test.go
+++ b/pkg/virt-controller/watch/vmi/vmi_test.go
@@ -4354,6 +4354,182 @@ var _ = Describe("VirtualMachineInstance watcher", func() {
 			Expect(err).ToNot(HaveOccurred())
 			expectPodExists(oldPod.Namespace, oldPod.Name)
 		})
+
+		DescribeTable("should clean up utility volume attachment pods when replacement pod is running",
+			func(includeUtilityPVC bool, includeUtilityMount bool, expectDelete bool) {
+				vmi := watchtesting.NewRunningVirtualMachine("testvmi", &k8sv1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "testnode",
+					},
+				})
+				vmi.Spec.UtilityVolumes = []virtv1.UtilityVolume{
+					{
+						Name: "utility-vol",
+						PersistentVolumeClaimVolumeSource: k8sv1.PersistentVolumeClaimVolumeSource{
+							ClaimName: "utility-pvc",
+						},
+					},
+				}
+				vmi.Status.VolumeStatus = []virtv1.VolumeStatus{
+					{
+						Name:  "utility-vol",
+						Phase: virtv1.HotplugVolumeMounted,
+						HotplugVolume: &virtv1.HotplugVolumeStatus{
+							AttachPodName: "new-pod",
+							AttachPodUID:  "new-uid",
+						},
+					},
+				}
+
+				oldPod := &k8sv1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "old-pod",
+						Namespace: vmi.Namespace,
+					},
+					Spec: k8sv1.PodSpec{
+						Volumes: []k8sv1.Volume{
+							{
+								Name: "utility-vol",
+								VolumeSource: k8sv1.VolumeSource{
+									PersistentVolumeClaim: &k8sv1.PersistentVolumeClaimVolumeSource{
+										ClaimName: "utility-pvc",
+									},
+								},
+							},
+						},
+					},
+					Status: k8sv1.PodStatus{
+						Phase: k8sv1.PodRunning,
+					},
+				}
+
+				currentPodSpec := k8sv1.PodSpec{
+					Volumes: []k8sv1.Volume{
+						{
+							Name: "hotplug-vol",
+							VolumeSource: k8sv1.VolumeSource{
+								PersistentVolumeClaim: &k8sv1.PersistentVolumeClaimVolumeSource{
+									ClaimName: "hotplug-pvc",
+								},
+							},
+						},
+					},
+				}
+				if includeUtilityPVC {
+					currentPodSpec.Volumes = append([]k8sv1.Volume{
+						{
+							Name: "utility-vol",
+							VolumeSource: k8sv1.VolumeSource{
+								PersistentVolumeClaim: &k8sv1.PersistentVolumeClaimVolumeSource{
+									ClaimName: "utility-pvc",
+								},
+							},
+						},
+					}, currentPodSpec.Volumes...)
+				}
+				if includeUtilityMount {
+					currentPodSpec.Containers = []k8sv1.Container{
+						{
+							Name: "hotplug-disk",
+							VolumeMounts: []k8sv1.VolumeMount{
+								{
+									Name:      "utility-vol",
+									MountPath: "/utility-vol",
+								},
+							},
+						},
+					}
+				}
+				currentPod := &k8sv1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "new-pod",
+						Namespace: vmi.Namespace,
+					},
+					Spec: currentPodSpec,
+					Status: k8sv1.PodStatus{
+						Phase: k8sv1.PodRunning,
+					},
+				}
+
+				addPod(oldPod)
+
+				err := controller.cleanupAttachmentPods(currentPod, []*k8sv1.Pod{oldPod}, vmi, 2)
+				Expect(err).ToNot(HaveOccurred())
+				if expectDelete {
+					testutils.ExpectEvent(recorder, kvcontroller.SuccessfulDeletePodReason)
+					expectPodDoesNotExist(oldPod.Namespace, oldPod.Name)
+				} else {
+					expectPodExists(oldPod.Namespace, oldPod.Name)
+				}
+			},
+			Entry("delete when replacement exposes utility volume", true, true, true),
+			Entry("keep when replacement is missing utility volume", false, false, false),
+			Entry("keep when replacement has utility PVC without container mount", true, false, false),
+		)
+
+		DescribeTable("volumeHandledByCurrentPod",
+			func(currentPod *k8sv1.Pod, volumeName string, specVolumes map[string]struct{}, expected bool) {
+				Expect(volumeHandledByCurrentPod(volumeName, currentPod, specVolumes)).To(Equal(expected))
+			},
+			Entry("nil pod", nil, "vol", map[string]struct{}{"vol": {}}, false),
+			Entry("pending pod", &k8sv1.Pod{Status: k8sv1.PodStatus{Phase: k8sv1.PodPending}}, "vol", map[string]struct{}{"vol": {}}, false),
+			Entry("volume not in spec map", &k8sv1.Pod{Status: k8sv1.PodStatus{Phase: k8sv1.PodRunning}}, "vol", map[string]struct{}{}, false),
+			Entry("pvc without container mount", &k8sv1.Pod{
+				Status: k8sv1.PodStatus{Phase: k8sv1.PodRunning},
+				Spec: k8sv1.PodSpec{
+					Volumes: []k8sv1.Volume{
+						{
+							Name: "vol",
+							VolumeSource: k8sv1.VolumeSource{
+								PersistentVolumeClaim: &k8sv1.PersistentVolumeClaimVolumeSource{ClaimName: "pvc"},
+							},
+						},
+					},
+				},
+			}, "vol", map[string]struct{}{"vol": {}}, false),
+			Entry("pvc with volume mount", &k8sv1.Pod{
+				Status: k8sv1.PodStatus{Phase: k8sv1.PodRunning},
+				Spec: k8sv1.PodSpec{
+					Containers: []k8sv1.Container{
+						{
+							Name: "hotplug-disk",
+							VolumeMounts: []k8sv1.VolumeMount{
+								{Name: "vol", MountPath: "/vol"},
+							},
+						},
+					},
+					Volumes: []k8sv1.Volume{
+						{
+							Name: "vol",
+							VolumeSource: k8sv1.VolumeSource{
+								PersistentVolumeClaim: &k8sv1.PersistentVolumeClaimVolumeSource{ClaimName: "pvc"},
+							},
+						},
+					},
+				},
+			}, "vol", map[string]struct{}{"vol": {}}, true),
+			Entry("pvc with volume device", &k8sv1.Pod{
+				Status: k8sv1.PodStatus{Phase: k8sv1.PodRunning},
+				Spec: k8sv1.PodSpec{
+					Containers: []k8sv1.Container{
+						{
+							Name: "hotplug-disk",
+							VolumeDevices: []k8sv1.VolumeDevice{
+								{Name: "vol", DevicePath: "/path/vol/uid"},
+							},
+						},
+					},
+					Volumes: []k8sv1.Volume{
+						{
+							Name: "vol",
+							VolumeSource: k8sv1.VolumeSource{
+								PersistentVolumeClaim: &k8sv1.PersistentVolumeClaimVolumeSource{ClaimName: "pvc"},
+							},
+						},
+					},
+				},
+			}, "vol", map[string]struct{}{"vol": {}}, true),
+		)
 	})
 
 	Context("topology hints", func() {

--- a/pkg/virt-controller/watch/vmi/volume-hotplug.go
+++ b/pkg/virt-controller/watch/vmi/volume-hotplug.go
@@ -84,12 +84,15 @@ func (c *Controller) cleanupAttachmentPods(currentPod *k8sv1.Pod, oldPods []*k8s
 		}
 	}
 
-	specHotplugVolumes := make(map[string]struct{})
+	specAttachmentVolumes := make(map[string]struct{})
 	for _, vmiVolume := range vmi.Spec.Volumes {
 		if storagetypes.IsHotplugVolume(&vmiVolume) {
-			specHotplugVolumes[vmiVolume.Name] = struct{}{}
+			specAttachmentVolumes[vmiVolume.Name] = struct{}{}
 			delete(statusMap, vmiVolume.Name)
 		}
+	}
+	for _, utilityVolume := range vmi.Spec.UtilityVolumes {
+		specAttachmentVolumes[utilityVolume.Name] = struct{}{}
 	}
 
 	currentPodIsNotRunning := currentPod == nil || currentPod.Status.Phase != k8sv1.PodRunning
@@ -98,13 +101,19 @@ func (c *Controller) cleanupAttachmentPods(currentPod *k8sv1.Pod, oldPods []*k8s
 			attachmentPod.Status.Phase == k8sv1.PodRunning && attachmentPod.DeletionTimestamp == nil &&
 			numReadyVolumes > 0 &&
 			currentPodIsNotRunning &&
-			podContainsVolumesToPreserve(attachmentPod, statusMap, specHotplugVolumes) {
+			podContainsVolumesToPreserve(attachmentPod, statusMap, specAttachmentVolumes) {
 			foundRunning = true
 			continue
 		}
 		volumesNotReadyForDelete := 0
 
 		for _, podVolume := range attachmentPod.Spec.Volumes {
+			if podVolume.PersistentVolumeClaim == nil {
+				continue
+			}
+			if volumeHandledByCurrentPod(podVolume.Name, currentPod, specAttachmentVolumes) {
+				continue
+			}
 			volumeStatus, ok := statusMap[podVolume.Name]
 			if ok && !volumeReadyForPodDelete(volumeStatus.Phase) {
 				volumesNotReadyForDelete++
@@ -133,6 +142,44 @@ func volumeReadyForPodDelete(phase v1.VolumePhase) bool {
 		return false
 	}
 	return true
+}
+
+func volumeHandledByCurrentPod(volumeName string, currentPod *k8sv1.Pod, specAttachmentVolumes map[string]struct{}) bool {
+	if currentPod == nil || currentPod.Status.Phase != k8sv1.PodRunning {
+		return false
+	}
+	if _, inSpec := specAttachmentVolumes[volumeName]; !inSpec {
+		return false
+	}
+	volumeInPodSpec := false
+	for _, podVolume := range currentPod.Spec.Volumes {
+		if podVolume.PersistentVolumeClaim != nil && podVolume.Name == volumeName {
+			volumeInPodSpec = true
+			break
+		}
+	}
+	if !volumeInPodSpec {
+		return false
+	}
+	return podVolumeExposedToContainer(currentPod, volumeName)
+}
+
+func podVolumeExposedToContainer(pod *k8sv1.Pod, volumeName string) bool {
+	if len(pod.Spec.Containers) == 0 {
+		return false
+	}
+	container := pod.Spec.Containers[0]
+	for _, mount := range container.VolumeMounts {
+		if mount.Name == volumeName {
+			return true
+		}
+	}
+	for _, device := range container.VolumeDevices {
+		if device.Name == volumeName {
+			return true
+		}
+	}
+	return false
 }
 
 // podContainsVolumesToPreserve returns true if the pod contains at least one


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Consider creating this PR as a draft: https://github.com/kubevirt/kubevirt/blob/main/CONTRIBUTING.md#consider-opening-your-pull-request-as-draft
2. Follow the instructions for writing a release note from k8s: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

### What this PR does

Manual backport of https://github.com/kubevirt/kubevirt/pull/18843

#### Before this PR:

#### After this PR:

### References
<!-- optional,
  Use `Fixes #<issue number>(, Fixes #<issue_number>, ...)` format, to close the issue(s) when PR gets merged.
  Use `Partially addresses #<issue number>` to link an issue without closing it when the PR merges.
  
- Fixes #
- Partially addresses #
-->
<!-- optional,
  VEP tracking issue if this PR is implementing one.
  For additional info about VEP tracking issue, see https://github.com/kubevirt/enhancements#process
  
- VEP tracking issue: https://github.com/kubevirt/enhancements/issues/<vep_tracking_issue_number>
-->

### Why we need it and why it was done in this way
The following tradeoffs were made:

The following alternatives were considered:

Links to places where the discussion took place: <!-- optional: slack, other GH issue, mailinglist, ... -->

### Special notes for your reviewer

<!-- optional -->

### Checklist

This checklist is not enforcing, but it's a reminder of items that could be relevant to every PR.
Approvers are expected to review this list.

- [ ] Design: A [VEP (virtualization enhancement proposal)](https://github.com/kubevirt/enhancements/blob/main/README.md) was considered and is present (link) or not required
- [ ] PR: The PR description is expressive enough and will help future contributors
- [ ] Code: [Write code that humans can understand](https://en.wikiquote.org/wiki/Martin_Fowler#code-for-humans) and [Keep it simple](https://en.wikipedia.org/wiki/KISS_principle)
- [ ] Refactor: You have [left the code cleaner than you found it (Boy Scout Rule)](https://learning.oreilly.com/library/view/97-things-every/9780596809515/ch08.html)
- [ ] Upgrade: Impact of this change on upgrade flows was considered and addressed if required
- [ ] Testing: New code requires [new unit tests](https://github.com/kubevirt/kubevirt/blob/main/docs/reviewer-guide.md#when-is-a-pr-good-enough). New features and bug fixes require at least one e2e test
- [ ] Documentation: A [user-guide update](https://github.com/kubevirt/user-guide/) was considered and is present (link) or not required. You want a user-guide update if it's a user facing feature / API change.
- [ ] Community: Announcement to [kubevirt-dev](https://groups.google.com/g/kubevirt-dev/) was considered
- [ ] AI Contributions: The PR abides by the [KubeVirt AI Contribution Policy](https://github.com/kubevirt/community/blob/main/ai-contribution-policy.md).

### Release note
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
BugFix: Prevent duplicate attachment pods when both utility volumes and hotplug volumes are used in a single VM
```

