### PR TITLE
Group PCI passthrough devices by PCIe root complex

### DIFF
--- a/pkg/util/hardware/hw_utils.go
+++ b/pkg/util/hardware/hw_utils.go
@@ -146,6 +146,45 @@ func GetDeviceNumaNode(pciAddress string) (*uint32, error) {
 	return &numaNode, nil
 }
 
+var (
+	pciDomainBusPattern = regexp.MustCompile(`^pci([\da-fA-F]{4}:[\da-fA-F]{2})$`)
+	pciBDFPattern       = regexp.MustCompile(PCI_ADDRESS_PATTERN)
+)
+
+func GetDevicePCIeRoot(pciAddress string) (string, error) {
+	devicePath := filepath.Join(PciBasePath, pciAddress)
+	resolved, err := filepath.EvalSymlinks(devicePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve sysfs path for device %s: %w", pciAddress, err)
+	}
+
+	parts := strings.Split(resolved, string(filepath.Separator))
+
+	domainIdx := -1
+	for i, part := range parts {
+		if pciDomainBusPattern.MatchString(part) {
+			domainIdx = i
+			break
+		}
+	}
+	if domainIdx < 0 {
+		return "", fmt.Errorf("no PCI domain segment found in sysfs path %s", resolved)
+	}
+
+	// The first BDF-shaped component after the domain segment is the root port.
+	// If none exists (device is directly on the root bus), use the domain segment.
+	for i := domainIdx + 1; i < len(parts); i++ {
+		if pciBDFPattern.MatchString(parts[i]) {
+			if parts[i] == pciAddress {
+				break
+			}
+			return parts[i], nil
+		}
+	}
+
+	return parts[domainIdx], nil
+}
+
 func GetDeviceAlignedCPUs(pciAddress string) ([]int, error) {
 	numaNode, err := GetDeviceNumaNode(pciAddress)
 	if err != nil {

--- a/pkg/util/hardware/hw_utils_test.go
+++ b/pkg/util/hardware/hw_utils_test.go
@@ -614,4 +614,98 @@ var _ = Describe("Hardware utils test", func() {
 			Expect(devicesNumaNodes).To(Equal(map[string]uint32{testPCIAddressNUMA1: 1}))
 		})
 	})
