### PR TITLE
tests: rename sig-operator CI lane to sig-control-plane

### DIFF
--- a/.github/ISSUE_TEMPLATE/flaky_test_report.md
+++ b/.github/ISSUE_TEMPLATE/flaky_test_report.md
@@ -17,7 +17,7 @@ Flaky test detected: {test_name} [1]
 
 <!-- sig assignment
      all tests contain a sig identifier, please assign the corresponding SIG to the issue, i.e.
-     for a test name containing [sig-compute] or [sig-operator]
+     for a test name containing [sig-compute] or [sig-control-plane]
 -->
 /sig compute
 

--- a/automation/test.sh
+++ b/automation/test.sh
@@ -156,6 +156,11 @@ case "$TARGET" in
   *sig-compute*)
     export KUBEVIRT_PROVIDER=${TARGET/-sig-compute/}
     ;;
+  *sig-control-plane*)
+    export KUBEVIRT_PROVIDER=${TARGET/-sig-control-plane*/}
+    export KUBEVIRT_WITH_CNAO=true
+    export KUBEVIRT_NUM_SECONDARY_NICS=1
+    ;;
   *sig-operator*)
     export KUBEVIRT_PROVIDER=${TARGET/-sig-operator*/}
     export KUBEVIRT_WITH_CNAO=true
