### PR TITLE
fix(virt-launcher): consolidate default ramfb display across vGPU builders

### DIFF
--- a/pkg/virt-launcher/virtwrap/device/hostdevice/gpu/hostdev.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/gpu/hostdev.go
@@ -35,6 +35,15 @@ const (
 	DefaultDisplayOn             = true
 )
 
+func IsVgpuDisplaySet(gpuSpecs []v1.GPU) bool {
+	for _, dev := range gpuSpecs {
+		if dev.VirtualGPUOptions != nil && dev.VirtualGPUOptions.Display != nil {
+			return true
+		}
+	}
+	return false
+}
+
 // TODO: Pass in also medata so metada can be constructed also in tests, include if display is possible
 func CreateHostDevices(vmiGPUs []v1.GPU) ([]api.HostDevice, error) {
 	return CreateHostDevicesFromPools(vmiGPUs, NewPCIAddressPool(vmiGPUs), NewMDEVAddressPool(vmiGPUs))

--- a/pkg/virt-launcher/virtwrap/device/hostdevice/gpu/hostdev_test.go
+++ b/pkg/virt-launcher/virtwrap/device/hostdevice/gpu/hostdev_test.go
@@ -42,6 +42,24 @@ var _ = Describe("GPU HostDevice", func() {
 		Expect(gpu.CreateHostDevices(vmi.Spec.Domain.Devices.GPUs)).To(BeEmpty())
 	})
 
+	It("correctly identifies when vGPU display options are set or unset", func() {
+		gpusWithoutDisplay := []v1.GPU{
+			{DeviceName: gpuResource0, Name: gpuName0},
+		}
+		Expect(gpu.IsVgpuDisplaySet(gpusWithoutDisplay)).To(BeFalse())
+
+		gpusWithDisplay := []v1.GPU{
+			{
+				DeviceName: gpuResource0,
+				Name:       gpuName0,
+				VirtualGPUOptions: &v1.VGPUOptions{
+					Display: &v1.VGPUDisplayOptions{},
+				},
+			},
+		}
+		Expect(gpu.IsVgpuDisplaySet(gpusWithDisplay)).To(BeTrue())
+	})
+
 	It("fails to create devices given no resource", func() {
 		vmi.Spec.Domain.Devices.GPUs = []v1.GPU{{DeviceName: gpuResource0, Name: gpuName0}}
 		_, err := gpu.CreateHostDevices(vmi.Spec.Domain.Devices.GPUs)

--- a/pkg/virt-launcher/virtwrap/manager.go
+++ b/pkg/virt-launcher/virtwrap/manager.go
@@ -1234,7 +1234,25 @@ func (l *LibvirtDomainManager) getGPUDevices(vmi *v1.VirtualMachineInstance) ([]
 	if err != nil {
 		return nil, err
 	}
-	return append(gpuHostDevices, gpuDRAHostDevices...), nil
+	devices := append(gpuHostDevices, gpuDRAHostDevices...)
+	if !gpu.IsVgpuDisplaySet(vmi.Spec.Domain.Devices.GPUs) {
+		consolidateDefaultDisplay(devices)
+	}
+	return devices, nil
+}
+
+func consolidateDefaultDisplay(devices []api.HostDevice) {
+	var foundFirst bool
+	for i := range devices {
+		if devices[i].RamFB == "on" {
+			if !foundFirst {
+				foundFirst = true
+			} else {
+				devices[i].RamFB = ""
+				devices[i].Display = ""
+			}
+		}
+	}
 }
 
 func (l *LibvirtDomainManager) generateConverterContext(vmi *v1.VirtualMachineInstance, allowEmulation bool, options *cmdv1.VirtualMachineOptions, isMigrationTarget bool) (*convertertypes.ConverterContext, error) {

--- a/pkg/virt-launcher/virtwrap/manager_test.go
+++ b/pkg/virt-launcher/virtwrap/manager_test.go
@@ -5001,4 +5001,68 @@ var _ = Describe("findDiskFileInImageVolume", func() {
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("failed to read image volume directory"))
 	})
+
+	Context("consolidateDefaultDisplay", func() {
+		It("should leave a single default ramfb display untouched", func() {
+			devices := []api.HostDevice{
+				{
+					Type:    api.HostDeviceMDev,
+					Display: "on",
+					RamFB:   "on",
+				},
+				{
+					Type: api.HostDeviceMDev,
+				},
+			}
+			consolidateDefaultDisplay(devices)
+			Expect(devices[0].RamFB).To(Equal("on"))
+			Expect(devices[0].Display).To(Equal("on"))
+			Expect(devices[1].RamFB).To(BeEmpty())
+			Expect(devices[1].Display).To(BeEmpty())
+		})
+
+		It("should consolidate multiple default ramfb displays to at most one", func() {
+			devices := []api.HostDevice{
+				{
+					Type:    api.HostDeviceMDev,
+					Display: "on",
+					RamFB:   "on",
+				},
+				{
+					Type:    api.HostDeviceMDev,
+					Display: "on",
+					RamFB:   "on",
+				},
+			}
+			consolidateDefaultDisplay(devices)
+			Expect(devices[0].RamFB).To(Equal("on"))
+			Expect(devices[0].Display).To(Equal("on"))
+			Expect(devices[1].RamFB).To(BeEmpty())
+			Expect(devices[1].Display).To(BeEmpty())
+		})
+
+		It("should keep the first default display even if preceding devices have no display", func() {
+			devices := []api.HostDevice{
+				{
+					Type: api.HostDevicePCI,
+				},
+				{
+					Type:    api.HostDeviceMDev,
+					Display: "on",
+					RamFB:   "on",
+				},
+				{
+					Type:    api.HostDeviceMDev,
+					Display: "on",
+					RamFB:   "on",
+				},
+			}
+			consolidateDefaultDisplay(devices)
+			Expect(devices[0].RamFB).To(BeEmpty())
+			Expect(devices[1].RamFB).To(Equal("on"))
+			Expect(devices[1].Display).To(Equal("on"))
+			Expect(devices[2].RamFB).To(BeEmpty())
+			Expect(devices[2].Display).To(BeEmpty())
+		})
+	})
 })


### PR DESCRIPTION
### What this PR does
#### Before this PR:
When a VMI mixes device-plugin vGPUs and Dynamic Resource Allocation (DRA) vGPUs without explicit display options configured, both `gpu.CreateHostDevices` and `dra.CreateDRAGPUHostDevices` independently set `Display = "on"` and `RamFB = "on"` on their respective first `mdev` device.
Concatenating both slices in `getGPUDevices` (`pkg/virt-launcher/virtwrap/manager.go`) resulted in two default `ramfb` displays in the domain XML, which QEMU rejects on startup with a domain definition error.

#### After this PR:
- Exported `IsVgpuDisplaySet` in `pkg/virt-launcher/virtwrap/device/hostdevice/gpu/hostdev.go` to detect whether explicit display options were configured across GPU specs.
- Added `consolidateDefaultDisplay` in `pkg/virt-launcher/virtwrap/manager.go` to ensure that at most one default `ramfb` display is enabled across the combined GPU host devices list when no explicit vGPU display was configured.
- Added unit tests in `pkg/virt-launcher/virtwrap/device/hostdevice/gpu/hostdev_test.go` and `pkg/virt-launcher/virtwrap/manager_test.go`.

### References
Fixes #18543

### Why we need it and why it was done in this way
In QEMU, configuring multiple `ramfb` displays is invalid and causes domain launch failure. Consolidating the default display after merging the device-plugin and DRA GPU lists preserves the "at most one default display per domain" guarantee while keeping the individual builders decoupled.

### Checklist
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Testing: New code requires new unit tests.
- [x] AI Contributions: The PR abides by the KubeVirt AI Contribution Policy.

### Release note
```release-note
Fixed an issue where combining device-plugin and DRA vGPUs without explicit display options could produce multiple default ramfb displays, causing QEMU domain initialization failure.
```