+
+	Context("get device PCIe root", func() {
+		var fakeSysDevices string
+
+		createPCITopology := func(devices map[string]string) {
+			var err error
+			fakeSysDevices, err = os.MkdirTemp("", "sys_devices")
+			Expect(err).ToNot(HaveOccurred())
+
+			for bdf, sysPath := range devices {
+				targetDir := filepath.Join(fakeSysDevices, sysPath)
+				err = os.MkdirAll(targetDir, 0o755)
+				Expect(err).ToNot(HaveOccurred())
+
+				symlinkPath := filepath.Join(fakePciBasePath, bdf)
+				os.RemoveAll(symlinkPath)
+				err = os.Symlink(targetDir, symlinkPath)
+				Expect(err).ToNot(HaveOccurred())
+			}
+		}
+
+		AfterEach(func() {
+			if fakeSysDevices != "" {
+				os.RemoveAll(fakeSysDevices)
+				fakeSysDevices = ""
+			}
+		})
+
+		It("should return the root port for a standard device", func() {
+			createPCITopology(map[string]string{
+				"0000:99:00.0": "devices/pci0000:98/0000:98:01.0/0000:99:00.0",
+			})
+			root, err := GetDevicePCIeRoot("0000:99:00.0")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(root).To(Equal("0000:98:01.0"))
+		})
+
+		It("should return the same root port for devices behind the same root port", func() {
+			createPCITopology(map[string]string{
+				"0000:99:00.0": "devices/pci0000:98/0000:98:01.0/0000:99:00.0",
+				"0000:99:00.1": "devices/pci0000:98/0000:98:01.0/0000:99:00.1",
+			})
+			root1, err := GetDevicePCIeRoot("0000:99:00.0")
+			Expect(err).ToNot(HaveOccurred())
+			root2, err := GetDevicePCIeRoot("0000:99:00.1")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(root1).To(Equal(root2))
+		})
+
+		It("should return different root ports for devices on different root ports", func() {
+			createPCITopology(map[string]string{
+				"0000:99:00.0": "devices/pci0000:98/0000:98:01.0/0000:99:00.0",
+				"0000:ad:00.0": "devices/pci0000:98/0000:98:02.0/0000:ad:00.0",
+			})
+			root1, err := GetDevicePCIeRoot("0000:99:00.0")
+			Expect(err).ToNot(HaveOccurred())
+			root2, err := GetDevicePCIeRoot("0000:ad:00.0")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(root1).ToNot(Equal(root2))
+			Expect(root1).To(Equal("0000:98:01.0"))
+			Expect(root2).To(Equal("0000:98:02.0"))
+		})
+
+		It("should return the domain segment for a device directly on the root bus", func() {
+			createPCITopology(map[string]string{
+				"0000:98:00.0": "devices/pci0000:98/0000:98:00.0",
+			})
+			root, err := GetDevicePCIeRoot("0000:98:00.0")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(root).To(Equal("pci0000:98"))
+		})
+
+		It("should return the root port for a VF behind its PF root port", func() {
+			createPCITopology(map[string]string{
+				"0000:99:00.3": "devices/pci0000:98/0000:98:01.0/0000:99:00.0/0000:99:00.3",
+			})
+			root, err := GetDevicePCIeRoot("0000:99:00.3")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(root).To(Equal("0000:98:01.0"))
+		})
+
+		It("should return an error for a non-existent device", func() {
+			_, err := GetDevicePCIeRoot("0000:ff:00.0")
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should return an error for a path without a PCI domain segment", func() {
+			createPCITopology(map[string]string{
+				"0000:01:00.0": "devices/virtual/0000:01:00.0",
+			})
+			_, err := GetDevicePCIeRoot("0000:01:00.0")
+			Expect(err).To(HaveOccurred())
+		})
+	})
 })

--- a/pkg/virt-launcher/virtwrap/converter/pci-placement.go
+++ b/pkg/virt-launcher/virtwrap/converter/pci-placement.go
@@ -185,22 +185,24 @@ func (p *pciRootSlotAssigner) PlacePCIDeviceAtNextSlot(address *api.Address) (*a
 	return address, nil
 }
 
-// numaAwareTopology represents the PCIe topology for a specific NUMA node.
+// numaAwareTopology represents the PCIe topology for a topology group
+// (PCIe root complex or NUMA node fallback).
 type numaAwareTopology struct {
 	expanderBus               *api.Controller
 	rootPorts                 []*api.Controller
 	addressPerDeviceSourcePCI map[string]*api.Address
 }
 