@@ -595,13 +600,13 @@ if [[ -z ${KUBEVIRT_E2E_FOCUS} && -z ${KUBEVIRT_E2E_SKIP} && -z ${label_filter} 
     label_filter='(sig-compute && !(GPU,VGPU,sig-compute-migrations,sig-storage,DRA-GPU) && !(SEV, SEVES, secure-execution))'
   elif [[ $TARGET =~ sig-monitoring ]]; then
     label_filter='(sig-monitoring)'
-  elif [[ $TARGET =~ sig-operator ]]; then
-    if [[ $TARGET =~ sig-operator-upgrade ]]; then
+  elif [[ $TARGET =~ sig-control-plane || $TARGET =~ sig-operator ]]; then
+    if [[ $TARGET =~ sig-control-plane-upgrade || $TARGET =~ sig-operator-upgrade ]]; then
       label_filter='(Upgrade)'
-    elif [[ $TARGET =~ sig-operator-configuration ]]; then
-      label_filter='(sig-operator && !(Upgrade))'
+    elif [[ $TARGET =~ sig-control-plane-configuration || $TARGET =~ sig-operator-configuration ]]; then
+      label_filter='(sig-control-plane && !(Upgrade))'
     else
-      label_filter='(sig-operator)'
+      label_filter='(sig-control-plane)'
     fi
   elif [[ $TARGET =~ gpu.* ]]; then
     label_filter='(GPU)'

--- a/hack/check-unassigned-tests.sh
+++ b/hack/check-unassigned-tests.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 
 main() {
-    skip="SRIOV|GPU|\\[sig-operator\\]|\\[sig-network\\]|\\[sig-storage\\]|\\[sig-compute\\]|\\[sig-compute-migrations\\]|\\[sig-performance\\]|\\[sig-compute-realtime\\]|\\[sig-monitoring\\]"
+    skip="SRIOV|GPU|\[sig-control-plane\]|\[sig-network\]|\[sig-storage\]|\[sig-compute\]|\[sig-compute-migrations\]|\[sig-performance\]|\[sig-compute-realtime\]|\[sig-monitoring\]"
     result=$(FUNC_TEST_ARGS="--dry-run --no-color -skip=${skip}" make functest)
     total_tests=$(echo "${result}" | sed -n "s/.*Ran \([0-9]\+\) of .* Specs in .* seconds.*/\1/p")
     if [ "${total_tests}" != "0" ]; then
         echo "Found ${total_tests} tests not assigned to any SIG, please check: ${result}"
         exit 1
     fi
-    labels="!(SRIOV,GPU,sig-operator,sig-network,sig-storage,sig-compute,sig-compute-migrations,sig-performance,sig-compute-realtime,sig-monitoring)"
+    labels="!(SRIOV,GPU,sig-control-plane,sig-network,sig-storage,sig-compute,sig-compute-migrations,sig-performance,sig-compute-realtime,sig-monitoring)"
     result=$(FUNC_TEST_ARGS="--dry-run --no-color --label-filter=${labels}" make functest)
     total_tests=$(echo "${result}" | sed -n "s/.*Ran \([0-9]\+\) of .* Specs in .* seconds.*/\1/p")
     if [ "${total_tests}" != "0" ]; then

--- a/tests/canary_upgrade_test.go
+++ b/tests/canary_upgrade_test.go
@@ -46,7 +46,7 @@ import (
 	"kubevirt.io/kubevirt/tests/libkubevirt"
 )
 
-var _ = Describe("[sig-operator]virt-handler canary upgrade", Serial, decorators.SigOperator, func() {
+var _ = Describe("[sig-control-plane]virt-handler canary upgrade", Serial, decorators.SigControlPlane, func() {
 
 	var originalKV *v1.KubeVirt
 	var virtCli kubecli.KubevirtClient

--- a/tests/decorators/decorators.go
+++ b/tests/decorators/decorators.go
@@ -10,7 +10,7 @@ var (
 	/* SIGs */
 
 	SigCompute             = Label("sig-compute")
-	SigOperator            = Label("sig-operator")
+	SigControlPlane        = Label("sig-control-plane")
 	SigNetwork             = Label("sig-network")
 	SigStorage             = Label("sig-storage")
 	SigComputeInstancetype = Label("sig-compute-instancetype")

--- a/tests/operator/operator.go
+++ b/tests/operator/operator.go
@@ -130,7 +130,7 @@ const (
 	secondaryNetworkName          = "secondarynet"
 )
 
-var _ = Describe("[sig-operator]Operator", Serial, decorators.SigOperator, func() {
+var _ = Describe("[sig-control-plane]Operator", Serial, decorators.SigControlPlane, func() {
 
 	var originalKv *v1.KubeVirt
 	var originalOperatorVersion string


### PR DESCRIPTION
### What this PR does
#### Before this PR:
The CI test lane covering operator and upgrade tests is labeled `sig-operator`, reflecting the legacy informal SIG grouping name.

#### After this PR:
The CI test lane and test decorators are renamed to `sig-control-plane` across the repository, matching the formal SIG name:
- Renames `SigOperator` to `SigControlPlane` in `tests/decorators/decorators.go`.
- Updates `[sig-operator]` Describe strings and decorator references in `tests/operator/operator.go` and `tests/canary_upgrade_test.go`.
- Updates pattern matching in `automation/test.sh` to support both `sig-control-plane` and `sig-operator` targets so that existing Prow presubmit jobs continue running seamlessly while `kubevirt/project-infra` transitions job definitions.
- Updates regex skip list and Ginkgo label filter in `hack/check-unassigned-tests.sh`.
- Updates issue template in `.github/ISSUE_TEMPLATE/flaky_test_report.md`.

### References
Fixes #18572
Related to kubevirt/project-infra#5319
Related to kubevirt/ci-health#169

### Why we need it and why it was done in this way
SIG Control Plane has been established as the successor to the informal sig-operator grouping. Maintaining the `sig-operator` CI lane causes confusion with OWNERS files, labels, and community documentation that already use SIG Control Plane.

By maintaining backwards-compatible matching in `automation/test.sh`, in-flight Prow presubmit jobs (`pull-kubevirt-e2e-k8s-*-sig-operator`) continue to match and run the newly tagged tests without requiring lock-step deployments across repositories.

### Checklist
- [x] PR: The PR description is expressive enough and will help future contributors
- [x] Code: Write code that humans can understand and Keep it simple
- [x] Testing: Renamed test decorators in existing functional suites; backwards-compatible CI test matching verified.
- [x] AI Contributions: The PR abides by the KubeVirt AI Contribution Policy.

### Release note
```release-note
NONE
```