-// expanderBusAssigner manages the assignment of PCIe expander buses and
-// NUMA aligned device placement.
+// expanderBusAssigner manages the assignment of PCIe expander buses,
+// grouping devices by PCIe root complex with NUMA node fallback.
 type expanderBusAssigner struct {
 	domainSpec              *api.DomainSpec
 	controllerIndex         uint32
 	controllerCount         uint32
-	topologyMap             map[uint32]*numaAwareTopology
+	topologyMap             map[string]*numaAwareTopology
 	devices                 map[string]*api.HostDevice
 	devicesNUMANodes        map[string]uint32
+	devicesPCIeRoots        map[string]string
 	deviceNUMANodeOverrides map[string]uint32
 	isolatedDevices         map[string]*api.IOMMUDevice
 	strict                  bool
@@ -242,9 +244,10 @@ func newExpanderBusAssignerWithOptions(domainSpec *api.DomainSpec, isolatedDevic
 
 	assigner := &expanderBusAssigner{
 		domainSpec:              domainSpec,
-		topologyMap:             make(map[uint32]*numaAwareTopology),
+		topologyMap:             make(map[string]*numaAwareTopology),
 		devices:                 make(map[string]*api.HostDevice),
 		devicesNUMANodes:        make(map[string]uint32),
+		devicesPCIeRoots:        make(map[string]string),
 		deviceNUMANodeOverrides: numaOverrides,
 		isolatedDevices:         isolatedDevices,
 		strict:                  options.strict,
@@ -331,6 +334,14 @@ func (a *expanderBusAssigner) addDevices(devices []api.HostDevice) error {
 	}
 
 	for _, address := range pciAddresses {
+		if root, err := hardware.GetDevicePCIeRoot(address); err == nil {
+			a.devicesPCIeRoots[address] = root
+		} else {
+			log.Log.Warningf("PCI NUMA-aware placement: failed to determine PCIe root for %s: %v", address, err)
+		}
+	}
+
+	for _, address := range pciAddresses {
 		device := devicesByAddress[address]
 		if numaNode, exists := a.deviceNUMANodeOverrides[address]; exists {
 			a.devices[address] = device
@@ -368,39 +379,57 @@ func (a *expanderBusAssigner) addStrictFailure(message string) {
 	}
 }
 
-// numaDeviceGroups represents a mapping of NUMA nodes to host devices.
-type numaDeviceGroups map[uint32][]*api.HostDevice
+// topologyDeviceGroups represents a mapping of topology keys to host devices.
+type topologyDeviceGroups map[string][]*api.HostDevice
 
-// groupDevicesByNUMA groups devices by their NUMA node.
-func (a *expanderBusAssigner) groupDevicesByNUMA() numaDeviceGroups {
-	groups := make(numaDeviceGroups)
+func (a *expanderBusAssigner) topologyKeyForDevice(address string) string {
+	if root, exists := a.devicesPCIeRoots[address]; exists {
+		return root
+	}
+	if numaNode, exists := a.devicesNUMANodes[address]; exists {
+		return fmt.Sprintf("numa:%d", numaNode)
+	}
+	return ""
+}
+
+func (a *expanderBusAssigner) numaNodeForTopologyGroup(devices []*api.HostDevice) uint32 {
+	for _, device := range devices {
+		address := hardware.PCIAddressToString(device.Source.Address)
+		if numaNode, exists := a.devicesNUMANodes[address]; exists {
+			return numaNode
+		}
+	}
+	return 0
+}
+
+// groupDevicesByTopology groups devices by PCIe root complex first,
+// falling back to NUMA node when PCIe root is unavailable.
+func (a *expanderBusAssigner) groupDevicesByTopology() topologyDeviceGroups {
+	groups := make(topologyDeviceGroups)
 	for addressKey, device := range a.devices {
-		numaNode, exists := a.devicesNUMANodes[addressKey]
-		if !exists {
+		key := a.topologyKeyForDevice(addressKey)
+		if key == "" {
 			continue
 		}
-		groups[numaNode] = append(groups[numaNode], device)
+		groups[key] = append(groups[key], device)
 	}
-	for numaNode := range groups {
-		sort.Slice(groups[numaNode], func(i, j int) bool {
-			return hardware.PCIAddressToString(groups[numaNode][i].Source.Address) <
-				hardware.PCIAddressToString(groups[numaNode][j].Source.Address)
+	for key := range groups {
+		sort.Slice(groups[key], func(i, j int) bool {
+			return hardware.PCIAddressToString(groups[key][i].Source.Address) <
+				hardware.PCIAddressToString(groups[key][j].Source.Address)
 		})
 	}
 	return groups
 }
 
-// getNumaAwareTopology handles NUMA aware topology retrieval or creation
-// from the topology map. It creates an expander bus if the topology for that
-// NUMA node doesn't exist and returns that topology.
-func (a *expanderBusAssigner) getNumaAwareTopology(numaKey uint32) *numaAwareTopology {
-	topology, exists := a.topologyMap[numaKey]
+func (a *expanderBusAssigner) getNumaAwareTopology(topologyKey string, numaNode uint32) *numaAwareTopology {
+	topology, exists := a.topologyMap[topologyKey]
 	if !exists {
 		topology = &numaAwareTopology{
-			expanderBus:               a.createController(api.ControllerModelPCIeExpanderBus, "", 0, &numaKey),
+			expanderBus:               a.createController(api.ControllerModelPCIeExpanderBus, "", 0, &numaNode),
 			addressPerDeviceSourcePCI: make(map[string]*api.Address),
 		}
-		a.topologyMap[numaKey] = topology
+		a.topologyMap[topologyKey] = topology
 	}
 	return topology
 }
@@ -434,19 +463,18 @@ func (a *expanderBusAssigner) createDeviceTopology(numaNode uint32) *numaAwareTo
 	}
 }
 
-// buildTopology groups devices by NUMA node by using a pcie-expander-bus per
-// NUMA node. Within a pcie-expander-bus one pcie-root-port per device is created.
-// Each device is then placed behind its respective root port.
+// buildTopology groups devices by PCIe root complex (or NUMA node as fallback)
+// using a pcie-expander-bus per group. Within a pcie-expander-bus one
+// pcie-root-port per device is created. Each device is then placed behind its
+// respective root port.
 //
-// pcie-expander-bus (one per NUMA node) -> pcie-root-port (one per device) -> device
-//
-// It modifies the topology per NUMA node in place by creating the necessary controllers
-// and updating the addresses of the devices.
+// pcie-expander-bus (one per PCIe root / NUMA node) -> pcie-root-port (one per device) -> device
 func (a *expanderBusAssigner) buildTopology() error {
-	numaDeviceGroups := a.groupDevicesByNUMA()
+	topologyGroups := a.groupDevicesByTopology()
 
-	for _, numaKey := range sortedKeys(numaDeviceGroups) {
-		devices := numaDeviceGroups[numaKey]
+	for _, topoKey := range sortedKeys(topologyGroups) {
+		devices := topologyGroups[topoKey]
+		numaNode := a.numaNodeForTopologyGroup(devices)
 
 		var normalDevices []*api.HostDevice
 		for _, device := range devices {
@@ -457,7 +485,11 @@ func (a *expanderBusAssigner) buildTopology() error {
 				continue
 			}
 
-			topology := a.createDeviceTopology(numaKey)
+			deviceNUMA := numaNode
+			if n, exists := a.devicesNUMANodes[address]; exists {
+				deviceNUMA = n
+			}
+			topology := a.createDeviceTopology(deviceNUMA)
 			if err := a.placeDevice(topology, device); err != nil {
 				return fmt.Errorf("failed to place isolated device %s: %w", address, err)
 			}
@@ -472,7 +504,7 @@ func (a *expanderBusAssigner) buildTopology() error {
 			continue
 		}
 
-		topology := a.getNumaAwareTopology(numaKey)
+		topology := a.getNumaAwareTopology(topoKey, numaNode)
 		for _, device := range normalDevices {
 			if err := a.placeDevice(topology, device); err != nil {
 				return fmt.Errorf("failed to place device %s: %w", hardware.PCIAddressToString(device.Source.Address), err)

--- a/pkg/virt-launcher/virtwrap/converter/pci-placement_test.go
+++ b/pkg/virt-launcher/virtwrap/converter/pci-placement_test.go
@@ -38,6 +38,7 @@ var _ = Describe("PCIe Expander Bus Assigner", func() {
 		originalNodeBasePath string
 		fakePciBasePath      string
 		fakeNodeBasePath     string
+		fakeSysDevices       string
 	)
 
 	createDomainSpecWithNUMA := func(numaCells []api.NUMACell, vcpuPins []api.CPUTuneVCPUPin) *api.DomainSpec {
@@ -171,7 +172,31 @@ var _ = Describe("PCIe Expander Bus Assigner", func() {
 		if fakeNodeBasePath != "" {
 			os.RemoveAll(fakeNodeBasePath)
 		}
+		if fakeSysDevices != "" {
+			os.RemoveAll(fakeSysDevices)
+			fakeSysDevices = ""
+		}
 	})
+
+	setupPCIeRootTopology := func(topology map[string]struct{ sysPath, numaNode string }) {
+		var err error
+		fakeSysDevices, err = os.MkdirTemp("", "sys_devices")
+		Expect(err).ToNot(HaveOccurred())
+
+		for bdf, info := range topology {
+			targetDir := filepath.Join(fakeSysDevices, info.sysPath)
+			err = os.MkdirAll(targetDir, 0o755)
+			Expect(err).ToNot(HaveOccurred())
+
+			err = os.WriteFile(filepath.Join(targetDir, "numa_node"), []byte(info.numaNode+"\n"), 0o644)
+			Expect(err).ToNot(HaveOccurred())
+
+			symlinkPath := filepath.Join(fakePciBasePath, bdf)
+			os.RemoveAll(symlinkPath)
+			err = os.Symlink(targetDir, symlinkPath)
+			Expect(err).ToNot(HaveOccurred())
+		}
+	}
 
 	Describe("getCurrentControllerIndex", func() {
 		It("should return the highest index of the existing controllers", func() {
@@ -394,7 +419,7 @@ var _ = Describe("PCIe Expander Bus Assigner", func() {
 				createPCIDevice("normal", "0x03"),
 			}
 			assigner = newExpanderBusAssignerWithOptions(domainSpec, map[string]*api.IOMMUDevice{
-				"0000:01:00.0": &api.IOMMUDevice{Model: "smmuv3", Driver: &api.IOMMUDriver{}},
+				"0000:01:00.0": {Model: "smmuv3", Driver: &api.IOMMUDriver{}},
 			}, nil)
 
 			err := assigner.PlaceNumaAlignedDevices()
@@ -410,7 +435,7 @@ var _ = Describe("PCIe Expander Bus Assigner", func() {
 		It("uses NUMA overrides when placing isolated devices", func() {
 			domainSpec.Devices.HostDevices = []api.HostDevice{createPCIDevice("isolated", "0x01")}
 			assigner = newExpanderBusAssignerWithOptions(domainSpec,
-				map[string]*api.IOMMUDevice{"0000:01:00.0": &api.IOMMUDevice{Model: "smmuv3", Driver: &api.IOMMUDriver{}}},
+				map[string]*api.IOMMUDevice{"0000:01:00.0": {Model: "smmuv3", Driver: &api.IOMMUDriver{}}},
 				map[string]uint32{"0000:01:00.0": 1},
 			)
 
@@ -718,6 +743,150 @@ var _ = Describe("PCIe Expander Bus Assigner", func() {
 			Expect(domainSpec.Devices.Controllers[3].Model).To(Equal(api.ControllerModelPCIeRootPort))
 			Expect(domainSpec.Devices.Controllers[3].Index).To(Equal("9"))
 			Expect(domainSpec.Devices.HostDevices[0].Address.Bus).To(Equal("9"))
+		})
+	})
+
+	Describe("PCIe root grouping", func() {
+		var domainSpec *api.DomainSpec
+
+		BeforeEach(func() {
+			domainSpec = createDomainSpecWithNUMA(
+				[]api.NUMACell{
+					{ID: "0", CPUs: "0-3"},
+					{ID: "1", CPUs: "4-7"},
+				},
+				[]api.CPUTuneVCPUPin{
+					{VCPU: 0, CPUSet: "0"}, {VCPU: 1, CPUSet: "1"},
+					{VCPU: 2, CPUSet: "2"}, {VCPU: 3, CPUSet: "3"},
+					{VCPU: 4, CPUSet: "4"}, {VCPU: 5, CPUSet: "5"},
+					{VCPU: 6, CPUSet: "6"}, {VCPU: 7, CPUSet: "7"},
+				},
+			)
+		})
+
+		It("should create separate pxb-pcie for devices on different PCIe roots but same NUMA", func() {
+			setupPCIeRootTopology(map[string]struct{ sysPath, numaNode string }{
+				"0000:01:00.0": {"devices/pci0000:00/0000:00:01.0/0000:01:00.0", "0"},
+				"0000:03:00.0": {"devices/pci0000:00/0000:00:03.0/0000:03:00.0", "0"},
+			})
+
+			domainSpec.Devices.HostDevices = []api.HostDevice{
+				createPCIDevice("gpu", "0x01"),
+				createPCIDevice("nic", "0x03"),
+			}
+
+			err := PlacePCIDevicesWithNUMAAlignment(domainSpec)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(countControllersByModel(domainSpec, api.ControllerModelPCIeExpanderBus)).To(Equal(2))
+			Expect(countControllersByModel(domainSpec, api.ControllerModelPCIeRootPort)).To(Equal(2))
+
+			for _, controller := range domainSpec.Devices.Controllers {
+				if controller.Model == api.ControllerModelPCIeExpanderBus {
+					Expect(controller.Target).ToNot(BeNil())
+					Expect(controller.Target.NUMANode).ToNot(BeNil())
+					Expect(*controller.Target.NUMANode).To(Equal(uint32(0)))
+				}
+			}
+		})
+
+		It("should create one pxb-pcie for devices on the same PCIe root", func() {
+			setupPCIeRootTopology(map[string]struct{ sysPath, numaNode string }{
+				"0000:01:00.0": {"devices/pci0000:00/0000:00:01.0/0000:01:00.0", "0"},
+				"0000:03:00.0": {"devices/pci0000:00/0000:00:01.0/0000:03:00.0", "0"},
+			})
+
+			domainSpec.Devices.HostDevices = []api.HostDevice{
+				createPCIDevice("gpu", "0x01"),
+				createPCIDevice("nic", "0x03"),
+			}
+
+			err := PlacePCIDevicesWithNUMAAlignment(domainSpec)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(countControllersByModel(domainSpec, api.ControllerModelPCIeExpanderBus)).To(Equal(1))
+			Expect(countControllersByModel(domainSpec, api.ControllerModelPCIeRootPort)).To(Equal(2))
+		})
+
+		It("should fall back to NUMA grouping when PCIe root is unavailable", func() {
+			domainSpec.Devices.HostDevices = []api.HostDevice{
+				createPCIDevice("device1", "0x01"),
+				createPCIDevice("device2", "0x03"),
+			}
+
+			err := PlacePCIDevicesWithNUMAAlignment(domainSpec)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(countControllersByModel(domainSpec, api.ControllerModelPCIeExpanderBus)).To(Equal(1))
+			Expect(countControllersByModel(domainSpec, api.ControllerModelPCIeRootPort)).To(Equal(2))
+		})
+
+		It("should group PCIe root devices separately from NUMA fallback devices", func() {
+			setupPCIeRootTopology(map[string]struct{ sysPath, numaNode string }{
+				"0000:01:00.0": {"devices/pci0000:00/0000:00:01.0/0000:01:00.0", "0"},
+			})
+
+			domainSpec.Devices.HostDevices = []api.HostDevice{
+				createPCIDevice("gpu", "0x01"),
+				createPCIDevice("nic", "0x03"),
+			}
+
+			err := PlacePCIDevicesWithNUMAAlignment(domainSpec)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(countControllersByModel(domainSpec, api.ControllerModelPCIeExpanderBus)).To(Equal(2))
+			Expect(countControllersByModel(domainSpec, api.ControllerModelPCIeRootPort)).To(Equal(2))
+		})
+
+		It("should place IOMMU-isolated device on its own pxb-pcie regardless of PCIe root", func() {
+			setupPCIeRootTopology(map[string]struct{ sysPath, numaNode string }{
+				"0000:01:00.0": {"devices/pci0000:00/0000:00:01.0/0000:01:00.0", "0"},
+				"0000:03:00.0": {"devices/pci0000:00/0000:00:01.0/0000:03:00.0", "0"},
+			})
+
+			assigner := newExpanderBusAssignerWithOptions(domainSpec,
+				map[string]*api.IOMMUDevice{"0000:01:00.0": {Model: "smmuv3", Driver: &api.IOMMUDriver{}}},
+				nil,
+			)
+			domainSpec.Devices.HostDevices = []api.HostDevice{
+				createPCIDevice("gpu", "0x01"),
+				createPCIDevice("nic", "0x03"),
+			}
+
+			err := assigner.PlaceNumaAlignedDevices()
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(countControllersByModel(domainSpec, api.ControllerModelPCIeExpanderBus)).To(Equal(2))
+		})
+
+		It("should set correct NUMA node on pxb-pcie target for each PCIe root group", func() {
+			setupPCIeRootTopology(map[string]struct{ sysPath, numaNode string }{
+				"0000:01:00.0": {"devices/pci0000:00/0000:00:01.0/0000:01:00.0", "0"},
+				"0000:02:00.0": {"devices/pci0000:00/0000:00:02.0/0000:02:00.0", "1"},
+			})
+
+			domainSpec.Devices.HostDevices = []api.HostDevice{
+				createPCIDevice("gpu", "0x01"),
+				createPCIDevice("nic", "0x02"),
+			}
+
+			err := PlacePCIDevicesWithNUMAAlignment(domainSpec)
+			Expect(err).ToNot(HaveOccurred())
+
+			expanders := 0
+			numaNodes := map[uint32]bool{}
+			for _, controller := range domainSpec.Devices.Controllers {
+				if controller.Model == api.ControllerModelPCIeExpanderBus {
+					expanders++
+					Expect(controller.Target).ToNot(BeNil())
+					Expect(controller.Target.NUMANode).ToNot(BeNil())
+					numaNodes[*controller.Target.NUMANode] = true
+				}
+			}
+			Expect(expanders).To(Equal(2))
+			Expect(numaNodes).To(HaveLen(2))
+			Expect(numaNodes).To(HaveKey(uint32(0)))
+			Expect(numaNodes).To(HaveKey(uint32(1)))
 		})
 	})
 })


### PR DESCRIPTION
## Summary

- Group passthrough devices by PCIe root complex instead of NUMA node, creating one `pxb-pcie` per root complex
- Add `GetDevicePCIeRoot()` sysfs utility that resolves the device realpath to extract the root port BDF
- Fall back to NUMA-only grouping when PCIe root is unavailable

Fixes #19103

## Motivation

On hardware with multiple PCIe root complexes per NUMA node (NPS1, Intel SNC off), all devices on the same NUMA node share a single `pxb-pcie` controller. The guest cannot distinguish devices on different root complexes, which breaks peer-to-peer DMA locality detection for GPU-direct RDMA.

## Changes

- `pkg/util/hardware/hw_utils.go`: new `GetDevicePCIeRoot(pciAddress)` resolves sysfs realpath to extract root port BDF. Handles multi-domain systems, VFs (share PF root port), bus-00 devices (domain fallback), and PCIe switches (returns root port, not switch).
- `pkg/virt-launcher/virtwrap/converter/pci-placement.go`: topology map key changed from `uint32` (NUMA node) to `string` (PCIe root BDF or `numa:<N>` fallback). New `groupDevicesByTopology()` replaces `groupDevicesByNUMA()`.

No API changes. No new feature gates. Gated by existing `PCINUMAAwareTopology`.

## Test plan

- [x] Unit tests for `GetDevicePCIeRoot`: standard device, shared root port, different root ports, bus-00 device, VF, error cases
- [x] Placement tests: different PCIe roots same NUMA (2 pxb-pcie), same root (1 pxb-pcie), NUMA fallback, mixed, IOMMU isolation, NUMA node target verification
- [x] All existing tests pass (regression: single-root-per-NUMA produces identical output)
- [x] E2e on Dell XE8640: Intel E810 (root `0000:59:01.0`) and Mellanox CX6DX (root `0000:26:01.0`) on NUMA 0 placed on separate `pxb-pcie` controllers. Guest `lspci -tv` shows separate PCI domains.

```release-note
Group PCI passthrough devices by PCIe root complex instead of NUMA node for accurate peer-to-peer DMA topology in the guest
```

/cc @alaypatel07